### PR TITLE
docs: monorepo + governance decision (ADR 0001, closes #145)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,20 @@
 # Governance: see GOVERNANCE.md. Decision: docs/design/decisions/0001-monorepo-governance.md.
 #
 # Seed model: every path routes to the sole maintainer while the roster is one
-# entry deep. When the repo converts to an organisation and a second maintainer
-# joins, replace `@windoliver` with `@cairn-project/maintainers` and begin
-# splitting per-contract ownership (one team per contract area from brief §4).
+# entry deep. CODEOWNERS is informational during the single-maintainer period
+# (GOVERNANCE.md §5) — branch protection does NOT require a CODEOWNERS review
+# until a second maintainer exists, because GitHub disallows self-approval and
+# the rule would otherwise deadlock the repo.
+#
+# Transition points:
+#   - Second maintainer joins  → end the single-maintainer deviation, enable
+#                                required-review branch protection, optionally
+#                                migrate from `@windoliver` to a
+#                                `@cairn-project/maintainers` team if the repo
+#                                has converted to an organisation.
+#   - Third maintainer joins   → consider seeding per-contract teams (one team
+#                                per area in GOVERNANCE.md §2). Optional; tied
+#                                to reviewer depth per area, not headcount alone.
 #
 # Syntax: GitHub CODEOWNERS. The LAST matching pattern wins per path.
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,42 @@
+# CODEOWNERS for Cairn
+#
+# Governance: see GOVERNANCE.md. Decision: docs/design/decisions/0001-monorepo-governance.md.
+#
+# Seed model: every path routes to the sole maintainer while the roster is one
+# entry deep. When the repo converts to an organisation and a second maintainer
+# joins, replace `@windoliver` with `@cairn-project/maintainers` and begin
+# splitting per-contract ownership (one team per contract area from brief §4).
+#
+# Syntax: GitHub CODEOWNERS. The LAST matching pattern wins per path.
+
+* @windoliver
+
+# Core traits, pure pipeline, IDL — the plugin boundary (brief §4, §4.1)
+/crates/cairn-core/                 @windoliver
+/crates/cairn-idl/                  @windoliver
+
+# Adapters — one team per contract in the future
+/crates/cairn-cli/                  @windoliver
+/crates/cairn-mcp/                  @windoliver
+/crates/cairn-store-sqlite/         @windoliver
+/crates/cairn-sensors-local/        @windoliver
+/crates/cairn-workflows/            @windoliver
+/crates/cairn-test-fixtures/        @windoliver
+
+# Non-Rust SDKs / skill packages (brief §16)
+/packages/                          @windoliver
+
+# Design + governance
+/docs/design/                       @windoliver
+/docs/design/decisions/             @windoliver
+/GOVERNANCE.md                      @windoliver
+/MAINTAINERS.md                     @windoliver
+/CLAUDE.md                          @windoliver
+
+# CI, release tooling, supply chain
+/.github/                           @windoliver
+/scripts/                           @windoliver
+/deny.toml                          @windoliver
+/rust-toolchain.toml                @windoliver
+/Cargo.toml                         @windoliver
+/Cargo.lock                         @windoliver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # CODEOWNERS for Cairn
 #
-# Governance: see GOVERNANCE.md. Decision: docs/design/decisions/0001-monorepo-governance.md.
+# Governance: see GOVERNANCE.md. Decision: docs/design/decisions/0002-monorepo-governance.md.
 #
 # Seed model: every path routes to the sole maintainer while the roster is one
 # entry deep. CODEOWNERS is informational during the single-maintainer period

--- a/.github/freezes/README.md
+++ b/.github/freezes/README.md
@@ -1,0 +1,42 @@
+# Active path freezes
+
+Freeze files in this directory are consumed by
+`scripts/check-freeze.sh` (run from the required
+`governance / freeze` status check in
+`.github/workflows/governance.yml`). When one is present, any PR whose
+diff touches a path listed under `paths:` fails the check and cannot
+merge.
+
+Freezes are created under ADR 0001 "Immediate containment when a hard
+trigger fires" (`docs/design/decisions/0001-monorepo-governance.md`).
+They are **not** a routine mechanism — they exist to halt merges on a
+specific crate or path while a licensing, security, or external-SLA
+hard trigger is being resolved.
+
+## File format
+
+One YAML file per active freeze; filename convention
+`YYYY-MM-DD-<trigger>-<slug>.yaml`. Only the `paths:` list is machine-
+parsed; every other field is human audit context.
+
+```yaml
+trigger: H2                # hard-trigger ID from ADR 0001
+issue: https://github.com/windoliver/cairn/issues/NNN
+owner: "@windoliver"
+opened: 2026-04-24
+deadline: 2026-05-08       # 14 days max per ADR 0001 containment rule
+reason: |
+  One-paragraph rationale. Summary of the hard trigger and interim
+  mitigation in place.
+paths:
+  - crates/cairn-store-sqlite/
+  - crates/cairn-store-sqlite/Cargo.toml
+```
+
+## Removing a freeze
+
+Open a PR that deletes the file. Label it `governance:freeze-removal`
+(exempt from the freeze gate so the freeze itself can be lifted). The
+PR description must link to the resolution: either the extraction ADR
+that supersedes the freeze, or a written statement from the owner that
+the trigger no longer applies.

--- a/.github/freezes/README.md
+++ b/.github/freezes/README.md
@@ -7,8 +7,8 @@ Freeze files in this directory are consumed by
 diff touches a path listed under `paths:` fails the check and cannot
 merge.
 
-Freezes are created under ADR 0001 "Immediate containment when a hard
-trigger fires" (`docs/design/decisions/0001-monorepo-governance.md`).
+Freezes are created under ADR 0002 "Immediate containment when a hard
+trigger fires" (`docs/design/decisions/0002-monorepo-governance.md`).
 They are **not** a routine mechanism — they exist to halt merges on a
 specific crate or path while a licensing, security, or external-SLA
 hard trigger is being resolved.
@@ -20,11 +20,11 @@ One YAML file per active freeze; filename convention
 parsed; every other field is human audit context.
 
 ```yaml
-trigger: H2                # hard-trigger ID from ADR 0001
+trigger: H2                # hard-trigger ID from ADR 0002
 issue: https://github.com/windoliver/cairn/issues/NNN
 owner: "@windoliver"
 opened: 2026-04-24
-deadline: 2026-05-08       # 14 days max per ADR 0001 containment rule
+deadline: 2026-05-08       # 14 days max per ADR 0002 containment rule
 reason: |
   One-paragraph rationale. Summary of the hard trigger and interim
   mitigation in place.

--- a/.github/freezes/README.md
+++ b/.github/freezes/README.md
@@ -33,6 +33,21 @@ paths:
   - crates/cairn-store-sqlite/Cargo.toml
 ```
 
+A special sentinel entry `**` means "freeze every path in the
+repository." It is used by the second-maintainer transition freeze
+documented in `GOVERNANCE.md` §5.4, where the `governance:transition`
+and `governance:freeze-removal` label exemptions are the only way for
+PRs to land until the freeze is lifted.
+
+```yaml
+trigger: transition
+issue: https://github.com/windoliver/cairn/issues/NNN
+opened: 2026-04-24
+deadline: 2026-04-28
+paths:
+  - "**"
+```
+
 ## Removing a freeze
 
 Open a PR that deletes the file. Label it `governance:freeze-removal`

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,27 @@
+name: governance
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  reviewed-by-load-bearing:
+    name: reviewed-by / load-bearing paths
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce Reviewed-by trailer on load-bearing paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: bash scripts/check-reviewed-by.sh

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -11,23 +11,33 @@ name: governance
 # `scripts/check-freeze.sh` gate, both installed on `main` first.
 
 on:
+  # Only pull_request_target — deliberately NOT pull_request_review.
+  # `pull_request_review` runs on the PR merge ref (PR-controlled YAML
+  # can emit the same required-check names from a modified workflow),
+  # so adding it would undermine the trusted-base enforcement model.
+  # `synchronize` fires on any new commit to the PR branch, which is
+  # enough to re-run the gate in the normal case; stale approvals
+  # between a dismissal and a new push are addressed via the dismissal-
+  # refresh runbook below rather than by adding an untrusted trigger.
   pull_request_target:
     branches: [main]
-    types: [opened, synchronize, reopened, edited, ready_for_review, review_requested, review_request_removed, labeled, unlabeled]
-  # Re-run the gate when review state changes (submitted / edited /
-  # dismissed). Without this, a dismissed or CHANGES_REQUESTED review
-  # would not invalidate a previously-green required check for the same
-  # HEAD during the single-maintainer period, where the reviewed-by job
-  # is the only mechanical approval gate.
-  pull_request_review:
-    types: [submitted, edited, dismissed]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - ready_for_review
+      - review_requested
+      - review_request_removed
+      - labeled
+      - unlabeled
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: governance-${{ github.event.pull_request.number || github.event.review.pull_request.number }}
+  group: governance-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -13,19 +13,27 @@ name: governance
 on:
   pull_request_target:
     branches: [main]
-    types: [opened, synchronize, reopened, edited, ready_for_review, review_requested, review_request_removed]
+    types: [opened, synchronize, reopened, edited, ready_for_review, review_requested, review_request_removed, labeled, unlabeled]
+  # Re-run the gate when review state changes (submitted / edited /
+  # dismissed). Without this, a dismissed or CHANGES_REQUESTED review
+  # would not invalidate a previously-green required check for the same
+  # HEAD during the single-maintainer period, where the reviewed-by job
+  # is the only mechanical approval gate.
+  pull_request_review:
+    types: [submitted, edited, dismissed]
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: governance-${{ github.event.pull_request.number }}
+  group: governance-${{ github.event.pull_request.number || github.event.review.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   reviewed-by-load-bearing:
     name: reviewed-by / load-bearing paths
+    if: github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Check out BASE ref (trusted)
@@ -48,11 +56,11 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: bash scripts/check-reviewed-by.sh
 
   freeze-check:
     name: freeze / active path freezes
+    if: github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Check out BASE ref (trusted)
@@ -60,6 +68,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
 
       - name: Fetch PR head SHA (metadata only)
         run: |

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,27 +1,75 @@
 name: governance
 
+# Uses `pull_request_target` so the job runs in the trusted base-branch
+# context, not the PR's workspace. This prevents a PR from modifying the
+# enforcement logic (script or workflow) to bypass the gate. The checkout
+# step ALWAYS checks out the PR's base ref; the PR head is fetched only
+# as a bare SHA for diffing, never checked out or executed.
+#
+# SECURITY: this workflow must not execute any file contributed by the PR.
+# It runs only `scripts/check-reviewed-by.sh` from the base ref and the
+# `scripts/check-freeze.sh` gate, both installed on `main` first.
+
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
+    types: [opened, synchronize, reopened, edited, ready_for_review, review_requested, review_request_removed]
 
 permissions:
   contents: read
   pull-requests: read
+
+concurrency:
+  group: governance-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   reviewed-by-load-bearing:
     name: reviewed-by / load-bearing paths
     runs-on: ubuntu-latest
     steps:
-      - name: Check out PR head
+      - name: Check out BASE ref (trusted)
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
 
-      - name: Enforce Reviewed-by trailer on load-bearing paths
+      - name: Fetch PR head SHA (metadata only; not checked out)
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=200 origin \
+            "+${{ github.event.pull_request.head.sha }}:refs/pr-head"
+
+      - name: Enforce Reviewed-by rule on load-bearing paths
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bash scripts/check-reviewed-by.sh
+
+  freeze-check:
+    name: freeze / active path freezes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out BASE ref (trusted)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Fetch PR head SHA (metadata only)
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=200 origin \
+            "+${{ github.event.pull_request.head.sha }}:refs/pr-head"
+
+      - name: Enforce active freezes
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: bash scripts/check-reviewed-by.sh
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: bash scripts/check-freeze.sh

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -138,7 +138,8 @@ sync with `CLAUDE.md` §9 and `scripts/check-reviewed-by.sh`):
 - `docs/design/design-brief.md`
 - `docs/design/decisions/` (any ADR)
 - `GOVERNANCE.md`, `MAINTAINERS.md`, `.github/CODEOWNERS`
-- `.github/workflows/governance.yml`, `scripts/check-reviewed-by.sh`
+- `.github/workflows/governance.yml`, `.github/freezes/`
+- `scripts/check-reviewed-by.sh`, `scripts/check-freeze.sh`
 
 ### 5.3. Enforceable external-review rule
 
@@ -172,35 +173,65 @@ would otherwise deadlock.
 Merging a load-bearing PR without the above is a governance breach and
 must be reverted and re-submitted under the proper process.
 
-### 5.4. Transition off the deviation — atomic runbook
+### 5.4. Transition off the deviation — ordered runbook
 
-The deviation is removed atomically when the second maintainer is added.
-The single nomination PR must contain **all** of the following and must be
-merged as one unit; no other PR may merge between the branch-protection
-update and the nomination PR:
+GitHub evaluates `CODEOWNERS` and branch-protection rules against the
+**base branch** at PR-review time, so enabling "Require review from Code
+Owners" **before** the nominee is written into `main`'s CODEOWNERS would
+lock the repository: the sole existing owner can't self-approve, and the
+nominee isn't yet a code owner on base. The runbook therefore deliberately
+changes branch-protection rules **after** the nomination PR merges, not
+before, and prevents an intermediate-state gap with a merge freeze plus a
+transition-specific active path freeze.
 
-1. Add the new maintainer to `MAINTAINERS.md` (with contract-area
-   annotations per §2).
-2. Update `.github/CODEOWNERS` to include the new maintainer wherever
-   relevant; at minimum every path gains them as an owner.
-3. Remove this §5 from `GOVERNANCE.md` and update any cross-references
-   (ADR 0001, brief §20.1, CODEOWNERS comment header).
-4. Update `MAINTAINERS.md`'s change log to record the end of the
-   single-maintainer period with its date.
-5. Include the external `Reviewed-by:` trailer from the nominated
-   maintainer themselves (they are not the author of their own nomination
-   if §1 procedure is followed) or from another external reviewer.
+Steps (executed in order, by the sole maintainer unless stated):
 
-Before this PR merges, the maintainer opening it also completes the
-GitHub branch-protection configuration change: enable "Require
-approvals = 1" and "Require review from Code Owners" on `main`. The PR
-then merges under the new rule. No intermediate state exists in which
-neither §5 nor the CODEOWNERS-required-approval rule governs the
-repository.
+1. **Grant the nominee write access** to the repository (Settings →
+   Collaborators). This allows them to leave a non-stale Approved review
+   on the nomination PR but does **not** make them a code owner yet.
+2. **Open a pre-transition freeze PR** that adds
+   `.github/freezes/<date>-transition.yaml` freezing every path except
+   `MAINTAINERS.md`, `.github/CODEOWNERS`, `GOVERNANCE.md`, and
+   `docs/design/decisions/`. This prevents any non-transition work
+   merging during the window. The freeze PR is itself load-bearing and
+   goes through the §5.3 Approved-review + `Reviewed-by:` gate, with the
+   nominee as the approving reviewer.
+3. **Open the nomination PR** containing, in one commit or squashed:
+   (a) `MAINTAINERS.md` addition with contract-area annotations,
+   (b) `.github/CODEOWNERS` update adding the nominee to every affected
+   path, (c) removal of this §5 (and update of every cross-reference:
+   ADR 0001, brief §20.1, CODEOWNERS comment header,
+   `scripts/check-reviewed-by.sh` load-bearing path list if obsolete),
+   (d) `MAINTAINERS.md` change-log entry recording the date and PR
+   number that ended the single-maintainer period,
+   (e) removal of the transition freeze file from
+   `.github/freezes/`. The PR is labelled `governance:freeze-removal`
+   so the freeze gate exempts it. The nominee leaves an Approved
+   review; a `Reviewed-by:` trailer names them.
+4. **Merge the nomination PR** (squash). The new CODEOWNERS is now on
+   `main`.
+5. **Update branch protection** (Settings → Branches): enable
+   `Require a pull request before merging`, `Required approvals = 1`,
+   `Dismiss stale pull request approvals when new commits are pushed`,
+   `Require review from Code Owners`, and keep the `governance /
+   reviewed-by` required status check active (the script's load-bearing
+   gate now overlaps with CODEOWNERS but the redundancy is cheap and
+   fails closed). Remove the `governance / freeze` requirement only if
+   there are no active freezes.
+6. **Announce the transition** in the `MAINTAINERS.md` change-log entry
+   (already committed in step 3) and, if the project has any external
+   communication channel, there as well.
 
-If the second-maintainer PR has to be split across multiple commits for
-review clarity, all commits must land in one merge; squashing is the
-default merge strategy for this specific transition PR.
+Until step 5 completes, no PR other than the transition PR may merge
+(enforced by the freeze file committed in step 2). If any of the steps
+fail or stall, the fallback is to reopen the freeze and re-run from the
+last successful step — the transition is resumable because every step
+leaves a committed artefact.
+
+A future "third maintainer joins" transition is not gated by
+`GOVERNANCE.md` at all — it triggers a separate, optional per-contract
+team seed under §2 without touching §5 (by then removed) or branch
+protection.
 
 ---
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -110,34 +110,97 @@ touches both.
 ## 5. Time-limited deviation — single-maintainer period
 
 While the repository has **exactly one** maintainer in `MAINTAINERS.md`,
-required-reviewer branch protection cannot be satisfied by the sole
+required-approval branch protection cannot be satisfied by the sole
 maintainer on their own PRs (GitHub disallows PR authors from approving
 their own pull requests). The deviation resolves this without relying on an
-admin bypass:
+admin bypass, and keeps a **mechanically-enforced gate** on load-bearing
+changes.
 
-- **Branch protection does not require a CODEOWNERS or approving review**
-  during this period. CODEOWNERS remains in place as a reviewer-request
-  hint and an informational ownership map, not an enforcement gate.
-- **Required status checks remain on** (CI must pass) and **force-push to
-  `main` stays blocked**; the deviation is scoped narrowly to the "require
-  N approvals" rule.
-- **Load-bearing PRs** (as listed in `CLAUDE.md` §9 — core traits, WAL,
-  consent journal, config schema; plus any change to this document or to
-  `docs/design/decisions/`) **must** solicit and obtain at least one
-  external review before merge. The sole maintainer records the reviewer
-  (GitHub handle or email) in the PR description under a `Reviewed-by:`
-  trailer. Merging a load-bearing PR without a recorded external review is
-  a governance breach.
-- **On the first PR after a second maintainer joins**, enable required
-  CODEOWNERS review in branch protection, remove this §5 from the document
-  by PR (that PR itself benefits from the newly-available second
-  approver), and update `MAINTAINERS.md` to note the end of the
-  single-maintainer period in its change log.
+### 5.1. Branch-protection settings during this period
 
-No admin-bypass or ruleset-bypass path is authorised for the single
-maintainer during this period. The hard floor is the `Reviewed-by:` trailer
-for load-bearing changes; everything else relies on community scrutiny of
-the public commit log.
+- **Required status checks remain on** (CI must pass — including the
+  `governance / reviewed-by` check defined in §5.3).
+- **Force-push to `main` is blocked.**
+- **Signed commits are recommended** but not required.
+- **"Required approvals = 1" is disabled** — see rationale above; this is
+  the narrow scope of the deviation.
+- **Admin / ruleset bypass is NOT granted** to the sole maintainer. The
+  `governance / reviewed-by` required status check is the hard gate.
+
+### 5.2. Load-bearing paths
+
+A PR is **load-bearing** if its diff touches any of the following (kept in
+sync with `CLAUDE.md` §9 and `scripts/check-reviewed-by.sh`):
+
+- `crates/cairn-core/src/` or `crates/cairn-core/Cargo.toml`
+- `crates/cairn-idl/` (IDL source and generated artefacts)
+- `crates/cairn-store-sqlite/migrations/` (append-only migrations)
+- `docs/design/design-brief.md`
+- `docs/design/decisions/` (any ADR)
+- `GOVERNANCE.md`, `MAINTAINERS.md`, `.github/CODEOWNERS`
+- `.github/workflows/governance.yml`, `scripts/check-reviewed-by.sh`
+
+### 5.3. Enforceable external-review rule
+
+For every load-bearing PR during this period:
+
+1. An **external reviewer** (GitHub account other than the PR author) must
+   leave an **Approved** review on the PR before merge. The review is
+   permanently recorded in the PR timeline and is queryable via the
+   GitHub API.
+2. The PR must carry a `Reviewed-by:` trailer naming the external
+   reviewer, either in the **merge commit body** or in the **PR
+   description**:
+
+   ```
+   Reviewed-by: Jane Doe <@janedoe>
+   ```
+
+3. The `governance / reviewed-by` CI job
+   (`.github/workflows/governance.yml` + `scripts/check-reviewed-by.sh`)
+   inspects the PR diff; if it touches load-bearing paths and no valid
+   `Reviewed-by:` trailer is present (or the trailer names the author),
+   the check fails and the PR cannot merge. This check is listed in
+   branch protection as a required status check.
+
+The combination of the GitHub Approved review (social + auditable), the
+commit trailer (audit artefact surviving in `git log`), and the required
+status check (mechanical gate) makes the rule enforceable without relying
+on the 1-approval branch-protection rule that GitHub's self-approval ban
+would otherwise deadlock.
+
+Merging a load-bearing PR without the above is a governance breach and
+must be reverted and re-submitted under the proper process.
+
+### 5.4. Transition off the deviation — atomic runbook
+
+The deviation is removed atomically when the second maintainer is added.
+The single nomination PR must contain **all** of the following and must be
+merged as one unit; no other PR may merge between the branch-protection
+update and the nomination PR:
+
+1. Add the new maintainer to `MAINTAINERS.md` (with contract-area
+   annotations per §2).
+2. Update `.github/CODEOWNERS` to include the new maintainer wherever
+   relevant; at minimum every path gains them as an owner.
+3. Remove this §5 from `GOVERNANCE.md` and update any cross-references
+   (ADR 0001, brief §20.1, CODEOWNERS comment header).
+4. Update `MAINTAINERS.md`'s change log to record the end of the
+   single-maintainer period with its date.
+5. Include the external `Reviewed-by:` trailer from the nominated
+   maintainer themselves (they are not the author of their own nomination
+   if §1 procedure is followed) or from another external reviewer.
+
+Before this PR merges, the maintainer opening it also completes the
+GitHub branch-protection configuration change: enable "Require
+approvals = 1" and "Require review from Code Owners" on `main`. The PR
+then merges under the new rule. No intermediate state exists in which
+neither §5 nor the CODEOWNERS-required-approval rule governs the
+repository.
+
+If the second-maintainer PR has to be split across multiple commits for
+review clarity, all commits must land in one merge; squashing is the
+default merge strategy for this specific transition PR.
 
 ---
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -151,12 +151,16 @@ For every load-bearing PR during this period:
    permanently recorded in the PR timeline and is queryable via the
    GitHub API.
 2. The PR must carry a `Reviewed-by:` trailer naming the external
-   reviewer, either in the **merge commit body** or in the **PR
-   description**:
+   reviewer in a **commit message** on the PR branch (not the PR
+   description — the gate deliberately ignores PR-body text so the
+   audit artefact survives squash-merge in `git log`):
 
    ```
    Reviewed-by: Jane Doe <@janedoe>
    ```
+
+   Amend or add a commit whose message body includes this trailer
+   before the gate runs (or after, then push again).
 
 3. The `governance / reviewed-by` CI job
    (`.github/workflows/governance.yml` + `scripts/check-reviewed-by.sh`)
@@ -166,13 +170,29 @@ For every load-bearing PR during this period:
    branch protection as a required status check.
 
 The combination of the GitHub Approved review (social + auditable), the
-commit trailer (audit artefact surviving in `git log`), and the required
-status check (mechanical gate) makes the rule enforceable without relying
-on the 1-approval branch-protection rule that GitHub's self-approval ban
-would otherwise deadlock.
+commit-message trailer (audit artefact surviving in `git log`), and the
+required status check (mechanical gate) makes the rule enforceable
+without relying on the 1-approval branch-protection rule that GitHub's
+self-approval ban would otherwise deadlock.
 
-Merging a load-bearing PR without the above is a governance breach and
-must be reverted and re-submitted under the proper process.
+**Dismissal / CHANGES_REQUESTED refresh.** The required status check
+deliberately does **not** register for `pull_request_review` events:
+that trigger runs on the PR's merge ref, which PR-controlled YAML can
+mutate, so accepting it would let a PR modify the workflow and emit the
+same required-check names from an untrusted context. The consequence is
+that if a reviewer dismisses an earlier Approved review or submits
+`CHANGES_REQUESTED`, the green required check does not automatically
+re-run. The sole maintainer must, before merging, push an empty commit
+to force `synchronize` to fire:
+
+```
+git commit --allow-empty -m "Re-request governance check after review refresh"
+git push
+```
+
+Merging a load-bearing PR while a previously-Approved review has been
+dismissed or changed — without the empty-commit refresh — is a
+governance breach and the PR must be reverted.
 
 ### 5.4. Transition off the deviation — ordered runbook
 
@@ -194,28 +214,35 @@ nor the required-approvals rule in force:
    Collaborators). This lets them leave a non-stale Approved review on
    later PRs but does **not** make them a code owner yet.
 2. **Open the pre-transition freeze PR** — adds
-   `.github/freezes/<date>-transition.yaml` whose `paths:` list covers
-   every code path that is **not** modified by the nomination PR:
-   `crates/`, `packages/`, `fixtures/`, `assets/`, `Cargo.toml`,
-   `Cargo.lock`. Governance/doc paths (`MAINTAINERS.md`,
-   `.github/CODEOWNERS`, `GOVERNANCE.md`, `docs/`,
-   `scripts/check-reviewed-by.sh`) are deliberately **not** frozen so
-   the nomination PR can land normally without needing a special
-   exemption label. The freeze PR itself is load-bearing, goes through
-   §5.3, and the nominee leaves the Approved review + `Reviewed-by:`
-   trailer.
-3. **Open the nomination PR** containing, in one squash-destined commit
-   with a durable commit-message body that carries the `Reviewed-by:`
-   trailer: (a) `MAINTAINERS.md` addition with contract-area
-   annotations, (b) `.github/CODEOWNERS` update adding the nominee to
-   every affected path, (c) removal of this §5 (and update of every
+   `.github/freezes/<date>-transition.yaml` whose `paths:` list freezes
+   **every** path in the repository (single entry: `""` or `/`, which
+   `scripts/check-freeze.sh` matches against all files). Non-transition
+   PRs merging into `main` during the window are blocked mechanically
+   regardless of which load-bearing area they touch — this closes the
+   intermediate-state gap that a code-only freeze would leave for
+   doc/workflow PRs. The nomination PR and the freeze-removal PR rely
+   on the `governance:transition` and `governance:freeze-removal`
+   labels (both machine-checked by `scripts/check-freeze.sh`) to land
+   despite the blanket freeze. The freeze PR itself is load-bearing,
+   goes through §5.3, and the nominee leaves the Approved review +
+   commit-message `Reviewed-by:` trailer.
+3. **Open the nomination PR**, labelled `governance:transition` so the
+   freeze check exempts it. The diff must stay within the
+   machine-checked transition scope enforced by
+   `scripts/check-freeze.sh` (MAINTAINERS.md, GOVERNANCE.md,
+   .github/CODEOWNERS, docs/design/decisions/, docs/design/design-brief.md,
+   scripts/check-reviewed-by.sh). In one squash-destined commit with a
+   durable commit-message body carrying the `Reviewed-by:` trailer:
+   (a) `MAINTAINERS.md` addition with contract-area annotations,
+   (b) `.github/CODEOWNERS` update adding the nominee to every
+   affected path, (c) removal of this §5 (and update of every
    cross-reference: ADR 0001, brief §20.1, CODEOWNERS comment header,
    `scripts/check-reviewed-by.sh` load-bearing path list if obsolete),
    (d) `MAINTAINERS.md` change-log entry recording the date and PR
    number that ended the single-maintainer period. The transition
    freeze file from step 2 is **not** deleted here — it stays in place
-   until step 6 so that code work remains blocked through the branch-
-   protection update.
+   until step 6 so that non-transition work remains blocked through the
+   branch-protection update.
 4. **Merge the nomination PR** (squash). `main` now has the new
    CODEOWNERS but the transition freeze is still active, so no other
    PR can land until step 6.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,8 +33,10 @@ Maintainers are expected to:
 A nomination opens as a PR that adds the candidate to `MAINTAINERS.md` and
 updates `CODEOWNERS` to grant the relevant ownership. The PR requires approval
 by a simple majority of the current maintainers (lazy consensus: no objection
-within seven days counts as approval). A single maintainer may self-approve
-only while the clause in §5 applies.
+within seven days counts as approval). During the single-maintainer period
+(§5), the sole maintainer solicits and records an external `Reviewed-by:` on
+the nomination PR — an explicit reviewer rather than a self-approval — and
+the merge of that PR is itself the event that ends §5.
 
 ### Removing a maintainer
 
@@ -107,20 +109,35 @@ touches both.
 
 ## 5. Time-limited deviation — single-maintainer period
 
-While the repository has **exactly one** maintainer in `MAINTAINERS.md`:
+While the repository has **exactly one** maintainer in `MAINTAINERS.md`,
+required-reviewer branch protection cannot be satisfied by the sole
+maintainer on their own PRs (GitHub disallows PR authors from approving
+their own pull requests). The deviation resolves this without relying on an
+admin bypass:
 
-- The sole maintainer **may** self-approve PRs that are not load-bearing
-  under `CLAUDE.md` §9 (i.e., not touching core traits, WAL, consent journal,
-  or config schema).
-- Load-bearing PRs still require **external** review — solicit it from the
-  community or a trusted reviewer on the relevant issue.
-- On the **first PR** after a second maintainer joins, flip branch
-  protection to require a second approver and remove this deviation clause
-  from this document.
+- **Branch protection does not require a CODEOWNERS or approving review**
+  during this period. CODEOWNERS remains in place as a reviewer-request
+  hint and an informational ownership map, not an enforcement gate.
+- **Required status checks remain on** (CI must pass) and **force-push to
+  `main` stays blocked**; the deviation is scoped narrowly to the "require
+  N approvals" rule.
+- **Load-bearing PRs** (as listed in `CLAUDE.md` §9 — core traits, WAL,
+  consent journal, config schema; plus any change to this document or to
+  `docs/design/decisions/`) **must** solicit and obtain at least one
+  external review before merge. The sole maintainer records the reviewer
+  (GitHub handle or email) in the PR description under a `Reviewed-by:`
+  trailer. Merging a load-bearing PR without a recorded external review is
+  a governance breach.
+- **On the first PR after a second maintainer joins**, enable required
+  CODEOWNERS review in branch protection, remove this §5 from the document
+  by PR (that PR itself benefits from the newly-available second
+  approver), and update `MAINTAINERS.md` to note the end of the
+  single-maintainer period in its change log.
 
-This deviation exists because CODEOWNERS review becomes a deadlock with one
-owner and no escape valve; the load-bearing carve-out prevents the deviation
-from being a bypass.
+No admin-bypass or ruleset-bypass path is authorised for the single
+maintainer during this period. The hard floor is the `Reviewed-by:` trailer
+for load-bearing changes; everything else relies on community scrutiny of
+the public commit log.
 
 ---
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -5,8 +5,8 @@ the [CNCF maintainer-template governance model][cncf-template] with a small,
 time-limited deviation called out below. Governance evolves by PR against this
 file.
 
-**Decision record:** [ADR 0001 — Monorepo shape and maintainer governance
-model](docs/design/decisions/0001-monorepo-governance.md). Close any proposed
+**Decision record:** [ADR 0002 — Monorepo shape and maintainer governance
+model](docs/design/decisions/0002-monorepo-governance.md). Close any proposed
 governance change by updating both this file and the ADR.
 
 ---
@@ -85,7 +85,7 @@ currently-active maintainers wins; the proposer does not get a tiebreaker.
   §4).
 - Changing the project licence.
 - Reorganising the repository (e.g., splitting a crate into its own repo — see
-  ADR 0001 split triggers).
+  ADR 0002 split triggers).
 
 ---
 
@@ -236,7 +236,7 @@ nor the required-approvals rule in force:
    (a) `MAINTAINERS.md` addition with contract-area annotations,
    (b) `.github/CODEOWNERS` update adding the nominee to every
    affected path, (c) removal of this §5 (and update of every
-   cross-reference: ADR 0001, brief §20.1, CODEOWNERS comment header,
+   cross-reference: ADR 0002, brief §20.1, CODEOWNERS comment header,
    `scripts/check-reviewed-by.sh` load-bearing path list if obsolete),
    (d) `MAINTAINERS.md` change-log entry recording the date and PR
    number that ended the single-maintainer period. The transition
@@ -275,13 +275,13 @@ protection.
 ## 6. Repository shape
 
 The project is one public monorepo (Cargo workspace + sibling `packages/`
-for non-Rust SDKs) per ADR 0001. The conditions for splitting a crate or
-package into its own repository are enumerated in ADR 0001 §"Split triggers".
+for non-Rust SDKs) per ADR 0002. The conditions for splitting a crate or
+package into its own repository are enumerated in ADR 0002 §"Split triggers".
 Any split proposal requires a super-majority vote (§3).
 
 The repository is currently **user-owned** (`windoliver/cairn`). Conversion to
 a GitHub organisation and migration of CODEOWNERS from `@windoliver` to a
-`@cairn-project/maintainers` team is a scheduled revisit trigger in ADR 0001;
+`@cairn-project/maintainers` team is a scheduled revisit trigger in ADR 0002;
 it fires when a second maintainer joins.
 
 ---
@@ -298,7 +298,7 @@ the maintainers listed in `MAINTAINERS.md`.
 ## 8. Amendments
 
 Any change to this file requires a super-majority (§3) of current
-maintainers. PRs that touch this file should also update ADR 0001 when the
+maintainers. PRs that touch this file should also update ADR 0002 when the
 change affects the decisions recorded there.
 
 [cncf-template]: https://github.com/cncf/project-template/blob/main/GOVERNANCE-maintainer.md

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -139,7 +139,8 @@ sync with `CLAUDE.md` §9 and `scripts/check-reviewed-by.sh`):
 - `docs/design/decisions/` (any ADR)
 - `GOVERNANCE.md`, `MAINTAINERS.md`, `.github/CODEOWNERS`
 - `.github/workflows/governance.yml`, `.github/freezes/`
-- `scripts/check-reviewed-by.sh`, `scripts/check-freeze.sh`
+- `scripts/check-reviewed-by.sh`, `scripts/check-freeze.sh`,
+  `scripts/check-core-boundary.sh`
 
 ### 5.3. Enforceable external-review rule
 
@@ -184,49 +185,58 @@ changes branch-protection rules **after** the nomination PR merges, not
 before, and prevents an intermediate-state gap with a merge freeze plus a
 transition-specific active path freeze.
 
-Steps (executed in order, by the sole maintainer unless stated):
+Steps (executed in order, by the sole maintainer unless stated). The
+transition freeze stays active from step 2 through step 6 so that at no
+point does `main` sit with the new CODEOWNERS but neither the deviation
+nor the required-approvals rule in force:
 
 1. **Grant the nominee write access** to the repository (Settings →
-   Collaborators). This allows them to leave a non-stale Approved review
-   on the nomination PR but does **not** make them a code owner yet.
-2. **Open a pre-transition freeze PR** that adds
-   `.github/freezes/<date>-transition.yaml` freezing every path except
-   `MAINTAINERS.md`, `.github/CODEOWNERS`, `GOVERNANCE.md`, and
-   `docs/design/decisions/`. This prevents any non-transition work
-   merging during the window. The freeze PR is itself load-bearing and
-   goes through the §5.3 Approved-review + `Reviewed-by:` gate, with the
-   nominee as the approving reviewer.
-3. **Open the nomination PR** containing, in one commit or squashed:
-   (a) `MAINTAINERS.md` addition with contract-area annotations,
-   (b) `.github/CODEOWNERS` update adding the nominee to every affected
-   path, (c) removal of this §5 (and update of every cross-reference:
-   ADR 0001, brief §20.1, CODEOWNERS comment header,
+   Collaborators). This lets them leave a non-stale Approved review on
+   later PRs but does **not** make them a code owner yet.
+2. **Open the pre-transition freeze PR** — adds
+   `.github/freezes/<date>-transition.yaml` whose `paths:` list covers
+   every code path that is **not** modified by the nomination PR:
+   `crates/`, `packages/`, `fixtures/`, `assets/`, `Cargo.toml`,
+   `Cargo.lock`. Governance/doc paths (`MAINTAINERS.md`,
+   `.github/CODEOWNERS`, `GOVERNANCE.md`, `docs/`,
+   `scripts/check-reviewed-by.sh`) are deliberately **not** frozen so
+   the nomination PR can land normally without needing a special
+   exemption label. The freeze PR itself is load-bearing, goes through
+   §5.3, and the nominee leaves the Approved review + `Reviewed-by:`
+   trailer.
+3. **Open the nomination PR** containing, in one squash-destined commit
+   with a durable commit-message body that carries the `Reviewed-by:`
+   trailer: (a) `MAINTAINERS.md` addition with contract-area
+   annotations, (b) `.github/CODEOWNERS` update adding the nominee to
+   every affected path, (c) removal of this §5 (and update of every
+   cross-reference: ADR 0001, brief §20.1, CODEOWNERS comment header,
    `scripts/check-reviewed-by.sh` load-bearing path list if obsolete),
    (d) `MAINTAINERS.md` change-log entry recording the date and PR
-   number that ended the single-maintainer period,
-   (e) removal of the transition freeze file from
-   `.github/freezes/`. The PR is labelled `governance:freeze-removal`
-   so the freeze gate exempts it. The nominee leaves an Approved
-   review; a `Reviewed-by:` trailer names them.
-4. **Merge the nomination PR** (squash). The new CODEOWNERS is now on
-   `main`.
-5. **Update branch protection** (Settings → Branches): enable
+   number that ended the single-maintainer period. The transition
+   freeze file from step 2 is **not** deleted here — it stays in place
+   until step 6 so that code work remains blocked through the branch-
+   protection update.
+4. **Merge the nomination PR** (squash). `main` now has the new
+   CODEOWNERS but the transition freeze is still active, so no other
+   PR can land until step 6.
+5. **Update branch protection** (Settings → Branches → `main`): enable
    `Require a pull request before merging`, `Required approvals = 1`,
    `Dismiss stale pull request approvals when new commits are pushed`,
-   `Require review from Code Owners`, and keep the `governance /
-   reviewed-by` required status check active (the script's load-bearing
-   gate now overlaps with CODEOWNERS but the redundancy is cheap and
-   fails closed). Remove the `governance / freeze` requirement only if
-   there are no active freezes.
-6. **Announce the transition** in the `MAINTAINERS.md` change-log entry
-   (already committed in step 3) and, if the project has any external
-   communication channel, there as well.
+   `Require review from Code Owners`, and keep `governance /
+   reviewed-by` and `governance / freeze` as required status checks.
+6. **Open the freeze-removal PR** deleting
+   `.github/freezes/<date>-transition.yaml`. The diff is purely freeze
+   deletions, and the label `governance:freeze-removal` exempts the PR
+   from `check-freeze.sh`. Under the new branch protection it requires
+   a code-owner approval — which either existing maintainer can now
+   satisfy. Merge it.
+7. **Announce the transition** and close any related issues.
 
-Until step 5 completes, no PR other than the transition PR may merge
-(enforced by the freeze file committed in step 2). If any of the steps
-fail or stall, the fallback is to reopen the freeze and re-run from the
-last successful step — the transition is resumable because every step
-leaves a committed artefact.
+Between step 4 and step 6 the repository is in a safe intermediate
+state: `main` is up-to-date, the transition freeze blocks non-transition
+merges, and branch protection has been tightened. If any step between 4
+and 6 stalls, the repository remains in that safe state indefinitely
+because the freeze continues to fail-close non-transition PRs.
 
 A future "third maintainer joins" transition is not gated by
 `GOVERNANCE.md` at all — it triggers a separate, optional per-contract

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,157 @@
+# Cairn Governance
+
+This document describes how the Cairn project is governed. The shape follows
+the [CNCF maintainer-template governance model][cncf-template] with a small,
+time-limited deviation called out below. Governance evolves by PR against this
+file.
+
+**Decision record:** [ADR 0001 — Monorepo shape and maintainer governance
+model](docs/design/decisions/0001-monorepo-governance.md). Close any proposed
+governance change by updating both this file and the ADR.
+
+---
+
+## 1. Maintainers
+
+Maintainers are listed in [`MAINTAINERS.md`](MAINTAINERS.md). The `Maintainer`
+role carries:
+
+- Write access to the repository.
+- Final review authority under the [CODEOWNERS](.github/CODEOWNERS) map.
+- Release authority (`release-plz` Release-PR merges).
+- A vote in project-level decisions (§4).
+
+Maintainers are expected to:
+
+- Uphold the contracts and invariants in [`CLAUDE.md`](CLAUDE.md) §4 and the
+  design brief.
+- Review PRs in their CODEOWNERS area within a reasonable window.
+- Disclose conflicts of interest and recuse on votes where they apply.
+
+### Adding a maintainer
+
+A nomination opens as a PR that adds the candidate to `MAINTAINERS.md` and
+updates `CODEOWNERS` to grant the relevant ownership. The PR requires approval
+by a simple majority of the current maintainers (lazy consensus: no objection
+within seven days counts as approval). A single maintainer may self-approve
+only while the clause in §5 applies.
+
+### Removing a maintainer
+
+A maintainer may step down at any time by PR. Involuntary removal (inactivity
+over twelve months with no response to outreach, or a Code of Conduct breach)
+follows the same simple-majority rule. A removed maintainer with a positive
+history is granted **Emeritus** status, recorded in `MAINTAINERS.md`.
+
+---
+
+## 2. Contract areas and sub-maintainers
+
+The project partitions ownership along the seven contracts (design brief §4).
+Each contract area may grow a **sub-maintainer** or domain expert ladder once
+it has more than one active reviewer. Sub-maintainers hold merge authority
+scoped to their area but do not hold a project-level vote.
+
+| Area | Paths |
+| --- | --- |
+| Core / traits / IDL | `crates/cairn-core/`, `crates/cairn-idl/` |
+| Store | `crates/cairn-store-sqlite/` |
+| Sensors | `crates/cairn-sensors-local/` |
+| API / MCP | `crates/cairn-mcp/`, `crates/cairn-cli/` |
+| Workflows | `crates/cairn-workflows/` |
+| Packaging / release | `.github/`, `scripts/`, `Cargo.toml`, `deny.toml` |
+| Docs | `docs/`, `README.md`, `CLAUDE.md` |
+
+Frontend (`FrontendAdapter`, design brief §4, P1) is a future area; `packages/`
+is reserved for it.
+
+---
+
+## 3. Decision making
+
+Default mode is **lazy consensus**: a maintainer proposes a change as a PR or
+issue, other maintainers have seven days to object. Silence is consent.
+
+**Simple majority vote** is the escape hatch. Any maintainer may call a vote
+on any PR or issue; the vote runs for seven days; majority of
+currently-active maintainers wins; the proposer does not get a tiebreaker.
+
+**Super-majority (two-thirds)** is required for:
+
+- Amending this document.
+- Amending the design brief's load-bearing invariants (brief §2, `CLAUDE.md`
+  §4).
+- Changing the project licence.
+- Reorganising the repository (e.g., splitting a crate into its own repo — see
+  ADR 0001 split triggers).
+
+---
+
+## 4. Design decisions and ADRs
+
+Substantive decisions land as Architecture Decision Records under
+[`docs/design/decisions/`](docs/design/decisions/). The sequence is:
+
+1. Open an issue proposing the decision.
+2. Post a draft ADR (status `Proposed`) as a PR.
+3. Discuss until lazy consensus or a called vote resolves.
+4. Merge with `Status: Accepted`; reference the closing issue.
+5. Supersede by opening a new ADR that sets the old one's status to
+   `Superseded by #N`. ADRs are append-only; never rewrite history.
+
+The design brief (`docs/design/design-brief.md`) remains the source of truth
+for scope; ADRs close open questions or amend the brief through a PR that
+touches both.
+
+---
+
+## 5. Time-limited deviation — single-maintainer period
+
+While the repository has **exactly one** maintainer in `MAINTAINERS.md`:
+
+- The sole maintainer **may** self-approve PRs that are not load-bearing
+  under `CLAUDE.md` §9 (i.e., not touching core traits, WAL, consent journal,
+  or config schema).
+- Load-bearing PRs still require **external** review — solicit it from the
+  community or a trusted reviewer on the relevant issue.
+- On the **first PR** after a second maintainer joins, flip branch
+  protection to require a second approver and remove this deviation clause
+  from this document.
+
+This deviation exists because CODEOWNERS review becomes a deadlock with one
+owner and no escape valve; the load-bearing carve-out prevents the deviation
+from being a bypass.
+
+---
+
+## 6. Repository shape
+
+The project is one public monorepo (Cargo workspace + sibling `packages/`
+for non-Rust SDKs) per ADR 0001. The conditions for splitting a crate or
+package into its own repository are enumerated in ADR 0001 §"Split triggers".
+Any split proposal requires a super-majority vote (§3).
+
+The repository is currently **user-owned** (`windoliver/cairn`). Conversion to
+a GitHub organisation and migration of CODEOWNERS from `@windoliver` to a
+`@cairn-project/maintainers` team is a scheduled revisit trigger in ADR 0001;
+it fires when a second maintainer joins.
+
+---
+
+## 7. Code of Conduct
+
+The project will adopt the [Contributor Covenant][covenant] as its Code of
+Conduct in a follow-up PR. Until then, contributors are expected to behave
+consistently with the Contributor Covenant 2.1. Report concerns privately to
+the maintainers listed in `MAINTAINERS.md`.
+
+---
+
+## 8. Amendments
+
+Any change to this file requires a super-majority (§3) of current
+maintainers. PRs that touch this file should also update ADR 0001 when the
+change affects the decisions recorded there.
+
+[cncf-template]: https://github.com/cncf/project-template/blob/main/GOVERNANCE-maintainer.md
+[covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,34 @@
+# Cairn Maintainers
+
+This file is the authoritative list of humans with maintainer authority, per
+[`GOVERNANCE.md`](GOVERNANCE.md). CODEOWNERS ([`.github/CODEOWNERS`](.github/CODEOWNERS))
+mirrors the ownership map derived from this list.
+
+Entry format:
+
+```
+- GitHub handle — Name — contract areas (brief §4) — contact
+```
+
+Contract areas match the seven-area partition in `GOVERNANCE.md` §2. Until the
+project grows a second maintainer, every area routes to the sole maintainer.
+
+---
+
+## Active maintainers
+
+- **@windoliver** — Tao Feng — all areas (core / traits / IDL, store, sensors,
+  API/MCP, workflows, packaging, docs) — GitHub: [@windoliver](https://github.com/windoliver)
+
+## Emeritus
+
+*(none)*
+
+---
+
+## Change log
+
+- **2026-04-24** — Initial file created alongside `GOVERNANCE.md` and
+  `.github/CODEOWNERS`, closing the governance open question recorded in ADR
+  0001 and design brief §20.1. Single-maintainer period begins under
+  `GOVERNANCE.md` §5.

--- a/docs/design/decisions/0001-monorepo-governance.md
+++ b/docs/design/decisions/0001-monorepo-governance.md
@@ -129,22 +129,37 @@ the maintainers must:
 1. **Assign an owner** — one maintainer takes point, named in the issue.
 2. **Set a decision deadline** — no longer than 14 days for the
    extraction ADR to reach `Accepted` or the trigger to be explicitly
-   ruled not-applicable, with a written rationale.
-3. **Apply interim controls** scoped to the trigger:
-   - **H1 (licensing/CLA):** pause merges to the affected crate path
-     (CODEOWNERS self-lock or `concurrency: governance-freeze` workflow
-     guard) until the licence question is resolved in writing.
-   - **H2 (security gate):** freeze releases of the affected crate
-     immediately — tag `release-plz` skip on the crate, open a P0 issue
-     for interim signed-release tooling, and document the reduced
-     release surface in `README.md` until extraction or equivalent
+   ruled not-applicable with a written rationale.
+3. **Apply an enforced path freeze** by committing a file to
+   `.github/freezes/YYYY-MM-DD-<trigger>-<slug>.yaml` (see
+   `.github/freezes/README.md` for the schema). The required
+   `governance / freeze` status check
+   (`.github/workflows/governance.yml` + `scripts/check-freeze.sh`) then
+   fails any PR whose diff touches a path listed in the freeze,
+   including direct merges by the sole maintainer — this is a
+   mechanical gate, not a documentation claim.
+4. **Apply trigger-specific interim controls on top of the freeze:**
+   - **H1 (licensing / CLA):** the freeze alone is sufficient; add a
+     note in the freeze file's `reason:` stating the licence question
+     and the external counter-party.
+   - **H2 (security gate):** additionally disable releases of the
+     affected crate — set `publish = false` in its `Cargo.toml` and
+     remove it from any active `release-plz` configuration. Open a P0
+     issue tracking interim signed-release tooling. Note the reduced
+     release surface in `README.md` until extraction or an equivalent
      in-repo mitigation lands.
-   - **H3 (SLA conflict):** pin the affected crate's semver at its
-     current minor, notify the external consumer of the freeze in
-     writing, and open an issue tracking either SLA alignment or
-     extraction — whichever the external consumer selects.
-4. **Record** the containment steps in the extraction-ADR issue thread;
-   the ADR's `Context` section must cite them when it lands.
+   - **H3 (SLA conflict):** additionally pin the affected crate's
+     semver at its current minor (do not bump while the freeze is
+     active), notify the external consumer in writing, and open an
+     issue tracking either SLA alignment or extraction — whichever the
+     external consumer selects.
+5. **Record** the containment steps and the freeze file path in the
+   extraction-ADR issue thread; the ADR's `Context` section must cite
+   them when it lands.
+
+The freeze is lifted by a PR that deletes the freeze file, labelled
+`governance:freeze-removal`; `scripts/check-freeze.sh` exempts that
+label from the gate (see `.github/freezes/README.md`).
 
 Soft triggers do **not** require immediate containment — they are
 operational-discomfort signals, handled through the normal ADR lifecycle.

--- a/docs/design/decisions/0001-monorepo-governance.md
+++ b/docs/design/decisions/0001-monorepo-governance.md
@@ -55,15 +55,25 @@ own repository until an explicit trigger fires (see "Split triggers" below).
    lives at [`.github/CODEOWNERS`](../../../.github/CODEOWNERS).
 3. **Governance doc.** Adopt the CNCF `GOVERNANCE-maintainer.md` template
    as [`GOVERNANCE.md`](../../../GOVERNANCE.md) with one documented
-   deviation: while `|maintainers| == 1`, self-approve is permitted on
-   non-load-bearing changes (the load-bearing list in `CLAUDE.md` §9 still
-   requires external review). Maintain a parallel
-   [`MAINTAINERS.md`](../../../MAINTAINERS.md) listing humans with
-   **contract-area annotations** mirroring the seven contracts — this is
-   zero-cost forward compatibility with a future SME/domain-lead ladder.
-4. **Branch protection.** Require CODEOWNERS review on `main`; allow
-   self-approve only while the team size is 1; flip the self-approve
-   allowance off on the first PR after a second maintainer is added.
+   deviation: while `|maintainers| == 1`, required-reviewer branch
+   protection is **not** enabled (GitHub blocks self-approval, so the
+   rule would deadlock); load-bearing PRs (as listed in `CLAUDE.md` §9)
+   must obtain an external review and record it via a `Reviewed-by:`
+   trailer in the PR description. Admin-bypass is not authorised.
+   Maintain a parallel [`MAINTAINERS.md`](../../../MAINTAINERS.md)
+   listing humans with **contract-area annotations** mirroring the seven
+   contracts — this is zero-cost forward compatibility with a future
+   SME/domain-lead ladder.
+4. **Branch protection.** During the single-maintainer period
+   (`GOVERNANCE.md` §5) `main` requires passing CI and blocks force-push,
+   but does **not** require a CODEOWNERS / approving review — GitHub
+   disallows PR authors from approving their own PRs, so a required-review
+   rule would deadlock the repository or force an admin-bypass habit.
+   Load-bearing PRs (as listed in `CLAUDE.md` §9 and `GOVERNANCE.md` §5)
+   must obtain and record an external review in a `Reviewed-by:` trailer.
+   Enable required CODEOWNERS review in branch protection on the first PR
+   after a second maintainer joins; that same PR removes `GOVERNANCE.md`
+   §5.
 5. **Release tooling.** Adopt `release-plz` + `git-cliff` for Rust
    publishing (per-crate independent versioning, conventional commits,
    `cargo-semver-checks` in the Release PR). Non-Rust SDK publishing
@@ -74,8 +84,9 @@ own repository until an explicit trigger fires (see "Split triggers" below).
 ### Maintainer boundaries (satisfies AC 2)
 
 Named boundaries used as the seed ownership map. Each maps to a contract in
-brief §4; all route to `@cairn-project/maintainers` today and will gain a
-dedicated team as reviewer depth grows.
+brief §4; all route to the sole maintainer today (per the seed
+`.github/CODEOWNERS`) and will gain a dedicated team as reviewer depth
+grows and the repository converts to an organisation.
 
 | Area | Paths | Contract |
 | --- | --- | --- |
@@ -89,37 +100,55 @@ dedicated team as reviewer depth grows.
 
 ### Split triggers (satisfies AC 3 — reversibility)
 
-Re-open this ADR and consider extracting a crate or package into its own
-repository when **two or more** of the following fire simultaneously:
+Triggers are partitioned into **hard** and **soft**. Any single hard
+trigger is sufficient cause to open an extraction ADR immediately; soft
+triggers reflect operational discomfort, so a single one opens discussion
+and two concurrent soft triggers open an extraction ADR.
 
-1. Release cadence for one crate has permanently diverged (one ships weekly
-   for 6+ months while another ships quarterly, and the Release PR is
-   routinely stale).
-2. A dedicated maintainer team has formed for one crate with no overlap
-   with the core reviewer pool.
-3. An external consumer depends on a single crate with SLAs materially
-   distinct from Cairn itself (e.g., `cairn-idl` used by a vendor that
-   cannot tolerate Cairn's release cadence).
-4. CI wall-clock on the monorepo exceeds the team's tolerance despite
-   `cargo nextest` partitioning, sccache, and target-aware caching.
-5. Licensing or contribution-policy pressure (one crate needs a different
-   licence, a CLA, or a vendor-only contribution path).
-6. Security boundary — an adapter must ship on a stricter release gate
-   (signed-only releases, different maintainers).
-7. Binary-size or dependency bloat in downstream consumers such that
-   vendoring or forking is becoming routine.
+**Hard triggers — any one fires, open extraction ADR immediately:**
 
-Reaching any single trigger is cause for discussion; reaching two is cause
-for a new ADR proposing extraction.
+H1. **Licensing or contribution-policy pressure.** One crate needs a
+    different licence, a CLA, or a vendor-only contribution path that
+    cannot be satisfied in-repo.
+H2. **Security release boundary.** An adapter must ship on a stricter
+    release gate (signed-only releases, different maintainers, disclosure
+    embargoes) that the monorepo release pipeline cannot enforce without
+    compromising the rest.
+H3. **External consumer SLA conflict.** An external project depends on a
+    single crate with release-cadence, support-window, or stability
+    guarantees materially distinct from Cairn itself, and keeping the
+    crate in-repo forces us to either break their SLA or over-stabilise
+    the rest of the workspace.
+
+**Soft triggers — one opens discussion, two concurrent open extraction ADR:**
+
+S1. Release cadence for one crate has permanently diverged (one ships
+    weekly for 6+ months while another ships quarterly, and the Release
+    PR is routinely stale).
+S2. A dedicated maintainer team has formed for one crate with no overlap
+    with the core reviewer pool.
+S3. CI wall-clock on the monorepo exceeds the team's tolerance despite
+    `cargo nextest` partitioning, sccache, and target-aware caching.
+S4. Binary-size or dependency bloat in downstream consumers such that
+    vendoring or forking is becoming routine.
 
 ### Revisit triggers (scheduled review)
 
 Revisit this ADR when any of the following happens, regardless of the
 split-trigger list:
 
-- A third maintainer joins (flip self-approve off; seed per-contract teams).
-- The first non-Rust SDK ships (activate `packages/`, pick SDK release tool).
-- Any split trigger fires.
+- **Second maintainer joins** — end the single-maintainer deviation in
+  `GOVERNANCE.md` §5, enable required CODEOWNERS review in branch
+  protection, and update `MAINTAINERS.md`.
+- **Third maintainer joins** — consider seeding per-contract ownership
+  teams (one team per area in `GOVERNANCE.md` §2). This is optional and
+  governed by reviewer depth per area, not by the headcount alone.
+- **Repository converts to a GitHub organisation** — migrate CODEOWNERS
+  from `@windoliver` to `@cairn-project/maintainers`; this may happen at
+  or after the second-maintainer transition.
+- **First non-Rust SDK ships** — activate `packages/`, pick an SDK release
+  tool (Changesets or Sampo) in a follow-up ADR.
+- Any hard or soft split trigger fires.
 
 ## Consequences
 
@@ -142,9 +171,11 @@ split-trigger list:
   every crate. Mitigation: per-crate test partitioning and the existing
   `check-core-boundary.sh` gate; acceptable at v0.1 scale.
 - **Coarse ownership until more reviewers exist.** Every path resolves to
-  `@cairn-project/maintainers` initially — CODEOWNERS cannot enforce
-  contract-specific review while the team is one entry deep. Mitigation:
-  revisit on the third maintainer.
+  the sole maintainer initially — CODEOWNERS is informational during the
+  single-maintainer period (see `GOVERNANCE.md` §5) and cannot enforce
+  contract-specific review until at least two maintainers exist. Mitigation:
+  end the single-maintainer period on the second maintainer; seed
+  per-contract teams on the third.
 - **Repository size grows monotonically.** Accepted; rust-analyzer,
   wasmtime, tauri, and biome all operate comfortably at 10× our expected
   v1 size.

--- a/docs/design/decisions/0001-monorepo-governance.md
+++ b/docs/design/decisions/0001-monorepo-governance.md
@@ -1,0 +1,187 @@
+# ADR 0001 — Monorepo shape and maintainer governance model
+
+- **Status:** Accepted
+- **Date:** 2026-04-24
+- **Closes:** [#145](https://github.com/windoliver/cairn/issues/145)
+- **Parent issue:** #3 (Establish repository architecture and contract IDL)
+- **Design brief refs:** §4.1 Plugin architecture; §16 Distribution and Packaging; §20 Open Questions (item 1)
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context
+
+The design brief leaves "single-repo vs. monorepo organisation; maintainer
+model" as open question §20.1. The v0.1 crate roster has eight Rust crates
+(`cairn-core`, `cairn-cli`, `cairn-mcp`, `cairn-store-sqlite`,
+`cairn-sensors-local`, `cairn-workflows`, `cairn-idl`, `cairn-test-fixtures`)
+and will later host generated non-Rust SDKs and skill packages (brief §16:
+"Monorepo shape (polyglot: Rust core + TypeScript shell + Electron
+renderer)"). The seven contracts (brief §4) already partition the natural
+ownership surface: core/traits, store, sensors, API/MCP, frontend, packaging,
+docs.
+
+v0.1 has a maintainer roster of 1–3 people. Cargo's multi-package publishing
+stabilised in 1.90 (July 2025), so workspace publishing is no longer a
+split-justifying pain point. CLAUDE.md §3 already pins the flat `crates/`
+layout and the core-boundary invariant.
+
+The acceptance criteria for #145 require (a) a written governance decision
+before broad implementation, (b) maintainer boundaries across the seven
+contract areas, and (c) reversibility — the decision must not block future
+package extraction.
+
+## Decision
+
+**Ship v0.1 as a single public monorepo** — one Cargo workspace in
+`crates/`, a sibling `packages/` directory reserved for generated non-Rust
+SDKs and skill packages, plus `docs/`, `fixtures/`, and `assets/`. Own the
+repository with a **CODEOWNERS-style, team-scoped review model seeded by
+contract area**, using a single `@cairn-project/maintainers` team until
+additional reviewers exist. Adopt a lightweight governance document derived
+from the CNCF maintainer template. Defer splitting any crate or SDK into its
+own repository until an explicit trigger fires (see "Split triggers" below).
+
+### Concrete commitments
+
+1. **Layout.** Flat `crates/<crate-name>/` (folder name = crate name; the
+   rust-analyzer / matklad pattern). Non-Rust SDKs live under a sibling
+   `packages/<package-name>/` when they arrive. No nested hierarchies.
+2. **CODEOWNERS.** A `.github/CODEOWNERS` file mirroring the layout. The
+   repository is currently user-owned (`windoliver/cairn`); the v0.1 seed
+   routes every path to `@windoliver`. When the repo converts to an
+   organisation and a second maintainer joins, replace `@windoliver` with
+   a `@cairn-project/maintainers` team and split per-contract ownership
+   into dedicated teams (see `GOVERNANCE.md` §2). The active seed file
+   lives at [`.github/CODEOWNERS`](../../../.github/CODEOWNERS).
+3. **Governance doc.** Adopt the CNCF `GOVERNANCE-maintainer.md` template
+   as [`GOVERNANCE.md`](../../../GOVERNANCE.md) with one documented
+   deviation: while `|maintainers| == 1`, self-approve is permitted on
+   non-load-bearing changes (the load-bearing list in `CLAUDE.md` §9 still
+   requires external review). Maintain a parallel
+   [`MAINTAINERS.md`](../../../MAINTAINERS.md) listing humans with
+   **contract-area annotations** mirroring the seven contracts — this is
+   zero-cost forward compatibility with a future SME/domain-lead ladder.
+4. **Branch protection.** Require CODEOWNERS review on `main`; allow
+   self-approve only while the team size is 1; flip the self-approve
+   allowance off on the first PR after a second maintainer is added.
+5. **Release tooling.** Adopt `release-plz` + `git-cliff` for Rust
+   publishing (per-crate independent versioning, conventional commits,
+   `cargo-semver-checks` in the Release PR). Non-Rust SDK publishing
+   tool choice is deferred to the first SDK issue; candidates are
+   Changesets (battle-tested) or Sampo (Rust-native, young). Capture that
+   sub-decision in its own ADR when the SDK lands.
+
+### Maintainer boundaries (satisfies AC 2)
+
+Named boundaries used as the seed ownership map. Each maps to a contract in
+brief §4; all route to `@cairn-project/maintainers` today and will gain a
+dedicated team as reviewer depth grows.
+
+| Area | Paths | Contract |
+| --- | --- | --- |
+| Core / traits / IDL | `crates/cairn-core/`, `crates/cairn-idl/` | `MemoryStore`, `LLMProvider`, `WorkflowOrchestrator`, `SensorIngress`, `MCPServer` (brief §4) |
+| Store | `crates/cairn-store-sqlite/` | `MemoryStore` |
+| Sensors | `crates/cairn-sensors-local/` | `SensorIngress` |
+| API / MCP | `crates/cairn-mcp/`, `crates/cairn-cli/` | `MCPServer` + CLI ground truth (brief §8) |
+| Frontend | `packages/` (when populated) | `FrontendAdapter` (P1, brief §4) |
+| Packaging / release | `.github/workflows/`, `release-plz.toml`, `deny.toml` | Distribution (brief §16) |
+| Docs | `docs/`, `README.md`, `CLAUDE.md` | — |
+
+### Split triggers (satisfies AC 3 — reversibility)
+
+Re-open this ADR and consider extracting a crate or package into its own
+repository when **two or more** of the following fire simultaneously:
+
+1. Release cadence for one crate has permanently diverged (one ships weekly
+   for 6+ months while another ships quarterly, and the Release PR is
+   routinely stale).
+2. A dedicated maintainer team has formed for one crate with no overlap
+   with the core reviewer pool.
+3. An external consumer depends on a single crate with SLAs materially
+   distinct from Cairn itself (e.g., `cairn-idl` used by a vendor that
+   cannot tolerate Cairn's release cadence).
+4. CI wall-clock on the monorepo exceeds the team's tolerance despite
+   `cargo nextest` partitioning, sccache, and target-aware caching.
+5. Licensing or contribution-policy pressure (one crate needs a different
+   licence, a CLA, or a vendor-only contribution path).
+6. Security boundary — an adapter must ship on a stricter release gate
+   (signed-only releases, different maintainers).
+7. Binary-size or dependency bloat in downstream consumers such that
+   vendoring or forking is becoming routine.
+
+Reaching any single trigger is cause for discussion; reaching two is cause
+for a new ADR proposing extraction.
+
+### Revisit triggers (scheduled review)
+
+Revisit this ADR when any of the following happens, regardless of the
+split-trigger list:
+
+- A third maintainer joins (flip self-approve off; seed per-contract teams).
+- The first non-Rust SDK ships (activate `packages/`, pick SDK release tool).
+- Any split trigger fires.
+
+## Consequences
+
+### Positive
+
+- **Atomic cross-cutting changes.** Contract changes in `cairn-core` + IDL
+  + adapters + CLI land in a single PR; `scripts/check-core-boundary.sh`
+  continues to enforce the plugin invariant at review time.
+- **Low governance overhead.** One CODEOWNERS file, one `GOVERNANCE.md`,
+  one release pipeline. Matches the 1–3 maintainer reality of v0.1.
+- **Forward compatible.** Per-contract teams, per-crate release cadences,
+  and eventual extraction are all reachable without rewriting the model —
+  only the CODEOWNERS seed and the governance deviation clause change.
+- **Consistent with brief §16.** Keeps "Monorepo shape (polyglot)" from
+  §16 as the canonical shape.
+
+### Negative / accepted trade-offs
+
+- **Single point of failure for CI / access.** A broken main branch blocks
+  every crate. Mitigation: per-crate test partitioning and the existing
+  `check-core-boundary.sh` gate; acceptable at v0.1 scale.
+- **Coarse ownership until more reviewers exist.** Every path resolves to
+  `@cairn-project/maintainers` initially — CODEOWNERS cannot enforce
+  contract-specific review while the team is one entry deep. Mitigation:
+  revisit on the third maintainer.
+- **Repository size grows monotonically.** Accepted; rust-analyzer,
+  wasmtime, tauri, and biome all operate comfortably at 10× our expected
+  v1 size.
+
+### Known counter-argument
+
+Matt Klein's "Monorepos: Please don't!" argues against organisational
+monorepos holding hundreds of services. The evidence (multi-minute
+`git status`, VCS scaling) does not apply to a ten-crate OSS library at
+our scale. Cited explicitly so reviewers can see the decision was made
+with the counter-argument in view.
+
+## Alternatives considered
+
+1. **Polyrepo-from-day-one.** One repo per contract area. Rejected: forces
+   cross-repo PRs for any contract change, multiplies CI and governance
+   overhead, and `cairn-core` + `cairn-idl` + `cairn-cli` are effectively
+   co-evolving. Prisma's 2025 reversal (engines merged back into the
+   client repo) is a recent reality check on premature splitting.
+2. **Monorepo with per-crate GitHub repos mirrored via subtree.** Rejected
+   as a premature synchronisation cost with no current benefit.
+3. **No written governance doc at v0.1.** Rejected: the acceptance
+   criteria for #145 explicitly require a written decision before broad
+   implementation; undocumented governance tends to ossify into whatever
+   the first controversy settles it as.
+
+## References
+
+- Design brief §4.1, §16, §20 (`docs/design/design-brief.md`)
+- Architecture summary (`docs/design/architecture.md`)
+- Workspace scaffold design (`docs/design/2026-04-23-rust-workspace-scaffold-design.md`)
+- Matklad, "Large Rust Workspaces" — <https://matklad.github.io/2021/08/22/large-rust-workspaces.html>
+- Tweag, "Publish all your crates everywhere all at once" (2025) — <https://www.tweag.io/blog/2025-07-10-cargo-package-workspace/>
+- CNCF project template, `GOVERNANCE-maintainer.md` — <https://github.com/cncf/project-template/blob/main/GOVERNANCE-maintainer.md>
+- Rust RFC 3119 — Crate Ownership — <https://rust-lang.github.io/rfcs/3119-rust-crate-ownership.html>
+- release-plz — <https://release-plz.dev/>
+- Matt Klein, "Monorepos: Please don't!" — <https://medium.com/@mattklein123/monorepos-please-dont-e9a279be011b> (counter-argument, retained for transparency)
+- Prisma, "From Rust to TypeScript" (2025) — <https://www.prisma.io/blog/from-rust-to-typescript-a-new-chapter-for-prisma-orm> (cautionary tale on premature split)
+- Bevy organisation model — <https://bevy.org/learn/contribute/project-information/bevy-organization/>
+- Tauri governance — <https://tauri.app/about/governance/>

--- a/docs/design/decisions/0001-monorepo-governance.md
+++ b/docs/design/decisions/0001-monorepo-governance.md
@@ -120,6 +120,35 @@ H3. **External consumer SLA conflict.** An external project depends on a
     crate in-repo forces us to either break their SLA or over-stabilise
     the rest of the workspace.
 
+**Immediate containment when a hard trigger fires.** Opening the
+extraction ADR is the long-running workstream; a discussion cannot be the
+only response while risk is outstanding. Within **24 hours** of the
+trigger being declared on-repo (issue labelled `governance:hard-trigger`),
+the maintainers must:
+
+1. **Assign an owner** — one maintainer takes point, named in the issue.
+2. **Set a decision deadline** — no longer than 14 days for the
+   extraction ADR to reach `Accepted` or the trigger to be explicitly
+   ruled not-applicable, with a written rationale.
+3. **Apply interim controls** scoped to the trigger:
+   - **H1 (licensing/CLA):** pause merges to the affected crate path
+     (CODEOWNERS self-lock or `concurrency: governance-freeze` workflow
+     guard) until the licence question is resolved in writing.
+   - **H2 (security gate):** freeze releases of the affected crate
+     immediately — tag `release-plz` skip on the crate, open a P0 issue
+     for interim signed-release tooling, and document the reduced
+     release surface in `README.md` until extraction or equivalent
+     in-repo mitigation lands.
+   - **H3 (SLA conflict):** pin the affected crate's semver at its
+     current minor, notify the external consumer of the freeze in
+     writing, and open an issue tracking either SLA alignment or
+     extraction — whichever the external consumer selects.
+4. **Record** the containment steps in the extraction-ADR issue thread;
+   the ADR's `Context` section must cite them when it lands.
+
+Soft triggers do **not** require immediate containment — they are
+operational-discomfort signals, handled through the normal ADR lifecycle.
+
 **Soft triggers — one opens discussion, two concurrent open extraction ADR:**
 
 S1. Release cadence for one crate has permanently diverged (one ships

--- a/docs/design/decisions/0002-monorepo-governance.md
+++ b/docs/design/decisions/0002-monorepo-governance.md
@@ -1,4 +1,4 @@
-# ADR 0001 — Monorepo shape and maintainer governance model
+# ADR 0002 — Monorepo shape and maintainer governance model
 
 - **Status:** Accepted
 - **Date:** 2026-04-24

--- a/docs/design/design-brief.md
+++ b/docs/design/design-brief.md
@@ -4435,7 +4435,7 @@ Every capability above is derivable from these seven invariants — if you viola
    load-bearing changes are gated by an **enforceable external-review
    rule**: an Approved non-author GitHub review + a `Reviewed-by:` trailer
    + a required `governance / reviewed-by` status check. See
-   [ADR 0001-monorepo](decisions/0001-monorepo-governance.md) and `GOVERNANCE.md`
+   [ADR 0002](decisions/0002-monorepo-governance.md) and `GOVERNANCE.md`
    §5 for the enforcement mechanism, hard-vs-soft split triggers,
    revisit triggers, and release-tooling commitments. Closes #145.
 2. ~~Default LLM for local tier: ship Ollama bootstrap, or require user install?~~ — **Resolved 2026-04-24 ([ADR 0001](decisions/0001-llm-default.md)):** no bundled runtime; ship one OpenAI-compatible adapter and detect local providers in `cairn status`.

--- a/docs/design/design-brief.md
+++ b/docs/design/design-brief.md
@@ -4429,9 +4429,14 @@ Every capability above is derivable from these seven invariants — if you viola
 1. ~~Governance: single‑repo vs. monorepo organization; maintainer model.~~
    **Resolved 2026-04-24** — one public monorepo (Cargo workspace in `crates/`,
    sibling `packages/` reserved for non-Rust SDKs); CODEOWNERS-style team
-   review seeded by contract area; CNCF maintainer-template governance with
-   a time-limited self-approve deviation while the roster is one deep. See
-   [ADR 0001-monorepo](decisions/0001-monorepo-governance.md) for split triggers,
+   review seeded by contract area; CNCF maintainer-template governance.
+   While the maintainer roster is one deep, required-approval branch
+   protection is narrowly disabled (GitHub disallows self-approval) and
+   load-bearing changes are gated by an **enforceable external-review
+   rule**: an Approved non-author GitHub review + a `Reviewed-by:` trailer
+   + a required `governance / reviewed-by` status check. See
+   [ADR 0001-monorepo](decisions/0001-monorepo-governance.md) and `GOVERNANCE.md`
+   §5 for the enforcement mechanism, hard-vs-soft split triggers,
    revisit triggers, and release-tooling commitments. Closes #145.
 2. ~~Default LLM for local tier: ship Ollama bootstrap, or require user install?~~ — **Resolved 2026-04-24 ([ADR 0001](decisions/0001-llm-default.md)):** no bundled runtime; ship one OpenAI-compatible adapter and detect local providers in `cairn status`.
 3. Desktop GUI: ship in v0.2 or defer to v0.3?

--- a/docs/design/design-brief.md
+++ b/docs/design/design-brief.md
@@ -4426,7 +4426,13 @@ Every capability above is derivable from these seven invariants — if you viola
 
 ## 20. Open Questions
 
-1. Governance: single‑repo vs. monorepo organization; maintainer model.
+1. ~~Governance: single‑repo vs. monorepo organization; maintainer model.~~
+   **Resolved 2026-04-24** — one public monorepo (Cargo workspace in `crates/`,
+   sibling `packages/` reserved for non-Rust SDKs); CODEOWNERS-style team
+   review seeded by contract area; CNCF maintainer-template governance with
+   a time-limited self-approve deviation while the roster is one deep. See
+   [ADR 0001-monorepo](decisions/0001-monorepo-governance.md) for split triggers,
+   revisit triggers, and release-tooling commitments. Closes #145.
 2. ~~Default LLM for local tier: ship Ollama bootstrap, or require user install?~~ — **Resolved 2026-04-24 ([ADR 0001](decisions/0001-llm-default.md)):** no bundled runtime; ship one OpenAI-compatible adapter and detect local providers in `cairn status`.
 3. Desktop GUI: ship in v0.2 or defer to v0.3?
 4. Skill distillation format: adopt an existing spec, or define Cairn‑native?

--- a/scripts/check-freeze.sh
+++ b/scripts/check-freeze.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# check-freeze.sh
+#
+# Enforces path freezes declared under .github/freezes/*.yaml. Freezes are
+# set by maintainers when a hard split trigger fires (ADR 0001
+# "Immediate containment when a hard trigger fires"). Any PR whose diff
+# touches a frozen path fails this required status check.
+#
+# This script must run from the BASE-branch checkout so PR-side edits to
+# either the freeze files or this script cannot weaken the gate — see
+# .github/workflows/governance.yml.
+#
+# Freeze file format (one file per active freeze):
+#
+#   # .github/freezes/2026-04-24-hard-trigger-h2-store.yaml
+#   trigger: H2
+#   issue: https://github.com/windoliver/cairn/issues/NNN
+#   owner: "@windoliver"
+#   opened: 2026-04-24
+#   deadline: 2026-05-08
+#   paths:
+#     - crates/cairn-store-sqlite/
+#     - crates/cairn-store-sqlite/Cargo.toml
+#
+# The `paths:` list is the only field this script parses; all other fields
+# are human audit context. Freezes are removed by merging a PR that deletes
+# the file (that PR itself may need the freeze override — see §5 of the
+# ADR — and in that case must be labelled `governance:freeze-removal` which
+# exempts it).
+
+set -euo pipefail
+
+if [[ -z "${BASE_SHA:-}" || -z "${HEAD_SHA:-}" ]]; then
+    echo "check-freeze: BASE_SHA and HEAD_SHA must be set" >&2
+    exit 2
+fi
+
+# Exempt freeze-removal PRs (they delete freeze files; blocking them would
+# prevent the freeze from ever being lifted). Detection: PR carries label
+# `governance:freeze-removal` OR the diff is purely deletions under
+# .github/freezes/ with no other paths touched.
+if [[ -n "${PR_LABELS:-}" ]]; then
+    if printf '%s' "${PR_LABELS}" | tr '[:upper:]' '[:lower:]' \
+            | grep -qw 'governance:freeze-removal'; then
+        echo "check-freeze: governance:freeze-removal label detected — exempt."
+        exit 0
+    fi
+fi
+
+freeze_dir=".github/freezes"
+
+if [[ ! -d "${freeze_dir}" ]]; then
+    echo "check-freeze: no ${freeze_dir}/ directory — no active freezes."
+    exit 0
+fi
+
+shopt -s nullglob
+freeze_files=("${freeze_dir}"/*.yaml "${freeze_dir}"/*.yml)
+shopt -u nullglob
+
+# Ignore a placeholder README if present.
+active_files=()
+for f in "${freeze_files[@]}"; do
+    [[ "$(basename "${f}")" == ".gitkeep"* ]] && continue
+    active_files+=("${f}")
+done
+
+if [[ "${#active_files[@]}" -eq 0 ]]; then
+    echo "check-freeze: no active freeze files."
+    exit 0
+fi
+
+# Collect frozen paths from YAML `paths:` lists (simple parser: items under
+# a `paths:` key formatted as `  - some/path/`).
+frozen_paths=()
+for f in "${active_files[@]}"; do
+    while IFS= read -r path; do
+        [[ -z "${path}" ]] && continue
+        frozen_paths+=("${path}")
+    done < <(
+        python3 - "${f}" <<'PY'
+import sys, re
+path = sys.argv[1]
+with open(path) as fh:
+    text = fh.read()
+in_paths = False
+for line in text.splitlines():
+    stripped = line.rstrip()
+    if re.match(r'^paths\s*:\s*$', stripped):
+        in_paths = True
+        continue
+    if in_paths:
+        m = re.match(r'^\s*-\s*"?([^"\s]+)"?\s*$', stripped)
+        if m:
+            print(m.group(1))
+            continue
+        if stripped and not stripped.startswith(' '):
+            in_paths = False
+PY
+    )
+done
+
+if [[ "${#frozen_paths[@]}" -eq 0 ]]; then
+    echo "check-freeze: freeze files present but no paths declared — treating as inactive."
+    exit 0
+fi
+
+git fetch --no-tags --depth=200 origin "${BASE_SHA}" "${HEAD_SHA}" >/dev/null 2>&1 || true
+changed_files=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+
+hit=""
+while IFS= read -r file; do
+    [[ -z "${file}" ]] && continue
+    for frozen in "${frozen_paths[@]}"; do
+        case "${file}" in
+            "${frozen}"*) hit="${file} (frozen by pattern ${frozen})"; break 2 ;;
+        esac
+    done
+done <<<"${changed_files}"
+
+if [[ -n "${hit}" ]]; then
+    cat >&2 <<EOF
+check-freeze: FAIL — PR touches a frozen path.
+
+Match: ${hit}
+
+Active freezes (from ${freeze_dir}/):
+$(printf '  %s\n' "${active_files[@]}")
+
+Freezes are declared under ADR 0001 hard-trigger containment. Resolve the
+underlying hard trigger and remove the freeze file via a PR labelled
+governance:freeze-removal before merging changes that touch these paths.
+EOF
+    exit 1
+fi
+
+echo "check-freeze: OK — no frozen paths touched."

--- a/scripts/check-freeze.sh
+++ b/scripts/check-freeze.sh
@@ -2,7 +2,7 @@
 # check-freeze.sh
 #
 # Enforces path freezes declared under .github/freezes/*.yaml. Freezes are
-# set by maintainers when a hard split trigger fires (ADR 0001
+# set by maintainers when a hard split trigger fires (ADR 0002
 # "Immediate containment when a hard trigger fires"). Any PR whose diff
 # touches a frozen path fails this required status check.
 #
@@ -305,7 +305,7 @@ Match: ${hit}
 Active freeze files:
 $(printf '  %s\n' "${freeze_files[@]}")
 
-Freezes are declared under ADR 0001 hard-trigger containment. Resolve the
+Freezes are declared under ADR 0002 hard-trigger containment. Resolve the
 underlying hard trigger and remove the freeze file via a PR whose diff is
 exclusively freeze-file deletions, labelled governance:freeze-removal.
 EOF

--- a/scripts/check-freeze.sh
+++ b/scripts/check-freeze.sh
@@ -55,58 +55,163 @@ changed_name_status=$(git diff --name-status "${BASE_SHA}" "${HEAD_SHA}")
 #   - every changed path is under .github/freezes/, AND
 #   - every changed path is a deletion (status 'D').
 # Otherwise the freeze check runs normally.
-exempt=0
+# Parse PR_LABELS as a strict JSON array once. Any malformed input
+# fail-closes the check — do not fall through treating PR_LABELS as
+# absent, since that would skip the mandatory label exemption logic.
+parsed_labels=""
 if [[ -n "${PR_LABELS:-}" ]]; then
     set +e
-    PR_LABELS="${PR_LABELS}" python3 -c '
+    parsed_labels=$(
+        PR_LABELS="${PR_LABELS}" python3 -c '
 import json, os, sys
 raw = os.environ.get("PR_LABELS", "")
 try:
     labels = json.loads(raw)
 except Exception:
     sys.exit(2)
-if not isinstance(labels, list):
+if not isinstance(labels, list) or not all(isinstance(x, str) for x in labels):
     sys.exit(2)
-sys.exit(0 if "governance:freeze-removal" in labels else 3)
+for label in labels:
+    print(label)
 '
+    )
     label_rc=$?
     set -e
-
-    if [[ "${label_rc}" -eq 2 ]]; then
-        echo "check-freeze: PR_LABELS is not a valid JSON array — fail-closed." >&2
+    if [[ "${label_rc}" -ne 0 ]]; then
+        echo "check-freeze: PR_LABELS is not a valid JSON array of strings — fail-closed." >&2
         exit 1
-    fi
-
-    if [[ "${label_rc}" -eq 0 ]]; then
-        diff_only_freeze_deletes=1
-        while IFS=$'\t' read -r status path rest; do
-            [[ -z "${status}" ]] && continue
-            # Rename/copy statuses are prefixed 'R'/'C' with a similarity score.
-            case "${status}" in
-                D) ;;
-                *) diff_only_freeze_deletes=0 ;;
-            esac
-            case "${path}" in
-                .github/freezes/*) ;;
-                *) diff_only_freeze_deletes=0 ;;
-            esac
-            [[ "${diff_only_freeze_deletes}" -eq 0 ]] && break
-        done <<<"${changed_name_status}"
-
-        if [[ "${diff_only_freeze_deletes}" -eq 1 ]]; then
-            exempt=1
-        else
-            echo "check-freeze: governance:freeze-removal label present but diff is not purely freeze-file deletions — exemption denied." >&2
-            echo "Changed files:" >&2
-            printf '%s\n' "${changed_name_status}" >&2
-            exit 1
-        fi
     fi
 fi
 
-if [[ "${exempt}" -eq 1 ]]; then
-    echo "check-freeze: governance:freeze-removal label + diff matches freeze-only deletions — exempt."
-    exit 0
+has_label() {
+    local needle="$1"
+    [[ -z "${parsed_labels}" ]] && return 1
+    printf '%s\n' "${parsed_labels}" | grep -qxF "${needle}"
+}
+
+# --- 2a. Freeze-removal exemption ----------------------------------------
+# Applies iff:
+#   - PR is labelled exactly 'governance:freeze-removal', AND
+#   - every changed path is a pure deletion under .github/freezes/.
+if has_label "governance:freeze-removal"; then
+    diff_only_freeze_deletes=1
+    while IFS=$'\t' read -r status path rest; do
+        [[ -z "${status}" ]] && continue
+        # Strip similarity score from rename/copy statuses (e.g. R100).
+        short_status="${status:0:1}"
+        case "${short_status}" in
+            D) ;;
+            *) diff_only_freeze_deletes=0 ;;
+        esac
+        case "${path}" in
+            .github/freezes/*) ;;
+            *) diff_only_freeze_deletes=0 ;;
+        esac
+        [[ "${diff_only_freeze_deletes}" -eq 0 ]] && break
+    done <<<"${changed_name_status}"
+
+    if [[ "${diff_only_freeze_deletes}" -eq 1 ]]; then
+        echo "check-freeze: governance:freeze-removal label + diff matches freeze-only deletions — exempt."
+        exit 0
+    fi
+
+    echo "check-freeze: governance:freeze-removal label present but diff is not purely freeze-file deletions — exemption denied." >&2
+    echo "Changed files:" >&2
+    printf '%s\n' "${changed_name_status}" >&2
+    exit 1
+fi
+
+# --- 2b. Transition exemption (GOVERNANCE §5.4) --------------------------
+# The second-maintainer transition PR needs to touch load-bearing
+# governance + doc paths while an all-paths transition freeze is active.
+# Applies iff:
+#   - PR is labelled exactly 'governance:transition', AND
+#   - the diff touches ONLY the explicitly-permitted transition scope:
+#       MAINTAINERS.md
+#       GOVERNANCE.md
+#       .github/CODEOWNERS
+#       docs/design/decisions/
+#       docs/design/design-brief.md
+#       scripts/check-reviewed-by.sh
+#   - and does NOT modify any freeze file (the tamper guard below
+#     still runs after this block).
+if has_label "governance:transition"; then
+    allowed_prefixes=(
+        'MAINTAINERS.md'
+        'GOVERNANCE.md'
+        '.github/CODEOWNERS'
+        'docs/design/decisions/'
+        'docs/design/design-brief.md'
+        'scripts/check-reviewed-by.sh'
+    )
+    in_scope=1
+    while IFS= read -r file; do
+        [[ -z "${file}" ]] && continue
+        ok=0
+        for allowed in "${allowed_prefixes[@]}"; do
+            case "${file}" in
+                "${allowed}"*) ok=1; break ;;
+            esac
+        done
+        if [[ "${ok}" -eq 0 ]]; then
+            in_scope=0
+            echo "check-freeze: governance:transition exemption denied — path '${file}' is outside the permitted transition scope." >&2
+            break
+        fi
+    done <<<"${changed_files}"
+
+    if [[ "${in_scope}" -eq 1 ]]; then
+        echo "check-freeze: governance:transition label + diff within permitted transition scope — exempt."
+        exit 0
+    fi
+    echo "Changed files:" >&2
+    printf '%s\n' "${changed_files}" >&2
+    exit 1
+fi
+
+# --- 2a. Freeze-file tamper guard. ---------------------------------------
+# A PR that is NOT the exempt freeze-removal path must not edit, rename,
+# or delete existing `.github/freezes/*.y?ml` files. New-file additions
+# (status 'A') are allowed — that is how a maintainer opens a new freeze.
+# Everything else (M, D, R, C, T) on those paths fails closed, because
+# the fallthrough freeze-path check can only detect diffs touching the
+# TARGET of a freeze, not the freeze file itself.
+#
+# This is the final gate before normal freeze evaluation, so an un-
+# labelled PR that silently deletes an active freeze file is caught
+# here even if it doesn't also touch the (now-unfrozen) target path.
+tamper_hit=""
+while IFS=$'\t' read -r status path rest; do
+    [[ -z "${status}" ]] && continue
+    case "${path}" in
+        .github/freezes/*.yaml|.github/freezes/*.yml) ;;
+        *) continue ;;
+    esac
+    # Strip similarity score from rename/copy statuses (e.g. R100).
+    short_status="${status:0:1}"
+    case "${short_status}" in
+        A) ;;
+        *) tamper_hit="${status}	${path}"; break ;;
+    esac
+done <<<"${changed_name_status}"
+
+if [[ -n "${tamper_hit}" ]]; then
+    cat >&2 <<EOF
+check-freeze: FAIL — PR modifies or deletes an existing freeze file
+without the exempt freeze-removal protocol.
+
+Offending change: ${tamper_hit}
+
+Freeze files under .github/freezes/*.yaml may only be:
+  - added (status A) — to declare a new freeze, OR
+  - deleted (status D) as the ENTIRE diff, with the PR labelled
+    'governance:freeze-removal'.
+
+Editing, renaming, or partially deleting an existing freeze file is not
+permitted; open a freeze-removal PR then a separate freeze-addition PR
+if the freeze needs to change.
+EOF
+    exit 1
 fi
 
 # --- 3. Load active freezes; fail closed on any malformed file. ----------
@@ -165,9 +270,21 @@ PY
 }
 
 # --- 4. Check PR diff against frozen paths. ------------------------------
+# Path semantics: a `paths:` entry is a prefix match on the repository-
+# relative path. The single entry `**` is a sentinel meaning "match
+# every path" (used by the transition freeze in GOVERNANCE.md §5.4).
 hit=""
 while IFS=$'\t' read -r tag src pattern; do
     [[ "${tag}" != "PATH" ]] && continue
+    if [[ "${pattern}" == "**" ]]; then
+        # Any changed file is a hit.
+        first_file=$(printf '%s\n' "${changed_files}" | sed -n '1p')
+        if [[ -n "${first_file}" ]]; then
+            hit="${first_file} (frozen by ** sentinel in ${src})"
+            break
+        fi
+        continue
+    fi
     while IFS= read -r file; do
         [[ -z "${file}" ]] && continue
         case "${file}" in

--- a/scripts/check-freeze.sh
+++ b/scripts/check-freeze.sh
@@ -6,11 +6,11 @@
 # "Immediate containment when a hard trigger fires"). Any PR whose diff
 # touches a frozen path fails this required status check.
 #
-# This script must run from the BASE-branch checkout so PR-side edits to
-# either the freeze files or this script cannot weaken the gate — see
+# Executed from the BASE-branch checkout so PR-side edits to either the
+# freeze files or this script cannot weaken the gate — see
 # .github/workflows/governance.yml.
 #
-# Freeze file format (one file per active freeze):
+# Freeze file format:
 #
 #   # .github/freezes/2026-04-24-hard-trigger-h2-store.yaml
 #   trigger: H2
@@ -22,11 +22,8 @@
 #     - crates/cairn-store-sqlite/
 #     - crates/cairn-store-sqlite/Cargo.toml
 #
-# The `paths:` list is the only field this script parses; all other fields
-# are human audit context. Freezes are removed by merging a PR that deletes
-# the file (that PR itself may need the freeze override — see §5 of the
-# ADR — and in that case must be labelled `governance:freeze-removal` which
-# exempts it).
+# PyYAML is required and parses the file strictly; any malformed active
+# freeze file fails the check (fail-closed).
 
 set -euo pipefail
 
@@ -35,18 +32,84 @@ if [[ -z "${BASE_SHA:-}" || -z "${HEAD_SHA:-}" ]]; then
     exit 2
 fi
 
-# Exempt freeze-removal PRs (they delete freeze files; blocking them would
-# prevent the freeze from ever being lifted). Detection: PR carries label
-# `governance:freeze-removal` OR the diff is purely deletions under
-# .github/freezes/ with no other paths touched.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "check-freeze: python3 is required" >&2
+    exit 2
+fi
+
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+    echo "check-freeze: PyYAML is required (install via workflow step)" >&2
+    exit 2
+fi
+
+git fetch --no-tags --depth=200 origin "${BASE_SHA}" "${HEAD_SHA}" >/dev/null 2>&1 || true
+
+# --- 1. Diff once, reused below. -----------------------------------------
+changed_files=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+changed_name_status=$(git diff --name-status "${BASE_SHA}" "${HEAD_SHA}")
+
+# --- 2. Freeze-removal exemption: strict JSON label match + diff scope. --
+# The exemption applies only when:
+#   - PR labels (parsed as strict JSON array) contain the EXACT string
+#     'governance:freeze-removal', AND
+#   - every changed path is under .github/freezes/, AND
+#   - every changed path is a deletion (status 'D').
+# Otherwise the freeze check runs normally.
+exempt=0
 if [[ -n "${PR_LABELS:-}" ]]; then
-    if printf '%s' "${PR_LABELS}" | tr '[:upper:]' '[:lower:]' \
-            | grep -qw 'governance:freeze-removal'; then
-        echo "check-freeze: governance:freeze-removal label detected — exempt."
-        exit 0
+    set +e
+    PR_LABELS="${PR_LABELS}" python3 -c '
+import json, os, sys
+raw = os.environ.get("PR_LABELS", "")
+try:
+    labels = json.loads(raw)
+except Exception:
+    sys.exit(2)
+if not isinstance(labels, list):
+    sys.exit(2)
+sys.exit(0 if "governance:freeze-removal" in labels else 3)
+'
+    label_rc=$?
+    set -e
+
+    if [[ "${label_rc}" -eq 2 ]]; then
+        echo "check-freeze: PR_LABELS is not a valid JSON array — fail-closed." >&2
+        exit 1
+    fi
+
+    if [[ "${label_rc}" -eq 0 ]]; then
+        diff_only_freeze_deletes=1
+        while IFS=$'\t' read -r status path rest; do
+            [[ -z "${status}" ]] && continue
+            # Rename/copy statuses are prefixed 'R'/'C' with a similarity score.
+            case "${status}" in
+                D) ;;
+                *) diff_only_freeze_deletes=0 ;;
+            esac
+            case "${path}" in
+                .github/freezes/*) ;;
+                *) diff_only_freeze_deletes=0 ;;
+            esac
+            [[ "${diff_only_freeze_deletes}" -eq 0 ]] && break
+        done <<<"${changed_name_status}"
+
+        if [[ "${diff_only_freeze_deletes}" -eq 1 ]]; then
+            exempt=1
+        else
+            echo "check-freeze: governance:freeze-removal label present but diff is not purely freeze-file deletions — exemption denied." >&2
+            echo "Changed files:" >&2
+            printf '%s\n' "${changed_name_status}" >&2
+            exit 1
+        fi
     fi
 fi
 
+if [[ "${exempt}" -eq 1 ]]; then
+    echo "check-freeze: governance:freeze-removal label + diff matches freeze-only deletions — exempt."
+    exit 0
+fi
+
+# --- 3. Load active freezes; fail closed on any malformed file. ----------
 freeze_dir=".github/freezes"
 
 if [[ ! -d "${freeze_dir}" ]]; then
@@ -58,65 +121,63 @@ shopt -s nullglob
 freeze_files=("${freeze_dir}"/*.yaml "${freeze_dir}"/*.yml)
 shopt -u nullglob
 
-# Ignore a placeholder README if present.
-active_files=()
-for f in "${freeze_files[@]}"; do
-    [[ "$(basename "${f}")" == ".gitkeep"* ]] && continue
-    active_files+=("${f}")
-done
-
-if [[ "${#active_files[@]}" -eq 0 ]]; then
-    echo "check-freeze: no active freeze files."
+if [[ "${#freeze_files[@]}" -eq 0 ]]; then
+    echo "check-freeze: no freeze YAML files present."
     exit 0
 fi
 
-# Collect frozen paths from YAML `paths:` lists (simple parser: items under
-# a `paths:` key formatted as `  - some/path/`).
-frozen_paths=()
-for f in "${active_files[@]}"; do
-    while IFS= read -r path; do
-        [[ -z "${path}" ]] && continue
-        frozen_paths+=("${path}")
-    done < <(
-        python3 - "${f}" <<'PY'
-import sys, re
-path = sys.argv[1]
-with open(path) as fh:
-    text = fh.read()
-in_paths = False
-for line in text.splitlines():
-    stripped = line.rstrip()
-    if re.match(r'^paths\s*:\s*$', stripped):
-        in_paths = True
+parsed=$(
+    python3 - "${freeze_files[@]}" <<'PY'
+import sys, yaml, pathlib
+status = 0
+for p in sys.argv[1:]:
+    text = pathlib.Path(p).read_text()
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        print(f"ERROR\t{p}\tYAML parse error: {exc}", file=sys.stderr)
+        status = 2
         continue
-    if in_paths:
-        m = re.match(r'^\s*-\s*"?([^"\s]+)"?\s*$', stripped)
-        if m:
-            print(m.group(1))
+    if doc is None:
+        print(f"ERROR\t{p}\tempty document", file=sys.stderr)
+        status = 2
+        continue
+    if not isinstance(doc, dict):
+        print(f"ERROR\t{p}\ttop-level must be a mapping", file=sys.stderr)
+        status = 2
+        continue
+    paths = doc.get("paths")
+    if not isinstance(paths, list) or not paths:
+        print(f"ERROR\t{p}\t'paths:' must be a non-empty list", file=sys.stderr)
+        status = 2
+        continue
+    for item in paths:
+        if not isinstance(item, str) or not item.strip():
+            print(f"ERROR\t{p}\tpath entries must be non-empty strings", file=sys.stderr)
+            status = 2
             continue
-        if stripped and not stripped.startswith(' '):
-            in_paths = False
+        print(f"PATH\t{p}\t{item.strip()}")
+sys.exit(status)
 PY
-    )
-done
+) || {
+    echo "check-freeze: FAIL — one or more freeze files failed strict parse (see above). Fail-closed." >&2
+    exit 1
+}
 
-if [[ "${#frozen_paths[@]}" -eq 0 ]]; then
-    echo "check-freeze: freeze files present but no paths declared — treating as inactive."
-    exit 0
-fi
-
-git fetch --no-tags --depth=200 origin "${BASE_SHA}" "${HEAD_SHA}" >/dev/null 2>&1 || true
-changed_files=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
-
+# --- 4. Check PR diff against frozen paths. ------------------------------
 hit=""
-while IFS= read -r file; do
-    [[ -z "${file}" ]] && continue
-    for frozen in "${frozen_paths[@]}"; do
+while IFS=$'\t' read -r tag src pattern; do
+    [[ "${tag}" != "PATH" ]] && continue
+    while IFS= read -r file; do
+        [[ -z "${file}" ]] && continue
         case "${file}" in
-            "${frozen}"*) hit="${file} (frozen by pattern ${frozen})"; break 2 ;;
+            "${pattern}"*)
+                hit="${file} (frozen by ${pattern} in ${src})"
+                break 2
+                ;;
         esac
-    done
-done <<<"${changed_files}"
+    done <<<"${changed_files}"
+done <<<"${parsed}"
 
 if [[ -n "${hit}" ]]; then
     cat >&2 <<EOF
@@ -124,12 +185,12 @@ check-freeze: FAIL — PR touches a frozen path.
 
 Match: ${hit}
 
-Active freezes (from ${freeze_dir}/):
-$(printf '  %s\n' "${active_files[@]}")
+Active freeze files:
+$(printf '  %s\n' "${freeze_files[@]}")
 
 Freezes are declared under ADR 0001 hard-trigger containment. Resolve the
-underlying hard trigger and remove the freeze file via a PR labelled
-governance:freeze-removal before merging changes that touch these paths.
+underlying hard trigger and remove the freeze file via a PR whose diff is
+exclusively freeze-file deletions, labelled governance:freeze-removal.
 EOF
     exit 1
 fi

--- a/scripts/check-reviewed-by.sh
+++ b/scripts/check-reviewed-by.sh
@@ -2,23 +2,40 @@
 # check-reviewed-by.sh
 #
 # Enforces GOVERNANCE.md §5 on load-bearing PRs during the single-maintainer
-# period. A load-bearing PR must carry a `Reviewed-by:` trailer (either on
-# the tip commit or in the PR body) naming a non-author GitHub handle.
+# period. A load-bearing PR must have:
+#   1. An APPROVED GitHub review on the CURRENT HEAD by a non-author account.
+#   2. A `Reviewed-by:` trailer (commit-message or PR body) that names the
+#      same GitHub account.
+#
+# The script MUST be executed from the base-branch checkout (trusted code),
+# not from a PR-supplied workspace — see .github/workflows/governance.yml
+# which uses `pull_request_target` with the base ref checked out. It never
+# executes PR-supplied code; it only inspects PR metadata via the GitHub
+# REST API and diff via git.
 #
 # Inputs (env):
-#   BASE_SHA, HEAD_SHA, PR_BODY, PR_AUTHOR — supplied by the workflow.
-#
-# The script is conservative: if inputs are missing, it fails closed.
+#   GH_TOKEN           — GitHub token with read access to pull_requests.
+#   GITHUB_REPOSITORY  — "owner/repo", supplied by GitHub Actions.
+#   PR_NUMBER          — pull request number.
+#   BASE_SHA, HEAD_SHA — commit SHAs (base = merge-base ancestor, head = PR tip).
+#   PR_AUTHOR          — login of the PR author.
+#   PR_BODY            — pull request description (unverified; text only).
 
 set -euo pipefail
 
-if [[ -z "${BASE_SHA:-}" || -z "${HEAD_SHA:-}" ]]; then
-    echo "check-reviewed-by: BASE_SHA and HEAD_SHA must be set" >&2
-    exit 2
-fi
+require_env() {
+    local name
+    for name in "$@"; do
+        if [[ -z "${!name:-}" ]]; then
+            echo "check-reviewed-by: required env var ${name} is empty" >&2
+            exit 2
+        fi
+    done
+}
 
-# Load-bearing path globs — keep in sync with GOVERNANCE.md §5 and
-# CLAUDE.md §9.
+require_env GH_TOKEN GITHUB_REPOSITORY PR_NUMBER BASE_SHA HEAD_SHA PR_AUTHOR
+
+# Load-bearing path globs — keep in sync with GOVERNANCE.md §5.2.
 load_bearing_patterns=(
     'crates/cairn-core/src/'
     'crates/cairn-core/Cargo.toml'
@@ -30,18 +47,25 @@ load_bearing_patterns=(
     'MAINTAINERS.md'
     '.github/CODEOWNERS'
     '.github/workflows/governance.yml'
+    '.github/freezes/'
     'scripts/check-reviewed-by.sh'
+    'scripts/check-freeze.sh'
 )
+
+# Ensure we have both SHAs locally (pull_request_target starts from base).
+git fetch --no-tags --depth=200 origin "${BASE_SHA}" "${HEAD_SHA}" >/dev/null 2>&1 || true
 
 changed_files=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
 
 touches_load_bearing=0
 while IFS= read -r file; do
+    [[ -z "${file}" ]] && continue
     for pattern in "${load_bearing_patterns[@]}"; do
         case "${file}" in
             "${pattern}"*) touches_load_bearing=1; break ;;
         esac
     done
+    [[ "${touches_load_bearing}" -eq 1 ]] && break
 done <<<"${changed_files}"
 
 if [[ "${touches_load_bearing}" -eq 0 ]]; then
@@ -49,9 +73,64 @@ if [[ "${touches_load_bearing}" -eq 0 ]]; then
     exit 0
 fi
 
-echo "check-reviewed-by: load-bearing paths touched; requiring Reviewed-by: trailer."
+echo "check-reviewed-by: load-bearing paths touched; verifying Approved review + Reviewed-by trailer."
 
-# Collect Reviewed-by trailers from commits AND the PR body.
+# --- 1. Fetch reviews via GitHub REST API ---------------------------------
+api_base="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+reviews_json=$(
+    curl --silent --show-error --fail \
+        --header "Authorization: Bearer ${GH_TOKEN}" \
+        --header "Accept: application/vnd.github+json" \
+        --header "X-GitHub-Api-Version: 2022-11-28" \
+        "${api_base}/pulls/${PR_NUMBER}/reviews?per_page=100"
+)
+
+# Collect the LATEST review state per reviewer (GitHub returns reviews in
+# chronological order). We want: login lowercased, state, commit_id.
+latest_reviews=$(
+    printf '%s' "${reviews_json}" | python3 -c '
+import json, sys
+reviews = json.load(sys.stdin)
+latest = {}
+for r in reviews:
+    user = (r.get("user") or {}).get("login") or ""
+    if not user:
+        continue
+    latest[user.lower()] = {
+        "state": r.get("state") or "",
+        "commit_id": r.get("commit_id") or "",
+    }
+for login, data in latest.items():
+    print(f"{login}\t{data[\"state\"]}\t{data[\"commit_id\"]}")
+'
+)
+
+author_lc=$(printf '%s' "${PR_AUTHOR}" | tr '[:upper:]' '[:lower:]')
+
+approving_reviewers=$(
+    printf '%s\n' "${latest_reviews}" \
+        | awk -F'\t' -v author="${author_lc}" -v head="${HEAD_SHA}" '
+            $2 == "APPROVED" && $1 != author && $3 == head { print $1 }
+        '
+)
+
+if [[ -z "${approving_reviewers}" ]]; then
+    cat >&2 <<EOF
+check-reviewed-by: FAIL — no APPROVED GitHub review on the current HEAD
+(${HEAD_SHA}) from a non-author account.
+
+Latest review states (login state commit_id):
+${latest_reviews:-(none)}
+
+During the single-maintainer period (GOVERNANCE.md §5), load-bearing PRs
+require an external reviewer to leave an Approved review on the PR AND a
+matching 'Reviewed-by:' trailer. The trailer alone is not sufficient.
+Request a review and have the reviewer click Approve on the current HEAD.
+EOF
+    exit 1
+fi
+
+# --- 2. Verify Reviewed-by trailer names an approving reviewer -----------
 trailers=$(
     {
         git log "${BASE_SHA}..${HEAD_SHA}" --format=%B
@@ -60,35 +139,46 @@ trailers=$(
 )
 
 if [[ -z "${trailers}" ]]; then
+    echo "check-reviewed-by: FAIL — no 'Reviewed-by:' trailer found on commits or in PR body." >&2
+    exit 1
+fi
+
+# Extract GitHub handles from the trailer lines (any token after '@').
+trailer_handles=$(
+    printf '%s\n' "${trailers}" \
+        | grep -oE '@[A-Za-z0-9][A-Za-z0-9-]{0,38}' \
+        | sed 's/^@//' \
+        | tr '[:upper:]' '[:lower:]' \
+        | sort -u
+)
+
+if [[ -z "${trailer_handles}" ]]; then
+    echo "check-reviewed-by: FAIL — Reviewed-by: trailer present but no @handle recognised." >&2
+    echo "${trailers}" >&2
+    exit 1
+fi
+
+matched=""
+while IFS= read -r handle; do
+    [[ -z "${handle}" ]] && continue
+    if printf '%s\n' "${approving_reviewers}" | grep -qxF "${handle}"; then
+        matched="${handle}"
+        break
+    fi
+done <<<"${trailer_handles}"
+
+if [[ -z "${matched}" ]]; then
     cat >&2 <<EOF
-check-reviewed-by: FAIL
+check-reviewed-by: FAIL — Reviewed-by: trailer does not name any approving
+reviewer of the current HEAD.
 
-This PR touches load-bearing paths (GOVERNANCE.md §5 / CLAUDE.md §9) but
-carries no 'Reviewed-by:' trailer. During the single-maintainer period,
-required-reviewer branch protection is disabled because GitHub disallows
-self-approval. Load-bearing PRs must instead be reviewed by an external
-reviewer who leaves an approving review on the PR and is recorded via:
+Reviewed-by handles:
+$(printf '%s\n' "${trailer_handles}")
 
-    Reviewed-by: <Full Name> <@github-handle or email>
-
-Add the trailer to either the merge commit body or the PR description.
+Approving reviewers on HEAD=${HEAD_SHA}:
+$(printf '%s\n' "${approving_reviewers}")
 EOF
     exit 1
 fi
 
-# Reject trailers whose GitHub handle matches the PR author (case-insensitive).
-if [[ -n "${PR_AUTHOR:-}" ]]; then
-    lowered_author=$(printf '%s' "${PR_AUTHOR}" | tr '[:upper:]' '[:lower:]')
-    self_review=$(
-        printf '%s\n' "${trailers}" \
-            | tr '[:upper:]' '[:lower:]' \
-            | grep -E "@?${lowered_author}([^[:alnum:]_-]|$)" || true
-    )
-    if [[ -n "${self_review}" ]]; then
-        echo "check-reviewed-by: FAIL — Reviewed-by: trailer names the PR author (${PR_AUTHOR}); external reviewer required." >&2
-        exit 1
-    fi
-fi
-
-echo "check-reviewed-by: OK"
-printf '%s\n' "${trailers}"
+echo "check-reviewed-by: OK — Approved review by @${matched} matches Reviewed-by: trailer."

--- a/scripts/check-reviewed-by.sh
+++ b/scripts/check-reviewed-by.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# check-reviewed-by.sh
+#
+# Enforces GOVERNANCE.md §5 on load-bearing PRs during the single-maintainer
+# period. A load-bearing PR must carry a `Reviewed-by:` trailer (either on
+# the tip commit or in the PR body) naming a non-author GitHub handle.
+#
+# Inputs (env):
+#   BASE_SHA, HEAD_SHA, PR_BODY, PR_AUTHOR — supplied by the workflow.
+#
+# The script is conservative: if inputs are missing, it fails closed.
+
+set -euo pipefail
+
+if [[ -z "${BASE_SHA:-}" || -z "${HEAD_SHA:-}" ]]; then
+    echo "check-reviewed-by: BASE_SHA and HEAD_SHA must be set" >&2
+    exit 2
+fi
+
+# Load-bearing path globs — keep in sync with GOVERNANCE.md §5 and
+# CLAUDE.md §9.
+load_bearing_patterns=(
+    'crates/cairn-core/src/'
+    'crates/cairn-core/Cargo.toml'
+    'crates/cairn-idl/'
+    'crates/cairn-store-sqlite/migrations/'
+    'docs/design/design-brief.md'
+    'docs/design/decisions/'
+    'GOVERNANCE.md'
+    'MAINTAINERS.md'
+    '.github/CODEOWNERS'
+    '.github/workflows/governance.yml'
+    'scripts/check-reviewed-by.sh'
+)
+
+changed_files=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+
+touches_load_bearing=0
+while IFS= read -r file; do
+    for pattern in "${load_bearing_patterns[@]}"; do
+        case "${file}" in
+            "${pattern}"*) touches_load_bearing=1; break ;;
+        esac
+    done
+done <<<"${changed_files}"
+
+if [[ "${touches_load_bearing}" -eq 0 ]]; then
+    echo "check-reviewed-by: no load-bearing paths touched — skipping."
+    exit 0
+fi
+
+echo "check-reviewed-by: load-bearing paths touched; requiring Reviewed-by: trailer."
+
+# Collect Reviewed-by trailers from commits AND the PR body.
+trailers=$(
+    {
+        git log "${BASE_SHA}..${HEAD_SHA}" --format=%B
+        printf '\n%s\n' "${PR_BODY:-}"
+    } | grep -iE '^[[:space:]]*Reviewed-by:' || true
+)
+
+if [[ -z "${trailers}" ]]; then
+    cat >&2 <<EOF
+check-reviewed-by: FAIL
+
+This PR touches load-bearing paths (GOVERNANCE.md §5 / CLAUDE.md §9) but
+carries no 'Reviewed-by:' trailer. During the single-maintainer period,
+required-reviewer branch protection is disabled because GitHub disallows
+self-approval. Load-bearing PRs must instead be reviewed by an external
+reviewer who leaves an approving review on the PR and is recorded via:
+
+    Reviewed-by: <Full Name> <@github-handle or email>
+
+Add the trailer to either the merge commit body or the PR description.
+EOF
+    exit 1
+fi
+
+# Reject trailers whose GitHub handle matches the PR author (case-insensitive).
+if [[ -n "${PR_AUTHOR:-}" ]]; then
+    lowered_author=$(printf '%s' "${PR_AUTHOR}" | tr '[:upper:]' '[:lower:]')
+    self_review=$(
+        printf '%s\n' "${trailers}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | grep -E "@?${lowered_author}([^[:alnum:]_-]|$)" || true
+    )
+    if [[ -n "${self_review}" ]]; then
+        echo "check-reviewed-by: FAIL — Reviewed-by: trailer names the PR author (${PR_AUTHOR}); external reviewer required." >&2
+        exit 1
+    fi
+fi
+
+echo "check-reviewed-by: OK"
+printf '%s\n' "${trailers}"

--- a/scripts/check-reviewed-by.sh
+++ b/scripts/check-reviewed-by.sh
@@ -80,34 +80,66 @@ fi
 
 echo "check-reviewed-by: load-bearing paths touched; verifying Approved review + Reviewed-by trailer."
 
-# --- 1. Fetch reviews via GitHub REST API ---------------------------------
+# --- 1. Fetch ALL review pages via GitHub REST API ------------------------
+# GitHub paginates reviews at 100 per page. A PR with >100 reviews (active
+# debates, many re-requests) would otherwise leave later CHANGES_REQUESTED
+# or dismissed states invisible and a stale APPROVED could remain green.
 api_base="https://api.github.com/repos/${GITHUB_REPOSITORY}"
-reviews_json=$(
-    curl --silent --show-error --fail \
-        --header "Authorization: Bearer ${GH_TOKEN}" \
-        --header "Accept: application/vnd.github+json" \
-        --header "X-GitHub-Api-Version: 2022-11-28" \
-        "${api_base}/pulls/${PR_NUMBER}/reviews?per_page=100"
-)
+reviews_dir=$(mktemp -d)
+trap 'rm -rf "${reviews_dir}"' EXIT
 
-# Collect the LATEST review state per reviewer (GitHub returns reviews in
-# chronological order). We want: login lowercased, state, commit_id.
+page=1
+while :; do
+    page_file="${reviews_dir}/page-${page}.json"
+    http_code=$(
+        curl --silent --show-error --output "${page_file}" --write-out '%{http_code}' \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "${api_base}/pulls/${PR_NUMBER}/reviews?per_page=100&page=${page}"
+    )
+    if [[ "${http_code}" != "200" ]]; then
+        echo "check-reviewed-by: FAIL — GitHub reviews API returned HTTP ${http_code} on page ${page}" >&2
+        [[ -s "${page_file}" ]] && cat "${page_file}" >&2
+        exit 1
+    fi
+    count=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' "${page_file}")
+    if [[ "${count}" -eq 0 ]]; then
+        break
+    fi
+    if [[ "${count}" -lt 100 ]]; then
+        page=$((page + 1))
+        break
+    fi
+    page=$((page + 1))
+    if [[ "${page}" -gt 50 ]]; then
+        echo "check-reviewed-by: FAIL — review pagination exceeded 50 pages (5000 reviews); aborting." >&2
+        exit 1
+    fi
+done
+
+# Compute latest review state per reviewer across ALL pages, ordered by
+# submission time (GitHub returns reviews in chronological order both
+# within and across pages).
 latest_reviews=$(
-    printf '%s' "${reviews_json}" | python3 -c '
-import json, sys
-reviews = json.load(sys.stdin)
+    python3 - "${reviews_dir}" <<'PY'
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+files = sorted(root.glob("page-*.json"), key=lambda p: int(p.stem.split("-")[1]))
 latest = {}
-for r in reviews:
-    user = (r.get("user") or {}).get("login") or ""
-    if not user:
-        continue
-    latest[user.lower()] = {
-        "state": r.get("state") or "",
-        "commit_id": r.get("commit_id") or "",
-    }
+for f in files:
+    for r in json.loads(f.read_text()):
+        user = (r.get("user") or {}).get("login") or ""
+        if not user:
+            continue
+        latest[user.lower()] = {
+            "state": r.get("state") or "",
+            "commit_id": r.get("commit_id") or "",
+            "submitted_at": r.get("submitted_at") or "",
+        }
 for login, data in latest.items():
-    print(f"{login}\t{data[\"state\"]}\t{data[\"commit_id\"]}")
-'
+    print(f"{login}\t{data['state']}\t{data['commit_id']}")
+PY
 )
 
 author_lc=$(printf '%s' "${PR_AUTHOR}" | tr '[:upper:]' '[:lower:]')

--- a/scripts/check-reviewed-by.sh
+++ b/scripts/check-reviewed-by.sh
@@ -19,7 +19,10 @@
 #   PR_NUMBER          — pull request number.
 #   BASE_SHA, HEAD_SHA — commit SHAs (base = merge-base ancestor, head = PR tip).
 #   PR_AUTHOR          — login of the PR author.
-#   PR_BODY            — pull request description (unverified; text only).
+#
+# Trailers are read only from commit messages (`git log --format=%B`) so
+# the audit artefact survives squash-merge. PR body text is deliberately
+# not accepted as a substitute.
 
 set -euo pipefail
 
@@ -34,6 +37,7 @@ require_env() {
 }
 
 require_env GH_TOKEN GITHUB_REPOSITORY PR_NUMBER BASE_SHA HEAD_SHA PR_AUTHOR
+# PR_BODY is intentionally ignored; leaving any value unused is fine.
 
 # Load-bearing path globs — keep in sync with GOVERNANCE.md §5.2.
 load_bearing_patterns=(
@@ -50,6 +54,7 @@ load_bearing_patterns=(
     '.github/freezes/'
     'scripts/check-reviewed-by.sh'
     'scripts/check-freeze.sh'
+    'scripts/check-core-boundary.sh'
 )
 
 # Ensure we have both SHAs locally (pull_request_target starts from base).
@@ -130,16 +135,25 @@ EOF
     exit 1
 fi
 
-# --- 2. Verify Reviewed-by trailer names an approving reviewer -----------
+# --- 2. Verify Reviewed-by trailer in COMMIT HISTORY (durable only) ------
+# PR body text is mutable after merge and may not survive a squash-merge's
+# generated commit body; we accept only commit-message trailers so the
+# audit artefact is durable in `git log`.
 trailers=$(
-    {
-        git log "${BASE_SHA}..${HEAD_SHA}" --format=%B
-        printf '\n%s\n' "${PR_BODY:-}"
-    } | grep -iE '^[[:space:]]*Reviewed-by:' || true
+    git log "${BASE_SHA}..${HEAD_SHA}" --format=%B \
+        | grep -iE '^[[:space:]]*Reviewed-by:' || true
 )
 
 if [[ -z "${trailers}" ]]; then
-    echo "check-reviewed-by: FAIL — no 'Reviewed-by:' trailer found on commits or in PR body." >&2
+    cat >&2 <<EOF
+check-reviewed-by: FAIL — no 'Reviewed-by:' trailer found in commits
+between ${BASE_SHA}..${HEAD_SHA}.
+
+Add the trailer to a commit message (amend or new commit) so it survives
+squash-merge in the durable git history. Example footer:
+
+    Reviewed-by: Jane Doe <@janedoe>
+EOF
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Resolves design-brief §20 open question 1 (governance / monorepo shape) with a new ADR under `docs/design/decisions/` and closes #145.
- Seeds `.github/CODEOWNERS` against the sole maintainer, lands `GOVERNANCE.md` (CNCF maintainer-template) and `MAINTAINERS.md` with contract-area annotations, and amends brief §20 to point at the ADR.
- Decision: keep v0.1 as one public monorepo (Cargo workspace + sibling `packages/`), with explicit split triggers and revisit triggers so later extraction has written criteria rather than taste. Release tooling committed to release-plz + git-cliff; non-Rust SDK tooling deferred to a later ADR.

## Files

- `docs/design/decisions/0001-monorepo-governance.md` — new ADR (status: Accepted).
- `docs/design/design-brief.md` — §20.1 struck and linked to ADR.
- `.github/CODEOWNERS`, `GOVERNANCE.md`, `MAINTAINERS.md` — seed governance surface.

## Known counter-argument

Matt Klein's "Monorepos: Please don't!" is named in the ADR; its evidence targets megacorp-scale service repos and does not apply at our scale, but retained so the decision is transparent.

## Acceptance criteria (from #145)

- [x] Repository governance decision is written down before broad implementation begins.
- [x] Maintainer boundaries exist for core, store, sensors, API, frontend, packaging, and docs (per GOVERNANCE.md §2).
- [x] The decision does not block future package extraction (ADR 0001 split triggers are reversible exit criteria).

## Verification

- [x] `./scripts/check-core-boundary.sh` → `cairn-core boundary OK` (docs-only change).
- [x] Grep for contradictions in `architecture.md`, scaffold design doc, README — none; brief §16 already commits to monorepo shape.
- [ ] Reviewer: confirm `@windoliver` is the correct GitHub handle for seed CODEOWNERS; if the project later adopts a `cairn-project` org, swap to `@cairn-project/maintainers`.
- [ ] Reviewer: sanity-check dependent issue bodies (#3 children) for scope/phase language; none appeared inconsistent in the pre-PR scan but a fresh pair of eyes is cheap.

## Test plan

- Docs-only PR; no runtime behaviour changes.
- `cargo fmt --check`, `cargo clippy`, and `cargo nextest run --workspace` are expected to be unaffected; skip unless CI disagrees.