### PR TITLE
[P0] Canonical IDL for verbs, envelopes, capabilities, and enums (#34)

### DIFF
--- a/crates/cairn-idl/schema/README.md
+++ b/crates/cairn-idl/schema/README.md
@@ -1,0 +1,38 @@
+# Cairn IDL Schema Sources
+
+This directory holds the canonical IDL for the `cairn.mcp.v1` contract. Every
+file is a draft-2020-12 JSON Schema. Cairn-specific metadata rides on
+`x-cairn-*` vendor keys — the fixed vocabulary lives in
+`docs/design/2026-04-23-cairn-idl-design.md`.
+
+## Layout
+
+- `index.json` — manifest: lists every schema file and freezes the
+  eight-verb set. Codegen (issue #35) reads this first; integrity tests
+  compare it against the filesystem.
+- `envelope/` — shared request / response / signed-intent envelopes
+  (§8.0.b + §4.2 in the design brief).
+- `errors/` — closed error `code` enum (§4.2, §8.0.c, §8.0.d, §13.5.c).
+- `capabilities/` — exhaustive P0 capability string enum (§8.0.a).
+- `extensions/` — registry of extension namespaces (names + version only).
+- `prelude/` — deterministic `status` + fresh `handshake` bodies (§8.0.a).
+- `verbs/` — one file per core verb. Each carries `$defs.Args`, `$defs.Data`,
+  `x-cairn-verb-id`, `x-cairn-cli`, `x-cairn-capability`, `x-cairn-auth`,
+  `x-cairn-skill-triggers`.
+
+## Authoring rules
+
+- Every schema file has `$schema`, `$id`, `title`, and `x-cairn-contract`
+  at the top level.
+- `$id` follows `https://cairn.dev/schema/cairn.mcp.v1/<relative path>`.
+- `x-cairn-contract` is always `cairn.mcp.v1` in this directory.
+- Vendor keys outside the fixed vocabulary are not allowed; see the design
+  spec for the full table.
+- No comments inside JSON. Human rationale belongs in this README or in
+  `docs/design/`.
+
+## Validation
+
+`cargo test -p cairn-idl` runs the seven structural checks defined in
+`crates/cairn-idl/tests/schema_files.rs`. Deep draft-2020-12 validator
+wiring is deferred to issue #35.

--- a/crates/cairn-idl/schema/README.md
+++ b/crates/cairn-idl/schema/README.md
@@ -30,6 +30,14 @@ file is a draft-2020-12 JSON Schema. Cairn-specific metadata rides on
   spec for the full table.
 - No comments inside JSON. Human rationale belongs in this README or in
   `docs/design/`.
+- Every object schema sets `additionalProperties: false` by default. The
+  only allowed exceptions are payloads that carry user-defined open maps —
+  specifically `ingest.frontmatter` (arbitrary user-authored frontmatter),
+  `search.scope`, `retrieve.ArgsScope.scope`, and `forget.ArgsScope.scope`
+  (scope filter grammar is open and mirrors `SearchArgs.filters` — §8.0.d).
+  These fields set `additionalProperties: true` explicitly so the intent
+  is reviewable in diff. Any new open-object exception must be justified
+  in this list before merge.
 
 ## Validation
 

--- a/crates/cairn-idl/schema/capabilities/capabilities.json
+++ b/crates/cairn-idl/schema/capabilities/capabilities.json
@@ -3,6 +3,7 @@
   "$id": "https://cairn.dev/schema/cairn.mcp.v1/capabilities/capabilities.json",
   "title": "Cairn capability strings (P0)",
   "x-cairn-contract": "cairn.mcp.v1",
+  "description": "Negotiable capability strings advertised on status.capabilities. A surface that is NOT in this enum is instead enumerated in x-cairn-mandatory-surfaces below — those are always present whenever the server speaks cairn.mcp.v1 and do not require advertisement. Every verb root, prelude response, hook, and sensor surface MUST appear in exactly one of the two lists.",
   "type": "string",
   "oneOf": [
     { "const": "cairn.mcp.v1.search.keyword",    "x-cairn-since": "v0.1" },
@@ -17,5 +18,17 @@
     { "const": "cairn.mcp.v1.forget.record",     "x-cairn-since": "v0.1" },
     { "const": "cairn.mcp.v1.forget.session",    "x-cairn-since": "v0.2" },
     { "const": "cairn.mcp.v1.forget.scope",      "x-cairn-since": "v0.3" }
+  ],
+  "x-cairn-mandatory-surfaces": [
+    { "surface": "prelude.status",        "since": "v0.1", "reason": "Required for version / incarnation probe before any signed intent." },
+    { "surface": "prelude.handshake",     "since": "v0.1", "reason": "Required to mint server_challenge nonces for signed intents." },
+    { "surface": "verb.ingest",           "since": "v0.1", "reason": "Core write verb; gating is per-auth, not per-capability." },
+    { "surface": "verb.search",           "since": "v0.1", "reason": "Root verb is always present; individual modes (keyword/semantic/hybrid) are negotiable." },
+    { "surface": "verb.retrieve",         "since": "v0.1", "reason": "Root verb is always present; individual targets are negotiable." },
+    { "surface": "verb.summarize",        "since": "v0.1", "reason": "Core synthesis verb; rebac-authorized, not capability-gated." },
+    { "surface": "verb.assemble_hot",     "since": "v0.1", "reason": "Core turn-start verb; rebac-authorized, not capability-gated." },
+    { "surface": "verb.capture_trace",    "since": "v0.1", "reason": "Core trace persistence; signed-chain-authorized, not capability-gated." },
+    { "surface": "verb.lint",             "since": "v0.1", "reason": "Core read-only vault-health verb." },
+    { "surface": "verb.forget",           "since": "v0.1", "reason": "Root verb is always present; individual modes are negotiable." }
   ]
 }

--- a/crates/cairn-idl/schema/capabilities/capabilities.json
+++ b/crates/cairn-idl/schema/capabilities/capabilities.json
@@ -17,7 +17,11 @@
     { "const": "cairn.mcp.v1.retrieve.profile",  "x-cairn-since": "v0.1" },
     { "const": "cairn.mcp.v1.forget.record",     "x-cairn-since": "v0.1" },
     { "const": "cairn.mcp.v1.forget.session",    "x-cairn-since": "v0.2" },
-    { "const": "cairn.mcp.v1.forget.scope",      "x-cairn-since": "v0.3" }
+    { "const": "cairn.mcp.v1.forget.scope",      "x-cairn-since": "v0.3" },
+    { "const": "cairn.mcp.v1.extension.aggregate",   "x-cairn-since": "v0.2" },
+    { "const": "cairn.mcp.v1.extension.admin",       "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.extension.federation",  "x-cairn-since": "v0.3" },
+    { "const": "cairn.mcp.v1.extension.sessiontree", "x-cairn-since": "v0.3" }
   ],
   "x-cairn-mandatory-surfaces": [
     { "surface": "prelude.status",        "since": "v0.1", "reason": "Required for version / incarnation probe before any signed intent." },

--- a/crates/cairn-idl/schema/capabilities/capabilities.json
+++ b/crates/cairn-idl/schema/capabilities/capabilities.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/capabilities/capabilities.json",
+  "title": "Cairn capability strings (P0)",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "string",
+  "oneOf": [
+    { "const": "cairn.mcp.v1.search.keyword",    "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.search.semantic",   "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.search.hybrid",     "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.record",   "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.session",  "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.turn",     "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.folder",   "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.scope",    "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.profile",  "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.forget.record",     "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.forget.session",    "x-cairn-since": "v0.2" },
+    { "const": "cairn.mcp.v1.forget.scope",      "x-cairn-since": "v0.3" }
+  ]
+}

--- a/crates/cairn-idl/schema/common/primitives.json
+++ b/crates/cairn-idl/schema/common/primitives.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/common/primitives.json",
+  "title": "Cairn primitive types",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "description": "Shared assertion-bearing primitives referenced across envelope/prelude/verb files. Keeping these in one place prevents identifier and crypto patterns from drifting between call sites.",
+  "$defs": {
+    "Ulid": {
+      "type": "string",
+      "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$",
+      "description": "Crockford base32 ULID — 26 characters, upper case, 48-bit ms timestamp + 80-bit entropy."
+    },
+    "Nonce16Base64": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9+/]{22}(==)?$",
+      "contentEncoding": "base64",
+      "description": "16 random bytes, base64-encoded. 22 chars unpadded or 24 chars with `==` padding."
+    },
+    "Ed25519Signature": {
+      "type": "string",
+      "pattern": "^ed25519:[0-9a-f]{128}$",
+      "description": "Ed25519 signature: 64 raw bytes rendered as 128 lowercase hex chars after the `ed25519:` tag."
+    },
+    "Identity": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(agt|usr|snr):[A-Za-z0-9._:-]+$",
+      "description": "AgentIdentity, HumanIdentity, or SensorIdentity. Examples: agt:claude-code:opus-4-7:reviewer:v1, usr:alice, snr:local:screen:host:v1."
+    }
+  }
+}

--- a/crates/cairn-idl/schema/common/primitives.json
+++ b/crates/cairn-idl/schema/common/primitives.json
@@ -26,6 +26,12 @@
       "minLength": 1,
       "pattern": "^(agt|usr|snr):[A-Za-z0-9._:-]+$",
       "description": "AgentIdentity, HumanIdentity, or SensorIdentity. Examples: agt:claude-code:opus-4-7:reviewer:v1, usr:alice, snr:local:screen:host:v1."
+    },
+    "Cursor": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "Opaque continuation token. Shared by every request cursor input and every response next_cursor so the pagination round-trip is validator-symmetric — a server cannot emit a cursor the next request cannot carry."
     }
   }
 }

--- a/crates/cairn-idl/schema/common/primitives.json
+++ b/crates/cairn-idl/schema/common/primitives.json
@@ -12,9 +12,9 @@
     },
     "Nonce16Base64": {
       "type": "string",
-      "pattern": "^[A-Za-z0-9+/]{22}(==)?$",
+      "pattern": "^[A-Za-z0-9+/]{21}[AQgw](==)?$",
       "contentEncoding": "base64",
-      "description": "16 random bytes, base64-encoded. 22 chars unpadded or 24 chars with `==` padding."
+      "description": "16 random bytes, base64-encoded. 22 significant chars + optional `==` padding; the 22nd significant char is constrained to [AQgw] so the trailing 4 bits are zero — this is the unique canonical encoding of exactly 16 bytes, rejecting non-canonical variants that strict decoders would refuse."
     },
     "Ed25519Signature": {
       "type": "string",

--- a/crates/cairn-idl/schema/common/scope_filter.json
+++ b/crates/cairn-idl/schema/common/scope_filter.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/common/scope_filter.json",
+  "title": "Cairn scope filter",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "description": "Shared narrowing grammar used by retrieve.ArgsScope and forget.ArgsScope. At least one recognized predicate MUST be present. Value types are constrained per-key so empty strings, empty arrays, and null payloads all reject at schema validation — preventing unbounded reads or deletes. Unknown keys are rejected.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "user":       { "type": "string", "minLength": 1 },
+    "agent":      { "type": "string", "minLength": 1 },
+    "tenant":     { "type": "string", "minLength": 1 },
+    "workspace":  { "type": "string", "minLength": 1 },
+    "session_id": { "type": "string", "minLength": 1 },
+    "kind": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "tags": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "record_ids": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "anyOf": [
+    { "required": ["user"] },
+    { "required": ["agent"] },
+    { "required": ["tenant"] },
+    { "required": ["workspace"] },
+    { "required": ["session_id"] },
+    { "required": ["kind"] },
+    { "required": ["tags"] },
+    { "required": ["record_ids"] }
+  ]
+}

--- a/crates/cairn-idl/schema/common/scope_filter.json
+++ b/crates/cairn-idl/schema/common/scope_filter.json
@@ -25,7 +25,7 @@
     "record_ids": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": { "$ref": "./primitives.json#/$defs/Ulid" }
     }
   },
   "anyOf": [

--- a/crates/cairn-idl/schema/common/scope_filter.json
+++ b/crates/cairn-idl/schema/common/scope_filter.json
@@ -3,7 +3,7 @@
   "$id": "https://cairn.dev/schema/cairn.mcp.v1/common/scope_filter.json",
   "title": "Cairn scope filter",
   "x-cairn-contract": "cairn.mcp.v1",
-  "description": "Shared narrowing grammar used by retrieve.ArgsScope and forget.ArgsScope. At least one recognized predicate MUST be present. Value types are constrained per-key so empty strings, empty arrays, and null payloads all reject at schema validation — preventing unbounded reads or deletes. Unknown keys are rejected.",
+  "description": "Shared narrowing grammar used by search.scope, retrieve.ArgsScope, and forget.ArgsScope. At least one recognized predicate MUST be present. Covers every signed-intent scope dimension (tenant/workspace/entity/tier) plus identity (user/agent), session, kind, tags, and record-ids so scoped reads and deletes can narrow across the same dimensions the signed intent was authorized against. Value types are constrained per-key so empty strings, empty arrays, and null payloads all reject at schema validation — preventing unbounded reads or deletes. Unknown keys are rejected.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -11,6 +11,12 @@
     "agent":      { "type": "string", "minLength": 1 },
     "tenant":     { "type": "string", "minLength": 1 },
     "workspace":  { "type": "string", "minLength": 1 },
+    "entity":     { "type": "string", "minLength": 1 },
+    "tier": {
+      "type": "string",
+      "enum": ["private", "session", "project", "team", "org", "public"],
+      "description": "Matches the tier enum in signed_intent.scope so callers can echo the signed-intent tier in scoped reads/deletes."
+    },
     "session_id": { "type": "string", "minLength": 1 },
     "kind": {
       "type": "array",
@@ -33,6 +39,8 @@
     { "required": ["agent"] },
     { "required": ["tenant"] },
     { "required": ["workspace"] },
+    { "required": ["entity"] },
+    { "required": ["tier"] },
     { "required": ["session_id"] },
     { "required": ["kind"] },
     { "required": ["tags"] },

--- a/crates/cairn-idl/schema/envelope/request.json
+++ b/crates/cairn-idl/schema/envelope/request.json
@@ -23,8 +23,18 @@
     },
     "signed_intent": { "$ref": "signed_intent.json" },
     "args": {
-      "description": "Per-verb argument payload. The exact shape is defined by the matching verbs/<verb>.json $defs/Args schema.",
-      "type": "object"
+      "description": "Per-verb argument payload. The concrete shape is dispatched by the allOf / if-then arms below, each binding args to verbs/<verb>.json#/$defs/Args for the matching verb.",
+      "type": ["object", "array"]
     }
-  }
+  },
+  "allOf": [
+    { "if": { "properties": { "verb": { "const": "ingest" } } },         "then": { "properties": { "args": { "$ref": "../verbs/ingest.json#/$defs/Args" } } } },
+    { "if": { "properties": { "verb": { "const": "search" } } },         "then": { "properties": { "args": { "$ref": "../verbs/search.json#/$defs/Args" } } } },
+    { "if": { "properties": { "verb": { "const": "retrieve" } } },       "then": { "properties": { "args": { "$ref": "../verbs/retrieve.json#/$defs/Args" } } } },
+    { "if": { "properties": { "verb": { "const": "summarize" } } },      "then": { "properties": { "args": { "$ref": "../verbs/summarize.json#/$defs/Args" } } } },
+    { "if": { "properties": { "verb": { "const": "assemble_hot" } } },   "then": { "properties": { "args": { "$ref": "../verbs/assemble_hot.json#/$defs/Args" } } } },
+    { "if": { "properties": { "verb": { "const": "capture_trace" } } },  "then": { "properties": { "args": { "$ref": "../verbs/capture_trace.json#/$defs/Args" } } } },
+    { "if": { "properties": { "verb": { "const": "lint" } } },           "then": { "properties": { "args": { "$ref": "../verbs/lint.json#/$defs/Args" } } } },
+    { "if": { "properties": { "verb": { "const": "forget" } } },         "then": { "properties": { "args": { "$ref": "../verbs/forget.json#/$defs/Args" } } } }
+  ]
 }

--- a/crates/cairn-idl/schema/envelope/request.json
+++ b/crates/cairn-idl/schema/envelope/request.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/envelope/request.json",
+  "title": "Cairn request envelope",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "verb", "signed_intent", "args"],
+  "properties": {
+    "contract": { "const": "cairn.mcp.v1" },
+    "verb": {
+      "type": "string",
+      "enum": [
+        "ingest",
+        "search",
+        "retrieve",
+        "summarize",
+        "assemble_hot",
+        "capture_trace",
+        "lint",
+        "forget"
+      ]
+    },
+    "signed_intent": { "$ref": "signed_intent.json" },
+    "args": {
+      "description": "Per-verb argument payload. The exact shape is defined by the matching verbs/<verb>.json $defs/Args schema.",
+      "type": "object"
+    }
+  }
+}

--- a/crates/cairn-idl/schema/envelope/response.json
+++ b/crates/cairn-idl/schema/envelope/response.json
@@ -18,8 +18,10 @@
         "assemble_hot",
         "capture_trace",
         "lint",
-        "forget"
-      ]
+        "forget",
+        "unknown"
+      ],
+      "description": "Echo of the request verb. The `unknown` sentinel is the canonical placeholder when the server could not parse or dispatch the request verb; it is only permitted with status=rejected and error.code=UnknownVerb. The actual attempted verb is then carried in error.data.verb."
     },
     "operation_id": {
       "allOf": [{ "$ref": "../common/primitives.json#/$defs/Ulid" }],
@@ -61,40 +63,68 @@
       "then": { "properties": { "data": { "$ref": "../verbs/ingest.json#/$defs/Data" } } } },
     { "if": { "properties": { "verb": { "const": "search" } },        "required": ["verb"] },
       "then": { "properties": { "data": { "$ref": "../verbs/search.json#/$defs/Data" } } } },
-    { "if":   { "properties": { "verb": { "const": "retrieve" } }, "required": ["verb"] },
+    { "$comment": "Retrieve target echo is required only on committed responses. Rejected/aborted retrieve paths may legitimately omit target (e.g. InvalidArgs before target was parsed, or UnknownVerb).",
+      "if":   { "allOf": [
+                  { "properties": { "verb":   { "const": "retrieve" } },  "required": ["verb"] },
+                  { "properties": { "status": { "const": "committed" } }, "required": ["status"] }
+                ]},
       "then": { "required": ["target"] } },
-    { "if":   { "properties": { "verb": { "not": { "const": "retrieve" } } }, "required": ["verb"] },
+    { "$comment": "target is retrieve-only — forbidden for every other verb.",
+      "if":   { "properties": { "verb": { "not": { "const": "retrieve" } } }, "required": ["verb"] },
       "then": { "not": { "required": ["target"] } } },
-    { "if":   { "allOf": [
-                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
-                  { "properties": { "target": { "const": "record" } },   "required": ["target"] }
+    { "$comment": "Per-target retrieve Data dispatch — only active on committed responses.",
+      "if":   { "allOf": [
+                  { "properties": { "verb":   { "const": "retrieve" } },  "required": ["verb"] },
+                  { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
+                  { "properties": { "target": { "const": "record" } },    "required": ["target"] }
                 ]},
       "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataRecord" } } } },
     { "if":   { "allOf": [
-                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
-                  { "properties": { "target": { "const": "profile" } },  "required": ["target"] }
+                  { "properties": { "verb":   { "const": "retrieve" } },  "required": ["verb"] },
+                  { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
+                  { "properties": { "target": { "const": "profile" } },   "required": ["target"] }
                 ]},
       "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataProfile" } } } },
     { "if":   { "allOf": [
-                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
-                  { "properties": { "target": { "const": "session" } },  "required": ["target"] }
+                  { "properties": { "verb":   { "const": "retrieve" } },  "required": ["verb"] },
+                  { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
+                  { "properties": { "target": { "const": "session" } },   "required": ["target"] }
                 ]},
       "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataSession" } } } },
     { "if":   { "allOf": [
-                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
-                  { "properties": { "target": { "const": "turn" } },     "required": ["target"] }
+                  { "properties": { "verb":   { "const": "retrieve" } },  "required": ["verb"] },
+                  { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
+                  { "properties": { "target": { "const": "turn" } },      "required": ["target"] }
                 ]},
       "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataTurn" } } } },
     { "if":   { "allOf": [
-                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
-                  { "properties": { "target": { "const": "folder" } },   "required": ["target"] }
+                  { "properties": { "verb":   { "const": "retrieve" } },  "required": ["verb"] },
+                  { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
+                  { "properties": { "target": { "const": "folder" } },    "required": ["target"] }
                 ]},
       "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataFolder" } } } },
     { "if":   { "allOf": [
-                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
-                  { "properties": { "target": { "const": "scope" } },    "required": ["target"] }
+                  { "properties": { "verb":   { "const": "retrieve" } },  "required": ["verb"] },
+                  { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
+                  { "properties": { "target": { "const": "scope" } },     "required": ["target"] }
                 ]},
       "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataScope" } } } },
+    { "$comment": "UnknownVerb bidirectional binding — verb=unknown iff status=rejected AND error.code=UnknownVerb.",
+      "if":   { "properties": { "verb": { "const": "unknown" } }, "required": ["verb"] },
+      "then": {
+        "properties": {
+          "status": { "const": "rejected" },
+          "error":  { "properties": { "code": { "const": "UnknownVerb" } }, "required": ["code"] }
+        },
+        "required": ["status", "error"]
+      }
+    },
+    { "if":   { "allOf": [
+                  { "properties": { "status": { "const": "rejected" } }, "required": ["status"] },
+                  { "properties": { "error": { "properties": { "code": { "const": "UnknownVerb" } }, "required": ["code"] } }, "required": ["error"] }
+                ]},
+      "then": { "properties": { "verb": { "const": "unknown" } }, "required": ["verb"] }
+    },
     { "if": { "properties": { "verb": { "const": "summarize" } },     "required": ["verb"] },
       "then": { "properties": { "data": { "$ref": "../verbs/summarize.json#/$defs/Data" } } } },
     { "if": { "properties": { "verb": { "const": "assemble_hot" } },  "required": ["verb"] },

--- a/crates/cairn-idl/schema/envelope/response.json
+++ b/crates/cairn-idl/schema/envelope/response.json
@@ -50,5 +50,29 @@
       }
     },
     "error": { "$ref": "../errors/error.json" }
-  }
+  },
+  "allOf": [
+    { "if": { "properties": { "verb": { "const": "ingest" } }, "required": ["verb"] },
+      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/ingest.json#/$defs/Data" }, { "type": "null" }] } } } },
+    { "if": { "properties": { "verb": { "const": "search" } }, "required": ["verb"] },
+      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/search.json#/$defs/Data" }, { "type": "null" }] } } } },
+    { "if": { "properties": { "verb": { "const": "retrieve" } }, "required": ["verb"] },
+      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/retrieve.json#/$defs/Data" }, { "type": "null" }] } } } },
+    { "if": { "properties": { "verb": { "const": "summarize" } }, "required": ["verb"] },
+      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/summarize.json#/$defs/Data" }, { "type": "null" }] } } } },
+    { "if": { "properties": { "verb": { "const": "assemble_hot" } }, "required": ["verb"] },
+      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/assemble_hot.json#/$defs/Data" }, { "type": "null" }] } } } },
+    { "if": { "properties": { "verb": { "const": "capture_trace" } }, "required": ["verb"] },
+      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/capture_trace.json#/$defs/Data" }, { "type": "null" }] } } } },
+    { "if": { "properties": { "verb": { "const": "lint" } }, "required": ["verb"] },
+      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/lint.json#/$defs/Data" }, { "type": "null" }] } } } },
+    { "if": { "properties": { "verb": { "const": "forget" } }, "required": ["verb"] },
+      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/forget.json#/$defs/Data" }, { "type": "null" }] } } } },
+    { "if": { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
+      "then": { "required": ["data"], "not": { "required": ["error"] } } },
+    { "if": { "properties": { "status": { "const": "rejected" } }, "required": ["status"] },
+      "then": { "required": ["error"] } },
+    { "if": { "properties": { "status": { "const": "aborted" } }, "required": ["status"] },
+      "then": { "required": ["error"] } }
+  ]
 }

--- a/crates/cairn-idl/schema/envelope/response.json
+++ b/crates/cairn-idl/schema/envelope/response.json
@@ -30,8 +30,8 @@
       "enum": ["committed", "aborted", "rejected"]
     },
     "data": {
-      "description": "Per-verb data payload. Shape defined by verbs/<verb>.json $defs/Data. Null on rejected/aborted calls.",
-      "type": ["object", "null"]
+      "description": "Per-verb data payload. Shape defined by verbs/<verb>.json $defs/Data. Object for most verbs; array for session / folder / scope retrieve variants; null on rejected / aborted calls.",
+      "type": ["object", "array", "null"]
     },
     "policy_trace": {
       "type": "array",

--- a/crates/cairn-idl/schema/envelope/response.json
+++ b/crates/cairn-idl/schema/envelope/response.json
@@ -30,8 +30,8 @@
       "enum": ["committed", "aborted", "rejected"]
     },
     "data": {
-      "description": "Per-verb data payload. Shape defined by verbs/<verb>.json $defs/Data. Object for most verbs; array for session / folder / scope retrieve variants; null on rejected / aborted calls.",
-      "type": ["object", "array", "null"]
+      "description": "Per-verb data payload on committed responses. Shape defined by verbs/<verb>.json $defs/Data. Object for most verbs; array for session / folder / scope retrieve variants. The field is absent on rejected / aborted responses.",
+      "type": ["object", "array"]
     },
     "policy_trace": {
       "type": "array",
@@ -52,27 +52,27 @@
     "error": { "$ref": "../errors/error.json" }
   },
   "allOf": [
-    { "if": { "properties": { "verb": { "const": "ingest" } }, "required": ["verb"] },
-      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/ingest.json#/$defs/Data" }, { "type": "null" }] } } } },
-    { "if": { "properties": { "verb": { "const": "search" } }, "required": ["verb"] },
-      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/search.json#/$defs/Data" }, { "type": "null" }] } } } },
-    { "if": { "properties": { "verb": { "const": "retrieve" } }, "required": ["verb"] },
-      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/retrieve.json#/$defs/Data" }, { "type": "null" }] } } } },
-    { "if": { "properties": { "verb": { "const": "summarize" } }, "required": ["verb"] },
-      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/summarize.json#/$defs/Data" }, { "type": "null" }] } } } },
-    { "if": { "properties": { "verb": { "const": "assemble_hot" } }, "required": ["verb"] },
-      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/assemble_hot.json#/$defs/Data" }, { "type": "null" }] } } } },
+    { "if": { "properties": { "verb": { "const": "ingest" } },        "required": ["verb"] },
+      "then": { "properties": { "data": { "$ref": "../verbs/ingest.json#/$defs/Data" } } } },
+    { "if": { "properties": { "verb": { "const": "search" } },        "required": ["verb"] },
+      "then": { "properties": { "data": { "$ref": "../verbs/search.json#/$defs/Data" } } } },
+    { "if": { "properties": { "verb": { "const": "retrieve" } },      "required": ["verb"] },
+      "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/Data" } } } },
+    { "if": { "properties": { "verb": { "const": "summarize" } },     "required": ["verb"] },
+      "then": { "properties": { "data": { "$ref": "../verbs/summarize.json#/$defs/Data" } } } },
+    { "if": { "properties": { "verb": { "const": "assemble_hot" } },  "required": ["verb"] },
+      "then": { "properties": { "data": { "$ref": "../verbs/assemble_hot.json#/$defs/Data" } } } },
     { "if": { "properties": { "verb": { "const": "capture_trace" } }, "required": ["verb"] },
-      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/capture_trace.json#/$defs/Data" }, { "type": "null" }] } } } },
-    { "if": { "properties": { "verb": { "const": "lint" } }, "required": ["verb"] },
-      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/lint.json#/$defs/Data" }, { "type": "null" }] } } } },
-    { "if": { "properties": { "verb": { "const": "forget" } }, "required": ["verb"] },
-      "then": { "properties": { "data": { "anyOf": [{ "$ref": "../verbs/forget.json#/$defs/Data" }, { "type": "null" }] } } } },
-    { "if": { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
+      "then": { "properties": { "data": { "$ref": "../verbs/capture_trace.json#/$defs/Data" } } } },
+    { "if": { "properties": { "verb": { "const": "lint" } },          "required": ["verb"] },
+      "then": { "properties": { "data": { "$ref": "../verbs/lint.json#/$defs/Data" } } } },
+    { "if": { "properties": { "verb": { "const": "forget" } },        "required": ["verb"] },
+      "then": { "properties": { "data": { "$ref": "../verbs/forget.json#/$defs/Data" } } } },
+    { "if":   { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
       "then": { "required": ["data"], "not": { "required": ["error"] } } },
-    { "if": { "properties": { "status": { "const": "rejected" } }, "required": ["status"] },
-      "then": { "required": ["error"] } },
-    { "if": { "properties": { "status": { "const": "aborted" } }, "required": ["status"] },
-      "then": { "required": ["error"] } }
+    { "if":   { "properties": { "status": { "const": "rejected" } },  "required": ["status"] },
+      "then": { "required": ["error"], "not": { "required": ["data"] } } },
+    { "if":   { "properties": { "status": { "const": "aborted" } },   "required": ["status"] },
+      "then": { "required": ["error"], "not": { "required": ["data"] } } }
   ]
 }

--- a/crates/cairn-idl/schema/envelope/response.json
+++ b/crates/cairn-idl/schema/envelope/response.json
@@ -22,8 +22,8 @@
       ]
     },
     "operation_id": {
-      "type": "string",
-      "description": "ULID matching the replay-ledger + WAL op for this call."
+      "allOf": [{ "$ref": "../common/primitives.json#/$defs/Ulid" }],
+      "description": "ULID matching the replay-ledger + WAL op for this call. Same shape as signed_intent.operation_id."
     },
     "status": {
       "type": "string",

--- a/crates/cairn-idl/schema/envelope/response.json
+++ b/crates/cairn-idl/schema/envelope/response.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/envelope/response.json",
+  "title": "Cairn response envelope",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "verb", "operation_id", "status", "policy_trace"],
+  "properties": {
+    "contract": { "const": "cairn.mcp.v1" },
+    "verb": {
+      "type": "string",
+      "enum": [
+        "ingest",
+        "search",
+        "retrieve",
+        "summarize",
+        "assemble_hot",
+        "capture_trace",
+        "lint",
+        "forget"
+      ]
+    },
+    "operation_id": {
+      "type": "string",
+      "description": "ULID matching the replay-ledger + WAL op for this call."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["committed", "aborted", "rejected"]
+    },
+    "data": {
+      "description": "Per-verb data payload. Shape defined by verbs/<verb>.json $defs/Data. Null on rejected/aborted calls.",
+      "type": ["object", "null"]
+    },
+    "policy_trace": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["gate", "result"],
+        "properties": {
+          "gate": { "type": "string" },
+          "result": {
+            "type": "string",
+            "enum": ["pass", "deny", "error"]
+          },
+          "detail": { "type": "string" }
+        }
+      }
+    },
+    "error": { "$ref": "../errors/error.json" }
+  }
+}

--- a/crates/cairn-idl/schema/envelope/response.json
+++ b/crates/cairn-idl/schema/envelope/response.json
@@ -33,6 +33,11 @@
       "description": "Per-verb data payload on committed responses. Shape defined by verbs/<verb>.json $defs/Data. Object for most verbs; array for session / folder / scope retrieve variants. The field is absent on rejected / aborted responses.",
       "type": ["object", "array"]
     },
+    "target": {
+      "type": "string",
+      "enum": ["record", "session", "turn", "folder", "scope", "profile"],
+      "description": "Retrieve-only discriminator echoing the requested target. Required when verb=retrieve; forbidden otherwise. Lets validators bind the per-target retrieve Data shape to the caller's request."
+    },
     "policy_trace": {
       "type": "array",
       "items": {
@@ -56,8 +61,40 @@
       "then": { "properties": { "data": { "$ref": "../verbs/ingest.json#/$defs/Data" } } } },
     { "if": { "properties": { "verb": { "const": "search" } },        "required": ["verb"] },
       "then": { "properties": { "data": { "$ref": "../verbs/search.json#/$defs/Data" } } } },
-    { "if": { "properties": { "verb": { "const": "retrieve" } },      "required": ["verb"] },
-      "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/Data" } } } },
+    { "if":   { "properties": { "verb": { "const": "retrieve" } }, "required": ["verb"] },
+      "then": { "required": ["target"] } },
+    { "if":   { "properties": { "verb": { "not": { "const": "retrieve" } } }, "required": ["verb"] },
+      "then": { "not": { "required": ["target"] } } },
+    { "if":   { "allOf": [
+                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
+                  { "properties": { "target": { "const": "record" } },   "required": ["target"] }
+                ]},
+      "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataRecord" } } } },
+    { "if":   { "allOf": [
+                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
+                  { "properties": { "target": { "const": "profile" } },  "required": ["target"] }
+                ]},
+      "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataProfile" } } } },
+    { "if":   { "allOf": [
+                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
+                  { "properties": { "target": { "const": "session" } },  "required": ["target"] }
+                ]},
+      "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataSession" } } } },
+    { "if":   { "allOf": [
+                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
+                  { "properties": { "target": { "const": "turn" } },     "required": ["target"] }
+                ]},
+      "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataTurn" } } } },
+    { "if":   { "allOf": [
+                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
+                  { "properties": { "target": { "const": "folder" } },   "required": ["target"] }
+                ]},
+      "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataFolder" } } } },
+    { "if":   { "allOf": [
+                  { "properties": { "verb":   { "const": "retrieve" } }, "required": ["verb"] },
+                  { "properties": { "target": { "const": "scope" } },    "required": ["target"] }
+                ]},
+      "then": { "properties": { "data": { "$ref": "../verbs/retrieve.json#/$defs/DataScope" } } } },
     { "if": { "properties": { "verb": { "const": "summarize" } },     "required": ["verb"] },
       "then": { "properties": { "data": { "$ref": "../verbs/summarize.json#/$defs/Data" } } } },
     { "if": { "properties": { "verb": { "const": "assemble_hot" } },  "required": ["verb"] },

--- a/crates/cairn-idl/schema/envelope/response.json
+++ b/crates/cairn-idl/schema/envelope/response.json
@@ -40,12 +40,12 @@
         "additionalProperties": false,
         "required": ["gate", "result"],
         "properties": {
-          "gate": { "type": "string" },
+          "gate": { "type": "string", "minLength": 1 },
           "result": {
             "type": "string",
             "enum": ["pass", "deny", "error"]
           },
-          "detail": { "type": "string" }
+          "detail": { "type": "string", "minLength": 1 }
         }
       }
     },
@@ -71,8 +71,74 @@
     { "if":   { "properties": { "status": { "const": "committed" } }, "required": ["status"] },
       "then": { "required": ["data"], "not": { "required": ["error"] } } },
     { "if":   { "properties": { "status": { "const": "rejected" } },  "required": ["status"] },
-      "then": { "required": ["error"], "not": { "required": ["data"] } } },
+      "then": {
+        "required": ["error"],
+        "not": { "required": ["data"] },
+        "properties": {
+          "error": {
+            "properties": {
+              "code": {
+                "enum": [
+                  "InvalidArgs",
+                  "InvalidFilter",
+                  "CapabilityUnavailable",
+                  "UnknownVerb",
+                  "ExpiredIntent",
+                  "ReplayDetected",
+                  "OutOfOrderSequence",
+                  "RevokedKey",
+                  "MissingSignature",
+                  "Unauthorized"
+                ]
+              }
+            },
+            "required": ["code"]
+          }
+        }
+      }
+    },
     { "if":   { "properties": { "status": { "const": "aborted" } },   "required": ["status"] },
-      "then": { "required": ["error"], "not": { "required": ["data"] } } }
-  ]
+      "then": {
+        "required": ["error"],
+        "not": { "required": ["data"] },
+        "properties": {
+          "error": {
+            "properties": {
+              "code": {
+                "enum": [
+                  "NotFound",
+                  "ConflictVersion",
+                  "QuarantineRequired",
+                  "PluginSuspended",
+                  "Internal"
+                ]
+              }
+            },
+            "required": ["code"]
+          }
+        }
+      }
+    }
+  ],
+  "x-cairn-error-code-families": {
+    "rejected": [
+      "InvalidArgs",
+      "InvalidFilter",
+      "CapabilityUnavailable",
+      "UnknownVerb",
+      "ExpiredIntent",
+      "ReplayDetected",
+      "OutOfOrderSequence",
+      "RevokedKey",
+      "MissingSignature",
+      "Unauthorized"
+    ],
+    "aborted": [
+      "NotFound",
+      "ConflictVersion",
+      "QuarantineRequired",
+      "PluginSuspended",
+      "Internal"
+    ]
+  }
 }

--- a/crates/cairn-idl/schema/envelope/signed_intent.json
+++ b/crates/cairn-idl/schema/envelope/signed_intent.json
@@ -19,14 +19,11 @@
   ],
   "properties": {
     "operation_id": {
-      "type": "string",
-      "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$",
+      "allOf": [{ "$ref": "../common/primitives.json#/$defs/Ulid" }],
       "description": "ULID (Crockford base32, 26 chars); unique per issuer within expires_at window."
     },
     "nonce": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "pattern": "^[A-Za-z0-9+/]{22}(==)?$",
+      "allOf": [{ "$ref": "../common/primitives.json#/$defs/Nonce16Base64" }],
       "description": "Fresh per message; 16 bytes base64-encoded (22 chars unpadded or 24 chars with `==` padding)."
     },
     "sequence": {
@@ -54,31 +51,23 @@
       }
     },
     "issuer": {
-      "type": "string",
-      "minLength": 1,
-      "pattern": "^(agt|usr|snr):[A-Za-z0-9._:-]+$",
+      "allOf": [{ "$ref": "../common/primitives.json#/$defs/Identity" }],
       "description": "AgentIdentity, HumanIdentity, or SensorIdentity. Examples: agt:claude-code:opus-4-7:reviewer:v1, usr:alice, snr:local:screen:host:v1."
     },
     "issued_at": { "type": "string", "format": "date-time", "minLength": 20 },
     "expires_at": { "type": "string", "format": "date-time", "minLength": 20 },
     "key_version": { "type": "integer", "minimum": 1 },
     "server_challenge": {
-      "type": "string",
-      "contentEncoding": "base64",
-      "pattern": "^[A-Za-z0-9+/]{22}(==)?$",
+      "allOf": [{ "$ref": "../common/primitives.json#/$defs/Nonce16Base64" }],
       "description": "Fresh nonce obtained from `cairn handshake`; required when sequence is absent. Same 16-byte base64 shape as nonce."
     },
     "chain_parents": {
       "type": "array",
-      "items": {
-        "type": "string",
-        "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$",
-        "description": "operation_id ULID of a prior operation this one depends on."
-      }
+      "items": { "$ref": "../common/primitives.json#/$defs/Ulid" },
+      "description": "operation_id ULIDs of prior operations this one depends on."
     },
     "signature": {
-      "type": "string",
-      "pattern": "^ed25519:[0-9a-f]{128}$",
+      "allOf": [{ "$ref": "../common/primitives.json#/$defs/Ed25519Signature" }],
       "description": "Ed25519 signature over the canonical JSON of every other field. 64 raw bytes = 128 lowercase hex chars."
     }
   },

--- a/crates/cairn-idl/schema/envelope/signed_intent.json
+++ b/crates/cairn-idl/schema/envelope/signed_intent.json
@@ -20,12 +20,14 @@
   "properties": {
     "operation_id": {
       "type": "string",
-      "description": "ULID; unique per issuer within expires_at window."
+      "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$",
+      "description": "ULID (Crockford base32, 26 chars); unique per issuer within expires_at window."
     },
     "nonce": {
       "type": "string",
       "contentEncoding": "base64",
-      "description": "Fresh per message; 16 bytes base64-encoded."
+      "pattern": "^[A-Za-z0-9+/]{22}(==)?$",
+      "description": "Fresh per message; 16 bytes base64-encoded (22 chars unpadded or 24 chars with `==` padding)."
     },
     "sequence": {
       "type": "integer",
@@ -42,9 +44,9 @@
       "additionalProperties": false,
       "required": ["tenant", "workspace", "entity", "tier"],
       "properties": {
-        "tenant": { "type": "string" },
-        "workspace": { "type": "string" },
-        "entity": { "type": "string" },
+        "tenant":    { "type": "string", "minLength": 1 },
+        "workspace": { "type": "string", "minLength": 1 },
+        "entity":    { "type": "string", "minLength": 1 },
         "tier": {
           "type": "string",
           "enum": ["private", "session", "project", "team", "org", "public"]
@@ -53,26 +55,31 @@
     },
     "issuer": {
       "type": "string",
-      "description": "e.g. agt:claude-code:opus-4-7:reviewer:v1 (AgentIdentity) or usr:<id> (HumanIdentity)."
+      "minLength": 1,
+      "pattern": "^(agt|usr|snr):[A-Za-z0-9._:-]+$",
+      "description": "AgentIdentity, HumanIdentity, or SensorIdentity. Examples: agt:claude-code:opus-4-7:reviewer:v1, usr:alice, snr:local:screen:host:v1."
     },
-    "issued_at": { "type": "string", "format": "date-time" },
-    "expires_at": { "type": "string", "format": "date-time" },
+    "issued_at": { "type": "string", "format": "date-time", "minLength": 20 },
+    "expires_at": { "type": "string", "format": "date-time", "minLength": 20 },
     "key_version": { "type": "integer", "minimum": 1 },
     "server_challenge": {
       "type": "string",
       "contentEncoding": "base64",
-      "description": "Fresh nonce obtained from `cairn handshake`; required when sequence is absent."
+      "pattern": "^[A-Za-z0-9+/]{22}(==)?$",
+      "description": "Fresh nonce obtained from `cairn handshake`; required when sequence is absent. Same 16-byte base64 shape as nonce."
     },
     "chain_parents": {
       "type": "array",
       "items": {
         "type": "string",
-        "description": "operation_id of a prior operation this one depends on."
+        "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$",
+        "description": "operation_id ULID of a prior operation this one depends on."
       }
     },
     "signature": {
       "type": "string",
-      "pattern": "^ed25519:[0-9a-f]+$"
+      "pattern": "^ed25519:[0-9a-f]{128}$",
+      "description": "Ed25519 signature over the canonical JSON of every other field. 64 raw bytes = 128 lowercase hex chars."
     }
   },
   "oneOf": [

--- a/crates/cairn-idl/schema/envelope/signed_intent.json
+++ b/crates/cairn-idl/schema/envelope/signed_intent.json
@@ -29,7 +29,8 @@
     "sequence": {
       "type": "integer",
       "minimum": 0,
-      "description": "Monotonic per-issuer counter; strictly increasing. Mutually exclusive with server_challenge."
+      "maximum": 9007199254740991,
+      "description": "Monotonic per-issuer counter; strictly increasing. Bounded by JSON's safe integer range (2^53 − 1) so validators and JSON decoders cannot disagree on the represented value. Mutually exclusive with server_challenge."
     },
     "target_hash": {
       "type": "string",
@@ -63,8 +64,10 @@
     },
     "chain_parents": {
       "type": "array",
+      "uniqueItems": true,
+      "maxItems": 64,
       "items": { "$ref": "../common/primitives.json#/$defs/Ulid" },
-      "description": "operation_id ULIDs of prior operations this one depends on."
+      "description": "operation_id ULIDs of prior operations this one depends on. Bounded and deduplicated so a malformed intent cannot push a pathologically large DAG fan-in at WAL dependency processing time."
     },
     "signature": {
       "allOf": [{ "$ref": "../common/primitives.json#/$defs/Ed25519Signature" }],

--- a/crates/cairn-idl/schema/envelope/signed_intent.json
+++ b/crates/cairn-idl/schema/envelope/signed_intent.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/envelope/signed_intent.json",
+  "title": "Cairn signed intent envelope",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "operation_id",
+    "nonce",
+    "target_hash",
+    "scope",
+    "issuer",
+    "issued_at",
+    "expires_at",
+    "key_version",
+    "chain_parents",
+    "signature"
+  ],
+  "properties": {
+    "operation_id": {
+      "type": "string",
+      "description": "ULID; unique per issuer within expires_at window."
+    },
+    "nonce": {
+      "type": "string",
+      "contentEncoding": "base64",
+      "description": "Fresh per message; 16 bytes base64-encoded."
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Monotonic per-issuer counter; strictly increasing. Mutually exclusive with server_challenge."
+    },
+    "target_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "sha256 of the record / plan / receipt this signature authorizes."
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tenant", "workspace", "entity", "tier"],
+      "properties": {
+        "tenant": { "type": "string" },
+        "workspace": { "type": "string" },
+        "entity": { "type": "string" },
+        "tier": {
+          "type": "string",
+          "enum": ["private", "session", "project", "team", "org", "public"]
+        }
+      }
+    },
+    "issuer": {
+      "type": "string",
+      "description": "e.g. agt:claude-code:opus-4-7:reviewer:v1 (AgentIdentity) or usr:<id> (HumanIdentity)."
+    },
+    "issued_at": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "key_version": { "type": "integer", "minimum": 1 },
+    "server_challenge": {
+      "type": "string",
+      "contentEncoding": "base64",
+      "description": "Fresh nonce obtained from `cairn handshake`; required when sequence is absent."
+    },
+    "chain_parents": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "operation_id of a prior operation this one depends on."
+      }
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^ed25519:[0-9a-f]+$"
+    }
+  },
+  "oneOf": [
+    { "required": ["sequence"], "not": { "required": ["server_challenge"] } },
+    { "required": ["server_challenge"], "not": { "required": ["sequence"] } }
+  ]
+}

--- a/crates/cairn-idl/schema/errors/error.json
+++ b/crates/cairn-idl/schema/errors/error.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/errors/error.json",
+  "title": "Cairn error",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["code", "message"],
+  "properties": {
+    "code": {
+      "type": "string",
+      "enum": [
+        "InvalidArgs",
+        "InvalidFilter",
+        "CapabilityUnavailable",
+        "UnknownVerb",
+        "ExpiredIntent",
+        "ReplayDetected",
+        "OutOfOrderSequence",
+        "RevokedKey",
+        "MissingSignature",
+        "Unauthorized",
+        "NotFound",
+        "ConflictVersion",
+        "QuarantineRequired",
+        "PluginSuspended",
+        "Internal"
+      ]
+    },
+    "message": { "type": "string" },
+    "data": {
+      "type": "object",
+      "description": "Per-code payload. See $defs for typed shapes consumed by codegen."
+    }
+  },
+  "$defs": {
+    "InvalidArgsData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "reason"],
+      "properties": {
+        "field": { "type": "string" },
+        "reason": { "type": "string" }
+      }
+    },
+    "InvalidFilterData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason"],
+      "properties": {
+        "reason": { "type": "string" },
+        "path": { "type": "string" }
+      }
+    },
+    "CapabilityUnavailableData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability"],
+      "properties": {
+        "capability": { "type": "string" }
+      }
+    },
+    "UnknownVerbData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verb"],
+      "properties": {
+        "verb": { "type": "string" }
+      }
+    },
+    "ExpiredIntentData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issued_at", "expires_at", "now"],
+      "properties": {
+        "issued_at": { "type": "string", "format": "date-time" },
+        "expires_at": { "type": "string", "format": "date-time" },
+        "now": { "type": "string", "format": "date-time" }
+      }
+    },
+    "ReplayDetectedData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation_id"],
+      "properties": {
+        "operation_id": { "type": "string" }
+      }
+    },
+    "OutOfOrderSequenceData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issuer", "high_water", "attempted"],
+      "properties": {
+        "issuer": { "type": "string" },
+        "high_water": { "type": "integer" },
+        "attempted": { "type": "integer" }
+      }
+    },
+    "RevokedKeyData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issuer", "key_version"],
+      "properties": {
+        "issuer": { "type": "string" },
+        "key_version": { "type": "integer" }
+      }
+    },
+    "MissingSignatureData": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    },
+    "UnauthorizedData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "string" }
+      }
+    },
+    "NotFoundData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target"],
+      "properties": {
+        "target": { "type": "string" }
+      }
+    },
+    "ConflictVersionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["expected", "actual"],
+      "properties": {
+        "expected": { "type": "integer" },
+        "actual": { "type": "integer" }
+      }
+    },
+    "QuarantineRequiredData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason"],
+      "properties": {
+        "reason": { "type": "string" },
+        "quarantine_id": { "type": "string" }
+      }
+    },
+    "PluginSuspendedData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["plugin_id"],
+      "properties": {
+        "plugin_id": { "type": "string" }
+      }
+    },
+    "InternalData": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "correlation_id": { "type": "string" }
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/errors/error.json
+++ b/crates/cairn-idl/schema/errors/error.json
@@ -6,21 +6,21 @@
   "type": "object",
   "required": ["code", "message"],
   "oneOf": [
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "InvalidArgs" },           "message": { "type": "string" }, "data": { "$ref": "#/$defs/InvalidArgsData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "InvalidFilter" },         "message": { "type": "string" }, "data": { "$ref": "#/$defs/InvalidFilterData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "CapabilityUnavailable" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/CapabilityUnavailableData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "UnknownVerb" },   "message": { "type": "string" }, "data": { "$ref": "#/$defs/UnknownVerbData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ExpiredIntent" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/ExpiredIntentData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ReplayDetected" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/ReplayDetectedData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "OutOfOrderSequence" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/OutOfOrderSequenceData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "RevokedKey" },    "message": { "type": "string" }, "data": { "$ref": "#/$defs/RevokedKeyData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message"],         "properties": { "code": { "const": "MissingSignature" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/MissingSignatureData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "Unauthorized" },  "message": { "type": "string" }, "data": { "$ref": "#/$defs/UnauthorizedData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "NotFound" },      "message": { "type": "string" }, "data": { "$ref": "#/$defs/NotFoundData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ConflictVersion" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/ConflictVersionData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "QuarantineRequired" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/QuarantineRequiredData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "PluginSuspended" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/PluginSuspendedData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message"],         "properties": { "code": { "const": "Internal" },      "message": { "type": "string" }, "data": { "$ref": "#/$defs/InternalData" } } }
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "InvalidArgs" },           "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/InvalidArgsData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "InvalidFilter" },         "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/InvalidFilterData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "CapabilityUnavailable" }, "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/CapabilityUnavailableData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "UnknownVerb" },   "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/UnknownVerbData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ExpiredIntent" }, "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/ExpiredIntentData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ReplayDetected" }, "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/ReplayDetectedData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "OutOfOrderSequence" }, "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/OutOfOrderSequenceData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "RevokedKey" },    "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/RevokedKeyData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message"],         "properties": { "code": { "const": "MissingSignature" }, "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/MissingSignatureData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "Unauthorized" },  "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/UnauthorizedData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "NotFound" },      "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/NotFoundData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ConflictVersion" }, "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/ConflictVersionData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "QuarantineRequired" }, "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/QuarantineRequiredData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "PluginSuspended" }, "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/PluginSuspendedData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message"],         "properties": { "code": { "const": "Internal" },      "message": { "type": "string", "minLength": 1 }, "data": { "$ref": "#/$defs/InternalData" } } }
   ],
   "$defs": {
     "InvalidArgsData": {
@@ -28,8 +28,8 @@
       "additionalProperties": false,
       "required": ["field", "reason"],
       "properties": {
-        "field": { "type": "string" },
-        "reason": { "type": "string" }
+        "field": { "type": "string", "minLength": 1 },
+        "reason": { "type": "string", "minLength": 1 }
       }
     },
     "InvalidFilterData": {
@@ -37,8 +37,8 @@
       "additionalProperties": false,
       "required": ["reason"],
       "properties": {
-        "reason": { "type": "string" },
-        "path": { "type": "string" }
+        "reason": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 }
       }
     },
     "CapabilityUnavailableData": {
@@ -46,7 +46,7 @@
       "additionalProperties": false,
       "required": ["capability"],
       "properties": {
-        "capability": { "type": "string" }
+        "capability": { "$ref": "../capabilities/capabilities.json" }
       }
     },
     "UnknownVerbData": {
@@ -54,7 +54,7 @@
       "additionalProperties": false,
       "required": ["verb"],
       "properties": {
-        "verb": { "type": "string" }
+        "verb": { "type": "string", "minLength": 1 }
       }
     },
     "ExpiredIntentData": {
@@ -80,9 +80,9 @@
       "additionalProperties": false,
       "required": ["issuer", "high_water", "attempted"],
       "properties": {
-        "issuer": { "type": "string" },
-        "high_water": { "type": "integer" },
-        "attempted": { "type": "integer" }
+        "issuer":      { "$ref": "../common/primitives.json#/$defs/Identity" },
+        "high_water": { "type": "integer", "minimum": 0 },
+        "attempted":  { "type": "integer", "minimum": 0 }
       }
     },
     "RevokedKeyData": {
@@ -90,8 +90,8 @@
       "additionalProperties": false,
       "required": ["issuer", "key_version"],
       "properties": {
-        "issuer": { "type": "string" },
-        "key_version": { "type": "integer" }
+        "issuer":      { "$ref": "../common/primitives.json#/$defs/Identity" },
+        "key_version": { "type": "integer", "minimum": 1 }
       }
     },
     "MissingSignatureData": {
@@ -104,7 +104,7 @@
       "additionalProperties": false,
       "required": ["required"],
       "properties": {
-        "required": { "type": "string" }
+        "required": { "type": "string", "minLength": 1 }
       }
     },
     "NotFoundData": {
@@ -112,7 +112,7 @@
       "additionalProperties": false,
       "required": ["target"],
       "properties": {
-        "target": { "type": "string" }
+        "target": { "type": "string", "minLength": 1 }
       }
     },
     "ConflictVersionData": {
@@ -120,8 +120,8 @@
       "additionalProperties": false,
       "required": ["expected", "actual"],
       "properties": {
-        "expected": { "type": "integer" },
-        "actual": { "type": "integer" }
+        "expected": { "type": "integer", "minimum": 0 },
+        "actual":   { "type": "integer", "minimum": 0 }
       }
     },
     "QuarantineRequiredData": {
@@ -129,8 +129,8 @@
       "additionalProperties": false,
       "required": ["reason"],
       "properties": {
-        "reason": { "type": "string" },
-        "quarantine_id": { "type": "string" }
+        "reason":        { "type": "string", "minLength": 1 },
+        "quarantine_id": { "$ref": "../common/primitives.json#/$defs/Ulid" }
       }
     },
     "PluginSuspendedData": {
@@ -138,14 +138,14 @@
       "additionalProperties": false,
       "required": ["plugin_id"],
       "properties": {
-        "plugin_id": { "type": "string" }
+        "plugin_id": { "type": "string", "minLength": 1 }
       }
     },
     "InternalData": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "correlation_id": { "type": "string" }
+        "correlation_id": { "$ref": "../common/primitives.json#/$defs/Ulid" }
       }
     }
   }

--- a/crates/cairn-idl/schema/errors/error.json
+++ b/crates/cairn-idl/schema/errors/error.json
@@ -6,8 +6,8 @@
   "type": "object",
   "required": ["code", "message"],
   "oneOf": [
-    { "type": "object", "additionalProperties": false, "required": ["code", "message"], "properties": { "code": { "const": "InvalidArgs" },           "message": { "type": "string" }, "data": { "$ref": "#/$defs/InvalidArgsData" } } },
-    { "type": "object", "additionalProperties": false, "required": ["code", "message"], "properties": { "code": { "const": "InvalidFilter" },         "message": { "type": "string" }, "data": { "$ref": "#/$defs/InvalidFilterData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "InvalidArgs" },           "message": { "type": "string" }, "data": { "$ref": "#/$defs/InvalidArgsData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "InvalidFilter" },         "message": { "type": "string" }, "data": { "$ref": "#/$defs/InvalidFilterData" } } },
     { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "CapabilityUnavailable" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/CapabilityUnavailableData" } } },
     { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "UnknownVerb" },   "message": { "type": "string" }, "data": { "$ref": "#/$defs/UnknownVerbData" } } },
     { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ExpiredIntent" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/ExpiredIntentData" } } },
@@ -72,7 +72,7 @@
       "additionalProperties": false,
       "required": ["operation_id"],
       "properties": {
-        "operation_id": { "type": "string" }
+        "operation_id": { "$ref": "../common/primitives.json#/$defs/Ulid" }
       }
     },
     "OutOfOrderSequenceData": {

--- a/crates/cairn-idl/schema/errors/error.json
+++ b/crates/cairn-idl/schema/errors/error.json
@@ -4,35 +4,24 @@
   "title": "Cairn error",
   "x-cairn-contract": "cairn.mcp.v1",
   "type": "object",
-  "additionalProperties": false,
   "required": ["code", "message"],
-  "properties": {
-    "code": {
-      "type": "string",
-      "enum": [
-        "InvalidArgs",
-        "InvalidFilter",
-        "CapabilityUnavailable",
-        "UnknownVerb",
-        "ExpiredIntent",
-        "ReplayDetected",
-        "OutOfOrderSequence",
-        "RevokedKey",
-        "MissingSignature",
-        "Unauthorized",
-        "NotFound",
-        "ConflictVersion",
-        "QuarantineRequired",
-        "PluginSuspended",
-        "Internal"
-      ]
-    },
-    "message": { "type": "string" },
-    "data": {
-      "type": "object",
-      "description": "Per-code payload. See $defs for typed shapes consumed by codegen."
-    }
-  },
+  "oneOf": [
+    { "type": "object", "additionalProperties": false, "required": ["code", "message"], "properties": { "code": { "const": "InvalidArgs" },           "message": { "type": "string" }, "data": { "$ref": "#/$defs/InvalidArgsData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message"], "properties": { "code": { "const": "InvalidFilter" },         "message": { "type": "string" }, "data": { "$ref": "#/$defs/InvalidFilterData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "CapabilityUnavailable" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/CapabilityUnavailableData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "UnknownVerb" },   "message": { "type": "string" }, "data": { "$ref": "#/$defs/UnknownVerbData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ExpiredIntent" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/ExpiredIntentData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ReplayDetected" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/ReplayDetectedData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "OutOfOrderSequence" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/OutOfOrderSequenceData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "RevokedKey" },    "message": { "type": "string" }, "data": { "$ref": "#/$defs/RevokedKeyData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message"],         "properties": { "code": { "const": "MissingSignature" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/MissingSignatureData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "Unauthorized" },  "message": { "type": "string" }, "data": { "$ref": "#/$defs/UnauthorizedData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "NotFound" },      "message": { "type": "string" }, "data": { "$ref": "#/$defs/NotFoundData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "ConflictVersion" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/ConflictVersionData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "QuarantineRequired" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/QuarantineRequiredData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message", "data"], "properties": { "code": { "const": "PluginSuspended" }, "message": { "type": "string" }, "data": { "$ref": "#/$defs/PluginSuspendedData" } } },
+    { "type": "object", "additionalProperties": false, "required": ["code", "message"],         "properties": { "code": { "const": "Internal" },      "message": { "type": "string" }, "data": { "$ref": "#/$defs/InternalData" } } }
+  ],
   "$defs": {
     "InvalidArgsData": {
       "type": "object",

--- a/crates/cairn-idl/schema/extensions/registry.json
+++ b/crates/cairn-idl/schema/extensions/registry.json
@@ -14,46 +14,50 @@
   },
   "$defs": {
     "namespace": {
-      "description": "One of the four registered extension triples. Independent enums on name / since / enabler would accept invalid combinations, so each namespace is pinned as a whole triple.",
+      "description": "One of the four registered extension triples. Independent enums on name / since / enabler would accept invalid combinations, so each namespace is pinned as a whole quadruple (name + since + enabler + capability). The capability string ties negotiation to the shared capabilities enum so status.extensions and status.capabilities cannot drift.",
       "oneOf": [
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["name", "x-cairn-since", "enabler"],
+          "required": ["name", "x-cairn-since", "enabler", "x-cairn-capability"],
           "properties": {
-            "name":          { "const": "cairn.aggregate.v1" },
-            "x-cairn-since": { "const": "v0.2" },
-            "enabler":       { "const": "agent.enable_aggregate" }
+            "name":                { "const": "cairn.aggregate.v1" },
+            "x-cairn-since":       { "const": "v0.2" },
+            "enabler":             { "const": "agent.enable_aggregate" },
+            "x-cairn-capability":  { "const": "cairn.mcp.v1.extension.aggregate" }
           }
         },
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["name", "x-cairn-since", "enabler"],
+          "required": ["name", "x-cairn-since", "enabler", "x-cairn-capability"],
           "properties": {
-            "name":          { "const": "cairn.admin.v1" },
-            "x-cairn-since": { "const": "v0.1" },
-            "enabler":       { "const": "operator role" }
+            "name":                { "const": "cairn.admin.v1" },
+            "x-cairn-since":       { "const": "v0.1" },
+            "enabler":             { "const": "operator role" },
+            "x-cairn-capability":  { "const": "cairn.mcp.v1.extension.admin" }
           }
         },
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["name", "x-cairn-since", "enabler"],
+          "required": ["name", "x-cairn-since", "enabler", "x-cairn-capability"],
           "properties": {
-            "name":          { "const": "cairn.federation.v1" },
-            "x-cairn-since": { "const": "v0.3" },
-            "enabler":       { "const": "enterprise deployment" }
+            "name":                { "const": "cairn.federation.v1" },
+            "x-cairn-since":       { "const": "v0.3" },
+            "enabler":             { "const": "enterprise deployment" },
+            "x-cairn-capability":  { "const": "cairn.mcp.v1.extension.federation" }
           }
         },
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["name", "x-cairn-since", "enabler"],
+          "required": ["name", "x-cairn-since", "enabler", "x-cairn-capability"],
           "properties": {
-            "name":          { "const": "cairn.sessiontree.v1" },
-            "x-cairn-since": { "const": "v0.3" },
-            "enabler":       { "const": "session.enable_tree" }
+            "name":                { "const": "cairn.sessiontree.v1" },
+            "x-cairn-since":       { "const": "v0.3" },
+            "enabler":             { "const": "session.enable_tree" },
+            "x-cairn-capability":  { "const": "cairn.mcp.v1.extension.sessiontree" }
           }
         }
       ]
@@ -63,10 +67,10 @@
       "type": "array",
       "items": { "$ref": "#/$defs/namespace" },
       "x-cairn-values": [
-        { "name": "cairn.aggregate.v1",   "x-cairn-since": "v0.2", "enabler": "agent.enable_aggregate" },
-        { "name": "cairn.admin.v1",       "x-cairn-since": "v0.1", "enabler": "operator role" },
-        { "name": "cairn.federation.v1",  "x-cairn-since": "v0.3", "enabler": "enterprise deployment" },
-        { "name": "cairn.sessiontree.v1", "x-cairn-since": "v0.3", "enabler": "session.enable_tree" }
+        { "name": "cairn.aggregate.v1",   "x-cairn-since": "v0.2", "enabler": "agent.enable_aggregate",  "x-cairn-capability": "cairn.mcp.v1.extension.aggregate" },
+        { "name": "cairn.admin.v1",       "x-cairn-since": "v0.1", "enabler": "operator role",           "x-cairn-capability": "cairn.mcp.v1.extension.admin" },
+        { "name": "cairn.federation.v1",  "x-cairn-since": "v0.3", "enabler": "enterprise deployment",   "x-cairn-capability": "cairn.mcp.v1.extension.federation" },
+        { "name": "cairn.sessiontree.v1", "x-cairn-since": "v0.3", "enabler": "session.enable_tree",     "x-cairn-capability": "cairn.mcp.v1.extension.sessiontree" }
       ]
     }
   }

--- a/crates/cairn-idl/schema/extensions/registry.json
+++ b/crates/cairn-idl/schema/extensions/registry.json
@@ -14,28 +14,49 @@
   },
   "$defs": {
     "namespace": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "x-cairn-since", "enabler"],
-      "properties": {
-        "name": {
-          "type": "string",
-          "enum": [
-            "cairn.aggregate.v1",
-            "cairn.admin.v1",
-            "cairn.federation.v1",
-            "cairn.sessiontree.v1"
-          ]
+      "description": "One of the four registered extension triples. Independent enums on name / since / enabler would accept invalid combinations, so each namespace is pinned as a whole triple.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "x-cairn-since", "enabler"],
+          "properties": {
+            "name":          { "const": "cairn.aggregate.v1" },
+            "x-cairn-since": { "const": "v0.2" },
+            "enabler":       { "const": "agent.enable_aggregate" }
+          }
         },
-        "x-cairn-since": {
-          "type": "string",
-          "enum": ["v0.1", "v0.2", "v0.3"]
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "x-cairn-since", "enabler"],
+          "properties": {
+            "name":          { "const": "cairn.admin.v1" },
+            "x-cairn-since": { "const": "v0.1" },
+            "enabler":       { "const": "operator role" }
+          }
         },
-        "enabler": {
-          "type": "string",
-          "description": "Config flag or role that activates this namespace."
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "x-cairn-since", "enabler"],
+          "properties": {
+            "name":          { "const": "cairn.federation.v1" },
+            "x-cairn-since": { "const": "v0.3" },
+            "enabler":       { "const": "enterprise deployment" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "x-cairn-since", "enabler"],
+          "properties": {
+            "name":          { "const": "cairn.sessiontree.v1" },
+            "x-cairn-since": { "const": "v0.3" },
+            "enabler":       { "const": "session.enable_tree" }
+          }
         }
-      }
+      ]
     },
     "known": {
       "description": "The four planned extensions at P0 — carried as literal values so codegen can emit an enum without re-walking the $defs.namespace schema.",

--- a/crates/cairn-idl/schema/extensions/registry.json
+++ b/crates/cairn-idl/schema/extensions/registry.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/extensions/registry.json",
+  "title": "Cairn extension namespace registry",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["namespaces"],
+  "properties": {
+    "namespaces": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/namespace" }
+    }
+  },
+  "$defs": {
+    "namespace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "x-cairn-since", "enabler"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": [
+            "cairn.aggregate.v1",
+            "cairn.admin.v1",
+            "cairn.federation.v1",
+            "cairn.sessiontree.v1"
+          ]
+        },
+        "x-cairn-since": {
+          "type": "string",
+          "enum": ["v0.1", "v0.2", "v0.3"]
+        },
+        "enabler": {
+          "type": "string",
+          "description": "Config flag or role that activates this namespace."
+        }
+      }
+    },
+    "known": {
+      "description": "The four planned extensions at P0 — carried as literal values so codegen can emit an enum without re-walking the $defs.namespace schema.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/namespace" },
+      "x-cairn-values": [
+        { "name": "cairn.aggregate.v1",   "x-cairn-since": "v0.2", "enabler": "agent.enable_aggregate" },
+        { "name": "cairn.admin.v1",       "x-cairn-since": "v0.1", "enabler": "operator role" },
+        { "name": "cairn.federation.v1",  "x-cairn-since": "v0.3", "enabler": "enterprise deployment" },
+        { "name": "cairn.sessiontree.v1", "x-cairn-since": "v0.3", "enabler": "session.enable_tree" }
+      ]
+    }
+  }
+}

--- a/crates/cairn-idl/schema/index.json
+++ b/crates/cairn-idl/schema/index.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/index.json",
+  "title": "Cairn contract manifest",
+  "type": "object",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-files": {
+    "envelope": [
+      "envelope/request.json",
+      "envelope/response.json",
+      "envelope/signed_intent.json"
+    ],
+    "errors": [
+      "errors/error.json"
+    ],
+    "capabilities": [
+      "capabilities/capabilities.json"
+    ],
+    "extensions": [
+      "extensions/registry.json"
+    ],
+    "prelude": [
+      "prelude/status.json",
+      "prelude/handshake.json"
+    ],
+    "verbs": [
+      "verbs/ingest.json",
+      "verbs/search.json",
+      "verbs/retrieve.json",
+      "verbs/summarize.json",
+      "verbs/assemble_hot.json",
+      "verbs/capture_trace.json",
+      "verbs/lint.json",
+      "verbs/forget.json"
+    ]
+  },
+  "x-cairn-verb-ids": [
+    "ingest",
+    "search",
+    "retrieve",
+    "summarize",
+    "assemble_hot",
+    "capture_trace",
+    "lint",
+    "forget"
+  ]
+}

--- a/crates/cairn-idl/schema/index.json
+++ b/crates/cairn-idl/schema/index.json
@@ -19,6 +19,9 @@
     "extensions": [
       "extensions/registry.json"
     ],
+    "common": [
+      "common/scope_filter.json"
+    ],
     "prelude": [
       "prelude/status.json",
       "prelude/handshake.json"

--- a/crates/cairn-idl/schema/index.json
+++ b/crates/cairn-idl/schema/index.json
@@ -20,6 +20,7 @@
       "extensions/registry.json"
     ],
     "common": [
+      "common/primitives.json",
       "common/scope_filter.json"
     ],
     "prelude": [

--- a/crates/cairn-idl/schema/prelude/handshake.json
+++ b/crates/cairn-idl/schema/prelude/handshake.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/prelude/handshake.json",
+  "title": "Cairn handshake response",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "challenge"],
+  "properties": {
+    "contract": { "const": "cairn.mcp.v1" },
+    "challenge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nonce", "expires_at"],
+      "properties": {
+        "nonce": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "Fresh 16-byte nonce; single-use; stored in outstanding_challenges."
+        },
+        "expires_at": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unix epoch milliseconds; default TTL 60 s."
+        }
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/prelude/handshake.json
+++ b/crates/cairn-idl/schema/prelude/handshake.json
@@ -14,9 +14,8 @@
       "required": ["nonce", "expires_at"],
       "properties": {
         "nonce": {
-          "type": "string",
-          "contentEncoding": "base64",
-          "description": "Fresh 16-byte nonce; single-use; stored in outstanding_challenges."
+          "allOf": [{ "$ref": "../common/primitives.json#/$defs/Nonce16Base64" }],
+          "description": "Fresh 16-byte nonce; single-use; stored in outstanding_challenges. This is the same shape clients later place into signed_intent.server_challenge."
         },
         "expires_at": {
           "type": "integer",

--- a/crates/cairn-idl/schema/prelude/status.json
+++ b/crates/cairn-idl/schema/prelude/status.json
@@ -24,11 +24,147 @@
     },
     "capabilities": {
       "type": "array",
+      "uniqueItems": true,
       "items": { "$ref": "../capabilities/capabilities.json" }
     },
     "extensions": {
       "type": "array",
+      "uniqueItems": true,
       "items": { "$ref": "../extensions/registry.json#/$defs/namespace" }
     }
-  }
+  },
+  "allOf": [
+    {
+      "$comment": "aggregate extension ↔ capability binding",
+      "if": {
+        "properties": {
+          "extensions": {
+            "contains": { "properties": { "name": { "const": "cairn.aggregate.v1" } }, "required": ["name"] }
+          }
+        },
+        "required": ["extensions"]
+      },
+      "then": {
+        "properties": {
+          "capabilities": { "contains": { "const": "cairn.mcp.v1.extension.aggregate" } }
+        },
+        "required": ["capabilities"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "capabilities": { "contains": { "const": "cairn.mcp.v1.extension.aggregate" } }
+        },
+        "required": ["capabilities"]
+      },
+      "then": {
+        "properties": {
+          "extensions": {
+            "contains": { "properties": { "name": { "const": "cairn.aggregate.v1" } }, "required": ["name"] }
+          }
+        },
+        "required": ["extensions"]
+      }
+    },
+    {
+      "$comment": "admin extension ↔ capability binding",
+      "if": {
+        "properties": {
+          "extensions": {
+            "contains": { "properties": { "name": { "const": "cairn.admin.v1" } }, "required": ["name"] }
+          }
+        },
+        "required": ["extensions"]
+      },
+      "then": {
+        "properties": {
+          "capabilities": { "contains": { "const": "cairn.mcp.v1.extension.admin" } }
+        },
+        "required": ["capabilities"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "capabilities": { "contains": { "const": "cairn.mcp.v1.extension.admin" } }
+        },
+        "required": ["capabilities"]
+      },
+      "then": {
+        "properties": {
+          "extensions": {
+            "contains": { "properties": { "name": { "const": "cairn.admin.v1" } }, "required": ["name"] }
+          }
+        },
+        "required": ["extensions"]
+      }
+    },
+    {
+      "$comment": "federation extension ↔ capability binding",
+      "if": {
+        "properties": {
+          "extensions": {
+            "contains": { "properties": { "name": { "const": "cairn.federation.v1" } }, "required": ["name"] }
+          }
+        },
+        "required": ["extensions"]
+      },
+      "then": {
+        "properties": {
+          "capabilities": { "contains": { "const": "cairn.mcp.v1.extension.federation" } }
+        },
+        "required": ["capabilities"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "capabilities": { "contains": { "const": "cairn.mcp.v1.extension.federation" } }
+        },
+        "required": ["capabilities"]
+      },
+      "then": {
+        "properties": {
+          "extensions": {
+            "contains": { "properties": { "name": { "const": "cairn.federation.v1" } }, "required": ["name"] }
+          }
+        },
+        "required": ["extensions"]
+      }
+    },
+    {
+      "$comment": "sessiontree extension ↔ capability binding",
+      "if": {
+        "properties": {
+          "extensions": {
+            "contains": { "properties": { "name": { "const": "cairn.sessiontree.v1" } }, "required": ["name"] }
+          }
+        },
+        "required": ["extensions"]
+      },
+      "then": {
+        "properties": {
+          "capabilities": { "contains": { "const": "cairn.mcp.v1.extension.sessiontree" } }
+        },
+        "required": ["capabilities"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "capabilities": { "contains": { "const": "cairn.mcp.v1.extension.sessiontree" } }
+        },
+        "required": ["capabilities"]
+      },
+      "then": {
+        "properties": {
+          "extensions": {
+            "contains": { "properties": { "name": { "const": "cairn.sessiontree.v1" } }, "required": ["name"] }
+          }
+        },
+        "required": ["extensions"]
+      }
+    }
+  ]
 }

--- a/crates/cairn-idl/schema/prelude/status.json
+++ b/crates/cairn-idl/schema/prelude/status.json
@@ -13,8 +13,8 @@
       "additionalProperties": false,
       "required": ["version", "build", "started_at", "incarnation"],
       "properties": {
-        "version":     { "type": "string" },
-        "build":       { "type": "string" },
+        "version":     { "type": "string", "minLength": 1 },
+        "build":       { "type": "string", "minLength": 1 },
         "started_at":  { "type": "string", "format": "date-time" },
         "incarnation": {
           "allOf": [{ "$ref": "../common/primitives.json#/$defs/Ulid" }],

--- a/crates/cairn-idl/schema/prelude/status.json
+++ b/crates/cairn-idl/schema/prelude/status.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/prelude/status.json",
+  "title": "Cairn status response",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "server_info", "capabilities", "extensions"],
+  "properties": {
+    "contract": { "const": "cairn.mcp.v1" },
+    "server_info": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "build", "started_at", "incarnation"],
+      "properties": {
+        "version":     { "type": "string" },
+        "build":       { "type": "string" },
+        "started_at":  { "type": "string", "format": "date-time" },
+        "incarnation": { "type": "string", "description": "ULID minted at daemon start." }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": { "$ref": "../capabilities/capabilities.json" }
+    },
+    "extensions": {
+      "type": "array",
+      "items": { "$ref": "../extensions/registry.json#/$defs/namespace" }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/prelude/status.json
+++ b/crates/cairn-idl/schema/prelude/status.json
@@ -16,7 +16,10 @@
         "version":     { "type": "string" },
         "build":       { "type": "string" },
         "started_at":  { "type": "string", "format": "date-time" },
-        "incarnation": { "type": "string", "description": "ULID minted at daemon start." }
+        "incarnation": {
+          "allOf": [{ "$ref": "../common/primitives.json#/$defs/Ulid" }],
+          "description": "ULID minted at daemon start."
+        }
       }
     },
     "capabilities": {

--- a/crates/cairn-idl/schema/verbs/assemble_hot.json
+++ b/crates/cairn-idl/schema/verbs/assemble_hot.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/assemble_hot.json",
+  "title": "Cairn verb: assemble_hot",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "assemble_hot",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "rebac",
+  "x-cairn-cli": {
+    "command": "assemble_hot",
+    "flags": [
+      { "name": "session_id", "long": "session", "value_source": "string" },
+      { "name": "budget",     "long": "budget",  "value_source": "u32" }
+    ]
+  },
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use at the start of every turn to load the hot-memory prefix for this agent/session"
+    ],
+    "negative": [
+      "do NOT call in a tight inner loop — one call per turn"
+    ],
+    "exclusivity": "this is the canonical hot-prefix surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "session_id": { "type": "string" },
+        "budget":     { "type": "integer", "minimum": 0, "description": "Byte budget for the assembled prefix (default 25000)." }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prefix", "bytes"],
+      "properties": {
+        "prefix": { "type": "string", "description": "Assembled hot-memory text ready to inject into the agent prompt." },
+        "bytes":  { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/verbs/assemble_hot.json
+++ b/crates/cairn-idl/schema/verbs/assemble_hot.json
@@ -28,8 +28,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "session_id": { "type": "string" },
-        "budget":     { "type": "integer", "minimum": 0, "description": "Byte budget for the assembled prefix (default 25000)." }
+        "session_id": { "type": "string", "minLength": 1 },
+        "budget":     { "type": "integer", "minimum": 0, "maximum": 4194304, "description": "Byte budget for the assembled prefix (default 25000; hard cap 4 MiB)." }
       }
     },
     "Data": {
@@ -37,8 +37,8 @@
       "additionalProperties": false,
       "required": ["prefix", "bytes"],
       "properties": {
-        "prefix": { "type": "string", "description": "Assembled hot-memory text ready to inject into the agent prompt." },
-        "bytes":  { "type": "integer", "minimum": 0 }
+        "prefix": { "type": "string", "description": "Assembled hot-memory text ready to inject into the agent prompt. May be empty when no hot-memory is available." },
+        "bytes":  { "type": "integer", "minimum": 0, "maximum": 4194304 }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/capture_trace.json
+++ b/crates/cairn-idl/schema/verbs/capture_trace.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/capture_trace.json",
+  "title": "Cairn verb: capture_trace",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "capture_trace",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "signed_chain",
+  "x-cairn-cli": {
+    "command": "capture_trace",
+    "flags": [
+      { "name": "from",       "long": "from",    "value_source": "path" },
+      { "name": "session_id", "long": "session", "value_source": "string" }
+    ]
+  },
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use to persist a reasoning trajectory / transcript for later ACE distillation"
+    ],
+    "negative": [
+      "do NOT use for durable facts about the user or world — call ingest"
+    ],
+    "exclusivity": "this is the canonical trace-capture surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from"],
+      "properties": {
+        "from":       { "type": "string", "description": "Path to the trace log or transcript file." },
+        "session_id": { "type": "string" }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id"],
+      "properties": {
+        "trace_id": { "type": "string" }
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/verbs/capture_trace.json
+++ b/crates/cairn-idl/schema/verbs/capture_trace.json
@@ -29,8 +29,8 @@
       "additionalProperties": false,
       "required": ["from"],
       "properties": {
-        "from":       { "type": "string", "description": "Path to the trace log or transcript file." },
-        "session_id": { "type": "string" }
+        "from":       { "type": "string", "minLength": 1, "description": "Path to the trace log or transcript file." },
+        "session_id": { "type": "string", "minLength": 1 }
       }
     },
     "Data": {
@@ -38,7 +38,7 @@
       "additionalProperties": false,
       "required": ["trace_id"],
       "properties": {
-        "trace_id": { "type": "string" }
+        "trace_id": { "$ref": "../common/primitives.json#/$defs/Ulid" }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/forget.json
+++ b/crates/cairn-idl/schema/verbs/forget.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/forget.json",
+  "title": "Cairn verb: forget",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "forget",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "forget_capability",
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use when the user asks to delete or forget a specific record / session / scope",
+      "use as part of a compliance-driven forget-me flow"
+    ],
+    "negative": [
+      "do NOT use to 'mark as resolved' — that belongs to an ingest with kind:feedback",
+      "do NOT use on a draft the user wants to edit — that belongs to ingest with version bump"
+    ],
+    "exclusivity": "this is the single delete surface — there is no other delete path"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "oneOf": [
+        { "$ref": "#/$defs/ArgsRecord" },
+        { "$ref": "#/$defs/ArgsSession" },
+        { "$ref": "#/$defs/ArgsScope" }
+      ]
+    },
+    "ArgsRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "record_id"],
+      "x-cairn-capability": "cairn.mcp.v1.forget.record",
+      "x-cairn-since": "v0.1",
+      "x-cairn-cli": {
+        "command": "forget",
+        "flags": [
+          { "name": "record_id", "long": "record", "value_source": "string" }
+        ]
+      },
+      "properties": {
+        "mode":      { "const": "record" },
+        "record_id": { "type": "string" }
+      }
+    },
+    "ArgsSession": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "session_id"],
+      "x-cairn-capability": "cairn.mcp.v1.forget.session",
+      "x-cairn-since": "v0.2",
+      "x-cairn-cli": {
+        "command": "forget",
+        "flags": [
+          { "name": "session_id", "long": "session", "value_source": "string" }
+        ]
+      },
+      "properties": {
+        "mode":       { "const": "session" },
+        "session_id": { "type": "string" }
+      }
+    },
+    "ArgsScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "scope"],
+      "x-cairn-capability": "cairn.mcp.v1.forget.scope",
+      "x-cairn-since": "v0.3",
+      "x-cairn-cli": {
+        "command": "forget",
+        "flags": [
+          { "name": "scope", "long": "scope", "value_source": "json" }
+        ]
+      },
+      "properties": {
+        "mode":  { "const": "scope" },
+        "scope": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["deleted_count"],
+      "properties": {
+        "deleted_count": { "type": "integer", "minimum": 0 },
+        "tombstones":    { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/verbs/forget.json
+++ b/crates/cairn-idl/schema/verbs/forget.json
@@ -40,7 +40,7 @@
       },
       "properties": {
         "mode":      { "const": "record" },
-        "record_id": { "type": "string", "minLength": 1 }
+        "record_id": { "$ref": "../common/primitives.json#/$defs/Ulid" }
       }
     },
     "ArgsSession": {
@@ -83,7 +83,7 @@
       "required": ["deleted_count"],
       "properties": {
         "deleted_count": { "type": "integer", "minimum": 0 },
-        "tombstones":    { "type": "array", "items": { "type": "string" } }
+        "tombstones":    { "type": "array", "items": { "$ref": "../common/primitives.json#/$defs/Ulid" } }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/forget.json
+++ b/crates/cairn-idl/schema/verbs/forget.json
@@ -74,21 +74,7 @@
       },
       "properties": {
         "mode":  { "const": "scope" },
-        "scope": {
-          "type": "object",
-          "additionalProperties": true,
-          "description": "Scope filter grammar — must include at least one recognized narrowing predicate from the enumerated keys below. Empty objects and payloads carrying only unknown keys are rejected at schema validation to prevent unbounded destructive forgets.",
-          "anyOf": [
-            { "required": ["user"] },
-            { "required": ["agent"] },
-            { "required": ["tenant"] },
-            { "required": ["workspace"] },
-            { "required": ["kind"] },
-            { "required": ["tags"] },
-            { "required": ["session_id"] },
-            { "required": ["record_ids"] }
-          ]
-        }
+        "scope": { "$ref": "../common/scope_filter.json" }
       }
     },
     "Data": {

--- a/crates/cairn-idl/schema/verbs/forget.json
+++ b/crates/cairn-idl/schema/verbs/forget.json
@@ -77,8 +77,17 @@
         "scope": {
           "type": "object",
           "additionalProperties": true,
-          "minProperties": 1,
-          "description": "Scope filter grammar — must include at least one narrowing predicate. An empty object is rejected at schema validation to prevent unbounded destructive forgets."
+          "description": "Scope filter grammar — must include at least one recognized narrowing predicate from the enumerated keys below. Empty objects and payloads carrying only unknown keys are rejected at schema validation to prevent unbounded destructive forgets.",
+          "anyOf": [
+            { "required": ["user"] },
+            { "required": ["agent"] },
+            { "required": ["tenant"] },
+            { "required": ["workspace"] },
+            { "required": ["kind"] },
+            { "required": ["tags"] },
+            { "required": ["session_id"] },
+            { "required": ["record_ids"] }
+          ]
         }
       }
     },

--- a/crates/cairn-idl/schema/verbs/forget.json
+++ b/crates/cairn-idl/schema/verbs/forget.json
@@ -40,7 +40,7 @@
       },
       "properties": {
         "mode":      { "const": "record" },
-        "record_id": { "type": "string" }
+        "record_id": { "type": "string", "minLength": 1 }
       }
     },
     "ArgsSession": {
@@ -57,7 +57,7 @@
       },
       "properties": {
         "mode":       { "const": "session" },
-        "session_id": { "type": "string" }
+        "session_id": { "type": "string", "minLength": 1 }
       }
     },
     "ArgsScope": {

--- a/crates/cairn-idl/schema/verbs/forget.json
+++ b/crates/cairn-idl/schema/verbs/forget.json
@@ -76,7 +76,9 @@
         "mode":  { "const": "scope" },
         "scope": {
           "type": "object",
-          "additionalProperties": true
+          "additionalProperties": true,
+          "minProperties": 1,
+          "description": "Scope filter grammar — must include at least one narrowing predicate. An empty object is rejected at schema validation to prevent unbounded destructive forgets."
         }
       }
     },

--- a/crates/cairn-idl/schema/verbs/ingest.json
+++ b/crates/cairn-idl/schema/verbs/ingest.json
@@ -69,8 +69,8 @@
       "additionalProperties": false,
       "required": ["record_id", "session_id"],
       "properties": {
-        "record_id":  { "type": "string", "description": "ULID of the newly stored record." },
-        "session_id": { "type": "string", "description": "Resolved session (created if absent — see §8.1)." }
+        "record_id":  { "$ref": "../common/primitives.json#/$defs/Ulid", "description": "ULID of the newly stored record." },
+        "session_id": { "type": "string", "minLength": 1, "description": "Resolved session (created if absent — see §8.1)." }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/ingest.json
+++ b/crates/cairn-idl/schema/verbs/ingest.json
@@ -42,15 +42,16 @@
       "properties": {
         "kind": {
           "type": "string",
+          "minLength": 1,
           "description": "Memory taxonomy kind (19 possible values — see §3 taxonomy). Validated beyond JSON Schema by the classifier."
         },
-        "body":  { "type": "string" },
-        "file":  { "type": "string", "description": "Path on the local filesystem." },
-        "url":   { "type": "string", "format": "uri" },
-        "session_id": { "type": "string" },
+        "body":  { "type": "string", "minLength": 1 },
+        "file":  { "type": "string", "minLength": 1, "description": "Path on the local filesystem." },
+        "url":   { "type": "string", "format": "uri", "minLength": 1 },
+        "session_id": { "type": "string", "minLength": 1 },
         "tags": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": { "type": "string", "minLength": 1 }
         },
         "frontmatter": {
           "type": "object",

--- a/crates/cairn-idl/schema/verbs/ingest.json
+++ b/crates/cairn-idl/schema/verbs/ingest.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/ingest.json",
+  "title": "Cairn verb: ingest",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "ingest",
+  "x-cairn-cli": {
+    "command": "ingest",
+    "flags": [
+      { "name": "kind",        "long": "kind",        "value_source": "string" },
+      { "name": "body",        "long": "body",        "value_source": "string" },
+      { "name": "file",        "long": "file",        "value_source": "path" },
+      { "name": "url",         "long": "url",         "value_source": "string" },
+      { "name": "session_id",  "long": "session",     "value_source": "string" },
+      { "name": "tags",        "long": "tags",        "value_source": "list<string>" }
+    ],
+    "positional": {
+      "name": "source",
+      "description": "File, URL, or '-' for stdin. Mutually exclusive with --body/--file/--url."
+    }
+  },
+  "x-cairn-capability": null,
+  "x-cairn-auth": "signed_chain",
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use when the user says 'remember that...', 'from now on...', or you detect a correction",
+      "use after a tool call that yields a durable fact worth keeping",
+      "use to file a clipped article, transcript, or manual note"
+    ],
+    "negative": [
+      "do NOT use for one-off computation results the user can re-derive",
+      "do NOT use for raw chat transcripts (those flow through capture_trace)"
+    ],
+    "exclusivity": "prefer this over other remember_* / save_* tools registered in this session"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Memory taxonomy kind (19 possible values — see §3 taxonomy). Validated beyond JSON Schema by the classifier."
+        },
+        "body":  { "type": "string" },
+        "file":  { "type": "string", "description": "Path on the local filesystem." },
+        "url":   { "type": "string", "format": "uri" },
+        "session_id": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "frontmatter": {
+          "type": "object",
+          "description": "Extra YAML frontmatter fields to store alongside the body."
+        }
+      },
+      "oneOf": [
+        { "required": ["body"] },
+        { "required": ["file"] },
+        { "required": ["url"] }
+      ]
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "session_id"],
+      "properties": {
+        "record_id":  { "type": "string", "description": "ULID of the newly stored record." },
+        "session_id": { "type": "string", "description": "Resolved session (created if absent — see §8.1)." }
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/verbs/lint.json
+++ b/crates/cairn-idl/schema/verbs/lint.json
@@ -58,12 +58,12 @@
             "required": ["kind", "message"],
             "properties": {
               "kind":      { "type": "string", "enum": ["contradiction", "orphan", "stale", "missing_concept", "data_gap"] },
-              "message":   { "type": "string" },
-              "record_id": { "type": "string" }
+              "message":   { "type": "string", "minLength": 1 },
+              "record_id": { "$ref": "../common/primitives.json#/$defs/Ulid" }
             }
           }
         },
-        "report_path": { "type": "string" }
+        "report_path": { "type": "string", "minLength": 1 }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/lint.json
+++ b/crates/cairn-idl/schema/verbs/lint.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/lint.json",
+  "title": "Cairn verb: lint",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "lint",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "read_only",
+  "x-cairn-cli": {
+    "command": "lint",
+    "flags": [
+      { "name": "write_report", "long": "write-report", "value_source": "bool" }
+    ]
+  },
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use to check vault health — contradictions, orphans, stale claims, missing concept pages"
+    ],
+    "negative": [
+      "do NOT call per turn — run on a cadence (daily / on PR)"
+    ],
+    "exclusivity": "this is the canonical vault-health surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "write_report": {
+          "type": "boolean",
+          "x-cairn-auth": "write_capability",
+          "description": "When true, writes .cairn/lint-report.md."
+        }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "findings"],
+      "properties": {
+        "summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["total"],
+          "properties": {
+            "total":          { "type": "integer", "minimum": 0 },
+            "contradictions": { "type": "integer", "minimum": 0 },
+            "orphans":        { "type": "integer", "minimum": 0 },
+            "stale":          { "type": "integer", "minimum": 0 }
+          }
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "message"],
+            "properties": {
+              "kind":      { "type": "string", "enum": ["contradiction", "orphan", "stale", "missing_concept", "data_gap"] },
+              "message":   { "type": "string" },
+              "record_id": { "type": "string" }
+            }
+          }
+        },
+        "report_path": { "type": "string" }
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -150,8 +150,54 @@
       ]
     },
     "Data": {
-      "type": ["object", "array"],
-      "description": "Shape depends on the matched Args branch. Record / profile variants return an object; session / folder / scope variants return an ordered array of items. The per-branch Data shape is resolved by codegen (#35) from the Args branch, not discriminated here."
+      "oneOf": [
+        { "$ref": "#/$defs/DataRecord" },
+        { "$ref": "#/$defs/DataProfile" },
+        { "$ref": "#/$defs/DataItemList" }
+      ],
+      "description": "Shape depends on the matched Args branch. Record / profile variants return an object; session / folder / scope variants return an ordered array of items. Codegen (#35) narrows which branch applies per call from the Args branch."
+    },
+    "DataRecord": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["record_id", "kind"],
+      "properties": {
+        "record_id": { "type": "string", "minLength": 1 },
+        "kind":      { "type": "string", "minLength": 1 },
+        "body":      { "type": "string" },
+        "frontmatter": { "type": "object" }
+      }
+    },
+    "DataProfile": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["subject"],
+      "properties": {
+        "subject": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "user":  { "type": "string", "minLength": 1 },
+            "agent": { "type": "string", "minLength": 1 }
+          },
+          "anyOf": [
+            { "required": ["user"] },
+            { "required": ["agent"] }
+          ]
+        },
+        "profile": { "type": "object" }
+      }
+    },
+    "DataItemList": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["record_id"],
+        "properties": {
+          "record_id": { "type": "string", "minLength": 1 }
+        }
+      }
     }
   }
 }

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -71,9 +71,7 @@
           "items": { "type": "string", "enum": ["tool_calls", "reasoning"] }
         },
         "cursor": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 512,
+          "$ref": "../common/primitives.json#/$defs/Cursor",
           "description": "Opaque continuation token from a prior DataSession.next_cursor."
         }
       }
@@ -222,7 +220,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/TurnItem" }
         },
-        "next_cursor": { "type": "string", "minLength": 1 }
+        "next_cursor": { "$ref": "../common/primitives.json#/$defs/Cursor" }
       }
     },
     "DataTurn": {
@@ -258,7 +256,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/RecordRef" }
         },
-        "next_cursor": { "type": "string", "minLength": 1 }
+        "next_cursor": { "$ref": "../common/primitives.json#/$defs/Cursor" }
       }
     },
     "TurnItem": {

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -157,10 +157,17 @@
       "oneOf": [
         { "$ref": "#/$defs/DataRecord" },
         { "$ref": "#/$defs/DataProfile" },
-        { "$ref": "#/$defs/DataItemList" }
+        { "$ref": "#/$defs/DataSession" },
+        { "$ref": "#/$defs/DataTurn" },
+        { "$ref": "#/$defs/DataFolder" },
+        { "$ref": "#/$defs/DataScope" }
       ],
-      "description": "Shape depends on the matched Args branch. Record / profile variants return an object; session / folder / scope variants return an ordered array of items. Codegen (#35) narrows which branch applies per call from the Args branch."
+      "description": "Shape depends on the matched Args target. The response envelope echoes target so validators can bind Data to the exact branch."
     },
+    "DataSession": { "$ref": "#/$defs/DataItemList" },
+    "DataTurn":    { "$ref": "#/$defs/DataItemList" },
+    "DataFolder":  { "$ref": "#/$defs/DataItemList" },
+    "DataScope":   { "$ref": "#/$defs/DataItemList" },
     "DataRecord": {
       "type": "object",
       "additionalProperties": true,

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -154,11 +154,8 @@
       ]
     },
     "Data": {
-      "oneOf": [
-        { "type": "object", "description": "Record response — see cairn-core MemoryRecord shape." },
-        { "type": "array",  "description": "Session / folder / scope responses return ordered item lists." },
-        { "type": "object", "description": "Profile response: { static: {...}, dynamic: {...}, updated_at }." }
-      ]
+      "type": ["object", "array"],
+      "description": "Shape depends on the matched Args branch. Record / profile variants return an object; session / folder / scope variants return an ordered array of items. The per-branch Data shape is resolved by codegen (#35) from the Args branch, not discriminated here."
     }
   }
 }

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -162,32 +162,23 @@
         { "$ref": "#/$defs/DataFolder" },
         { "$ref": "#/$defs/DataScope" }
       ],
-      "description": "Shape depends on the matched Args target. The response envelope echoes target so validators can bind Data to the exact branch."
+      "description": "Shape depends on the matched Args target. The response envelope echoes target so validators can bind Data to the exact branch. Each branch requires its target metadata so a session response can never be mistaken for a folder response even outside the envelope."
     },
-    "DataSession": { "$ref": "#/$defs/DataItemList" },
-    "DataTurn":    { "$ref": "#/$defs/DataItemList" },
-    "DataFolder":  { "$ref": "#/$defs/DataItemList" },
-    "DataScope":   { "$ref": "#/$defs/DataItemList" },
     "DataRecord": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": ["record_id", "kind"],
-      "not": { "required": ["subject"] },
       "properties": {
-        "record_id": { "$ref": "../common/primitives.json#/$defs/Ulid" },
-        "kind":      { "type": "string", "minLength": 1 },
-        "body":      { "type": "string" },
+        "record_id":   { "$ref": "../common/primitives.json#/$defs/Ulid" },
+        "kind":        { "type": "string", "minLength": 1 },
+        "body":        { "type": "string" },
         "frontmatter": { "type": "object" }
       }
     },
     "DataProfile": {
       "type": "object",
-      "additionalProperties": true,
-      "required": ["subject"],
-      "allOf": [
-        { "not": { "required": ["record_id"] } },
-        { "not": { "required": ["kind"] } }
-      ],
+      "additionalProperties": false,
+      "required": ["subject", "profile"],
       "properties": {
         "subject": {
           "type": "object",
@@ -201,18 +192,81 @@
             { "required": ["agent"] }
           ]
         },
-        "profile": { "type": "object" }
+        "profile": {
+          "type": "object",
+          "description": "Free-form profile payload — typed in a later increment once the profile taxonomy lands."
+        }
       }
     },
-    "DataItemList": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": true,
-        "required": ["record_id"],
-        "properties": {
-          "record_id": { "$ref": "../common/primitives.json#/$defs/Ulid" }
+    "DataSession": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["session_id", "items"],
+      "properties": {
+        "session_id": { "type": "string", "minLength": 1 },
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TurnItem" }
+        },
+        "next_cursor": { "type": "string", "minLength": 1 }
+      }
+    },
+    "DataTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["session_id", "turn_id", "turn"],
+      "properties": {
+        "session_id": { "type": "string", "minLength": 1 },
+        "turn_id":    { "type": "integer", "minimum": 0 },
+        "turn":       { "$ref": "#/$defs/TurnItem" }
+      }
+    },
+    "DataFolder": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "items"],
+      "properties": {
+        "path":  { "type": "string", "minLength": 1 },
+        "depth": { "type": "integer", "minimum": 0, "maximum": 16 },
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/RecordRef" }
         }
+      }
+    },
+    "DataScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "items"],
+      "properties": {
+        "scope": { "$ref": "../common/scope_filter.json" },
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/RecordRef" }
+        },
+        "next_cursor": { "type": "string", "minLength": 1 }
+      }
+    },
+    "TurnItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["turn_id", "role"],
+      "properties": {
+        "turn_id": { "type": "integer", "minimum": 0 },
+        "role":    { "type": "string", "enum": ["user", "assistant", "tool", "system"] },
+        "content": { "type": "string" },
+        "tool_calls": { "type": "array", "items": { "type": "object" } },
+        "reasoning":  { "type": "string" }
+      }
+    },
+    "RecordRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "kind"],
+      "properties": {
+        "record_id": { "$ref": "../common/primitives.json#/$defs/Ulid" },
+        "kind":      { "type": "string", "minLength": 1 },
+        "snippet":   { "type": "string" }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/retrieve.json",
+  "title": "Cairn verb: retrieve",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "retrieve",
+  "x-cairn-auth": "rebac",
+  "x-cairn-capability": null,
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use when you already have a record id, session id, turn id, folder path, scope, or need the user profile",
+      "use before summarize to pull source material into context"
+    ],
+    "negative": [
+      "do NOT use for free-text lookup — call search instead"
+    ],
+    "exclusivity": "this is the canonical by-id retrieval surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "oneOf": [
+        { "$ref": "#/$defs/ArgsRecord" },
+        { "$ref": "#/$defs/ArgsSession" },
+        { "$ref": "#/$defs/ArgsTurn" },
+        { "$ref": "#/$defs/ArgsFolder" },
+        { "$ref": "#/$defs/ArgsScope" },
+        { "$ref": "#/$defs/ArgsProfile" }
+      ]
+    },
+    "ArgsRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "id"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.record",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "positional": { "name": "id", "description": "Record ULID" }
+      },
+      "properties": {
+        "target": { "const": "record" },
+        "id": { "type": "string" }
+      }
+    },
+    "ArgsSession": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "session_id"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.session",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "session_id", "long": "session",   "value_source": "string" },
+          { "name": "limit",      "long": "limit",     "value_source": "u32" },
+          { "name": "order",      "long": "order",     "value_source": "enum(asc,desc)" },
+          { "name": "rehydrate",  "long": "rehydrate", "value_source": "bool" },
+          { "name": "include",    "long": "include",   "value_source": "list<enum(tool_calls,reasoning)>" }
+        ]
+      },
+      "properties": {
+        "target":     { "const": "session" },
+        "session_id": { "type": "string" },
+        "limit":      { "type": "integer", "minimum": 1, "maximum": 10000 },
+        "order":      { "type": "string", "enum": ["asc", "desc"] },
+        "rehydrate":  { "type": "boolean" },
+        "include": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["tool_calls", "reasoning"] }
+        }
+      }
+    },
+    "ArgsTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "session_id", "turn_id"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.turn",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "session_id", "long": "session", "value_source": "string" },
+          { "name": "turn_id",    "long": "turn",    "value_source": "u64" },
+          { "name": "include",    "long": "include", "value_source": "list<enum(tool_calls,reasoning)>" }
+        ]
+      },
+      "properties": {
+        "target":     { "const": "turn" },
+        "session_id": { "type": "string" },
+        "turn_id":    { "type": "integer", "minimum": 0 },
+        "include": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["tool_calls", "reasoning"] }
+        }
+      }
+    },
+    "ArgsFolder": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "path"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.folder",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "path",  "long": "folder", "value_source": "string" },
+          { "name": "depth", "long": "depth",  "value_source": "u8" }
+        ]
+      },
+      "properties": {
+        "target": { "const": "folder" },
+        "path":   { "type": "string" },
+        "depth":  { "type": "integer", "minimum": 0, "maximum": 16 }
+      }
+    },
+    "ArgsScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "scope"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.scope",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "scope", "long": "scope", "value_source": "json" }
+        ]
+      },
+      "properties": {
+        "target": { "const": "scope" },
+        "scope": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "ScopeFilter — same grammar as SearchArgs.filters."
+        }
+      }
+    },
+    "ArgsProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.profile",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "profile", "long": "profile", "value_source": "bool" },
+          { "name": "user",    "long": "user",    "value_source": "string" },
+          { "name": "agent",   "long": "agent",   "value_source": "string" }
+        ]
+      },
+      "properties": {
+        "target": { "const": "profile" },
+        "user":   { "type": "string" },
+        "agent":  { "type": "string" }
+      },
+      "anyOf": [
+        { "required": ["user"] },
+        { "required": ["agent"] }
+      ]
+    },
+    "Data": {
+      "oneOf": [
+        { "type": "object", "description": "Record response — see cairn-core MemoryRecord shape." },
+        { "type": "array",  "description": "Session / folder / scope responses return ordered item lists." },
+        { "type": "object", "description": "Profile response: { static: {...}, dynamic: {...}, updated_at }." }
+      ]
+    }
+  }
+}

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -39,7 +39,7 @@
       },
       "properties": {
         "target": { "const": "record" },
-        "id": { "type": "string" }
+        "id": { "$ref": "../common/primitives.json#/$defs/Ulid" }
       }
     },
     "ArgsSession": {
@@ -59,12 +59,14 @@
       },
       "properties": {
         "target":     { "const": "session" },
-        "session_id": { "type": "string" },
+        "session_id": { "type": "string", "minLength": 1 },
         "limit":      { "type": "integer", "minimum": 1, "maximum": 10000 },
         "order":      { "type": "string", "enum": ["asc", "desc"] },
         "rehydrate":  { "type": "boolean" },
         "include": {
           "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
           "items": { "type": "string", "enum": ["tool_calls", "reasoning"] }
         }
       }
@@ -84,10 +86,12 @@
       },
       "properties": {
         "target":     { "const": "turn" },
-        "session_id": { "type": "string" },
+        "session_id": { "type": "string", "minLength": 1 },
         "turn_id":    { "type": "integer", "minimum": 0 },
         "include": {
           "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
           "items": { "type": "string", "enum": ["tool_calls", "reasoning"] }
         }
       }
@@ -106,7 +110,7 @@
       },
       "properties": {
         "target": { "const": "folder" },
-        "path":   { "type": "string" },
+        "path":   { "type": "string", "minLength": 1 },
         "depth":  { "type": "integer", "minimum": 0, "maximum": 16 }
       }
     },
@@ -141,8 +145,8 @@
       },
       "properties": {
         "target": { "const": "profile" },
-        "user":   { "type": "string" },
-        "agent":  { "type": "string" }
+        "user":   { "type": "string", "minLength": 1 },
+        "agent":  { "type": "string", "minLength": 1 }
       },
       "anyOf": [
         { "required": ["user"] },
@@ -163,7 +167,7 @@
       "required": ["record_id", "kind"],
       "not": { "required": ["subject"] },
       "properties": {
-        "record_id": { "type": "string", "minLength": 1 },
+        "record_id": { "$ref": "../common/primitives.json#/$defs/Ulid" },
         "kind":      { "type": "string", "minLength": 1 },
         "body":      { "type": "string" },
         "frontmatter": { "type": "object" }
@@ -200,7 +204,7 @@
         "additionalProperties": true,
         "required": ["record_id"],
         "properties": {
-          "record_id": { "type": "string", "minLength": 1 }
+          "record_id": { "$ref": "../common/primitives.json#/$defs/Ulid" }
         }
       }
     }

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -161,6 +161,7 @@
       "type": "object",
       "additionalProperties": true,
       "required": ["record_id", "kind"],
+      "not": { "required": ["subject"] },
       "properties": {
         "record_id": { "type": "string", "minLength": 1 },
         "kind":      { "type": "string", "minLength": 1 },
@@ -172,6 +173,10 @@
       "type": "object",
       "additionalProperties": true,
       "required": ["subject"],
+      "allOf": [
+        { "not": { "required": ["record_id"] } },
+        { "not": { "required": ["kind"] } }
+      ],
       "properties": {
         "subject": {
           "type": "object",

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -123,11 +123,7 @@
       },
       "properties": {
         "target": { "const": "scope" },
-        "scope": {
-          "type": "object",
-          "additionalProperties": true,
-          "description": "ScopeFilter — same grammar as SearchArgs.filters."
-        }
+        "scope":  { "$ref": "../common/scope_filter.json" }
       }
     },
     "ArgsProfile": {

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -54,7 +54,8 @@
           { "name": "limit",      "long": "limit",     "value_source": "u32" },
           { "name": "order",      "long": "order",     "value_source": "enum(asc,desc)" },
           { "name": "rehydrate",  "long": "rehydrate", "value_source": "bool" },
-          { "name": "include",    "long": "include",   "value_source": "list<enum(tool_calls,reasoning)>" }
+          { "name": "include",    "long": "include",   "value_source": "list<enum(tool_calls,reasoning)>" },
+          { "name": "cursor",     "long": "cursor",    "value_source": "string" }
         ]
       },
       "properties": {
@@ -68,6 +69,12 @@
           "minItems": 1,
           "uniqueItems": true,
           "items": { "type": "string", "enum": ["tool_calls", "reasoning"] }
+        },
+        "cursor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "Opaque continuation token from a prior DataSession.next_cursor."
         }
       }
     },
@@ -122,12 +129,19 @@
       "x-cairn-cli": {
         "command": "retrieve",
         "flags": [
-          { "name": "scope", "long": "scope", "value_source": "json" }
+          { "name": "scope",  "long": "scope",  "value_source": "json" },
+          { "name": "cursor", "long": "cursor", "value_source": "string" }
         ]
       },
       "properties": {
         "target": { "const": "scope" },
-        "scope":  { "$ref": "../common/scope_filter.json" }
+        "scope":  { "$ref": "../common/scope_filter.json" },
+        "cursor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "Opaque continuation token from a prior DataScope.next_cursor."
+        }
       }
     },
     "ArgsProfile": {

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/search.json",
+  "title": "Cairn verb: search",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "search",
+  "x-cairn-cli": {
+    "command": "search",
+    "flags": [
+      { "name": "mode",       "long": "mode",       "value_source": "enum(keyword,semantic,hybrid)" },
+      { "name": "limit",      "long": "limit",      "value_source": "u32" },
+      { "name": "filters",    "long": "filters",    "value_source": "json" },
+      { "name": "citations",  "long": "citations",  "value_source": "enum(on,compact,off)" }
+    ],
+    "positional": {
+      "name": "query",
+      "description": "Free-text query string."
+    }
+  },
+  "x-cairn-capability": null,
+  "x-cairn-auth": "rebac",
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use when you need to recall prior memories by topic, speaker, or time",
+      "use to ground an answer in stored evidence instead of parametric guessing"
+    ],
+    "negative": [
+      "do NOT use when the user just asked a computation question",
+      "do NOT use to fetch a known record id — call retrieve instead"
+    ],
+    "exclusivity": "this is the canonical search surface for the active vault"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["query"],
+      "properties": {
+        "query": { "type": "string" },
+        "mode": {
+          "oneOf": [
+            { "const": "keyword",  "x-cairn-capability": "cairn.mcp.v1.search.keyword" },
+            { "const": "semantic", "x-cairn-capability": "cairn.mcp.v1.search.semantic" },
+            { "const": "hybrid",   "x-cairn-capability": "cairn.mcp.v1.search.hybrid" }
+          ]
+        },
+        "scope": {
+          "type": "object",
+          "description": "Optional scope narrowing (user / agent / tenant / workspace).",
+          "additionalProperties": true,
+          "properties": {
+            "user": { "type": "string" },
+            "agent": { "type": "string" },
+            "tenant": { "type": "string" },
+            "workspace": { "type": "string" }
+          }
+        },
+        "filters": { "$ref": "#/$defs/filter" },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "citations": {
+          "type": "string",
+          "enum": ["on", "compact", "off"]
+        }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hits"],
+      "properties": {
+        "hits": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Hit" }
+        },
+        "next_cursor": { "type": "string" }
+      }
+    },
+    "Hit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "score"],
+      "properties": {
+        "record_id": { "type": "string" },
+        "score":     { "type": "number" },
+        "snippet":   { "type": "string" },
+        "citation":  { "type": "string" },
+        "trust":     { "type": "string", "enum": ["verified", "unverified"] }
+      }
+    },
+    "filter": {
+      "oneOf": [
+        { "$ref": "#/$defs/filter_and" },
+        { "$ref": "#/$defs/filter_or" },
+        { "$ref": "#/$defs/filter_not" },
+        { "$ref": "#/$defs/filter_leaf" }
+      ]
+    },
+    "filter_and": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["and"],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/filter" }
+        }
+      }
+    },
+    "filter_or": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["or"],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/filter" }
+        }
+      }
+    },
+    "filter_not": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": { "$ref": "#/$defs/filter" }
+      }
+    },
+    "filter_leaf": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op": {
+          "type": "string",
+          "enum": [
+            "eq", "neq", "in", "nin",
+            "string_contains", "string_starts_with", "string_ends_with",
+            "lt", "lte", "gt", "gte", "between",
+            "array_contains", "array_contains_any", "array_contains_all", "array_size_eq"
+          ]
+        },
+        "value": {}
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -133,6 +133,17 @@
       }
     },
     "filter_leaf": {
+      "oneOf": [
+        { "$ref": "#/$defs/filter_leaf_string" },
+        { "$ref": "#/$defs/filter_leaf_string_set" },
+        { "$ref": "#/$defs/filter_leaf_number" },
+        { "$ref": "#/$defs/filter_leaf_number_set" },
+        { "$ref": "#/$defs/filter_leaf_number_between" },
+        { "$ref": "#/$defs/filter_leaf_boolean" },
+        { "$ref": "#/$defs/filter_leaf_array" }
+      ]
+    },
+    "filter_leaf_string": {
       "type": "object",
       "additionalProperties": false,
       "required": ["field", "op", "value"],
@@ -140,14 +151,90 @@
         "field": { "type": "string" },
         "op": {
           "type": "string",
-          "enum": [
-            "eq", "neq", "in", "nin",
-            "string_contains", "string_starts_with", "string_ends_with",
-            "lt", "lte", "gt", "gte", "between",
-            "array_contains", "array_contains_any", "array_contains_all", "array_size_eq"
-          ]
+          "enum": ["eq", "neq", "string_contains", "string_starts_with", "string_ends_with"]
         },
-        "value": {}
+        "value": { "type": "string" }
+      }
+    },
+    "filter_leaf_string_set": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op":    { "type": "string", "enum": ["in", "nin"] },
+        "value": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "filter_leaf_number": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op":    { "type": "string", "enum": ["eq", "neq", "lt", "lte", "gt", "gte"] },
+        "value": { "type": "number" }
+      }
+    },
+    "filter_leaf_number_set": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op":    { "type": "string", "enum": ["in", "nin"] },
+        "value": {
+          "type": "array",
+          "items": { "type": "number" }
+        }
+      }
+    },
+    "filter_leaf_number_between": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op":    { "const": "between" },
+        "value": {
+          "type": "array",
+          "items": { "type": "number" },
+          "minItems": 2,
+          "maxItems": 2
+        }
+      }
+    },
+    "filter_leaf_boolean": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op":    { "const": "eq" },
+        "value": { "type": "boolean" }
+      }
+    },
+    "filter_leaf_array": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op": {
+          "type": "string",
+          "enum": ["array_contains", "array_contains_any", "array_contains_all", "array_size_eq"]
+        },
+        "value": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "number" },
+            { "type": "integer" },
+            { "type": "array", "items": { "type": ["string", "number"] } }
+          ]
+        }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -7,11 +7,31 @@
   "x-cairn-cli": {
     "command": "search",
     "flags": [
-      { "name": "mode",       "long": "mode",       "value_source": "enum(keyword,semantic,hybrid)" },
-      { "name": "limit",      "long": "limit",      "value_source": "u32" },
-      { "name": "filters",    "long": "filters",    "value_source": "json" },
-      { "name": "citations",  "long": "citations",  "value_source": "enum(on,compact,off)" },
-      { "name": "cursor",     "long": "cursor",     "value_source": "string" }
+      {
+        "name": "mode",
+        "long": "mode",
+        "value_source": "enum(keyword,semantic,hybrid)"
+      },
+      {
+        "name": "limit",
+        "long": "limit",
+        "value_source": "u32"
+      },
+      {
+        "name": "filters",
+        "long": "filters",
+        "value_source": "json"
+      },
+      {
+        "name": "citations",
+        "long": "citations",
+        "value_source": "enum(on,compact,off)"
+      },
+      {
+        "name": "cursor",
+        "long": "cursor",
+        "value_source": "string"
+      }
     ],
     "positional": {
       "name": "query",
@@ -27,7 +47,7 @@
     ],
     "negative": [
       "do NOT use when the user just asked a computation question",
-      "do NOT use to fetch a known record id — call retrieve instead"
+      "do NOT use to fetch a known record id \u2014 call retrieve instead"
     ],
     "exclusivity": "this is the canonical search surface for the active vault"
   },
@@ -36,21 +56,38 @@
     "Args": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["query", "mode"],
+      "required": [
+        "query",
+        "mode"
+      ],
       "properties": {
-        "query": { "type": "string", "minLength": 1 },
+        "query": {
+          "type": "string",
+          "minLength": 1
+        },
         "mode": {
           "oneOf": [
-            { "const": "keyword",  "x-cairn-capability": "cairn.mcp.v1.search.keyword" },
-            { "const": "semantic", "x-cairn-capability": "cairn.mcp.v1.search.semantic" },
-            { "const": "hybrid",   "x-cairn-capability": "cairn.mcp.v1.search.hybrid" }
+            {
+              "const": "keyword",
+              "x-cairn-capability": "cairn.mcp.v1.search.keyword"
+            },
+            {
+              "const": "semantic",
+              "x-cairn-capability": "cairn.mcp.v1.search.semantic"
+            },
+            {
+              "const": "hybrid",
+              "x-cairn-capability": "cairn.mcp.v1.search.hybrid"
+            }
           ]
         },
         "scope": {
           "$ref": "../common/scope_filter.json",
-          "description": "Optional narrowing of the already-authorized signed-intent scope. Reuses the closed scope filter grammar — unknown keys and empty values reject at schema validation so a typo cannot silently widen reads."
+          "description": "Optional narrowing of the already-authorized signed-intent scope. Reuses the closed scope filter grammar \u2014 unknown keys and empty values reject at schema validation so a typo cannot silently widen reads."
         },
-        "filters": { "$ref": "#/$defs/filter" },
+        "filters": {
+          "$ref": "#/$defs/filter"
+        },
         "limit": {
           "type": "integer",
           "minimum": 1,
@@ -58,12 +95,14 @@
         },
         "citations": {
           "type": "string",
-          "enum": ["on", "compact", "off"]
+          "enum": [
+            "on",
+            "compact",
+            "off"
+          ]
         },
         "cursor": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 512,
+          "$ref": "../common/primitives.json#/$defs/Cursor",
           "description": "Opaque continuation token from a prior search Data.next_cursor."
         }
       }
@@ -71,146 +110,227 @@
     "Data": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["hits"],
+      "required": [
+        "hits"
+      ],
       "properties": {
         "hits": {
           "type": "array",
-          "items": { "$ref": "#/$defs/Hit" }
+          "items": {
+            "$ref": "#/$defs/Hit"
+          }
         },
-        "next_cursor": { "type": "string", "minLength": 1 }
+        "next_cursor": {
+          "$ref": "../common/primitives.json#/$defs/Cursor"
+        }
       }
     },
     "Hit": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["record_id", "score", "trust"],
+      "required": [
+        "record_id",
+        "score",
+        "trust"
+      ],
       "properties": {
-        "record_id": { "$ref": "../common/primitives.json#/$defs/Ulid" },
-        "score":     { "type": "number" },
-        "snippet":   { "type": "string" },
-        "citation":  { "type": "string" },
-        "trust":     { "type": "string", "enum": ["verified", "unverified", "unknown"] }
+        "record_id": {
+          "$ref": "../common/primitives.json#/$defs/Ulid"
+        },
+        "score": {
+          "type": "number"
+        },
+        "snippet": {
+          "type": "string"
+        },
+        "citation": {
+          "type": "string"
+        },
+        "trust": {
+          "type": "string",
+          "enum": [
+            "verified",
+            "unverified",
+            "unknown"
+          ]
+        }
       }
     },
     "filter": {
       "x-cairn-max-depth": 8,
       "x-cairn-max-fanout": 32,
-      "description": "Boolean filter grammar. JSON Schema cannot directly bound recursion, so codegen and the runtime enforce the depth (8) and fanout (32) limits via x-cairn-max-depth / x-cairn-max-fanout. Over-limit filters reject at ingest before query planning.",
-      "oneOf": [
-        { "$ref": "#/$defs/filter_and" },
-        { "$ref": "#/$defs/filter_or" },
-        { "$ref": "#/$defs/filter_not" },
-        { "$ref": "#/$defs/filter_leaf" }
-      ]
-    },
-    "filter_and": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["and"],
-      "properties": {
-        "and": {
-          "type": "array",
-          "minItems": 1,
-          "maxItems": 32,
-          "items": { "$ref": "#/$defs/filter" }
-        }
-      }
-    },
-    "filter_or": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["or"],
-      "properties": {
-        "or": {
-          "type": "array",
-          "minItems": 1,
-          "maxItems": 32,
-          "items": { "$ref": "#/$defs/filter" }
-        }
-      }
-    },
-    "filter_not": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["not"],
-      "properties": {
-        "not": { "$ref": "#/$defs/filter" }
-      }
+      "description": "Boolean filter grammar, unrolled to depth 8 so the recursion cap is a schema assertion, not runtime-only metadata. and/or fanout capped at 32 per node.",
+      "$ref": "#/$defs/filter_L8"
     },
     "filter_leaf": {
       "oneOf": [
-        { "$ref": "#/$defs/filter_leaf_string" },
-        { "$ref": "#/$defs/filter_leaf_string_set" },
-        { "$ref": "#/$defs/filter_leaf_number" },
-        { "$ref": "#/$defs/filter_leaf_number_set" },
-        { "$ref": "#/$defs/filter_leaf_number_between" },
-        { "$ref": "#/$defs/filter_leaf_boolean" },
-        { "$ref": "#/$defs/filter_leaf_array_contains" },
-        { "$ref": "#/$defs/filter_leaf_array_contains_set" },
-        { "$ref": "#/$defs/filter_leaf_array_size" }
+        {
+          "$ref": "#/$defs/filter_leaf_string"
+        },
+        {
+          "$ref": "#/$defs/filter_leaf_string_set"
+        },
+        {
+          "$ref": "#/$defs/filter_leaf_number"
+        },
+        {
+          "$ref": "#/$defs/filter_leaf_number_set"
+        },
+        {
+          "$ref": "#/$defs/filter_leaf_number_between"
+        },
+        {
+          "$ref": "#/$defs/filter_leaf_boolean"
+        },
+        {
+          "$ref": "#/$defs/filter_leaf_array_contains"
+        },
+        {
+          "$ref": "#/$defs/filter_leaf_array_contains_set"
+        },
+        {
+          "$ref": "#/$defs/filter_leaf_array_size"
+        }
       ]
     },
     "filter_leaf_string": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "op", "value"],
+      "required": [
+        "field",
+        "op",
+        "value"
+      ],
       "properties": {
-        "field": { "type": "string", "minLength": 1 },
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
         "op": {
           "type": "string",
-          "enum": ["eq", "neq", "string_contains", "string_starts_with", "string_ends_with"]
+          "enum": [
+            "eq",
+            "neq",
+            "string_contains",
+            "string_starts_with",
+            "string_ends_with"
+          ]
         },
-        "value": { "type": "string", "minLength": 1 }
+        "value": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "filter_leaf_string_set": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "op", "value"],
+      "required": [
+        "field",
+        "op",
+        "value"
+      ],
       "properties": {
-        "field": { "type": "string", "minLength": 1 },
-        "op":    { "type": "string", "enum": ["in", "nin"] },
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "op": {
+          "type": "string",
+          "enum": [
+            "in",
+            "nin"
+          ]
+        },
         "value": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     },
     "filter_leaf_number": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "op", "value"],
+      "required": [
+        "field",
+        "op",
+        "value"
+      ],
       "properties": {
-        "field": { "type": "string", "minLength": 1 },
-        "op":    { "type": "string", "enum": ["eq", "neq", "lt", "lte", "gt", "gte"] },
-        "value": { "type": "number" }
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "op": {
+          "type": "string",
+          "enum": [
+            "eq",
+            "neq",
+            "lt",
+            "lte",
+            "gt",
+            "gte"
+          ]
+        },
+        "value": {
+          "type": "number"
+        }
       }
     },
     "filter_leaf_number_set": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "op", "value"],
+      "required": [
+        "field",
+        "op",
+        "value"
+      ],
       "properties": {
-        "field": { "type": "string", "minLength": 1 },
-        "op":    { "type": "string", "enum": ["in", "nin"] },
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "op": {
+          "type": "string",
+          "enum": [
+            "in",
+            "nin"
+          ]
+        },
         "value": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "number" }
+          "items": {
+            "type": "number"
+          }
         }
       }
     },
     "filter_leaf_number_between": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "op", "value"],
+      "required": [
+        "field",
+        "op",
+        "value"
+      ],
       "properties": {
-        "field": { "type": "string", "minLength": 1 },
-        "op":    { "const": "between" },
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "op": {
+          "const": "between"
+        },
         "value": {
           "type": "array",
-          "items": { "type": "number" },
+          "items": {
+            "type": "number"
+          },
           "minItems": 2,
           "maxItems": 2
         }
@@ -219,24 +339,49 @@
     "filter_leaf_boolean": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "op", "value"],
+      "required": [
+        "field",
+        "op",
+        "value"
+      ],
       "properties": {
-        "field": { "type": "string", "minLength": 1 },
-        "op":    { "const": "eq" },
-        "value": { "type": "boolean" }
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "op": {
+          "const": "eq"
+        },
+        "value": {
+          "type": "boolean"
+        }
       }
     },
     "filter_leaf_array_contains": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "op", "value"],
+      "required": [
+        "field",
+        "op",
+        "value"
+      ],
       "properties": {
-        "field": { "type": "string", "minLength": 1 },
-        "op":    { "const": "array_contains" },
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "op": {
+          "const": "array_contains"
+        },
         "value": {
           "oneOf": [
-            { "type": "string", "minLength": 1 },
-            { "type": "number" }
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "number"
+            }
           ]
         }
       }
@@ -244,17 +389,35 @@
     "filter_leaf_array_contains_set": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "op", "value"],
+      "required": [
+        "field",
+        "op",
+        "value"
+      ],
       "properties": {
-        "field": { "type": "string", "minLength": 1 },
-        "op":    { "type": "string", "enum": ["array_contains_any", "array_contains_all"] },
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "op": {
+          "type": "string",
+          "enum": [
+            "array_contains_any",
+            "array_contains_all"
+          ]
+        },
         "value": {
           "type": "array",
           "minItems": 1,
           "items": {
             "oneOf": [
-              { "type": "string", "minLength": 1 },
-              { "type": "number" }
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "number"
+              }
             ]
           }
         }
@@ -263,11 +426,530 @@
     "filter_leaf_array_size": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "op", "value"],
+      "required": [
+        "field",
+        "op",
+        "value"
+      ],
       "properties": {
-        "field": { "type": "string", "minLength": 1 },
-        "op":    { "const": "array_size_eq" },
-        "value": { "type": "integer", "minimum": 0 }
+        "field": {
+          "type": "string",
+          "minLength": 1
+        },
+        "op": {
+          "const": "array_size_eq"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "filter_L0": {
+      "$ref": "#/$defs/filter_leaf"
+    },
+    "filter_L1": {
+      "description": "Filter at boolean depth 1: either a leaf predicate, or and/or/not composing operands at depth \u2264 0.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/filter_leaf"
+        },
+        {
+          "$ref": "#/$defs/filter_and_L1"
+        },
+        {
+          "$ref": "#/$defs/filter_or_L1"
+        },
+        {
+          "$ref": "#/$defs/filter_not_L1"
+        }
+      ]
+    },
+    "filter_and_L1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "and"
+      ],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L0"
+          }
+        }
+      }
+    },
+    "filter_or_L1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "or"
+      ],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L0"
+          }
+        }
+      }
+    },
+    "filter_not_L1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "not"
+      ],
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/filter_L0"
+        }
+      }
+    },
+    "filter_L2": {
+      "description": "Filter at boolean depth 2: either a leaf predicate, or and/or/not composing operands at depth \u2264 1.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/filter_leaf"
+        },
+        {
+          "$ref": "#/$defs/filter_and_L2"
+        },
+        {
+          "$ref": "#/$defs/filter_or_L2"
+        },
+        {
+          "$ref": "#/$defs/filter_not_L2"
+        }
+      ]
+    },
+    "filter_and_L2": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "and"
+      ],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L1"
+          }
+        }
+      }
+    },
+    "filter_or_L2": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "or"
+      ],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L1"
+          }
+        }
+      }
+    },
+    "filter_not_L2": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "not"
+      ],
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/filter_L1"
+        }
+      }
+    },
+    "filter_L3": {
+      "description": "Filter at boolean depth 3: either a leaf predicate, or and/or/not composing operands at depth \u2264 2.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/filter_leaf"
+        },
+        {
+          "$ref": "#/$defs/filter_and_L3"
+        },
+        {
+          "$ref": "#/$defs/filter_or_L3"
+        },
+        {
+          "$ref": "#/$defs/filter_not_L3"
+        }
+      ]
+    },
+    "filter_and_L3": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "and"
+      ],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L2"
+          }
+        }
+      }
+    },
+    "filter_or_L3": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "or"
+      ],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L2"
+          }
+        }
+      }
+    },
+    "filter_not_L3": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "not"
+      ],
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/filter_L2"
+        }
+      }
+    },
+    "filter_L4": {
+      "description": "Filter at boolean depth 4: either a leaf predicate, or and/or/not composing operands at depth \u2264 3.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/filter_leaf"
+        },
+        {
+          "$ref": "#/$defs/filter_and_L4"
+        },
+        {
+          "$ref": "#/$defs/filter_or_L4"
+        },
+        {
+          "$ref": "#/$defs/filter_not_L4"
+        }
+      ]
+    },
+    "filter_and_L4": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "and"
+      ],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L3"
+          }
+        }
+      }
+    },
+    "filter_or_L4": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "or"
+      ],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L3"
+          }
+        }
+      }
+    },
+    "filter_not_L4": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "not"
+      ],
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/filter_L3"
+        }
+      }
+    },
+    "filter_L5": {
+      "description": "Filter at boolean depth 5: either a leaf predicate, or and/or/not composing operands at depth \u2264 4.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/filter_leaf"
+        },
+        {
+          "$ref": "#/$defs/filter_and_L5"
+        },
+        {
+          "$ref": "#/$defs/filter_or_L5"
+        },
+        {
+          "$ref": "#/$defs/filter_not_L5"
+        }
+      ]
+    },
+    "filter_and_L5": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "and"
+      ],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L4"
+          }
+        }
+      }
+    },
+    "filter_or_L5": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "or"
+      ],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L4"
+          }
+        }
+      }
+    },
+    "filter_not_L5": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "not"
+      ],
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/filter_L4"
+        }
+      }
+    },
+    "filter_L6": {
+      "description": "Filter at boolean depth 6: either a leaf predicate, or and/or/not composing operands at depth \u2264 5.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/filter_leaf"
+        },
+        {
+          "$ref": "#/$defs/filter_and_L6"
+        },
+        {
+          "$ref": "#/$defs/filter_or_L6"
+        },
+        {
+          "$ref": "#/$defs/filter_not_L6"
+        }
+      ]
+    },
+    "filter_and_L6": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "and"
+      ],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L5"
+          }
+        }
+      }
+    },
+    "filter_or_L6": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "or"
+      ],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L5"
+          }
+        }
+      }
+    },
+    "filter_not_L6": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "not"
+      ],
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/filter_L5"
+        }
+      }
+    },
+    "filter_L7": {
+      "description": "Filter at boolean depth 7: either a leaf predicate, or and/or/not composing operands at depth \u2264 6.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/filter_leaf"
+        },
+        {
+          "$ref": "#/$defs/filter_and_L7"
+        },
+        {
+          "$ref": "#/$defs/filter_or_L7"
+        },
+        {
+          "$ref": "#/$defs/filter_not_L7"
+        }
+      ]
+    },
+    "filter_and_L7": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "and"
+      ],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L6"
+          }
+        }
+      }
+    },
+    "filter_or_L7": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "or"
+      ],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L6"
+          }
+        }
+      }
+    },
+    "filter_not_L7": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "not"
+      ],
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/filter_L6"
+        }
+      }
+    },
+    "filter_L8": {
+      "description": "Filter at boolean depth 8: either a leaf predicate, or and/or/not composing operands at depth \u2264 7.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/filter_leaf"
+        },
+        {
+          "$ref": "#/$defs/filter_and_L8"
+        },
+        {
+          "$ref": "#/$defs/filter_or_L8"
+        },
+        {
+          "$ref": "#/$defs/filter_not_L8"
+        }
+      ]
+    },
+    "filter_and_L8": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "and"
+      ],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L7"
+          }
+        }
+      }
+    },
+    "filter_or_L8": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "or"
+      ],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/filter_L7"
+          }
+        }
+      }
+    },
+    "filter_not_L8": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "not"
+      ],
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/filter_L7"
+        }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -37,7 +37,7 @@
       "additionalProperties": false,
       "required": ["query"],
       "properties": {
-        "query": { "type": "string" },
+        "query": { "type": "string", "minLength": 1 },
         "mode": {
           "oneOf": [
             { "const": "keyword",  "x-cairn-capability": "cairn.mcp.v1.search.keyword" },
@@ -70,7 +70,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/Hit" }
         },
-        "next_cursor": { "type": "string" }
+        "next_cursor": { "type": "string", "minLength": 1 }
       }
     },
     "Hit": {
@@ -78,7 +78,7 @@
       "additionalProperties": false,
       "required": ["record_id", "score", "trust"],
       "properties": {
-        "record_id": { "type": "string", "minLength": 1 },
+        "record_id": { "$ref": "../common/primitives.json#/$defs/Ulid" },
         "score":     { "type": "number" },
         "snippet":   { "type": "string" },
         "citation":  { "type": "string" },
@@ -143,12 +143,12 @@
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
-        "field": { "type": "string" },
+        "field": { "type": "string", "minLength": 1 },
         "op": {
           "type": "string",
           "enum": ["eq", "neq", "string_contains", "string_starts_with", "string_ends_with"]
         },
-        "value": { "type": "string" }
+        "value": { "type": "string", "minLength": 1 }
       }
     },
     "filter_leaf_string_set": {
@@ -156,11 +156,12 @@
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
-        "field": { "type": "string" },
+        "field": { "type": "string", "minLength": 1 },
         "op":    { "type": "string", "enum": ["in", "nin"] },
         "value": {
           "type": "array",
-          "items": { "type": "string" }
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
         }
       }
     },
@@ -169,7 +170,7 @@
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
-        "field": { "type": "string" },
+        "field": { "type": "string", "minLength": 1 },
         "op":    { "type": "string", "enum": ["eq", "neq", "lt", "lte", "gt", "gte"] },
         "value": { "type": "number" }
       }
@@ -179,10 +180,11 @@
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
-        "field": { "type": "string" },
+        "field": { "type": "string", "minLength": 1 },
         "op":    { "type": "string", "enum": ["in", "nin"] },
         "value": {
           "type": "array",
+          "minItems": 1,
           "items": { "type": "number" }
         }
       }
@@ -192,7 +194,7 @@
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
-        "field": { "type": "string" },
+        "field": { "type": "string", "minLength": 1 },
         "op":    { "const": "between" },
         "value": {
           "type": "array",
@@ -207,7 +209,7 @@
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
-        "field": { "type": "string" },
+        "field": { "type": "string", "minLength": 1 },
         "op":    { "const": "eq" },
         "value": { "type": "boolean" }
       }
@@ -217,11 +219,11 @@
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
-        "field": { "type": "string" },
+        "field": { "type": "string", "minLength": 1 },
         "op":    { "const": "array_contains" },
         "value": {
           "oneOf": [
-            { "type": "string" },
+            { "type": "string", "minLength": 1 },
             { "type": "number" }
           ]
         }
@@ -232,12 +234,17 @@
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
-        "field": { "type": "string" },
+        "field": { "type": "string", "minLength": 1 },
         "op":    { "type": "string", "enum": ["array_contains_any", "array_contains_all"] },
         "value": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": ["string", "number"] }
+          "items": {
+            "oneOf": [
+              { "type": "string", "minLength": 1 },
+              { "type": "number" }
+            ]
+          }
         }
       }
     },
@@ -246,7 +253,7 @@
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
-        "field": { "type": "string" },
+        "field": { "type": "string", "minLength": 1 },
         "op":    { "const": "array_size_eq" },
         "value": { "type": "integer", "minimum": 0 }
       }

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -83,13 +83,13 @@
     "Hit": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["record_id", "score"],
+      "required": ["record_id", "score", "trust"],
       "properties": {
-        "record_id": { "type": "string" },
+        "record_id": { "type": "string", "minLength": 1 },
         "score":     { "type": "number" },
         "snippet":   { "type": "string" },
         "citation":  { "type": "string" },
-        "trust":     { "type": "string", "enum": ["verified", "unverified"] }
+        "trust":     { "type": "string", "enum": ["verified", "unverified", "unknown"] }
       }
     },
     "filter": {
@@ -140,7 +140,9 @@
         { "$ref": "#/$defs/filter_leaf_number_set" },
         { "$ref": "#/$defs/filter_leaf_number_between" },
         { "$ref": "#/$defs/filter_leaf_boolean" },
-        { "$ref": "#/$defs/filter_leaf_array" }
+        { "$ref": "#/$defs/filter_leaf_array_contains" },
+        { "$ref": "#/$defs/filter_leaf_array_contains_set" },
+        { "$ref": "#/$defs/filter_leaf_array_size" }
       ]
     },
     "filter_leaf_string": {
@@ -217,23 +219,43 @@
         "value": { "type": "boolean" }
       }
     },
-    "filter_leaf_array": {
+    "filter_leaf_array_contains": {
       "type": "object",
       "additionalProperties": false,
       "required": ["field", "op", "value"],
       "properties": {
         "field": { "type": "string" },
-        "op": {
-          "type": "string",
-          "enum": ["array_contains", "array_contains_any", "array_contains_all", "array_size_eq"]
-        },
+        "op":    { "const": "array_contains" },
         "value": {
           "oneOf": [
             { "type": "string" },
-            { "type": "number" },
-            { "type": "array", "items": { "type": ["string", "number"] } }
+            { "type": "number" }
           ]
         }
+      }
+    },
+    "filter_leaf_array_contains_set": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op":    { "type": "string", "enum": ["array_contains_any", "array_contains_all"] },
+        "value": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": ["string", "number"] }
+        }
+      }
+    },
+    "filter_leaf_array_size": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op":    { "const": "array_size_eq" },
+        "value": { "type": "integer", "minimum": 0 }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -46,15 +46,8 @@
           ]
         },
         "scope": {
-          "type": "object",
-          "description": "Optional scope narrowing (user / agent / tenant / workspace).",
-          "additionalProperties": true,
-          "properties": {
-            "user": { "type": "string" },
-            "agent": { "type": "string" },
-            "tenant": { "type": "string" },
-            "workspace": { "type": "string" }
-          }
+          "$ref": "../common/scope_filter.json",
+          "description": "Optional narrowing of the already-authorized signed-intent scope. Reuses the closed scope filter grammar — unknown keys and empty values reject at schema validation so a typo cannot silently widen reads."
         },
         "filters": { "$ref": "#/$defs/filter" },
         "limit": {

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -231,7 +231,6 @@
           "oneOf": [
             { "type": "string" },
             { "type": "number" },
-            { "type": "integer" },
             { "type": "array", "items": { "type": ["string", "number"] } }
           ]
         }

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -86,6 +86,9 @@
       }
     },
     "filter": {
+      "x-cairn-max-depth": 8,
+      "x-cairn-max-fanout": 32,
+      "description": "Boolean filter grammar. JSON Schema cannot directly bound recursion, so codegen and the runtime enforce the depth (8) and fanout (32) limits via x-cairn-max-depth / x-cairn-max-fanout. Over-limit filters reject at ingest before query planning.",
       "oneOf": [
         { "$ref": "#/$defs/filter_and" },
         { "$ref": "#/$defs/filter_or" },
@@ -101,6 +104,7 @@
         "and": {
           "type": "array",
           "minItems": 1,
+          "maxItems": 32,
           "items": { "$ref": "#/$defs/filter" }
         }
       }
@@ -113,6 +117,7 @@
         "or": {
           "type": "array",
           "minItems": 1,
+          "maxItems": 32,
           "items": { "$ref": "#/$defs/filter" }
         }
       }

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -10,7 +10,8 @@
       { "name": "mode",       "long": "mode",       "value_source": "enum(keyword,semantic,hybrid)" },
       { "name": "limit",      "long": "limit",      "value_source": "u32" },
       { "name": "filters",    "long": "filters",    "value_source": "json" },
-      { "name": "citations",  "long": "citations",  "value_source": "enum(on,compact,off)" }
+      { "name": "citations",  "long": "citations",  "value_source": "enum(on,compact,off)" },
+      { "name": "cursor",     "long": "cursor",     "value_source": "string" }
     ],
     "positional": {
       "name": "query",
@@ -35,7 +36,7 @@
     "Args": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["query"],
+      "required": ["query", "mode"],
       "properties": {
         "query": { "type": "string", "minLength": 1 },
         "mode": {
@@ -58,6 +59,12 @@
         "citations": {
           "type": "string",
           "enum": ["on", "compact", "off"]
+        },
+        "cursor": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "Opaque continuation token from a prior search Data.next_cursor."
         }
       }
     },

--- a/crates/cairn-idl/schema/verbs/summarize.json
+++ b/crates/cairn-idl/schema/verbs/summarize.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/summarize.json",
+  "title": "Cairn verb: summarize",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "summarize",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "rebac",
+  "x-cairn-cli": {
+    "command": "summarize",
+    "positional": { "name": "record_ids", "description": "One or more record ULIDs.", "repeatable": true },
+    "flags": [
+      { "name": "persist",   "long": "persist",   "value_source": "bool" },
+      { "name": "kind",      "long": "kind",      "value_source": "string" },
+      { "name": "citations", "long": "citations", "value_source": "enum(on,compact,off)" }
+    ]
+  },
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use to roll up a list of known record ids into a single synthesis"
+    ],
+    "negative": [
+      "do NOT use to answer a general question — call search first"
+    ],
+    "exclusivity": "this is the canonical summarize surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_ids"],
+      "properties": {
+        "record_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "persist": {
+          "type": "boolean",
+          "x-cairn-auth": "write_capability",
+          "description": "When true, files the synthesis as a new reference or strategy_success memory."
+        },
+        "kind":      { "type": "string", "description": "Kind to file under if persist is true." },
+        "citations": { "type": "string", "enum": ["on", "compact", "off"] }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary"],
+      "properties": {
+        "summary":            { "type": "string" },
+        "persisted_record_id":{ "type": "string", "description": "Present when persist was true." }
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/verbs/summarize.json
+++ b/crates/cairn-idl/schema/verbs/summarize.json
@@ -34,14 +34,14 @@
         "record_ids": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "string" }
+          "items": { "$ref": "../common/primitives.json#/$defs/Ulid" }
         },
         "persist": {
           "type": "boolean",
           "x-cairn-auth": "write_capability",
           "description": "When true, files the synthesis as a new reference or strategy_success memory."
         },
-        "kind":      { "type": "string", "description": "Kind to file under if persist is true." },
+        "kind":      { "type": "string", "minLength": 1, "description": "Kind to file under if persist is true." },
         "citations": { "type": "string", "enum": ["on", "compact", "off"] }
       }
     },
@@ -50,8 +50,8 @@
       "additionalProperties": false,
       "required": ["summary"],
       "properties": {
-        "summary":            { "type": "string" },
-        "persisted_record_id":{ "type": "string", "description": "Present when persist was true." }
+        "summary":            { "type": "string", "minLength": 1 },
+        "persisted_record_id":{ "$ref": "../common/primitives.json#/$defs/Ulid", "description": "Present when persist was true." }
       }
     }
   }

--- a/crates/cairn-idl/src/lib.rs
+++ b/crates/cairn-idl/src/lib.rs
@@ -1,5 +1,10 @@
 //! Cairn IDL source and codegen driver.
 //!
-//! P0 scaffold. Real IDL content lands in #34; generators land in #35.
+//! P0 scaffold. IDL content lands here (issue #34); generators land in issue #35.
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+/// Absolute path to the `schema/` directory that holds every IDL source file
+/// for the `cairn.mcp.v1` contract. Downstream crates (codegen, CLI, MCP) read
+/// this to locate the schema root without duplicating the path.
+pub const SCHEMA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/schema");

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -289,6 +289,82 @@ fn error_code_enum() -> BTreeSet<String> {
         .collect()
 }
 
+fn response_inline_family_enums() -> std::collections::BTreeMap<String, BTreeSet<String>> {
+    // Extract the rejected/aborted code enums from the if/then dispatch
+    // arms in envelope/response.json. These are what JSON Schema validators
+    // actually enforce and must agree with the x-cairn-error-code-families
+    // vendor key codegen will consume.
+    let resp = read_json(&schema_dir().join("envelope/response.json"));
+    let all_of = resp
+        .get("allOf")
+        .and_then(Value::as_array)
+        .expect("response.json allOf must be an array");
+
+    let mut map: std::collections::BTreeMap<String, BTreeSet<String>> = Default::default();
+    for arm in all_of {
+        let Some(if_obj) = arm.get("if").and_then(Value::as_object) else {
+            continue;
+        };
+        let Some(status_const) = if_obj
+            .get("properties")
+            .and_then(|p| p.get("status"))
+            .and_then(|s| s.get("const"))
+            .and_then(Value::as_str)
+        else {
+            continue;
+        };
+        if status_const != "rejected" && status_const != "aborted" {
+            continue;
+        }
+        let Some(code_enum) = arm
+            .get("then")
+            .and_then(|t| t.get("properties"))
+            .and_then(|p| p.get("error"))
+            .and_then(|e| e.get("properties"))
+            .and_then(|p| p.get("code"))
+            .and_then(|c| c.get("enum"))
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+        let set: BTreeSet<String> = code_enum
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect();
+        map.insert(status_const.to_string(), set);
+    }
+    map
+}
+
+#[test]
+fn response_inline_enums_match_x_cairn_error_code_families_vendor_key() {
+    let resp = read_json(&schema_dir().join("envelope/response.json"));
+    let vendor = resp
+        .get("x-cairn-error-code-families")
+        .and_then(Value::as_object)
+        .expect("response.json must carry x-cairn-error-code-families");
+    let vendor_map: std::collections::BTreeMap<String, BTreeSet<String>> = vendor
+        .iter()
+        .map(|(family, codes)| {
+            let set: BTreeSet<String> = codes
+                .as_array()
+                .unwrap_or_else(|| panic!("family {family} must be an array"))
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect();
+            (family.clone(), set)
+        })
+        .collect();
+
+    let inline = response_inline_family_enums();
+    assert_eq!(
+        vendor_map, inline,
+        "x-cairn-error-code-families must exactly match the rejected/aborted if/then enum arms in response.json — otherwise codegen (reading the vendor key) and validators (enforcing the inline arms) will disagree"
+    );
+}
+
 #[test]
 fn every_error_code_is_in_exactly_one_response_status_family() {
     let resp = read_json(&schema_dir().join("envelope/response.json"));
@@ -520,6 +596,9 @@ fn every_typed_field_asserts_bounds_or_is_allowlisted() {
         ("verbs/search.json",       "/$defs/Hit/properties/citation"),
         ("verbs/assemble_hot.json", "/$defs/Data/properties/prefix"),
         ("verbs/retrieve.json",     "/$defs/DataRecord/properties/body"),
+        ("verbs/retrieve.json",     "/$defs/RecordRef/properties/snippet"),
+        ("verbs/retrieve.json",     "/$defs/TurnItem/properties/content"),
+        ("verbs/retrieve.json",     "/$defs/TurnItem/properties/reasoning"),
         ("verbs/ingest.json",       "/$defs/Args/properties/kind"),
         // kind has minLength:1 — guarded by parent fallback; skip
     ]

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -154,3 +154,55 @@ fn walk_json(dir: &Path, out: &mut BTreeSet<PathBuf>) {
         }
     }
 }
+
+fn capabilities_enum() -> BTreeSet<String> {
+    let caps = read_json(&schema_dir().join("capabilities/capabilities.json"));
+    let arr = caps
+        .get("oneOf")
+        .and_then(Value::as_array)
+        .expect("capabilities.json: oneOf must be an array");
+    arr.iter()
+        .map(|entry| {
+            entry
+                .get("const")
+                .and_then(Value::as_str)
+                .expect("capabilities.json oneOf entries must have a const string")
+                .to_string()
+        })
+        .collect()
+}
+
+fn collect_capability_refs(v: &Value, out: &mut Vec<String>) {
+    match v {
+        Value::Object(map) => {
+            if let Some(cap) = map.get("x-cairn-capability").and_then(Value::as_str) {
+                out.push(cap.to_string());
+            }
+            for (_, child) in map {
+                collect_capability_refs(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_capability_refs(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn every_x_cairn_capability_is_in_capabilities_enum() {
+    let enum_set = capabilities_enum();
+    for path in manifest_paths() {
+        let v = read_json(&path);
+        let mut refs: Vec<String> = Vec::new();
+        collect_capability_refs(&v, &mut refs);
+        for cap in refs {
+            assert!(
+                enum_set.contains(&cap),
+                "{path:?} references capability {cap:?} that is not in capabilities.json"
+            );
+        }
+    }
+}

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -270,6 +270,68 @@ fn ref_resolves(source_path: &Path, reference: &str) -> bool {
     resolve_fragment(&target_doc, fragment).is_some()
 }
 
+fn error_code_enum() -> BTreeSet<String> {
+    let err = read_json(&schema_dir().join("errors/error.json"));
+    let arr = err
+        .get("oneOf")
+        .and_then(Value::as_array)
+        .expect("errors/error.json: oneOf must be an array");
+    arr.iter()
+        .map(|branch| {
+            branch
+                .get("properties")
+                .and_then(|p| p.get("code"))
+                .and_then(|c| c.get("const"))
+                .and_then(Value::as_str)
+                .expect("every error.oneOf branch must pin properties.code.const")
+                .to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn every_error_code_is_in_exactly_one_response_status_family() {
+    let resp = read_json(&schema_dir().join("envelope/response.json"));
+    let families = resp
+        .get("x-cairn-error-code-families")
+        .and_then(Value::as_object)
+        .expect("response.json: x-cairn-error-code-families must be an object");
+
+    let mut seen: std::collections::BTreeMap<String, Vec<String>> = Default::default();
+    for (family, codes) in families {
+        let codes = codes
+            .as_array()
+            .unwrap_or_else(|| panic!("family {family} must be an array"));
+        for code in codes {
+            let code = code
+                .as_str()
+                .unwrap_or_else(|| panic!("family {family} entries must be strings"))
+                .to_string();
+            seen.entry(code).or_default().push(family.clone());
+        }
+    }
+
+    let defined = error_code_enum();
+    // Every defined error code appears in exactly one family.
+    for code in &defined {
+        let families_for = seen.get(code);
+        match families_for {
+            None => panic!("error code {code:?} has no response status family"),
+            Some(fs) if fs.len() != 1 => {
+                panic!("error code {code:?} appears in multiple families: {fs:?}")
+            }
+            _ => {}
+        }
+    }
+    // Every family entry is a real error code.
+    for code in seen.keys() {
+        assert!(
+            defined.contains(code),
+            "family lists {code:?} but errors/error.json does not define it"
+        );
+    }
+}
+
 fn mandatory_surface_set() -> BTreeSet<String> {
     let caps = read_json(&schema_dir().join("capabilities/capabilities.json"));
     let arr = caps
@@ -318,9 +380,167 @@ fn every_verb_and_prelude_surface_is_in_capabilities_or_mandatory_list() {
         }
     }
 
+    // Extension namespaces: each registered triple must carry an
+    // x-cairn-capability that exists in the capability enum. This ties
+    // status.extensions advertisement to the capability registry so the
+    // two cannot drift.
+    let reg = read_json(&schema_dir().join("extensions/registry.json"));
+    let branches = reg
+        .get("$defs")
+        .and_then(|d| d.get("namespace"))
+        .and_then(|n| n.get("oneOf"))
+        .and_then(Value::as_array)
+        .expect("extensions/registry.json $defs.namespace.oneOf must exist");
+    for branch in branches {
+        let props = branch
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("namespace branch must have properties");
+        let name = props
+            .get("name")
+            .and_then(|n| n.get("const"))
+            .and_then(Value::as_str)
+            .expect("namespace branch must pin name.const")
+            .to_string();
+        let cap = props
+            .get("x-cairn-capability")
+            .and_then(|c| c.get("const"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        match cap {
+            None => missing.push(format!("extension.{name} (no x-cairn-capability)")),
+            Some(c) if !enum_set.contains(&c) => {
+                missing.push(format!("extension.{name} -> {c} (not in capability enum)"))
+            }
+            _ => {}
+        }
+    }
+
     assert!(
         missing.is_empty(),
         "surfaces not covered by capability enum or mandatory allowlist: {missing:?}"
+    );
+}
+
+fn is_string_constrained(node: &serde_json::Map<String, Value>) -> bool {
+    for key in [
+        "minLength",
+        "pattern",
+        "enum",
+        "format",
+        "const",
+        "contentEncoding",
+        "oneOf",
+        "anyOf",
+    ] {
+        if node.contains_key(key) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_array_constrained(node: &serde_json::Map<String, Value>) -> bool {
+    if node.contains_key("minItems") || node.contains_key("const") || node.contains_key("enum") {
+        return true;
+    }
+    if let Some(items) = node.get("items").and_then(Value::as_object) {
+        if items.contains_key("$ref")
+            || items.contains_key("const")
+            || items.contains_key("enum")
+            || items.contains_key("oneOf")
+            || items.contains_key("anyOf")
+        {
+            return true;
+        }
+        if let Some(ty) = items.get("type").and_then(Value::as_str) {
+            if ty == "object" {
+                return true;
+            }
+            if ty == "string" && is_string_constrained(items) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn is_integer_constrained(node: &serde_json::Map<String, Value>) -> bool {
+    for key in ["minimum", "maximum", "enum", "const", "exclusiveMinimum", "exclusiveMaximum"] {
+        if node.contains_key(key) {
+            return true;
+        }
+    }
+    false
+}
+
+fn walk_unguarded(
+    doc: &Value,
+    pointer: String,
+    file: &str,
+    allowlist: &BTreeSet<(String, String)>,
+    out: &mut Vec<String>,
+) {
+    match doc {
+        Value::Object(map) => {
+            if let Some(ty) = map.get("type").and_then(Value::as_str) {
+                let ok = match ty {
+                    "string" => is_string_constrained(map),
+                    "array" => is_array_constrained(map),
+                    "integer" => is_integer_constrained(map),
+                    _ => true,
+                };
+                if !ok {
+                    let key = (file.to_string(), pointer.clone());
+                    if !allowlist.contains(&key) {
+                        out.push(format!("{file}#{pointer} (unguarded {ty})"));
+                    }
+                }
+            }
+            for (k, v) in map {
+                let escaped = k.replace('~', "~0").replace('/', "~1");
+                walk_unguarded(v, format!("{pointer}/{escaped}"), file, allowlist, out);
+            }
+        }
+        Value::Array(items) => {
+            for (i, item) in items.iter().enumerate() {
+                walk_unguarded(item, format!("{pointer}/{i}"), file, allowlist, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn every_typed_field_asserts_bounds_or_is_allowlisted() {
+    // Open fields with no assertion must be explicitly allowlisted with a
+    // reason; a bare `"type": "string"` anywhere else is a policy failure.
+    let allow: BTreeSet<(String, String)> = [
+        ("verbs/search.json",       "/$defs/Hit/properties/snippet"),
+        ("verbs/search.json",       "/$defs/Hit/properties/citation"),
+        ("verbs/assemble_hot.json", "/$defs/Data/properties/prefix"),
+        ("verbs/retrieve.json",     "/$defs/DataRecord/properties/body"),
+        ("verbs/ingest.json",       "/$defs/Args/properties/kind"),
+        // kind has minLength:1 — guarded by parent fallback; skip
+    ]
+        .iter()
+        .map(|(f, p)| (f.to_string(), p.to_string()))
+        .collect();
+
+    let mut findings: Vec<String> = Vec::new();
+    for path in manifest_paths() {
+        let rel = path
+            .strip_prefix(schema_dir())
+            .expect("path under schema dir")
+            .to_string_lossy()
+            .into_owned();
+        let v = read_json(&path);
+        walk_unguarded(&v, String::new(), &rel, &allow, &mut findings);
+    }
+    assert!(
+        findings.is_empty(),
+        "unguarded typed fields found (add a minLength/minItems/minimum or allowlist the pointer):\n  {}",
+        findings.join("\n  ")
     );
 }
 

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -270,6 +270,60 @@ fn ref_resolves(source_path: &Path, reference: &str) -> bool {
     resolve_fragment(&target_doc, fragment).is_some()
 }
 
+fn mandatory_surface_set() -> BTreeSet<String> {
+    let caps = read_json(&schema_dir().join("capabilities/capabilities.json"));
+    let arr = caps
+        .get("x-cairn-mandatory-surfaces")
+        .and_then(Value::as_array)
+        .expect("capabilities.json: x-cairn-mandatory-surfaces must be an array");
+    arr.iter()
+        .map(|entry| {
+            entry
+                .get("surface")
+                .and_then(Value::as_str)
+                .expect("x-cairn-mandatory-surfaces entries must have a 'surface' string")
+                .to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn every_verb_and_prelude_surface_is_in_capabilities_or_mandatory_list() {
+    let enum_set = capabilities_enum();
+    let mandatory = mandatory_surface_set();
+    let mut missing: Vec<String> = Vec::new();
+
+    // Verb roots: surface id is "verb.<id>". Must appear in mandatory OR
+    // have an x-cairn-capability already covered elsewhere.
+    for verb in EXPECTED_VERB_IDS {
+        let surface = format!("verb.{verb}");
+        let path = schema_dir().join(format!("verbs/{verb}.json"));
+        let v = read_json(&path);
+        let root_cap = v.get("x-cairn-capability");
+        let is_mandatory = mandatory.contains(&surface);
+        let has_root_cap = root_cap
+            .and_then(Value::as_str)
+            .map(|c| enum_set.contains(c))
+            .unwrap_or(false);
+        if !is_mandatory && !has_root_cap {
+            missing.push(surface);
+        }
+    }
+
+    // Preludes: "prelude.<name>".
+    for prelude in ["status", "handshake"] {
+        let surface = format!("prelude.{prelude}");
+        if !mandatory.contains(&surface) {
+            missing.push(surface);
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "surfaces not covered by capability enum or mandatory allowlist: {missing:?}"
+    );
+}
+
 #[test]
 fn every_ref_resolves_to_a_real_file_or_local_fragment() {
     for path in manifest_paths() {

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -226,16 +226,48 @@ fn collect_refs(v: &Value, out: &mut Vec<String>) {
     }
 }
 
-fn ref_points_at_existing_file(source_path: &Path, reference: &str) -> bool {
-    let (file_part, _fragment) = reference
+fn resolve_fragment<'a>(doc: &'a Value, fragment: &str) -> Option<&'a Value> {
+    // Fragment per RFC 6901 JSON Pointer. Empty fragment ⇒ root.
+    if fragment.is_empty() {
+        return Some(doc);
+    }
+    if !fragment.starts_with('/') {
+        return None;
+    }
+    let mut current = doc;
+    for raw in fragment.split('/').skip(1) {
+        // Decode JSON Pointer escapes: ~1 → /, ~0 → ~. Order matters (~1 first).
+        let seg = raw.replace("~1", "/").replace("~0", "~");
+        match current {
+            Value::Object(m) => {
+                current = m.get(&seg)?;
+            }
+            Value::Array(a) => {
+                let idx: usize = seg.parse().ok()?;
+                current = a.get(idx)?;
+            }
+            _ => return None,
+        }
+    }
+    Some(current)
+}
+
+fn ref_resolves(source_path: &Path, reference: &str) -> bool {
+    let (file_part, fragment) = reference
         .split_once('#')
         .unwrap_or((reference, ""));
-    if file_part.is_empty() {
-        return true; // local #/... ref — resolution deferred to #35 validator
-    }
-    let source_dir = source_path.parent().expect("schema file has parent");
-    let target = source_dir.join(file_part);
-    target.is_file()
+    let target_doc: Value = if file_part.is_empty() {
+        // Local fragment — resolve against the source document itself.
+        read_json(source_path)
+    } else {
+        let source_dir = source_path.parent().expect("schema file has parent");
+        let target = source_dir.join(file_part);
+        if !target.is_file() {
+            return false;
+        }
+        read_json(&target)
+    };
+    resolve_fragment(&target_doc, fragment).is_some()
 }
 
 #[test]
@@ -246,8 +278,8 @@ fn every_ref_resolves_to_a_real_file_or_local_fragment() {
         collect_refs(&v, &mut refs);
         for r in refs {
             assert!(
-                ref_points_at_existing_file(&path, &r),
-                "{path:?} references {r:?} which does not resolve to a sibling schema file"
+                ref_resolves(&path, &r),
+                "{path:?} references {r:?} which does not resolve to a real target (file and/or JSON Pointer fragment missing)"
             );
         }
     }

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -1,0 +1,156 @@
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+const EXPECTED_VERB_IDS: [&str; 8] = [
+    "ingest",
+    "search",
+    "retrieve",
+    "summarize",
+    "assemble_hot",
+    "capture_trace",
+    "lint",
+    "forget",
+];
+
+const EXPECTED_CONTRACT: &str = "cairn.mcp.v1";
+
+fn schema_dir() -> &'static Path {
+    Path::new(cairn_idl::SCHEMA_DIR)
+}
+
+fn read_json(path: &Path) -> Value {
+    let bytes = fs::read(path)
+        .unwrap_or_else(|err| panic!("failed to read {path:?}: {err}"));
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|err| panic!("failed to parse {path:?} as JSON: {err}"))
+}
+
+fn manifest() -> Value {
+    read_json(&schema_dir().join("index.json"))
+}
+
+fn manifest_paths() -> Vec<PathBuf> {
+    let manifest = manifest();
+    let files = manifest
+        .get("x-cairn-files")
+        .and_then(Value::as_object)
+        .expect("index.json: x-cairn-files must be an object");
+    let mut out: Vec<PathBuf> = Vec::new();
+    for (category, arr) in files {
+        let arr = arr
+            .as_array()
+            .unwrap_or_else(|| panic!("x-cairn-files.{category} must be an array"));
+        for entry in arr {
+            let rel = entry
+                .as_str()
+                .unwrap_or_else(|| panic!("x-cairn-files.{category} entries must be strings"));
+            out.push(schema_dir().join(rel));
+        }
+    }
+    out
+}
+
+fn require_object<'a>(v: &'a Value, path: &Path) -> &'a serde_json::Map<String, Value> {
+    v.as_object()
+        .unwrap_or_else(|| panic!("{path:?}: top-level value must be a JSON object"))
+}
+
+#[test]
+fn manifest_parses_and_has_required_top_level_keys() {
+    let m = manifest();
+    let path = schema_dir().join("index.json");
+    let obj = require_object(&m, &path);
+    for key in ["$schema", "$id", "title", "x-cairn-contract", "x-cairn-files", "x-cairn-verb-ids"] {
+        assert!(obj.contains_key(key), "index.json missing required key {key}");
+    }
+    assert_eq!(
+        obj.get("x-cairn-contract").and_then(Value::as_str),
+        Some(EXPECTED_CONTRACT),
+        "index.json x-cairn-contract mismatch"
+    );
+}
+
+#[test]
+fn manifest_verb_ids_match_eight_verb_set_in_order() {
+    let m = manifest();
+    let verb_ids: Vec<String> = m
+        .get("x-cairn-verb-ids")
+        .and_then(Value::as_array)
+        .expect("index.json x-cairn-verb-ids must be an array")
+        .iter()
+        .map(|v| {
+            v.as_str()
+                .expect("x-cairn-verb-ids entries must be strings")
+                .to_string()
+        })
+        .collect();
+    let expected: Vec<String> = EXPECTED_VERB_IDS.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(
+        verb_ids, expected,
+        "x-cairn-verb-ids must match §8.0 exactly, in order"
+    );
+}
+
+#[test]
+fn every_manifest_file_exists_and_parses_and_has_top_level_fields() {
+    for path in manifest_paths() {
+        assert!(
+            path.is_file(),
+            "manifest lists {path:?} but file does not exist"
+        );
+        let v = read_json(&path);
+        let obj = require_object(&v, &path);
+        for key in ["$schema", "$id", "title", "x-cairn-contract"] {
+            assert!(
+                obj.contains_key(key),
+                "{path:?} missing required top-level key {key}"
+            );
+        }
+        assert_eq!(
+            obj.get("x-cairn-contract").and_then(Value::as_str),
+            Some(EXPECTED_CONTRACT),
+            "{path:?} x-cairn-contract mismatch"
+        );
+    }
+}
+
+#[test]
+fn manifest_and_filesystem_are_bijective() {
+    // Every .json file under schema/ (except index.json) must be listed.
+    let mut on_disk: BTreeSet<PathBuf> = BTreeSet::new();
+    walk_json(schema_dir(), &mut on_disk);
+    on_disk.remove(&schema_dir().join("index.json"));
+
+    let in_manifest: BTreeSet<PathBuf> = manifest_paths().into_iter().collect();
+
+    let missing_in_manifest: Vec<_> = on_disk.difference(&in_manifest).collect();
+    let missing_on_disk: Vec<_> = in_manifest.difference(&on_disk).collect();
+    assert!(
+        missing_in_manifest.is_empty(),
+        "files on disk but not in manifest: {missing_in_manifest:?}"
+    );
+    assert!(
+        missing_on_disk.is_empty(),
+        "files in manifest but missing on disk: {missing_on_disk:?}"
+    );
+}
+
+fn walk_json(dir: &Path, out: &mut BTreeSet<PathBuf>) {
+    for entry in fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("failed to read dir {dir:?}: {err}"))
+    {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            walk_json(&path, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("json") {
+            out.insert(path);
+        }
+    }
+}

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -206,3 +206,49 @@ fn every_x_cairn_capability_is_in_capabilities_enum() {
         }
     }
 }
+
+fn collect_refs(v: &Value, out: &mut Vec<String>) {
+    match v {
+        Value::Object(map) => {
+            if let Some(r) = map.get("$ref").and_then(Value::as_str) {
+                out.push(r.to_string());
+            }
+            for (_, child) in map {
+                collect_refs(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_refs(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn ref_points_at_existing_file(source_path: &Path, reference: &str) -> bool {
+    let (file_part, _fragment) = reference
+        .split_once('#')
+        .unwrap_or((reference, ""));
+    if file_part.is_empty() {
+        return true; // local #/... ref — resolution deferred to #35 validator
+    }
+    let source_dir = source_path.parent().expect("schema file has parent");
+    let target = source_dir.join(file_part);
+    target.is_file()
+}
+
+#[test]
+fn every_ref_resolves_to_a_real_file_or_local_fragment() {
+    for path in manifest_paths() {
+        let v = read_json(&path);
+        let mut refs: Vec<String> = Vec::new();
+        collect_refs(&v, &mut refs);
+        for r in refs {
+            assert!(
+                ref_points_at_existing_file(&path, &r),
+                "{path:?} references {r:?} which does not resolve to a sibling schema file"
+            );
+        }
+    }
+}

--- a/crates/cairn-idl/tests/smoke.rs
+++ b/crates/cairn-idl/tests/smoke.rs
@@ -24,3 +24,14 @@ fn codegen_binary_fails_closed() {
     let stdout = String::from_utf8(out.stdout).expect("utf-8 stdout");
     assert!(stdout.is_empty(), "scaffold must not print to stdout: {stdout:?}");
 }
+
+#[test]
+fn schema_dir_constant_points_at_crate_schema_dir() {
+    let dir = std::path::Path::new(cairn_idl::SCHEMA_DIR);
+    let expected = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("schema");
+    assert_eq!(
+        dir, expected,
+        "SCHEMA_DIR should resolve to <crate>/schema, got {dir:?}"
+    );
+    assert!(dir.is_dir(), "SCHEMA_DIR must exist on disk: {dir:?}");
+}

--- a/docs/design/2026-04-23-cairn-idl-design.md
+++ b/docs/design/2026-04-23-cairn-idl-design.md
@@ -28,7 +28,7 @@ Rationale:
 - **Single parser dep (`serde_json`) — already in the workspace.** No YAML / TOML / DSL parser added at P0.
 - **`x-*` vendor keys are the documented escape hatch.** They keep Cairn-specific semantics (CLI flags, Rust enum tags, capability gates, skill triggers) out of the spec-compliant core while staying in a reviewable single file per concept.
 - **Reviewable diffs in PR.** One file per verb / envelope / extension registration; changes show exactly which surface moved.
-- **YAML's comment advantage does not pay off here.** Schema files are mechanical truth. Human rationale lives in this design doc and in sibling `README.md` files under `crates/cairn-idl/schema/`, never inside schema files.
+- **YAML's comment advantage does not pay off here.** Schema files are mechanical truth. Human rationale lives in this design doc and in a sibling `README.md` at `crates/cairn-idl/schema/README.md`, never inside schema files.
 
 ## Filesystem Layout
 
@@ -69,7 +69,7 @@ crates/cairn-idl/
 
 ## Manifest Contract (`schema/index.json`)
 
-Single source of truth for "what files compose `cairn.mcp.v1`". Codegen (#35) reads this file first; CI (#15) diffs its contents against the filesystem.
+Single source of truth for "what files compose `cairn.mcp.v1`". Codegen (issue #35) reads this file first; the §15 CI wire-compat tests diff its contents against the filesystem.
 
 ```json
 {
@@ -118,12 +118,12 @@ Authoring rules:
 
 ```
 { contract: const "cairn.mcp.v1",
-  verb: enum(8 core verb ids ∪ extension verb ids — see §8.0.a),
+  verb: enum of the eight core verb ids at P0,
   signed_intent: $ref signed_intent.json,
   args: object (per-verb — the verb file supplies the concrete args schema) }
 ```
 
-Uses `oneOf` on `verb` + `if/then` to bind `args` to the right per-verb `$ref`. Codegen in #35 either resolves the whole `oneOf` or loads per-verb files directly — both forms work from this file.
+The `verb` enum is closed to the eight core verbs at #34; each extension issue extends it additively when its verb schemas land. Uses `oneOf` on `verb` + `if/then` to bind `args` to the right per-verb `$ref`. Codegen in #35 either resolves the whole `oneOf` or loads per-verb files directly — both forms work from this file.
 
 **`envelope/response.json`.**
 

--- a/docs/design/2026-04-23-cairn-idl-design.md
+++ b/docs/design/2026-04-23-cairn-idl-design.md
@@ -123,7 +123,7 @@ Authoring rules:
   args: object (per-verb — the verb file supplies the concrete args schema) }
 ```
 
-The `verb` enum is closed to the eight core verbs at #34; each extension issue extends it additively when its verb schemas land. Uses `oneOf` on `verb` + `if/then` to bind `args` to the right per-verb `$ref`. Codegen in #35 either resolves the whole `oneOf` or loads per-verb files directly — both forms work from this file.
+The `verb` enum is closed to the eight core verbs at #34; each extension issue extends it additively when its verb schemas land. At P0 the `args` field is declared as an untyped `object` — per-verb argument shapes live in `verbs/<verb>.json`'s `$defs/Args`, and codegen (#35) loads the matching verb file to resolve the concrete shape rather than reading a dispatch table from `request.json`. A full `oneOf` + `if/then` dispatch table inside `request.json` is deliberately deferred; encoding 8 `if/then` arms with cross-file `$ref` buys no expressiveness over the per-verb-file form and triples the review surface.
 
 **`envelope/response.json`.**
 
@@ -137,7 +137,7 @@ The `verb` enum is closed to the eight core verbs at #34; each extension issue e
   error?: $ref errors/error.json }
 ```
 
-`policy_trace` is required on mutating verbs per §8.0.b; the schema marks it `required` and codegen emits a non-`Option` field for those verbs.
+`policy_trace` is required on every response for a uniform wire shape — the field is always present and may be an empty array on read-only verbs. Codegen emits a `Vec<PolicyGate>` field (never `Option`) so consumers do not have to branch per verb.
 
 **`envelope/signed_intent.json`.** Exact §4.2 shape:
 
@@ -163,7 +163,7 @@ MissingSignature, Unauthorized, NotFound, ConflictVersion,
 QuarantineRequired, PluginSuspended, Internal
 ```
 
-Shape: `{ code: enum, message: string, data: object }`. Per-code `data` payload schemas (e.g. `CapabilityUnavailable` carries `{ capability: string }`) are declared with `oneOf` + `const code` discriminator.
+Shape: `{ code: enum, message: string, data: object }`. The per-code `data` payload shapes (e.g. `CapabilityUnavailable` carries `{ capability: string }`) ship as named `$defs` entries — `<Code>Data` per code — for codegen (#35) to emit typed Rust variants. The wire-level `data` field is deliberately an unconstrained object at P0: a full `oneOf` + `const code` discriminator chain with 15 branches is deferred to #35's validator pipeline, where the discriminator is applied *after* `data` has been parsed into the matching typed variant. At P0 the schema validates the code is one of the closed 15 values; the per-code shape is a codegen-only contract.
 
 Every variant listed above is referenced somewhere in the design brief (§4.2, §8.0.c, §8.0.d, §13.5.c). Adding a new variant in a later PR is a compatible minor revision; removing one breaks `cairn.mcp.v1`.
 

--- a/docs/design/2026-04-23-cairn-idl-design.md
+++ b/docs/design/2026-04-23-cairn-idl-design.md
@@ -163,7 +163,7 @@ MissingSignature, Unauthorized, NotFound, ConflictVersion,
 QuarantineRequired, PluginSuspended, Internal
 ```
 
-Shape: `{ code: enum, message: string, data: object }`. The per-code `data` payload shapes (e.g. `CapabilityUnavailable` carries `{ capability: string }`) ship as named `$defs` entries — `<Code>Data` per code — for codegen (#35) to emit typed Rust variants. The wire-level `data` field is deliberately an unconstrained object at P0: a full `oneOf` + `const code` discriminator chain with 15 branches is deferred to #35's validator pipeline, where the discriminator is applied *after* `data` has been parsed into the matching typed variant. At P0 the schema validates the code is one of the closed 15 values; the per-code shape is a codegen-only contract.
+Shape: `{ code: enum, message: string, data: object }` framed as a 15-branch `oneOf`: each branch pins `code: const "<Code>"` and constrains `data` to the matching `$defs/<Code>Data` schema. Variants that carry no structured data (`MissingSignature`, `Internal`) declare an empty `$defs` object. Codegen (#35) lowers the `oneOf` directly to a Rust `enum Error` with per-variant typed payloads; a JSON Schema validator rejects a `code: "InvalidArgs"` paired with data missing `field` or `reason`.
 
 Every variant listed above is referenced somewhere in the design brief (§4.2, §8.0.c, §8.0.d, §13.5.c). Adding a new variant in a later PR is a compatible minor revision; removing one breaks `cairn.mcp.v1`.
 

--- a/docs/design/2026-04-23-cairn-idl-design.md
+++ b/docs/design/2026-04-23-cairn-idl-design.md
@@ -123,7 +123,7 @@ Authoring rules:
   args: object (per-verb — the verb file supplies the concrete args schema) }
 ```
 
-The `verb` enum is closed to the eight core verbs at #34; each extension issue extends it additively when its verb schemas land. At P0 the `args` field is declared as an untyped `object` — per-verb argument shapes live in `verbs/<verb>.json`'s `$defs/Args`, and codegen (#35) loads the matching verb file to resolve the concrete shape rather than reading a dispatch table from `request.json`. A full `oneOf` + `if/then` dispatch table inside `request.json` is deliberately deferred; encoding 8 `if/then` arms with cross-file `$ref` buys no expressiveness over the per-verb-file form and triples the review surface.
+The `verb` enum is closed to the eight core verbs at #34; each extension issue extends it additively when its verb schemas land. `args` is constrained by an `allOf` of eight `if/then` arms — each arm matches `verb: const "<v>"` and binds `args` to `../verbs/<v>.json#/$defs/Args`. A JSON Schema validator rejects a request whose `verb` and `args` shapes disagree (e.g. `verb: "forget"` paired with an `ingest`-shaped payload). Codegen (#35) either resolves the `allOf` arms directly or loads each verb file separately — both forms converge on the same per-verb typed shape.
 
 **`envelope/response.json`.**
 

--- a/docs/design/2026-04-23-cairn-idl-design.md
+++ b/docs/design/2026-04-23-cairn-idl-design.md
@@ -1,0 +1,325 @@
+# Canonical IDL for Verbs, Envelopes, Capabilities, Enums — Design
+
+**Date:** 2026-04-23
+**Issue:** [#34](https://github.com/windoliver/cairn/issues/34) (parent [#3](https://github.com/windoliver/cairn/issues/3))
+**Phase:** v0.1 — Minimum substrate (P0)
+**Depends on:** [#33](https://github.com/windoliver/cairn/issues/33) (workspace scaffold)
+**Toolchain:** Rust 1.95.0, Edition 2024, Cargo resolver 3
+**Design source:** §8.0 core verbs · §8.0.a preludes · §8.0.a-bis contract version · §8.0.b envelopes · §8.0.c `RetrieveArgs` · §8.0.d filter DSL · §13.3 commands · §13.5 single-IDL claim · §4.2 signed payload
+
+## Goal
+
+Check in one canonical machine-readable IDL source for the eight core verbs plus the two protocol preludes (`status`, `handshake`), the shared request / response / signed-intent envelopes, the closed error variant set, the exhaustive P0 capability list, and the extension namespace registry — sufficient for issue #35 to generate Rust structs, clap definitions, MCP `inputSchema` payloads, and SKILL.md triggers without hand-maintained duplicate schemas.
+
+## Non-Goals
+
+- Generating Rust / clap / TypeScript / SKILL.md bindings (that is #35 — codegen).
+- Authoring extension verb schemas for `cairn.aggregate.v1` / `cairn.admin.v1` / `cairn.federation.v1` / `cairn.sessiontree.v1`. This IDL only registers the **namespaces**; each extension gets its own issue for its verb schemas.
+- Full JSON Schema draft-2020-12 conformance validation (loaded by `jsonschema` crate at runtime). #34 ships structural parse + manifest-integrity checks only; deep validator wiring is #35.
+- Verb behaviour, storage adapters, sensor capture, codegen output.
+
+## Format Decision — Pure JSON Schema + `x-cairn-*` Vendor Keys
+
+Author every file as draft-2020-12 JSON Schema. Cairn-specific metadata rides on JSON Schema's standard vendor extension channel (`x-*` / top-level unknown keywords).
+
+Rationale:
+
+- **MCP consumes JSON Schema natively.** `tools/list` returns `inputSchema` in JSON Schema; authoring the IDL in the same format means zero translation between IDL and wire.
+- **Single parser dep (`serde_json`) — already in the workspace.** No YAML / TOML / DSL parser added at P0.
+- **`x-*` vendor keys are the documented escape hatch.** They keep Cairn-specific semantics (CLI flags, Rust enum tags, capability gates, skill triggers) out of the spec-compliant core while staying in a reviewable single file per concept.
+- **Reviewable diffs in PR.** One file per verb / envelope / extension registration; changes show exactly which surface moved.
+- **YAML's comment advantage does not pay off here.** Schema files are mechanical truth. Human rationale lives in this design doc and in sibling `README.md` files under `crates/cairn-idl/schema/`, never inside schema files.
+
+## Filesystem Layout
+
+```
+crates/cairn-idl/
+├── Cargo.toml                          # unchanged (scaffold already exists)
+├── src/lib.rs                          # gains a single constant: path to the schema root
+├── src/bin/cairn-codegen.rs            # unchanged — still fails closed (#35 owns generation)
+├── schema/
+│   ├── README.md                       # map of files + authoring rules
+│   ├── index.json                      # manifest: contract version + every file listed
+│   ├── envelope/
+│   │   ├── request.json                # §8.0.b request envelope
+│   │   ├── response.json               # §8.0.b response envelope (including policy_trace)
+│   │   └── signed_intent.json          # §4.2 signed payload (ULID / nonce / sequence / challenge / key_version / chain_parents / signature)
+│   ├── errors/
+│   │   └── error.json                  # closed `code` enum + typed `data` payload
+│   ├── capabilities/
+│   │   └── capabilities.json           # exhaustive P0 capability string enum
+│   ├── extensions/
+│   │   └── registry.json               # namespace names + version + enabler flag (no verb schemas)
+│   ├── prelude/
+│   │   ├── status.json                 # deterministic status response
+│   │   └── handshake.json              # fresh challenge mint
+│   └── verbs/
+│       ├── ingest.json
+│       ├── search.json                 # SearchArgs.filters recursive DSL inline
+│       ├── retrieve.json               # RetrieveArgs tagged union (6 targets)
+│       ├── summarize.json
+│       ├── assemble_hot.json
+│       ├── capture_trace.json
+│       ├── lint.json
+│       └── forget.json                 # mode variants: record (always) / session / scope
+└── tests/
+    ├── smoke.rs                        # existing — unchanged
+    └── schema_files.rs                 # new — structural integrity (see Validation section)
+```
+
+## Manifest Contract (`schema/index.json`)
+
+Single source of truth for "what files compose `cairn.mcp.v1`". Codegen (#35) reads this file first; CI (#15) diffs its contents against the filesystem.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/index.json",
+  "title": "Cairn contract manifest",
+  "type": "object",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-files": {
+    "envelope": [
+      "envelope/request.json",
+      "envelope/response.json",
+      "envelope/signed_intent.json"
+    ],
+    "errors":        ["errors/error.json"],
+    "capabilities":  ["capabilities/capabilities.json"],
+    "extensions":    ["extensions/registry.json"],
+    "prelude":       ["prelude/status.json", "prelude/handshake.json"],
+    "verbs": [
+      "verbs/ingest.json",
+      "verbs/search.json",
+      "verbs/retrieve.json",
+      "verbs/summarize.json",
+      "verbs/assemble_hot.json",
+      "verbs/capture_trace.json",
+      "verbs/lint.json",
+      "verbs/forget.json"
+    ]
+  },
+  "x-cairn-verb-ids": [
+    "ingest", "search", "retrieve", "summarize",
+    "assemble_hot", "capture_trace", "lint", "forget"
+  ]
+}
+```
+
+Authoring rules:
+
+- `x-cairn-verb-ids` matches §8.0 exactly, underscores, no dash aliases.
+- Every path in `x-cairn-files` must exist under `schema/`; every `.json` file under `schema/` (except `index.json` itself) must be listed. Enforced by `tests/schema_files.rs`.
+- `$id` version segment (`cairn.mcp.v1`) is the ground truth for the contract version string used across the CLI, MCP `initialize` response, and SDK constants.
+
+## Envelope Schemas
+
+**`envelope/request.json`.** Wraps every verb call. Shape (abridged):
+
+```
+{ contract: const "cairn.mcp.v1",
+  verb: enum(8 core verb ids ∪ extension verb ids — see §8.0.a),
+  signed_intent: $ref signed_intent.json,
+  args: object (per-verb — the verb file supplies the concrete args schema) }
+```
+
+Uses `oneOf` on `verb` + `if/then` to bind `args` to the right per-verb `$ref`. Codegen in #35 either resolves the whole `oneOf` or loads per-verb files directly — both forms work from this file.
+
+**`envelope/response.json`.**
+
+```
+{ contract: const "cairn.mcp.v1",
+  verb: same enum as request,
+  operation_id: string (ULID),
+  status: enum("committed", "aborted", "rejected"),
+  data: object | null,
+  policy_trace: array of { gate: string, result: enum("pass", "deny", "error"), detail?: string },
+  error?: $ref errors/error.json }
+```
+
+`policy_trace` is required on mutating verbs per §8.0.b; the schema marks it `required` and codegen emits a non-`Option` field for those verbs.
+
+**`envelope/signed_intent.json`.** Exact §4.2 shape:
+
+```
+{ operation_id (ULID), nonce (base64, 16B), sequence (u64, optional),
+  target_hash (sha256:<hex>), scope { tenant, workspace, entity, tier },
+  issuer (string), issued_at (RFC3339), expires_at (RFC3339),
+  key_version (u32), server_challenge (base64, optional),
+  chain_parents (array of operation ids),
+  signature (ed25519:<hex>) }
+```
+
+Either `sequence` or `server_challenge` must be present (`oneOf` enforces mutual substitutability per §4.2 "Atomic replay + ordering check").
+
+## Error Variants — Closed at P0
+
+**`errors/error.json`.** One closed string enum keyed by `code`:
+
+```
+InvalidArgs, InvalidFilter, CapabilityUnavailable, UnknownVerb,
+ExpiredIntent, ReplayDetected, OutOfOrderSequence, RevokedKey,
+MissingSignature, Unauthorized, NotFound, ConflictVersion,
+QuarantineRequired, PluginSuspended, Internal
+```
+
+Shape: `{ code: enum, message: string, data: object }`. Per-code `data` payload schemas (e.g. `CapabilityUnavailable` carries `{ capability: string }`) are declared with `oneOf` + `const code` discriminator.
+
+Every variant listed above is referenced somewhere in the design brief (§4.2, §8.0.c, §8.0.d, §13.5.c). Adding a new variant in a later PR is a compatible minor revision; removing one breaks `cairn.mcp.v1`.
+
+## Capabilities — Exhaustive P0 Enum
+
+**`capabilities/capabilities.json`.** A JSON Schema string `enum` listing every capability `status.capabilities` may advertise at P0:
+
+```
+cairn.mcp.v1.search.keyword
+cairn.mcp.v1.search.semantic
+cairn.mcp.v1.search.hybrid
+cairn.mcp.v1.retrieve.record
+cairn.mcp.v1.retrieve.session
+cairn.mcp.v1.retrieve.turn
+cairn.mcp.v1.retrieve.folder
+cairn.mcp.v1.retrieve.scope
+cairn.mcp.v1.retrieve.profile
+cairn.mcp.v1.forget.record
+cairn.mcp.v1.forget.session          (x-cairn-since: v0.2)
+cairn.mcp.v1.forget.scope            (x-cairn-since: v0.3)
+```
+
+`x-cairn-since` is a vendor key recording the earliest runtime version that may advertise the capability — codegen uses it to emit correct defaults in `src/mcp/status.rs`; CI wire-compat (§15) asserts a v0.1 runtime never advertises a capability whose `x-cairn-since` is later than the build.
+
+## Extension Registry — Names Only at P0
+
+**`extensions/registry.json`.** Enumerates the four planned extension namespaces so codegen can emit the enum used by `status.extensions`:
+
+```
+cairn.aggregate.v1    (x-cairn-since: v0.2, enabler: agent.enable_aggregate)
+cairn.admin.v1        (x-cairn-since: v0.1, enabler: operator role)
+cairn.federation.v1   (x-cairn-since: v0.3, enabler: enterprise deployment)
+cairn.sessiontree.v1  (x-cairn-since: v0.3, enabler: session.enable_tree)
+```
+
+No verb schemas for these extensions land in #34. Each extension gets its own issue that adds `schema/extensions/<name>/verbs/*.json` and updates this registry.
+
+## Prelude Schemas
+
+**`prelude/status.json`.** Deterministic body from §8.0.a:
+
+```
+{ contract: const "cairn.mcp.v1",
+  server_info: { version, build, started_at, incarnation (ULID) },
+  capabilities: array of $ref capabilities.json,
+  extensions: array of $ref extensions/registry.json#/$defs/namespace }
+```
+
+**`prelude/handshake.json`.** Per-call fresh body:
+
+```
+{ contract: const "cairn.mcp.v1",
+  challenge: { nonce (base64, 16B), expires_at (epoch ms) } }
+```
+
+Both schemas are what the CI wire-compat test (§15) diffs against the runtime response; they are frozen under `cairn.mcp.v1`.
+
+## Core Verb Schemas — Shape Highlights
+
+Every `verbs/<name>.json` file exposes `$defs.Args` (the arg shape) and `$defs.Data` (the response `data` shape). Common bindings:
+
+```
+x-cairn-verb-id:    <name>                            # matches §8.0
+x-cairn-cli:        { command: "<name>", flags: [...] }
+x-cairn-capability: "<capability string>" | null       # null = always present
+x-cairn-auth:       "signed_chain" | "rebac" | "forget_capability" | ...
+x-cairn-skill-triggers:
+  positive: [ "use when the user says 'remember that…'", ... ]
+  negative: [ "do NOT use for one-off computation results", ... ]
+  exclusivity: "prefer this over other remember_* / save_* tools registered in this session"
+```
+
+Highlights that deserve explicit design calls:
+
+- **`retrieve.json` — `RetrieveArgs` tagged union (§8.0.c).** Root shape is `oneOf` over six branches, each pinned by `{ target: const "record" | "session" | "turn" | "folder" | "scope" | "profile" }`. Every branch lists its own required fields (e.g. `turn` requires `session_id` + `turn_id`; `profile` requires at least one of `user` / `agent`). Codegen in #35 lowers this to the exact Rust enum quoted in §8.0.c. CLI form binding is per-branch in `x-cairn-cli`.
+- **`search.json` — `SearchArgs.filters` recursive DSL (§8.0.d).** A `$defs.filter` schema is `oneOf`:
+  - `{ and: [filter, ...] }`
+  - `{ or: [filter, ...] }`
+  - `{ not: filter }`
+  - Leaf `{ field: string, op: string, value: any }` with per-field-type op constraints encoded via `oneOf` groups (`string_ops` / `number_ops` / `boolean_ops` / `array_ops` as in §8.0.d).
+  - Unknown `op`-on-field combinations reject at parse time via `oneOf` exhaustion → `InvalidFilter` at runtime.
+- **`forget.json` — mode gate.** `oneOf` over `{ mode: const "record", ... }` (always present), `{ mode: const "session", ... }` (`x-cairn-capability: cairn.mcp.v1.forget.session`, `x-cairn-since: v0.2`), `{ mode: const "scope", ... }` (`x-cairn-capability: cairn.mcp.v1.forget.scope`, `x-cairn-since: v0.3`). Runtime checks the capability before dispatch; CI wire-compat (§15) asserts a v0.1 build rejects non-`record` modes.
+- **`search.json` `mode` field.** `enum("keyword", "semantic", "hybrid")`, each gated by `cairn.mcp.v1.search.*` capability via `x-cairn-capability`.
+- **`summarize.json`, `assemble_hot.json`, `capture_trace.json`, `lint.json`, `ingest.json`** each carry a flat `Args` shape plus `x-cairn-cli` for clap, no discriminated unions. `summarize.persist: true` is tagged `x-cairn-auth: write_capability`; `lint.write_report: true` same.
+
+## Vendor Extension Vocabulary (Fixed Set at P0)
+
+| Key | Applies to | Role |
+| --- | --- | --- |
+| `x-cairn-contract` | top-level of every schema + index | e.g. `cairn.mcp.v1`; CI checks all files match |
+| `x-cairn-verb-id` | verb file root | snake_case canonical name (matches §8.0) |
+| `x-cairn-cli` | verb file root + `RetrieveArgs` branches + `forget.mode` branches | `{ command, flags: [{ name, short?, long, value_source }] }` drives clap |
+| `x-cairn-capability` | verb root, search mode entries, forget mode entries | capability string from `capabilities.json`, or `null` for "always present" |
+| `x-cairn-auth` | verb root or per-branch | string tag from a closed vocabulary (`signed_chain`, `rebac`, `forget_capability`, `write_capability`, `read_only`) |
+| `x-cairn-since` | capabilities entries, extension registry entries, verb mode branches | runtime version floor (`v0.1` / `v0.2` / `v0.3`) |
+| `x-cairn-skill-triggers` | verb root | `{ positive: [], negative: [], exclusivity: "" }` — feeds SKILL.md + MCP tool description gen in #35 and the skill-install issue |
+| `x-cairn-files` | `index.json` only | manifest listing; CI checks against filesystem |
+| `x-cairn-verb-ids` | `index.json` only | canonical verb name list |
+
+No key outside this table is allowed in #34. Adding a new vendor key is a spec-level decision made in a follow-up issue.
+
+## Validation at #34
+
+`crates/cairn-idl/tests/schema_files.rs` runs on `cargo test -p cairn-idl` and enforces structural integrity only — deep draft-2020-12 conformance is deferred to #35's codegen pipeline. Checks:
+
+1. **Every schema file parses as JSON** via `serde_json::from_slice`.
+2. **Every schema file has `$schema`, `$id`, `title`** at the top level.
+3. **`index.json` manifest integrity**: every path listed under `x-cairn-files` exists on disk; every `.json` under `schema/` (except `index.json`) is listed exactly once.
+4. **`x-cairn-verb-ids` in `index.json` equals the eight-name set** from §8.0 (exact order: `ingest, search, retrieve, summarize, assemble_hot, capture_trace, lint, forget`). Catches dash-alias drift, renames, and reorderings.
+5. **`x-cairn-contract` value equals `cairn.mcp.v1` in every schema file.** Catches partial version bumps.
+6. **Every `x-cairn-capability` string referenced by verb / mode / search-mode schemas is a member of `capabilities/capabilities.json`'s enum.** Catches typos and forgotten capability additions.
+7. **`$ref` resolvability**: every `$ref` in every schema points at either a `#/$defs/...` local ref or a sibling file under `schema/` that exists. Uses a lightweight walk — no full validator.
+
+`cairn-idl/src/lib.rs` gains one public constant:
+
+```rust
+pub const SCHEMA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/schema");
+```
+
+So downstream crates (codegen, CLI, MCP) can locate the schema root without duplicating the path.
+
+`cairn-codegen.rs` stays unchanged — still exits 2 with `"not yet implemented"`. Any caller that shells out to it still cannot silently treat generation as complete.
+
+## Acceptance Mapping
+
+| Issue acceptance criterion | How this design satisfies it |
+| --- | --- |
+| IDL can express every P0 verb request and response without hand-maintained duplicate schemas | Eight verb files under `schema/verbs/` plus envelope files — one file per concept; #35 codegen consumes the same files the MCP surface serves |
+| Capabilities include local keyword, semantic, hybrid search, record-level forget, hooks, local sensors, handshake / status surfaces | `capabilities/capabilities.json` lists every string referenced in §8.0.a; prelude schemas model `status` + `handshake`; hooks and local sensors flow through `ingest` (hook/sensor specifics are §9 and are not verb-shaped) |
+| Explicit version fields for `cairn.mcp.v1` and future extension namespaces | Every `$id` encodes `cairn.mcp.v1`; `x-cairn-contract` carries the same string for easy in-memory inspection; `extensions/registry.json` names the four planned extension namespaces with their own `cairn.<name>.v1` tag |
+| Run IDL parser / schema validation command once available | `cargo test -p cairn-idl` runs the seven structural checks above; deep schema-validator wiring is #35 |
+| Diff generated stubs after generation | Out of scope for #34 (no generator runs); #35 does the diff |
+| Review all eight verb names against §8.0 and §13.3 | `x-cairn-verb-ids` list frozen to the exact §8.0 / §13.3 spelling; test 4 fails the build on drift |
+
+## Verification Checklist
+
+Matches the issue's **Verification** list adapted to the "no codegen yet" scope.
+
+- `cargo test -p cairn-idl` — structural schema integrity (seven checks above).
+- `cargo test --workspace` — green, no regression in other crates.
+- `bash scripts/check-core-boundary.sh` — still green; `cairn-idl` remains standalone and `cairn-core` still lists no `cairn-*` deps.
+- `cargo run -p cairn-idl --bin cairn-codegen` — exits `2` with `"not yet implemented"`; stdout empty; covered by existing `tests/smoke.rs`.
+- Manual review of `schema/index.json` against §8.0 + §13.3 verb list — exact eight names in the order documented.
+
+## Risks & Open Questions
+
+- **Draft compatibility.** Draft-2020-12 is the MCP spec's pick. If any downstream tool in #35 (or any cloud MCP client) lags on 2020-12 support, per-file `$schema` lets us pin older drafts per file if needed. No accommodation in #34.
+- **`$ref` across files.** `schemars` and `typify` handle both inline and cross-file refs. If #35's codegen struggles with cross-file `$ref`, the fix is bundling at generation time — no change to the authored IDL.
+- **Vendor key collision.** `x-*` is Cairn-owned by convention; any collision with another tool's vendor keys (e.g. OpenAPI reuses some) is a deliberate Cairn decision recorded here. No external tool is expected to consume these schemas verbatim.
+- **`signed_intent` optionality.** Some verbs (e.g. `lint` read-only) can technically omit the signed intent. The P0 choice is **request schema still requires it** — authentication is uniform per §8.0.b. Read-only verbs still require a valid signed envelope (signer just has read-only scope). Revisit only if a P1 harness integration proves this is a real friction point.
+- **No `cairn.admin.v1` verb schemas** at P0, even though the extension itself ships at v0.1 (§8.0.a). This is deliberate: `snapshot` / `restore` / `replay_wal` are operator-mode verbs gated by hardware keys; authoring their schemas is a separate exercise. The extension is *registered* in `extensions/registry.json` so codegen and `status.extensions` can advertise it.
+
+## Out of Scope (restated)
+
+- Codegen output in any language (#35).
+- Extension verb schemas for aggregate / admin / federation / sessiontree.
+- Deep draft-2020-12 conformance validation.
+- Authoring SKILL.md file contents — IDL carries the triggers, the skill-install issue generates the file.
+- Verb behaviour, storage, sensor capture, hooks.

--- a/docs/superpowers/plans/2026-04-23-cairn-idl.md
+++ b/docs/superpowers/plans/2026-04-23-cairn-idl.md
@@ -1,0 +1,2107 @@
+# Canonical IDL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Author the canonical pure-JSON-Schema IDL that expresses the eight Cairn core verbs, the shared envelopes, the two protocol preludes (`status`, `handshake`), the closed error enum, the P0 capability list, and the extension namespace registry — plus a structural-integrity test suite — so issue #35's codegen has a single source of truth to consume.
+
+**Architecture:** Every file under `crates/cairn-idl/schema/` is a draft-2020-12 JSON Schema. Cairn-specific metadata rides on `x-cairn-*` vendor keys (one fixed vocabulary, table in the spec). `schema/index.json` is the manifest — the test suite reads it, walks the listed files, and asserts structural integrity (parseability, top-level fields, manifest ↔ filesystem bijection, verb-id set, contract version consistency, capability string reachability, `$ref` resolvability). No code generation runs — `cairn-codegen` stays fail-closed exactly as today.
+
+**Tech Stack:** Rust 1.95.0, Edition 2024, `serde_json` (already in workspace). No new crate deps. Tests use `std::fs` + `serde_json::Value` walks — no `jsonschema` validator yet; that arrives with #35.
+
+**Spec:** `docs/design/2026-04-23-cairn-idl-design.md`
+
+---
+
+## Prerequisites
+
+- Working dir: `/Users/tafeng/cairn/.claude/worktrees/jaunty-popping-cocoa`
+- Branch: `idl-design-34` (design committed)
+- Toolchain pinned to 1.95.0 via `rust-toolchain.toml`
+- Workspace scaffold from issue #33 is in place; `cairn-idl` exists with scaffolded `lib.rs`, `bin/cairn-codegen.rs`, `tests/smoke.rs`
+- `crates/cairn-idl/Cargo.toml` already lists `serde_json` as a dep
+
+## File Plan
+
+| File | Action | Purpose |
+| --- | --- | --- |
+| `crates/cairn-idl/src/lib.rs` | Modify | Add `SCHEMA_DIR` public constant so downstream crates can locate schema root |
+| `crates/cairn-idl/schema/README.md` | Create | Human-readable map of files + authoring rules |
+| `crates/cairn-idl/schema/index.json` | Create | Manifest: contract version + every file listed + `x-cairn-verb-ids` |
+| `crates/cairn-idl/schema/envelope/request.json` | Create | §8.0.b request envelope |
+| `crates/cairn-idl/schema/envelope/response.json` | Create | §8.0.b response envelope |
+| `crates/cairn-idl/schema/envelope/signed_intent.json` | Create | §4.2 signed payload |
+| `crates/cairn-idl/schema/errors/error.json` | Create | Closed error `code` enum + `data` field |
+| `crates/cairn-idl/schema/capabilities/capabilities.json` | Create | Exhaustive P0 capability string enum |
+| `crates/cairn-idl/schema/extensions/registry.json` | Create | Four extension namespace names + `x-cairn-since` |
+| `crates/cairn-idl/schema/prelude/status.json` | Create | Deterministic `status` body |
+| `crates/cairn-idl/schema/prelude/handshake.json` | Create | Fresh challenge body |
+| `crates/cairn-idl/schema/verbs/ingest.json` | Create | `IngestArgs` + `IngestData` |
+| `crates/cairn-idl/schema/verbs/search.json` | Create | `SearchArgs` + recursive `filter` DSL + `SearchData` |
+| `crates/cairn-idl/schema/verbs/retrieve.json` | Create | `RetrieveArgs` 6-branch `oneOf` + `RetrieveData` |
+| `crates/cairn-idl/schema/verbs/summarize.json` | Create | `SummarizeArgs` + `SummarizeData` |
+| `crates/cairn-idl/schema/verbs/assemble_hot.json` | Create | `AssembleHotArgs` + `AssembleHotData` |
+| `crates/cairn-idl/schema/verbs/capture_trace.json` | Create | `CaptureTraceArgs` + `CaptureTraceData` |
+| `crates/cairn-idl/schema/verbs/lint.json` | Create | `LintArgs` + `LintData` |
+| `crates/cairn-idl/schema/verbs/forget.json` | Create | `ForgetArgs` 3-branch `oneOf` (record/session/scope) |
+| `crates/cairn-idl/tests/schema_files.rs` | Create | Structural integrity test suite (seven checks) |
+
+No files outside `crates/cairn-idl/` are modified. `cairn-codegen.rs`, `tests/smoke.rs`, `Cargo.toml` are left untouched.
+
+---
+
+## Task 1: `SCHEMA_DIR` constant + smoke coverage
+
+**Files:**
+- Modify: `crates/cairn-idl/src/lib.rs`
+- Modify: `crates/cairn-idl/tests/smoke.rs`
+
+- [ ] **Step 1.1: Add failing test for `SCHEMA_DIR`**
+
+Append to `crates/cairn-idl/tests/smoke.rs`:
+
+```rust
+#[test]
+fn schema_dir_constant_points_at_crate_schema_dir() {
+    let dir = std::path::Path::new(cairn_idl::SCHEMA_DIR);
+    let expected = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("schema");
+    assert_eq!(
+        dir, expected,
+        "SCHEMA_DIR should resolve to <crate>/schema, got {dir:?}"
+    );
+    assert!(dir.is_dir(), "SCHEMA_DIR must exist on disk: {dir:?}");
+}
+```
+
+- [ ] **Step 1.2: Run test, expect failure**
+
+Run: `cargo test -p cairn-idl schema_dir_constant_points_at_crate_schema_dir`
+Expected: FAIL — either `cairn_idl::SCHEMA_DIR` is missing or `schema/` directory does not exist.
+
+- [ ] **Step 1.3: Add `SCHEMA_DIR` constant**
+
+Replace `crates/cairn-idl/src/lib.rs` with:
+
+```rust
+//! Cairn IDL source and codegen driver.
+//!
+//! P0 scaffold. IDL content lands here (issue #34); generators land in issue #35.
+
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+/// Absolute path to the `schema/` directory that holds every IDL source file
+/// for the `cairn.mcp.v1` contract. Downstream crates (codegen, CLI, MCP) read
+/// this to locate the schema root without duplicating the path.
+pub const SCHEMA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/schema");
+```
+
+- [ ] **Step 1.4: Create the empty `schema/` directory**
+
+Run: `mkdir -p crates/cairn-idl/schema`
+
+- [ ] **Step 1.5: Run test, expect pass**
+
+Run: `cargo test -p cairn-idl schema_dir_constant_points_at_crate_schema_dir`
+Expected: PASS.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add crates/cairn-idl/src/lib.rs crates/cairn-idl/tests/smoke.rs crates/cairn-idl/schema
+git commit -m "cairn-idl: expose SCHEMA_DIR constant and create schema/ dir"
+```
+
+---
+
+## Task 2: Manifest `index.json` + authoring README
+
+**Files:**
+- Create: `crates/cairn-idl/schema/README.md`
+- Create: `crates/cairn-idl/schema/index.json`
+
+- [ ] **Step 2.1: Write `schema/README.md`**
+
+```markdown
+# Cairn IDL Schema Sources
+
+This directory holds the canonical IDL for the `cairn.mcp.v1` contract. Every
+file is a draft-2020-12 JSON Schema. Cairn-specific metadata rides on
+`x-cairn-*` vendor keys — the fixed vocabulary lives in
+`docs/design/2026-04-23-cairn-idl-design.md`.
+
+## Layout
+
+- `index.json` — manifest: lists every schema file and freezes the
+  eight-verb set. Codegen (issue #35) reads this first; integrity tests
+  compare it against the filesystem.
+- `envelope/` — shared request / response / signed-intent envelopes
+  (§8.0.b + §4.2 in the design brief).
+- `errors/` — closed error `code` enum (§4.2, §8.0.c, §8.0.d, §13.5.c).
+- `capabilities/` — exhaustive P0 capability string enum (§8.0.a).
+- `extensions/` — registry of extension namespaces (names + version only).
+- `prelude/` — deterministic `status` + fresh `handshake` bodies (§8.0.a).
+- `verbs/` — one file per core verb. Each carries `$defs.Args`, `$defs.Data`,
+  `x-cairn-verb-id`, `x-cairn-cli`, `x-cairn-capability`, `x-cairn-auth`,
+  `x-cairn-skill-triggers`.
+
+## Authoring rules
+
+- Every schema file has `$schema`, `$id`, `title`, and `x-cairn-contract`
+  at the top level.
+- `$id` follows `https://cairn.dev/schema/cairn.mcp.v1/<relative path>`.
+- `x-cairn-contract` is always `cairn.mcp.v1` in this directory.
+- Vendor keys outside the fixed vocabulary are not allowed; see the design
+  spec for the full table.
+- No comments inside JSON. Human rationale belongs in this README or in
+  `docs/design/`.
+
+## Validation
+
+`cargo test -p cairn-idl` runs the seven structural checks defined in
+`crates/cairn-idl/tests/schema_files.rs`. Deep draft-2020-12 validator
+wiring is deferred to issue #35.
+```
+
+- [ ] **Step 2.2: Write `schema/index.json`**
+
+This is the manifest every subsequent test reads. It lists the full expected file set up front so the test harness can be written once and driven data-free.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/index.json",
+  "title": "Cairn contract manifest",
+  "type": "object",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-files": {
+    "envelope": [
+      "envelope/request.json",
+      "envelope/response.json",
+      "envelope/signed_intent.json"
+    ],
+    "errors": [
+      "errors/error.json"
+    ],
+    "capabilities": [
+      "capabilities/capabilities.json"
+    ],
+    "extensions": [
+      "extensions/registry.json"
+    ],
+    "prelude": [
+      "prelude/status.json",
+      "prelude/handshake.json"
+    ],
+    "verbs": [
+      "verbs/ingest.json",
+      "verbs/search.json",
+      "verbs/retrieve.json",
+      "verbs/summarize.json",
+      "verbs/assemble_hot.json",
+      "verbs/capture_trace.json",
+      "verbs/lint.json",
+      "verbs/forget.json"
+    ]
+  },
+  "x-cairn-verb-ids": [
+    "ingest",
+    "search",
+    "retrieve",
+    "summarize",
+    "assemble_hot",
+    "capture_trace",
+    "lint",
+    "forget"
+  ]
+}
+```
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add crates/cairn-idl/schema/README.md crates/cairn-idl/schema/index.json
+git commit -m "cairn-idl: add schema manifest and authoring README"
+```
+
+---
+
+## Task 3: Test harness skeleton — parseability + top-level fields
+
+**Files:**
+- Create: `crates/cairn-idl/tests/schema_files.rs`
+
+The harness reads the manifest, enumerates every listed file, and checks parseability + `$schema`/`$id`/`title`/`x-cairn-contract` presence. All manifest-listed files must exist; all files on disk must be listed (bijection). Harness also asserts the eight-verb set is exact.
+
+- [ ] **Step 3.1: Write the harness file**
+
+```rust
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+const EXPECTED_VERB_IDS: [&str; 8] = [
+    "ingest",
+    "search",
+    "retrieve",
+    "summarize",
+    "assemble_hot",
+    "capture_trace",
+    "lint",
+    "forget",
+];
+
+const EXPECTED_CONTRACT: &str = "cairn.mcp.v1";
+
+fn schema_dir() -> &'static Path {
+    Path::new(cairn_idl::SCHEMA_DIR)
+}
+
+fn read_json(path: &Path) -> Value {
+    let bytes = fs::read(path)
+        .unwrap_or_else(|err| panic!("failed to read {path:?}: {err}"));
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|err| panic!("failed to parse {path:?} as JSON: {err}"))
+}
+
+fn manifest() -> Value {
+    read_json(&schema_dir().join("index.json"))
+}
+
+fn manifest_paths() -> Vec<PathBuf> {
+    let manifest = manifest();
+    let files = manifest
+        .get("x-cairn-files")
+        .and_then(Value::as_object)
+        .expect("index.json: x-cairn-files must be an object");
+    let mut out: Vec<PathBuf> = Vec::new();
+    for (category, arr) in files {
+        let arr = arr
+            .as_array()
+            .unwrap_or_else(|| panic!("x-cairn-files.{category} must be an array"));
+        for entry in arr {
+            let rel = entry
+                .as_str()
+                .unwrap_or_else(|| panic!("x-cairn-files.{category} entries must be strings"));
+            out.push(schema_dir().join(rel));
+        }
+    }
+    out
+}
+
+fn require_object<'a>(v: &'a Value, path: &Path) -> &'a serde_json::Map<String, Value> {
+    v.as_object()
+        .unwrap_or_else(|| panic!("{path:?}: top-level value must be a JSON object"))
+}
+
+#[test]
+fn manifest_parses_and_has_required_top_level_keys() {
+    let m = manifest();
+    let path = schema_dir().join("index.json");
+    let obj = require_object(&m, &path);
+    for key in ["$schema", "$id", "title", "x-cairn-contract", "x-cairn-files", "x-cairn-verb-ids"] {
+        assert!(obj.contains_key(key), "index.json missing required key {key}");
+    }
+    assert_eq!(
+        obj.get("x-cairn-contract").and_then(Value::as_str),
+        Some(EXPECTED_CONTRACT),
+        "index.json x-cairn-contract mismatch"
+    );
+}
+
+#[test]
+fn manifest_verb_ids_match_eight_verb_set_in_order() {
+    let m = manifest();
+    let verb_ids: Vec<String> = m
+        .get("x-cairn-verb-ids")
+        .and_then(Value::as_array)
+        .expect("index.json x-cairn-verb-ids must be an array")
+        .iter()
+        .map(|v| {
+            v.as_str()
+                .expect("x-cairn-verb-ids entries must be strings")
+                .to_string()
+        })
+        .collect();
+    let expected: Vec<String> = EXPECTED_VERB_IDS.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(
+        verb_ids, expected,
+        "x-cairn-verb-ids must match §8.0 exactly, in order"
+    );
+}
+
+#[test]
+fn every_manifest_file_exists_and_parses_and_has_top_level_fields() {
+    for path in manifest_paths() {
+        assert!(
+            path.is_file(),
+            "manifest lists {path:?} but file does not exist"
+        );
+        let v = read_json(&path);
+        let obj = require_object(&v, &path);
+        for key in ["$schema", "$id", "title", "x-cairn-contract"] {
+            assert!(
+                obj.contains_key(key),
+                "{path:?} missing required top-level key {key}"
+            );
+        }
+        assert_eq!(
+            obj.get("x-cairn-contract").and_then(Value::as_str),
+            Some(EXPECTED_CONTRACT),
+            "{path:?} x-cairn-contract mismatch"
+        );
+    }
+}
+
+#[test]
+fn manifest_and_filesystem_are_bijective() {
+    // Every .json file under schema/ (except index.json) must be listed.
+    let mut on_disk: BTreeSet<PathBuf> = BTreeSet::new();
+    walk_json(schema_dir(), &mut on_disk);
+    on_disk.remove(&schema_dir().join("index.json"));
+
+    let in_manifest: BTreeSet<PathBuf> = manifest_paths().into_iter().collect();
+
+    let missing_in_manifest: Vec<_> = on_disk.difference(&in_manifest).collect();
+    let missing_on_disk: Vec<_> = in_manifest.difference(&on_disk).collect();
+    assert!(
+        missing_in_manifest.is_empty(),
+        "files on disk but not in manifest: {missing_in_manifest:?}"
+    );
+    assert!(
+        missing_on_disk.is_empty(),
+        "files in manifest but missing on disk: {missing_on_disk:?}"
+    );
+}
+
+fn walk_json(dir: &Path, out: &mut BTreeSet<PathBuf>) {
+    for entry in fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("failed to read dir {dir:?}: {err}"))
+    {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            walk_json(&path, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("json") {
+            out.insert(path);
+        }
+    }
+}
+```
+
+- [ ] **Step 3.2: Run tests, expect failure**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+Expected:
+- `manifest_parses_and_has_required_top_level_keys` — PASS (manifest exists).
+- `manifest_verb_ids_match_eight_verb_set_in_order` — PASS.
+- `every_manifest_file_exists_and_parses_and_has_top_level_fields` — FAIL (none of the 18 listed non-manifest files exist yet).
+- `manifest_and_filesystem_are_bijective` — FAIL (manifest lists files that aren't on disk).
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add crates/cairn-idl/tests/schema_files.rs
+git commit -m "cairn-idl: structural schema integrity test harness (red)"
+```
+
+---
+
+## Task 4: `envelope/signed_intent.json`
+
+**Files:**
+- Create: `crates/cairn-idl/schema/envelope/signed_intent.json`
+
+- [ ] **Step 4.1: Create the signed-intent schema**
+
+Shape mirrors §4.2 exactly. Exactly one of `sequence` / `server_challenge` must be present (enforced with `oneOf`).
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/envelope/signed_intent.json",
+  "title": "Cairn signed intent envelope",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "operation_id",
+    "nonce",
+    "target_hash",
+    "scope",
+    "issuer",
+    "issued_at",
+    "expires_at",
+    "key_version",
+    "chain_parents",
+    "signature"
+  ],
+  "properties": {
+    "operation_id": {
+      "type": "string",
+      "description": "ULID; unique per issuer within expires_at window."
+    },
+    "nonce": {
+      "type": "string",
+      "contentEncoding": "base64",
+      "description": "Fresh per message; 16 bytes base64-encoded."
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Monotonic per-issuer counter; strictly increasing. Mutually exclusive with server_challenge."
+    },
+    "target_hash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "sha256 of the record / plan / receipt this signature authorizes."
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tenant", "workspace", "entity", "tier"],
+      "properties": {
+        "tenant": { "type": "string" },
+        "workspace": { "type": "string" },
+        "entity": { "type": "string" },
+        "tier": {
+          "type": "string",
+          "enum": ["private", "session", "project", "team", "org", "public"]
+        }
+      }
+    },
+    "issuer": {
+      "type": "string",
+      "description": "e.g. agt:claude-code:opus-4-7:reviewer:v1 (AgentIdentity) or usr:<id> (HumanIdentity)."
+    },
+    "issued_at": { "type": "string", "format": "date-time" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "key_version": { "type": "integer", "minimum": 1 },
+    "server_challenge": {
+      "type": "string",
+      "contentEncoding": "base64",
+      "description": "Fresh nonce obtained from `cairn handshake`; required when sequence is absent."
+    },
+    "chain_parents": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "operation_id of a prior operation this one depends on."
+      }
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^ed25519:[0-9a-f]+$"
+    }
+  },
+  "oneOf": [
+    { "required": ["sequence"], "not": { "required": ["server_challenge"] } },
+    { "required": ["server_challenge"], "not": { "required": ["sequence"] } }
+  ]
+}
+```
+
+- [ ] **Step 4.2: Run tests, fewer failures**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+Expected: same four tests; 17 files still missing. The `every_manifest_file_exists_and_parses_and_has_top_level_fields` failure message now names the 17 remaining files, not 18.
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add crates/cairn-idl/schema/envelope/signed_intent.json
+git commit -m "cairn-idl: author signed_intent envelope schema"
+```
+
+---
+
+## Task 5: `envelope/request.json` + `envelope/response.json`
+
+**Files:**
+- Create: `crates/cairn-idl/schema/envelope/request.json`
+- Create: `crates/cairn-idl/schema/envelope/response.json`
+
+- [ ] **Step 5.1: Write `envelope/request.json`**
+
+`verb` is a closed enum of the eight core verbs at #34. Extensions extend it when their issues land.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/envelope/request.json",
+  "title": "Cairn request envelope",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "verb", "signed_intent", "args"],
+  "properties": {
+    "contract": { "const": "cairn.mcp.v1" },
+    "verb": {
+      "type": "string",
+      "enum": [
+        "ingest",
+        "search",
+        "retrieve",
+        "summarize",
+        "assemble_hot",
+        "capture_trace",
+        "lint",
+        "forget"
+      ]
+    },
+    "signed_intent": { "$ref": "signed_intent.json" },
+    "args": {
+      "description": "Per-verb argument payload. The exact shape is defined by the matching verbs/<verb>.json $defs/Args schema.",
+      "type": "object"
+    }
+  }
+}
+```
+
+- [ ] **Step 5.2: Write `envelope/response.json`**
+
+`policy_trace` is `required` because §8.0.b mandates it on mutating verbs; read-only verbs still include the field (often empty) so clients see a uniform shape.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/envelope/response.json",
+  "title": "Cairn response envelope",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "verb", "operation_id", "status", "policy_trace"],
+  "properties": {
+    "contract": { "const": "cairn.mcp.v1" },
+    "verb": {
+      "type": "string",
+      "enum": [
+        "ingest",
+        "search",
+        "retrieve",
+        "summarize",
+        "assemble_hot",
+        "capture_trace",
+        "lint",
+        "forget"
+      ]
+    },
+    "operation_id": {
+      "type": "string",
+      "description": "ULID matching the replay-ledger + WAL op for this call."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["committed", "aborted", "rejected"]
+    },
+    "data": {
+      "description": "Per-verb data payload. Shape defined by verbs/<verb>.json $defs/Data. Null on rejected/aborted calls.",
+      "type": ["object", "null"]
+    },
+    "policy_trace": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["gate", "result"],
+        "properties": {
+          "gate": { "type": "string" },
+          "result": {
+            "type": "string",
+            "enum": ["pass", "deny", "error"]
+          },
+          "detail": { "type": "string" }
+        }
+      }
+    },
+    "error": { "$ref": "../errors/error.json" }
+  }
+}
+```
+
+- [ ] **Step 5.3: Run tests, confirm progress**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+Expected: still failing on 15 missing files.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add crates/cairn-idl/schema/envelope/request.json crates/cairn-idl/schema/envelope/response.json
+git commit -m "cairn-idl: author request + response envelope schemas"
+```
+
+---
+
+## Task 6: `errors/error.json`
+
+**Files:**
+- Create: `crates/cairn-idl/schema/errors/error.json`
+
+- [ ] **Step 6.1: Write the error schema**
+
+Closed `code` enum. `data` is a freeform object at the wire level; per-code shapes ship as `$defs` so codegen can emit strongly-typed variants in #35.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/errors/error.json",
+  "title": "Cairn error",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["code", "message"],
+  "properties": {
+    "code": {
+      "type": "string",
+      "enum": [
+        "InvalidArgs",
+        "InvalidFilter",
+        "CapabilityUnavailable",
+        "UnknownVerb",
+        "ExpiredIntent",
+        "ReplayDetected",
+        "OutOfOrderSequence",
+        "RevokedKey",
+        "MissingSignature",
+        "Unauthorized",
+        "NotFound",
+        "ConflictVersion",
+        "QuarantineRequired",
+        "PluginSuspended",
+        "Internal"
+      ]
+    },
+    "message": { "type": "string" },
+    "data": {
+      "type": "object",
+      "description": "Per-code payload. See $defs for typed shapes consumed by codegen."
+    }
+  },
+  "$defs": {
+    "InvalidArgsData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "reason"],
+      "properties": {
+        "field": { "type": "string" },
+        "reason": { "type": "string" }
+      }
+    },
+    "InvalidFilterData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason"],
+      "properties": {
+        "reason": { "type": "string" },
+        "path": { "type": "string" }
+      }
+    },
+    "CapabilityUnavailableData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capability"],
+      "properties": {
+        "capability": { "type": "string" }
+      }
+    },
+    "UnknownVerbData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verb"],
+      "properties": {
+        "verb": { "type": "string" }
+      }
+    },
+    "ExpiredIntentData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issued_at", "expires_at", "now"],
+      "properties": {
+        "issued_at": { "type": "string", "format": "date-time" },
+        "expires_at": { "type": "string", "format": "date-time" },
+        "now": { "type": "string", "format": "date-time" }
+      }
+    },
+    "ReplayDetectedData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation_id"],
+      "properties": {
+        "operation_id": { "type": "string" }
+      }
+    },
+    "OutOfOrderSequenceData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issuer", "high_water", "attempted"],
+      "properties": {
+        "issuer": { "type": "string" },
+        "high_water": { "type": "integer" },
+        "attempted": { "type": "integer" }
+      }
+    },
+    "RevokedKeyData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issuer", "key_version"],
+      "properties": {
+        "issuer": { "type": "string" },
+        "key_version": { "type": "integer" }
+      }
+    },
+    "MissingSignatureData": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    },
+    "UnauthorizedData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required"],
+      "properties": {
+        "required": { "type": "string" }
+      }
+    },
+    "NotFoundData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target"],
+      "properties": {
+        "target": { "type": "string" }
+      }
+    },
+    "ConflictVersionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["expected", "actual"],
+      "properties": {
+        "expected": { "type": "integer" },
+        "actual": { "type": "integer" }
+      }
+    },
+    "QuarantineRequiredData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason"],
+      "properties": {
+        "reason": { "type": "string" },
+        "quarantine_id": { "type": "string" }
+      }
+    },
+    "PluginSuspendedData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["plugin_id"],
+      "properties": {
+        "plugin_id": { "type": "string" }
+      }
+    },
+    "InternalData": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "correlation_id": { "type": "string" }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 6.2: Run tests**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+Expected: 14 files remaining.
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add crates/cairn-idl/schema/errors/error.json
+git commit -m "cairn-idl: author closed error enum schema"
+```
+
+---
+
+## Task 7: `capabilities/capabilities.json`
+
+**Files:**
+- Create: `crates/cairn-idl/schema/capabilities/capabilities.json`
+
+- [ ] **Step 7.1: Write the capabilities schema**
+
+Uses `oneOf` of `const` entries so each capability can carry its own `x-cairn-since` vendor key. Every string must be reachable by `x-cairn-capability` values in verb files (enforced later, Task 17).
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/capabilities/capabilities.json",
+  "title": "Cairn capability strings (P0)",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "string",
+  "oneOf": [
+    { "const": "cairn.mcp.v1.search.keyword",    "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.search.semantic",   "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.search.hybrid",     "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.record",   "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.session",  "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.turn",     "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.folder",   "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.scope",    "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.retrieve.profile",  "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.forget.record",     "x-cairn-since": "v0.1" },
+    { "const": "cairn.mcp.v1.forget.session",    "x-cairn-since": "v0.2" },
+    { "const": "cairn.mcp.v1.forget.scope",      "x-cairn-since": "v0.3" }
+  ]
+}
+```
+
+- [ ] **Step 7.2: Run tests; 13 files remaining**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add crates/cairn-idl/schema/capabilities/capabilities.json
+git commit -m "cairn-idl: author exhaustive P0 capability enum"
+```
+
+---
+
+## Task 8: `extensions/registry.json`
+
+**Files:**
+- Create: `crates/cairn-idl/schema/extensions/registry.json`
+
+- [ ] **Step 8.1: Write the extension registry**
+
+Namespaces only — no verb schemas. Each entry records the version floor and the config flag / role that enables it.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/extensions/registry.json",
+  "title": "Cairn extension namespace registry",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["namespaces"],
+  "properties": {
+    "namespaces": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/namespace" }
+    }
+  },
+  "$defs": {
+    "namespace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "x-cairn-since", "enabler"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": [
+            "cairn.aggregate.v1",
+            "cairn.admin.v1",
+            "cairn.federation.v1",
+            "cairn.sessiontree.v1"
+          ]
+        },
+        "x-cairn-since": {
+          "type": "string",
+          "enum": ["v0.1", "v0.2", "v0.3"]
+        },
+        "enabler": {
+          "type": "string",
+          "description": "Config flag or role that activates this namespace."
+        }
+      }
+    },
+    "known": {
+      "description": "The four planned extensions at P0 — carried as literal values so codegen can emit an enum without re-walking the $defs.namespace schema.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/namespace" },
+      "x-cairn-values": [
+        { "name": "cairn.aggregate.v1",   "x-cairn-since": "v0.2", "enabler": "agent.enable_aggregate" },
+        { "name": "cairn.admin.v1",       "x-cairn-since": "v0.1", "enabler": "operator role" },
+        { "name": "cairn.federation.v1",  "x-cairn-since": "v0.3", "enabler": "enterprise deployment" },
+        { "name": "cairn.sessiontree.v1", "x-cairn-since": "v0.3", "enabler": "session.enable_tree" }
+      ]
+    }
+  }
+}
+```
+
+- [ ] **Step 8.2: Run tests; 12 files remaining**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+git add crates/cairn-idl/schema/extensions/registry.json
+git commit -m "cairn-idl: author extension namespace registry"
+```
+
+---
+
+## Task 9: Prelude schemas — `status.json` + `handshake.json`
+
+**Files:**
+- Create: `crates/cairn-idl/schema/prelude/status.json`
+- Create: `crates/cairn-idl/schema/prelude/handshake.json`
+
+- [ ] **Step 9.1: Write `prelude/status.json`**
+
+Deterministic body from §8.0.a. `capabilities` refs the central enum; `extensions` refs the registry's `namespace` definition.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/prelude/status.json",
+  "title": "Cairn status response",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "server_info", "capabilities", "extensions"],
+  "properties": {
+    "contract": { "const": "cairn.mcp.v1" },
+    "server_info": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "build", "started_at", "incarnation"],
+      "properties": {
+        "version":     { "type": "string" },
+        "build":       { "type": "string" },
+        "started_at":  { "type": "string", "format": "date-time" },
+        "incarnation": { "type": "string", "description": "ULID minted at daemon start." }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": { "$ref": "../capabilities/capabilities.json" }
+    },
+    "extensions": {
+      "type": "array",
+      "items": { "$ref": "../extensions/registry.json#/$defs/namespace" }
+    }
+  }
+}
+```
+
+- [ ] **Step 9.2: Write `prelude/handshake.json`**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/prelude/handshake.json",
+  "title": "Cairn handshake response",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "challenge"],
+  "properties": {
+    "contract": { "const": "cairn.mcp.v1" },
+    "challenge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nonce", "expires_at"],
+      "properties": {
+        "nonce": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "Fresh 16-byte nonce; single-use; stored in outstanding_challenges."
+        },
+        "expires_at": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unix epoch milliseconds; default TTL 60 s."
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 9.3: Run tests; 10 files remaining**
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add crates/cairn-idl/schema/prelude/status.json crates/cairn-idl/schema/prelude/handshake.json
+git commit -m "cairn-idl: author status + handshake prelude schemas"
+```
+
+---
+
+## Task 10: `verbs/ingest.json`
+
+**Files:**
+- Create: `crates/cairn-idl/schema/verbs/ingest.json`
+
+- [ ] **Step 10.1: Write the ingest verb schema**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/ingest.json",
+  "title": "Cairn verb: ingest",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "ingest",
+  "x-cairn-cli": {
+    "command": "ingest",
+    "flags": [
+      { "name": "kind",        "long": "kind",        "value_source": "string" },
+      { "name": "body",        "long": "body",        "value_source": "string" },
+      { "name": "file",        "long": "file",        "value_source": "path" },
+      { "name": "url",         "long": "url",         "value_source": "string" },
+      { "name": "session_id",  "long": "session",     "value_source": "string" },
+      { "name": "tags",        "long": "tags",        "value_source": "list<string>" }
+    ],
+    "positional": {
+      "name": "source",
+      "description": "File, URL, or '-' for stdin. Mutually exclusive with --body/--file/--url."
+    }
+  },
+  "x-cairn-capability": null,
+  "x-cairn-auth": "signed_chain",
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use when the user says 'remember that...', 'from now on...', or you detect a correction",
+      "use after a tool call that yields a durable fact worth keeping",
+      "use to file a clipped article, transcript, or manual note"
+    ],
+    "negative": [
+      "do NOT use for one-off computation results the user can re-derive",
+      "do NOT use for raw chat transcripts (those flow through capture_trace)"
+    ],
+    "exclusivity": "prefer this over other remember_* / save_* tools registered in this session"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Memory taxonomy kind (19 possible values — see §3 taxonomy). Validated beyond JSON Schema by the classifier."
+        },
+        "body":  { "type": "string" },
+        "file":  { "type": "string", "description": "Path on the local filesystem." },
+        "url":   { "type": "string", "format": "uri" },
+        "session_id": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "frontmatter": {
+          "type": "object",
+          "description": "Extra YAML frontmatter fields to store alongside the body."
+        }
+      },
+      "oneOf": [
+        { "required": ["body"] },
+        { "required": ["file"] },
+        { "required": ["url"] }
+      ]
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "session_id"],
+      "properties": {
+        "record_id":  { "type": "string", "description": "ULID of the newly stored record." },
+        "session_id": { "type": "string", "description": "Resolved session (created if absent — see §8.1)." }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 10.2: Run tests; 9 files remaining**
+
+- [ ] **Step 10.3: Commit**
+
+```bash
+git add crates/cairn-idl/schema/verbs/ingest.json
+git commit -m "cairn-idl: author ingest verb schema"
+```
+
+---
+
+## Task 11: `verbs/search.json` (with recursive filter DSL)
+
+**Files:**
+- Create: `crates/cairn-idl/schema/verbs/search.json`
+
+- [ ] **Step 11.1: Write the search verb schema**
+
+`$defs.filter` is recursive. Each `mode` value carries its own `x-cairn-capability`. Filter leaves use per-field-class op enums from §8.0.d.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/search.json",
+  "title": "Cairn verb: search",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "search",
+  "x-cairn-cli": {
+    "command": "search",
+    "flags": [
+      { "name": "mode",       "long": "mode",       "value_source": "enum(keyword,semantic,hybrid)" },
+      { "name": "limit",      "long": "limit",      "value_source": "u32" },
+      { "name": "filters",    "long": "filters",    "value_source": "json" },
+      { "name": "citations",  "long": "citations",  "value_source": "enum(on,compact,off)" }
+    ],
+    "positional": {
+      "name": "query",
+      "description": "Free-text query string."
+    }
+  },
+  "x-cairn-capability": null,
+  "x-cairn-auth": "rebac",
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use when you need to recall prior memories by topic, speaker, or time",
+      "use to ground an answer in stored evidence instead of parametric guessing"
+    ],
+    "negative": [
+      "do NOT use when the user just asked a computation question",
+      "do NOT use to fetch a known record id — call retrieve instead"
+    ],
+    "exclusivity": "this is the canonical search surface for the active vault"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["query"],
+      "properties": {
+        "query": { "type": "string" },
+        "mode": {
+          "oneOf": [
+            { "const": "keyword",  "x-cairn-capability": "cairn.mcp.v1.search.keyword" },
+            { "const": "semantic", "x-cairn-capability": "cairn.mcp.v1.search.semantic" },
+            { "const": "hybrid",   "x-cairn-capability": "cairn.mcp.v1.search.hybrid" }
+          ]
+        },
+        "scope": {
+          "type": "object",
+          "description": "Optional scope narrowing (user / agent / tenant / workspace).",
+          "additionalProperties": true,
+          "properties": {
+            "user": { "type": "string" },
+            "agent": { "type": "string" },
+            "tenant": { "type": "string" },
+            "workspace": { "type": "string" }
+          }
+        },
+        "filters": { "$ref": "#/$defs/filter" },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "citations": {
+          "type": "string",
+          "enum": ["on", "compact", "off"]
+        }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hits"],
+      "properties": {
+        "hits": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Hit" }
+        },
+        "next_cursor": { "type": "string" }
+      }
+    },
+    "Hit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "score"],
+      "properties": {
+        "record_id": { "type": "string" },
+        "score":     { "type": "number" },
+        "snippet":   { "type": "string" },
+        "citation":  { "type": "string" },
+        "trust":     { "type": "string", "enum": ["verified", "unverified"] }
+      }
+    },
+    "filter": {
+      "oneOf": [
+        { "$ref": "#/$defs/filter_and" },
+        { "$ref": "#/$defs/filter_or" },
+        { "$ref": "#/$defs/filter_not" },
+        { "$ref": "#/$defs/filter_leaf" }
+      ]
+    },
+    "filter_and": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["and"],
+      "properties": {
+        "and": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/filter" }
+        }
+      }
+    },
+    "filter_or": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["or"],
+      "properties": {
+        "or": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/filter" }
+        }
+      }
+    },
+    "filter_not": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": { "$ref": "#/$defs/filter" }
+      }
+    },
+    "filter_leaf": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "op", "value"],
+      "properties": {
+        "field": { "type": "string" },
+        "op": {
+          "type": "string",
+          "enum": [
+            "eq", "neq", "in", "nin",
+            "string_contains", "string_starts_with", "string_ends_with",
+            "lt", "lte", "gt", "gte", "between",
+            "array_contains", "array_contains_any", "array_contains_all", "array_size_eq"
+          ]
+        },
+        "value": {}
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 11.2: Run tests; 8 files remaining**
+
+- [ ] **Step 11.3: Commit**
+
+```bash
+git add crates/cairn-idl/schema/verbs/search.json
+git commit -m "cairn-idl: author search verb schema with recursive filter DSL"
+```
+
+---
+
+## Task 12: `verbs/retrieve.json` (6-branch tagged union)
+
+**Files:**
+- Create: `crates/cairn-idl/schema/verbs/retrieve.json`
+
+- [ ] **Step 12.1: Write the retrieve verb schema**
+
+Each branch has `{ target: const "..." }` as the discriminator, its own required fields, and its own `x-cairn-capability`. CLI forms are per-branch.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/retrieve.json",
+  "title": "Cairn verb: retrieve",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "retrieve",
+  "x-cairn-auth": "rebac",
+  "x-cairn-capability": null,
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use when you already have a record id, session id, turn id, folder path, scope, or need the user profile",
+      "use before summarize to pull source material into context"
+    ],
+    "negative": [
+      "do NOT use for free-text lookup — call search instead"
+    ],
+    "exclusivity": "this is the canonical by-id retrieval surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "oneOf": [
+        { "$ref": "#/$defs/ArgsRecord" },
+        { "$ref": "#/$defs/ArgsSession" },
+        { "$ref": "#/$defs/ArgsTurn" },
+        { "$ref": "#/$defs/ArgsFolder" },
+        { "$ref": "#/$defs/ArgsScope" },
+        { "$ref": "#/$defs/ArgsProfile" }
+      ]
+    },
+    "ArgsRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "id"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.record",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "positional": { "name": "id", "description": "Record ULID" }
+      },
+      "properties": {
+        "target": { "const": "record" },
+        "id": { "type": "string" }
+      }
+    },
+    "ArgsSession": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "session_id"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.session",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "session_id", "long": "session",   "value_source": "string" },
+          { "name": "limit",      "long": "limit",     "value_source": "u32" },
+          { "name": "order",      "long": "order",     "value_source": "enum(asc,desc)" },
+          { "name": "rehydrate",  "long": "rehydrate", "value_source": "bool" },
+          { "name": "include",    "long": "include",   "value_source": "list<enum(tool_calls,reasoning)>" }
+        ]
+      },
+      "properties": {
+        "target":     { "const": "session" },
+        "session_id": { "type": "string" },
+        "limit":      { "type": "integer", "minimum": 1, "maximum": 10000 },
+        "order":      { "type": "string", "enum": ["asc", "desc"] },
+        "rehydrate":  { "type": "boolean" },
+        "include": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["tool_calls", "reasoning"] }
+        }
+      }
+    },
+    "ArgsTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "session_id", "turn_id"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.turn",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "session_id", "long": "session", "value_source": "string" },
+          { "name": "turn_id",    "long": "turn",    "value_source": "u64" },
+          { "name": "include",    "long": "include", "value_source": "list<enum(tool_calls,reasoning)>" }
+        ]
+      },
+      "properties": {
+        "target":     { "const": "turn" },
+        "session_id": { "type": "string" },
+        "turn_id":    { "type": "integer", "minimum": 0 },
+        "include": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["tool_calls", "reasoning"] }
+        }
+      }
+    },
+    "ArgsFolder": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "path"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.folder",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "path",  "long": "folder", "value_source": "string" },
+          { "name": "depth", "long": "depth",  "value_source": "u8" }
+        ]
+      },
+      "properties": {
+        "target": { "const": "folder" },
+        "path":   { "type": "string" },
+        "depth":  { "type": "integer", "minimum": 0, "maximum": 16 }
+      }
+    },
+    "ArgsScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target", "scope"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.scope",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "scope", "long": "scope", "value_source": "json" }
+        ]
+      },
+      "properties": {
+        "target": { "const": "scope" },
+        "scope": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "ScopeFilter — same grammar as SearchArgs.filters."
+        }
+      }
+    },
+    "ArgsProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target"],
+      "x-cairn-capability": "cairn.mcp.v1.retrieve.profile",
+      "x-cairn-cli": {
+        "command": "retrieve",
+        "flags": [
+          { "name": "profile", "long": "profile", "value_source": "bool" },
+          { "name": "user",    "long": "user",    "value_source": "string" },
+          { "name": "agent",   "long": "agent",   "value_source": "string" }
+        ]
+      },
+      "properties": {
+        "target": { "const": "profile" },
+        "user":   { "type": "string" },
+        "agent":  { "type": "string" }
+      },
+      "anyOf": [
+        { "required": ["user"] },
+        { "required": ["agent"] }
+      ]
+    },
+    "Data": {
+      "oneOf": [
+        { "type": "object", "description": "Record response — see cairn-core MemoryRecord shape." },
+        { "type": "array",  "description": "Session / folder / scope responses return ordered item lists." },
+        { "type": "object", "description": "Profile response: { static: {...}, dynamic: {...}, updated_at }." }
+      ]
+    }
+  }
+}
+```
+
+- [ ] **Step 12.2: Run tests; 7 files remaining**
+
+- [ ] **Step 12.3: Commit**
+
+```bash
+git add crates/cairn-idl/schema/verbs/retrieve.json
+git commit -m "cairn-idl: author retrieve verb schema with six-branch tagged union"
+```
+
+---
+
+## Task 13: Flat-args verbs — `summarize`, `assemble_hot`, `capture_trace`, `lint`
+
+**Files:**
+- Create: `crates/cairn-idl/schema/verbs/summarize.json`
+- Create: `crates/cairn-idl/schema/verbs/assemble_hot.json`
+- Create: `crates/cairn-idl/schema/verbs/capture_trace.json`
+- Create: `crates/cairn-idl/schema/verbs/lint.json`
+
+- [ ] **Step 13.1: Write `verbs/summarize.json`**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/summarize.json",
+  "title": "Cairn verb: summarize",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "summarize",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "rebac",
+  "x-cairn-cli": {
+    "command": "summarize",
+    "positional": { "name": "record_ids", "description": "One or more record ULIDs.", "repeatable": true },
+    "flags": [
+      { "name": "persist",   "long": "persist",   "value_source": "bool" },
+      { "name": "kind",      "long": "kind",      "value_source": "string" },
+      { "name": "citations", "long": "citations", "value_source": "enum(on,compact,off)" }
+    ]
+  },
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use to roll up a list of known record ids into a single synthesis"
+    ],
+    "negative": [
+      "do NOT use to answer a general question — call search first"
+    ],
+    "exclusivity": "this is the canonical summarize surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_ids"],
+      "properties": {
+        "record_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "persist": {
+          "type": "boolean",
+          "x-cairn-auth": "write_capability",
+          "description": "When true, files the synthesis as a new reference or strategy_success memory."
+        },
+        "kind":      { "type": "string", "description": "Kind to file under if persist is true." },
+        "citations": { "type": "string", "enum": ["on", "compact", "off"] }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary"],
+      "properties": {
+        "summary":            { "type": "string" },
+        "persisted_record_id":{ "type": "string", "description": "Present when persist was true." }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 13.2: Write `verbs/assemble_hot.json`**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/assemble_hot.json",
+  "title": "Cairn verb: assemble_hot",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "assemble_hot",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "rebac",
+  "x-cairn-cli": {
+    "command": "assemble_hot",
+    "flags": [
+      { "name": "session_id", "long": "session", "value_source": "string" },
+      { "name": "budget",     "long": "budget",  "value_source": "u32" }
+    ]
+  },
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use at the start of every turn to load the hot-memory prefix for this agent/session"
+    ],
+    "negative": [
+      "do NOT call in a tight inner loop — one call per turn"
+    ],
+    "exclusivity": "this is the canonical hot-prefix surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "session_id": { "type": "string" },
+        "budget":     { "type": "integer", "minimum": 0, "description": "Byte budget for the assembled prefix (default 25000)." }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prefix", "bytes"],
+      "properties": {
+        "prefix": { "type": "string", "description": "Assembled hot-memory text ready to inject into the agent prompt." },
+        "bytes":  { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 13.3: Write `verbs/capture_trace.json`**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/capture_trace.json",
+  "title": "Cairn verb: capture_trace",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "capture_trace",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "signed_chain",
+  "x-cairn-cli": {
+    "command": "capture_trace",
+    "flags": [
+      { "name": "from",       "long": "from",    "value_source": "path" },
+      { "name": "session_id", "long": "session", "value_source": "string" }
+    ]
+  },
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use to persist a reasoning trajectory / transcript for later ACE distillation"
+    ],
+    "negative": [
+      "do NOT use for durable facts about the user or world — call ingest"
+    ],
+    "exclusivity": "this is the canonical trace-capture surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from"],
+      "properties": {
+        "from":       { "type": "string", "description": "Path to the trace log or transcript file." },
+        "session_id": { "type": "string" }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trace_id"],
+      "properties": {
+        "trace_id": { "type": "string" }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 13.4: Write `verbs/lint.json`**
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/lint.json",
+  "title": "Cairn verb: lint",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "lint",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "read_only",
+  "x-cairn-cli": {
+    "command": "lint",
+    "flags": [
+      { "name": "write_report", "long": "write-report", "value_source": "bool" }
+    ]
+  },
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use to check vault health — contradictions, orphans, stale claims, missing concept pages"
+    ],
+    "negative": [
+      "do NOT call per turn — run on a cadence (daily / on PR)"
+    ],
+    "exclusivity": "this is the canonical vault-health surface"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "write_report": {
+          "type": "boolean",
+          "x-cairn-auth": "write_capability",
+          "description": "When true, writes .cairn/lint-report.md."
+        }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "findings"],
+      "properties": {
+        "summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["total"],
+          "properties": {
+            "total":          { "type": "integer", "minimum": 0 },
+            "contradictions": { "type": "integer", "minimum": 0 },
+            "orphans":        { "type": "integer", "minimum": 0 },
+            "stale":          { "type": "integer", "minimum": 0 }
+          }
+        },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "message"],
+            "properties": {
+              "kind":      { "type": "string", "enum": ["contradiction", "orphan", "stale", "missing_concept", "data_gap"] },
+              "message":   { "type": "string" },
+              "record_id": { "type": "string" }
+            }
+          }
+        },
+        "report_path": { "type": "string" }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 13.5: Run tests; 1 file remaining**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+
+- [ ] **Step 13.6: Commit**
+
+```bash
+git add crates/cairn-idl/schema/verbs/summarize.json crates/cairn-idl/schema/verbs/assemble_hot.json crates/cairn-idl/schema/verbs/capture_trace.json crates/cairn-idl/schema/verbs/lint.json
+git commit -m "cairn-idl: author summarize, assemble_hot, capture_trace, lint verb schemas"
+```
+
+---
+
+## Task 14: `verbs/forget.json` (3-branch mode gate)
+
+**Files:**
+- Create: `crates/cairn-idl/schema/verbs/forget.json`
+
+- [ ] **Step 14.1: Write the forget verb schema**
+
+Each mode branch pins `mode: const "..."` and carries its own `x-cairn-capability` + `x-cairn-since`. Runtime checks the capability before dispatch; a v0.1 build rejects non-`record` modes.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/verbs/forget.json",
+  "title": "Cairn verb: forget",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "x-cairn-verb-id": "forget",
+  "x-cairn-capability": null,
+  "x-cairn-auth": "forget_capability",
+  "x-cairn-skill-triggers": {
+    "positive": [
+      "use when the user asks to delete or forget a specific record / session / scope",
+      "use as part of a compliance-driven forget-me flow"
+    ],
+    "negative": [
+      "do NOT use to 'mark as resolved' — that belongs to an ingest with kind:feedback",
+      "do NOT use on a draft the user wants to edit — that belongs to ingest with version bump"
+    ],
+    "exclusivity": "this is the single delete surface — there is no other delete path"
+  },
+  "type": "object",
+  "$defs": {
+    "Args": {
+      "oneOf": [
+        { "$ref": "#/$defs/ArgsRecord" },
+        { "$ref": "#/$defs/ArgsSession" },
+        { "$ref": "#/$defs/ArgsScope" }
+      ]
+    },
+    "ArgsRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "record_id"],
+      "x-cairn-capability": "cairn.mcp.v1.forget.record",
+      "x-cairn-since": "v0.1",
+      "x-cairn-cli": {
+        "command": "forget",
+        "flags": [
+          { "name": "record_id", "long": "record", "value_source": "string" }
+        ]
+      },
+      "properties": {
+        "mode":      { "const": "record" },
+        "record_id": { "type": "string" }
+      }
+    },
+    "ArgsSession": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "session_id"],
+      "x-cairn-capability": "cairn.mcp.v1.forget.session",
+      "x-cairn-since": "v0.2",
+      "x-cairn-cli": {
+        "command": "forget",
+        "flags": [
+          { "name": "session_id", "long": "session", "value_source": "string" }
+        ]
+      },
+      "properties": {
+        "mode":       { "const": "session" },
+        "session_id": { "type": "string" }
+      }
+    },
+    "ArgsScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "scope"],
+      "x-cairn-capability": "cairn.mcp.v1.forget.scope",
+      "x-cairn-since": "v0.3",
+      "x-cairn-cli": {
+        "command": "forget",
+        "flags": [
+          { "name": "scope", "long": "scope", "value_source": "json" }
+        ]
+      },
+      "properties": {
+        "mode":  { "const": "scope" },
+        "scope": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "Data": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["deleted_count"],
+      "properties": {
+        "deleted_count": { "type": "integer", "minimum": 0 },
+        "tombstones":    { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 14.2: Run tests; all manifest files now exist**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+Expected: all four existing tests PASS.
+
+- [ ] **Step 14.3: Commit**
+
+```bash
+git add crates/cairn-idl/schema/verbs/forget.json
+git commit -m "cairn-idl: author forget verb schema with three-mode gate"
+```
+
+---
+
+## Task 15: `x-cairn-capability` reachability check
+
+**Files:**
+- Modify: `crates/cairn-idl/tests/schema_files.rs`
+
+- [ ] **Step 15.1: Add the test**
+
+Append to `crates/cairn-idl/tests/schema_files.rs`:
+
+```rust
+fn capabilities_enum() -> BTreeSet<String> {
+    let caps = read_json(&schema_dir().join("capabilities/capabilities.json"));
+    let arr = caps
+        .get("oneOf")
+        .and_then(Value::as_array)
+        .expect("capabilities.json: oneOf must be an array");
+    arr.iter()
+        .map(|entry| {
+            entry
+                .get("const")
+                .and_then(Value::as_str)
+                .expect("capabilities.json oneOf entries must have a const string")
+                .to_string()
+        })
+        .collect()
+}
+
+fn collect_capability_refs(v: &Value, out: &mut Vec<String>) {
+    match v {
+        Value::Object(map) => {
+            if let Some(cap) = map.get("x-cairn-capability").and_then(Value::as_str) {
+                out.push(cap.to_string());
+            }
+            for (_, child) in map {
+                collect_capability_refs(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_capability_refs(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn every_x_cairn_capability_is_in_capabilities_enum() {
+    let enum_set = capabilities_enum();
+    for path in manifest_paths() {
+        let v = read_json(&path);
+        let mut refs: Vec<String> = Vec::new();
+        collect_capability_refs(&v, &mut refs);
+        for cap in refs {
+            assert!(
+                enum_set.contains(&cap),
+                "{path:?} references capability {cap:?} that is not in capabilities.json"
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 15.2: Run tests; all pass**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+Expected: all PASS.
+
+- [ ] **Step 15.3: Commit**
+
+```bash
+git add crates/cairn-idl/tests/schema_files.rs
+git commit -m "cairn-idl: test every x-cairn-capability resolves in capabilities enum"
+```
+
+---
+
+## Task 16: `$ref` resolvability check
+
+**Files:**
+- Modify: `crates/cairn-idl/tests/schema_files.rs`
+
+Every `$ref` is either a local `#/$defs/...` pointer or a sibling file under `schema/` that exists. The walk is intentionally lightweight — JSON-Pointer resolution is deferred to the #35 validator pipeline.
+
+- [ ] **Step 16.1: Add the test**
+
+Append to `crates/cairn-idl/tests/schema_files.rs`:
+
+```rust
+fn collect_refs(v: &Value, out: &mut Vec<String>) {
+    match v {
+        Value::Object(map) => {
+            if let Some(r) = map.get("$ref").and_then(Value::as_str) {
+                out.push(r.to_string());
+            }
+            for (_, child) in map {
+                collect_refs(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_refs(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn ref_points_at_existing_file(source_path: &Path, reference: &str) -> bool {
+    let (file_part, _fragment) = reference
+        .split_once('#')
+        .unwrap_or((reference, ""));
+    if file_part.is_empty() {
+        return true; // local #/... ref — resolution deferred to #35 validator
+    }
+    let source_dir = source_path.parent().expect("schema file has parent");
+    let target = source_dir.join(file_part);
+    target.is_file()
+}
+
+#[test]
+fn every_ref_resolves_to_a_real_file_or_local_fragment() {
+    for path in manifest_paths() {
+        let v = read_json(&path);
+        let mut refs: Vec<String> = Vec::new();
+        collect_refs(&v, &mut refs);
+        for r in refs {
+            assert!(
+                ref_points_at_existing_file(&path, &r),
+                "{path:?} references {r:?} which does not resolve to a sibling schema file"
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 16.2: Run tests; all pass**
+
+Run: `cargo test -p cairn-idl --test schema_files`
+Expected: all PASS.
+
+- [ ] **Step 16.3: Commit**
+
+```bash
+git add crates/cairn-idl/tests/schema_files.rs
+git commit -m "cairn-idl: test every cross-file \$ref resolves to a real schema file"
+```
+
+---
+
+## Task 17: Final workspace verification
+
+**Files:**
+- No file changes. Verification only.
+
+- [ ] **Step 17.1: Run full workspace tests**
+
+Run: `cargo test --workspace`
+Expected: all green across every crate.
+
+- [ ] **Step 17.2: Run core boundary script**
+
+Run: `bash scripts/check-core-boundary.sh`
+Expected: `cairn-core boundary OK`.
+
+- [ ] **Step 17.3: Confirm `cairn-codegen` still fails closed**
+
+Run: `cargo run -p cairn-idl --bin cairn-codegen`
+Expected: exit code `2`; stderr contains `"not yet implemented"`; stdout empty. This is exercised by the existing `tests/smoke.rs::codegen_binary_fails_closed` test.
+
+- [ ] **Step 17.4: Spot-check manifest against §8.0 / §13.3**
+
+Run: `python3 -c 'import json,sys; m=json.load(open("crates/cairn-idl/schema/index.json")); print("\n".join(m["x-cairn-verb-ids"]))'`
+Expected output, exactly:
+
+```
+ingest
+search
+retrieve
+summarize
+assemble_hot
+capture_trace
+lint
+forget
+```
+
+Cross-check against `docs/design/2026-04-23-cairn-idl-design.md` "Acceptance Mapping" table.
+
+- [ ] **Step 17.5: Confirm no extra files on disk under `schema/`**
+
+Run: `find crates/cairn-idl/schema -type f | sort`
+Expected:
+
+```
+crates/cairn-idl/schema/README.md
+crates/cairn-idl/schema/capabilities/capabilities.json
+crates/cairn-idl/schema/envelope/request.json
+crates/cairn-idl/schema/envelope/response.json
+crates/cairn-idl/schema/envelope/signed_intent.json
+crates/cairn-idl/schema/errors/error.json
+crates/cairn-idl/schema/extensions/registry.json
+crates/cairn-idl/schema/index.json
+crates/cairn-idl/schema/prelude/handshake.json
+crates/cairn-idl/schema/prelude/status.json
+crates/cairn-idl/schema/verbs/assemble_hot.json
+crates/cairn-idl/schema/verbs/capture_trace.json
+crates/cairn-idl/schema/verbs/forget.json
+crates/cairn-idl/schema/verbs/ingest.json
+crates/cairn-idl/schema/verbs/lint.json
+crates/cairn-idl/schema/verbs/retrieve.json
+crates/cairn-idl/schema/verbs/search.json
+crates/cairn-idl/schema/verbs/summarize.json
+```
+
+- [ ] **Step 17.6: Clean working tree**
+
+Run: `git status`
+Expected: `nothing to commit, working tree clean`.
+
+---
+
+## Done When
+
+- `cargo test --workspace` is green.
+- `bash scripts/check-core-boundary.sh` exits 0.
+- `find crates/cairn-idl/schema -type f` matches the 18-file list above exactly.
+- `crates/cairn-idl/schema/index.json` `x-cairn-verb-ids` is the literal §8.0 eight-name set in order.
+- `cairn-codegen` still exits `2` with `"not yet implemented"`.
+- `crates/cairn-idl/tests/schema_files.rs` contains six tests: `manifest_parses_and_has_required_top_level_keys`, `manifest_verb_ids_match_eight_verb_set_in_order`, `every_manifest_file_exists_and_parses_and_has_top_level_fields`, `manifest_and_filesystem_are_bijective`, `every_x_cairn_capability_is_in_capabilities_enum`, `every_ref_resolves_to_a_real_file_or_local_fragment`. Existing `tests/smoke.rs` keeps its three tests (including the Task 1 addition). Spec's seven structural checks map onto these: checks 1/2/5 are covered by the two `*_top_level_*` tests (they assert parse, required top-level keys, and `x-cairn-contract` equality together); checks 3/4/6/7 have their own tests.


### PR DESCRIPTION
## Summary
- Authored the P0 canonical IDL as JSON Schema draft-2020-12 + `x-cairn-*` vendor keys under `crates/cairn-idl/schema/`, covering all 8 verbs (ingest, search, retrieve, summarize, assemble_hot, capture_trace, lint, forget), the signed-intent/request/response envelopes, the closed error enum, the capability + mandatory-surface registry, the extension namespace registry, and the shared primitives (ULID, Nonce16Base64, Ed25519Signature, Identity, Cursor) + scope_filter grammar.
- Response envelope dispatches per-verb and per-(verb, retrieve target); rejected/aborted statuses partition the error codes across vendor-key + inline-arm enums; UnknownVerb has a canonical `verb: "unknown"` sentinel; every extension is bidirectionally bound to its capability in status.
- Ten rounds of Codex adversarial review landed structural tightening: canonical 16-byte base64 nonces, ULID refs on every identifier, scope filter covering every signed-intent dimension, shared Cursor for round-trip pagination, filter recursion unrolled to depth 8 (a schema assertion, not just metadata), per-target retrieve Data shapes, and a Rust test harness (10 tests) that enforces schema bijection, capability coverage, assertion coverage, vendor-key/inline-enum agreement, and $ref resolvability.

Closes #34.

## Test plan
- [x] `cargo test -p cairn-idl` — 10 structural tests pass
- [x] Python `jsonschema` Draft 2020-12 validates every file
- [x] Functional spot-checks across rounds 4–10 verify negative cases: bad nonces, non-ULID ids, scope typos, UnknownVerb misuse, retrieve target mismatch, cursor > 512 bytes, filter depth > 8
- [ ] Reviewer confirms the vendor-key/mandatory-surface split in `capabilities.json` matches runtime expectations
- [ ] Reviewer confirms retrieve per-target Data shapes (DataSession/Turn/Folder/Scope/Record/Profile) align with downstream codegen plan (#35)