### PR TITLE
feat(core): contract traits, CONTRACT_VERSION, capability manifest, register_plugin! (#174)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cairn-cli"
 version = "0.0.1"
 dependencies = [
@@ -25,8 +36,11 @@ dependencies = [
 name = "cairn-core"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "serde",
+ "serde_json",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -80,6 +94,28 @@ dependencies = [
  "cairn-test-fixtures",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -168,6 +204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +265,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +341,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,6 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "serde",
- "serde_json",
  "thiserror",
  "toml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,35 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +47,51 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cairn-cli"
@@ -46,8 +120,10 @@ dependencies = [
 name = "cairn-idl"
 version = "0.0.1"
 dependencies = [
+ "jsonschema",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -96,10 +172,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -108,13 +279,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -124,10 +398,159 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50180452e7808015fe083eae3efcf1ec98b89b45dd8cc204f7b4a6b7b81ea675"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -136,10 +559,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -158,6 +625,99 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -212,6 +772,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +792,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -240,6 +823,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -336,10 +929,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "winnow"
@@ -348,6 +1035,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ thiserror = "2"
 tokio = "1"
 tracing = "0.1"
 anyhow = "1"
+async-trait = "0.1"
+toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 
 # Path + version on intra-workspace deps so `cargo publish` can rewrite the
 # path to a registry version without losing the constraint. The version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio = "1"
 tracing = "0.1"
 anyhow = "1"
 async-trait = "0.1"
+jsonschema = { version = "0.46", default-features = false }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 
 # Path + version on intra-workspace deps so `cargo publish` can rewrite the

--- a/crates/cairn-core/Cargo.toml
+++ b/crates/cairn-core/Cargo.toml
@@ -12,11 +12,10 @@ description = "Cairn verb layer, domain types, and error enums. No I/O, no adapt
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
+async-trait = { workspace = true }
+toml = { workspace = true }
 
 [lints]
 workspace = true
-
-# Forward-declared scaffold deps. Drop entries as their first call site lands.
-[package.metadata.cargo-machete]
-ignored = ["serde", "thiserror"]

--- a/crates/cairn-core/Cargo.toml
+++ b/crates/cairn-core/Cargo.toml
@@ -12,7 +12,6 @@ description = "Cairn verb layer, domain types, and error enums. No I/O, no adapt
 
 [dependencies]
 serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 toml = { workspace = true }

--- a/crates/cairn-core/Cargo.toml
+++ b/crates/cairn-core/Cargo.toml
@@ -17,5 +17,8 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 toml = { workspace = true }
 
+[dev-dependencies]
+async-trait = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/cairn-core/src/contract/agent_provider.rs
+++ b/crates/cairn-core/src/contract/agent_provider.rs
@@ -7,6 +7,7 @@
 use crate::contract::version::{ContractVersion, VersionRange};
 
 /// Contract version for `AgentProvider`. Bumps when the trait surface changes.
+#[doc(hidden)]
 pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 0, 1);
 
 /// Static capability declaration for an `AgentProvider` impl.
@@ -14,6 +15,7 @@ pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 0, 1);
 // machine adds indirection with no clarity gain here.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[doc(hidden)]
 pub struct AgentProviderCapabilities {
     /// Whether the agent respects a caller-supplied cost budget.
     pub honors_cost_budget: bool,
@@ -30,6 +32,7 @@ pub struct AgentProviderCapabilities {
 /// Brief §4 row 6: P2 forward stub. Method surface, cost-budget enforcement,
 /// and conformance suite land in #124 / #125.
 #[async_trait::async_trait]
+#[doc(hidden)]
 pub trait AgentProvider: Send + Sync {
     /// Stable identifier of the registered plugin instance.
     fn name(&self) -> &str;

--- a/crates/cairn-core/src/contract/agent_provider.rs
+++ b/crates/cairn-core/src/contract/agent_provider.rs
@@ -1,0 +1,42 @@
+//! `AgentProvider` contract — P2 forward stub (brief §4 row 6).
+//!
+//! Surface frozen here so the registry has a slot for agent-mode workers.
+//! Full method surface, cost-budget enforcement, and conformance suite
+//! land in #124 / #125.
+
+use crate::contract::version::{ContractVersion, VersionRange};
+
+/// Contract version for `AgentProvider`. Bumps when the trait surface changes.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 0, 1);
+
+/// Static capability declaration for an `AgentProvider` impl.
+// Four flags cover distinct agent safety/capability dimensions; a state
+// machine adds indirection with no clarity gain here.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AgentProviderCapabilities {
+    /// Whether the agent respects a caller-supplied cost budget.
+    pub honors_cost_budget: bool,
+    /// Whether the agent enforces scope restrictions on its actions.
+    pub scope_enforced: bool,
+    /// Whether the agent can invoke MCP tools.
+    pub mcp_tools: bool,
+    /// Whether the agent can invoke CLI subprocess tools.
+    pub cli_subprocess_tools: bool,
+}
+
+/// Agent provider contract — autonomous agent workers with bounded scope.
+///
+/// Brief §4 row 6: P2 forward stub. Method surface, cost-budget enforcement,
+/// and conformance suite land in #124 / #125.
+#[async_trait::async_trait]
+pub trait AgentProvider: Send + Sync {
+    /// Stable identifier of the registered plugin instance.
+    fn name(&self) -> &str;
+
+    /// Static capability advertisement (brief §4.1).
+    fn capabilities(&self) -> &AgentProviderCapabilities;
+
+    /// Range of `AgentProvider::CONTRACT_VERSION` values this impl accepts.
+    fn supported_contract_versions(&self) -> VersionRange;
+}

--- a/crates/cairn-core/src/contract/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/frontend_adapter.rs
@@ -1,0 +1,40 @@
+//! `FrontendAdapter` contract — P1 forward stub (brief §4 row 7).
+//!
+//! Surface frozen here so the registry has a slot for editor / desktop /
+//! plugin adapters. Full method surface and conformance suite ship with
+//! v0.2 in #113.
+
+use crate::contract::version::{ContractVersion, VersionRange};
+
+/// Contract version for `FrontendAdapter`. Bumps when the trait surface changes.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 0, 1);
+
+/// Static capability declaration for a `FrontendAdapter` impl.
+// Three flags cover distinct frontend projection dimensions; a state machine
+// adds indirection with no clarity gain here.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FrontendAdapterCapabilities {
+    /// Whether the adapter can project memory records as rendered markdown.
+    pub markdown_projection: bool,
+    /// Whether the adapter supports live event push to the frontend.
+    pub live_events: bool,
+    /// Whether the adapter can apply reverse edits back into the vault.
+    pub reverse_edits: bool,
+}
+
+/// Frontend adapter contract — projects vault state into editor / desktop UIs.
+///
+/// Brief §4 row 7: P1 forward stub. Method surface and conformance suite
+/// ship in #113.
+#[async_trait::async_trait]
+pub trait FrontendAdapter: Send + Sync {
+    /// Stable identifier of the registered plugin instance.
+    fn name(&self) -> &str;
+
+    /// Static capability advertisement (brief §4.1).
+    fn capabilities(&self) -> &FrontendAdapterCapabilities;
+
+    /// Range of `FrontendAdapter::CONTRACT_VERSION` values this impl accepts.
+    fn supported_contract_versions(&self) -> VersionRange;
+}

--- a/crates/cairn-core/src/contract/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/frontend_adapter.rs
@@ -7,6 +7,7 @@
 use crate::contract::version::{ContractVersion, VersionRange};
 
 /// Contract version for `FrontendAdapter`. Bumps when the trait surface changes.
+#[doc(hidden)]
 pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 0, 1);
 
 /// Static capability declaration for a `FrontendAdapter` impl.
@@ -14,6 +15,7 @@ pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 0, 1);
 // adds indirection with no clarity gain here.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[doc(hidden)]
 pub struct FrontendAdapterCapabilities {
     /// Whether the adapter can project memory records as rendered markdown.
     pub markdown_projection: bool,
@@ -28,6 +30,7 @@ pub struct FrontendAdapterCapabilities {
 /// Brief §4 row 7: P1 forward stub. Method surface and conformance suite
 /// ship in #113.
 #[async_trait::async_trait]
+#[doc(hidden)]
 pub trait FrontendAdapter: Send + Sync {
     /// Stable identifier of the registered plugin instance.
     fn name(&self) -> &str;

--- a/crates/cairn-core/src/contract/llm_provider.rs
+++ b/crates/cairn-core/src/contract/llm_provider.rs
@@ -1,0 +1,71 @@
+//! `LLMProvider` contract (brief §4 row 2).
+//!
+//! P0 scaffold: surface only. The single `complete(prompt, schema?)` method
+//! and structured-output enforcement arrive in #144.
+
+use crate::contract::version::{ContractVersion, VersionRange};
+
+/// Contract version for `LLMProvider`. Bumps when the trait surface changes.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 1, 0);
+
+/// Static capability declaration for a `LLMProvider` impl.
+// Three flags cover distinct LLM API dimensions; a state machine adds
+// indirection with no clarity gain here.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LLMProviderCapabilities {
+    /// Whether the provider supports structured JSON output mode.
+    pub json_mode: bool,
+    /// Whether the provider supports streaming completions.
+    pub streaming: bool,
+    /// Whether the provider supports parallel tool calls.
+    pub tool_calls: bool,
+}
+
+/// LLM contract — `complete(prompt, schema?) → text | json`.
+///
+/// Default impl in #144: `cairn-llm-openai-compat` over `async-openai`
+/// with configurable `base_url` (`OpenAI` / `Ollama` / `vLLM` / `LiteLLM` / …).
+#[async_trait::async_trait]
+pub trait LLMProvider: Send + Sync {
+    /// Stable identifier of the registered plugin instance.
+    fn name(&self) -> &str;
+
+    /// Static capability advertisement (brief §4.1).
+    fn capabilities(&self) -> &LLMProviderCapabilities;
+
+    /// Range of `LLMProvider::CONTRACT_VERSION` values this impl accepts.
+    fn supported_contract_versions(&self) -> VersionRange;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubLlm;
+
+    #[async_trait::async_trait]
+    impl LLMProvider for StubLlm {
+        fn name(&self) -> &'static str {
+            "stub-llm"
+        }
+        fn capabilities(&self) -> &LLMProviderCapabilities {
+            static CAPS: LLMProviderCapabilities = LLMProviderCapabilities {
+                json_mode: true,
+                streaming: false,
+                tool_calls: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+        }
+    }
+
+    #[test]
+    fn dyn_compatible() {
+        let l: Box<dyn LLMProvider> = Box::new(StubLlm);
+        assert_eq!(l.name(), "stub-llm");
+        assert!(l.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+}

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -44,7 +44,7 @@ macro_rules! register_plugin {
     (SensorIngress, $impl:ty, $name:literal) => {
         $crate::__register_plugin_helper!(register_sensor_ingress, $impl, $name);
     };
-    (McpServer, $impl:ty, $name:literal) => {
+    (MCPServer, $impl:ty, $name:literal) => {
         $crate::__register_plugin_helper!(register_mcp_server, $impl, $name);
     };
     (FrontendAdapter, $impl:ty, $name:literal) => {

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -12,6 +12,24 @@
 /// in the calling crate that registers `$impl` under contract `$contract`
 /// with the stable name `$name`.
 ///
+/// # Construction discipline
+///
+/// The generated `register` function constructs the impl via
+/// `<$impl as Default>::default()` **before** the registry runs version,
+/// identity, or duplicate-name checks. Implementations of [`Default::default`]
+/// must therefore be **side-effect free**: no I/O, no resource allocation,
+/// no panics. Open files, network connections, model handles, etc. belong in
+/// a separate `init`/`open` step the host invokes after registration —
+/// typically driven by `.cairn/config.yaml` (brief §4.1).
+///
+/// Config-driven construction (e.g., a `MemoryStore` impl that needs a
+/// database path at build time) is **not yet supported** by this macro;
+/// it will arrive in a follow-up issue that adds a factory variant
+/// (`register_plugin_with!(<contract>, <impl>, <name>, |cfg| <factory>)`)
+/// alongside trait-level associated consts so compatibility can be checked
+/// before construction. Until then: keep `Default` cheap, push real init
+/// behind an explicit `init(&Config)` method on your impl.
+///
 /// # Examples
 /// ```ignore
 /// use cairn_core::contract::register_plugin;

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -1,0 +1,80 @@
+//! `register_plugin!` declarative macro.
+//!
+//! Brief §4.1: "Plugins call `cairn_core::register_plugin!(<trait>, <impl>,
+//! <name>)` in their entry point. The host assembles the active set from
+//! config at startup."
+//!
+//! The macro expands to a public `pub fn register(reg: &mut PluginRegistry)`
+//! that constructs the impl via `Default::default()` and inserts it into
+//! the registry under the given contract.
+
+/// Emit a `register(&mut PluginRegistry) -> Result<(), PluginError>` function
+/// in the calling crate that registers `$impl` under contract `$contract`
+/// with the stable name `$name`.
+///
+/// # Examples
+/// ```ignore
+/// use cairn_core::contract::register_plugin;
+/// # use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
+/// # use cairn_core::contract::version::{ContractVersion, VersionRange};
+///
+/// #[derive(Default)]
+/// struct MyStore;
+///
+/// #[async_trait::async_trait]
+/// impl MemoryStore for MyStore {
+///     fn name(&self) -> &str { "acme-store" }
+///     fn capabilities(&self) -> &MemoryStoreCapabilities { unimplemented!() }
+///     fn supported_contract_versions(&self) -> VersionRange { unimplemented!() }
+/// }
+///
+/// register_plugin!(MemoryStore, MyStore, "acme-store");
+/// ```
+#[macro_export]
+macro_rules! register_plugin {
+    (MemoryStore, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_memory_store, $impl, $name);
+    };
+    (LLMProvider, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_llm_provider, $impl, $name);
+    };
+    (WorkflowOrchestrator, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_workflow_orchestrator, $impl, $name);
+    };
+    (SensorIngress, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_sensor_ingress, $impl, $name);
+    };
+    (McpServer, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_mcp_server, $impl, $name);
+    };
+    (FrontendAdapter, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_frontend_adapter, $impl, $name);
+    };
+    (AgentProvider, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_agent_provider, $impl, $name);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_plugin_helper {
+    ($method:ident, $impl:ty, $name:literal) => {
+        /// Plugin entry point. Hosts call this during startup assembly.
+        ///
+        /// # Errors
+        /// Returns [`cairn_core::contract::registry::PluginError`] when the
+        /// name is invalid, the contract version is unsupported, or another
+        /// plugin already holds this name.
+        pub fn register(
+            reg: &mut $crate::contract::registry::PluginRegistry,
+        ) -> ::core::result::Result<(), $crate::contract::registry::PluginError> {
+            let name = $crate::contract::registry::PluginName::new($name)?;
+            reg.$method(
+                name,
+                ::std::sync::Arc::new(
+                    <$impl as ::core::default::Default>::default(),
+                ),
+            )
+        }
+    };
+}

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -71,9 +71,7 @@ macro_rules! __register_plugin_helper {
             let name = $crate::contract::registry::PluginName::new($name)?;
             reg.$method(
                 name,
-                ::std::sync::Arc::new(
-                    <$impl as ::core::default::Default>::default(),
-                ),
+                ::std::sync::Arc::new(<$impl as ::core::default::Default>::default()),
             )
         }
     };

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -31,10 +31,11 @@
 /// behind an explicit `init(&Config)` method on your impl.
 ///
 /// # Examples
-/// ```ignore
-/// use cairn_core::contract::register_plugin;
+///
+/// ```
 /// # use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
 /// # use cairn_core::contract::version::{ContractVersion, VersionRange};
+/// use cairn_core::register_plugin;
 ///
 /// #[derive(Default)]
 /// struct MyStore;
@@ -42,11 +43,29 @@
 /// #[async_trait::async_trait]
 /// impl MemoryStore for MyStore {
 ///     fn name(&self) -> &str { "acme-store" }
-///     fn capabilities(&self) -> &MemoryStoreCapabilities { unimplemented!() }
-///     fn supported_contract_versions(&self) -> VersionRange { unimplemented!() }
+///     fn capabilities(&self) -> &MemoryStoreCapabilities {
+///         static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+///             fts: false,
+///             vector: false,
+///             graph_edges: false,
+///             transactions: false,
+///         };
+///         &CAPS
+///     }
+///     fn supported_contract_versions(&self) -> VersionRange {
+///         VersionRange::new(
+///             ContractVersion::new(0, 1, 0),
+///             ContractVersion::new(0, 2, 0),
+///         )
+///     }
 /// }
 ///
 /// register_plugin!(MemoryStore, MyStore, "acme-store");
+///
+/// // The macro emits a `register` fn that hosts call during startup.
+/// // Constructing a registry and verifying registration works:
+/// let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+/// register(&mut reg).expect("compatible plugin registers");
 /// ```
 #[macro_export]
 macro_rules! register_plugin {

--- a/crates/cairn-core/src/contract/manifest.rs
+++ b/crates/cairn-core/src/contract/manifest.rs
@@ -148,27 +148,37 @@ impl PluginManifest {
         })
     }
 
-    /// Verify the manifest's `contract_version_range` accepts the supplied
-    /// host `CONTRACT_VERSION` for the same contract.
+    /// Verify the manifest declares `expected` contract and that
+    /// `contract_version_range` accepts the supplied host `CONTRACT_VERSION`.
     ///
     /// Hosts call this before invoking a plugin's `register(&mut PluginRegistry)`
-    /// to fail closed on manifest-level version mismatch — independent of the
-    /// runtime check the registry itself performs.
+    /// to fail closed on both contract-kind and version mismatches — independent
+    /// of the runtime check the registry itself performs.
     ///
     /// # Errors
-    /// [`PluginError::UnsupportedContractVersion`] when `host_version` is
-    /// outside `self.contract_version_range`.
-    pub fn verify_compatible_with(&self, host_version: ContractVersion) -> Result<(), PluginError> {
-        if self.contract_version_range.accepts(host_version) {
-            Ok(())
-        } else {
-            Err(PluginError::UnsupportedContractVersion {
-                contract: self.contract.as_static_str(),
+    /// - [`PluginError::ContractMismatch`] when `self.contract != expected`.
+    /// - [`PluginError::UnsupportedContractVersion`] when `host_version` is
+    ///   outside `self.contract_version_range`.
+    pub fn verify_compatible_with(
+        &self,
+        expected: ContractKind,
+        host_version: ContractVersion,
+    ) -> Result<(), PluginError> {
+        if self.contract != expected {
+            return Err(PluginError::ContractMismatch {
+                expected,
+                actual: self.contract,
+            });
+        }
+        if !self.contract_version_range.accepts(host_version) {
+            return Err(PluginError::UnsupportedContractVersion {
+                contract: expected.as_static_str(),
                 plugin: self.name.clone(),
                 plugin_range: self.contract_version_range,
                 host: host_version,
-            })
+            });
         }
+        Ok(())
     }
 }
 
@@ -390,11 +400,11 @@ mod tests {
     fn verify_compatible_with_accepts_host_in_range() {
         let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
         assert!(
-            m.verify_compatible_with(ContractVersion::new(0, 1, 0))
+            m.verify_compatible_with(ContractKind::MemoryStore, ContractVersion::new(0, 1, 0))
                 .is_ok()
         );
         assert!(
-            m.verify_compatible_with(ContractVersion::new(0, 1, 9))
+            m.verify_compatible_with(ContractKind::MemoryStore, ContractVersion::new(0, 1, 9))
                 .is_ok()
         );
     }
@@ -403,12 +413,28 @@ mod tests {
     fn verify_compatible_with_rejects_host_outside_range() {
         let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
         let err = m
-            .verify_compatible_with(ContractVersion::new(0, 2, 0))
+            .verify_compatible_with(ContractKind::MemoryStore, ContractVersion::new(0, 2, 0))
             .expect_err("host outside range must fail");
         match err {
             PluginError::UnsupportedContractVersion { contract, host, .. } => {
                 assert_eq!(contract, "MemoryStore");
                 assert_eq!(host, ContractVersion::new(0, 2, 0));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_compatible_with_rejects_contract_mismatch() {
+        let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
+        // Fixture is a MemoryStore manifest; verify against LLMProvider must fail.
+        let err = m
+            .verify_compatible_with(ContractKind::LLMProvider, ContractVersion::new(0, 1, 0))
+            .expect_err("contract kind mismatch must fail");
+        match err {
+            PluginError::ContractMismatch { expected, actual } => {
+                assert_eq!(expected, ContractKind::LLMProvider);
+                assert_eq!(actual, ContractKind::MemoryStore);
             }
             other => panic!("wrong variant: {other:?}"),
         }

--- a/crates/cairn-core/src/contract/manifest.rs
+++ b/crates/cairn-core/src/contract/manifest.rs
@@ -195,7 +195,30 @@ mod tests {
     use super::*;
     use crate::contract::version::ContractVersion;
 
-    const FIXTURE: &str = include_str!("../../../cairn-idl/schema/plugin/example.toml");
+    // Inlined from `crates/cairn-idl/schema/plugin/example.toml` so that
+    // `cargo package -p cairn-core` does not pull in a sibling crate path that
+    // is absent from the published package.  The cairn-idl-side file is kept
+    // intact for the JSON-Schema validation test in
+    // `crates/cairn-idl/tests/plugin_manifest_validation.rs`.
+    const FIXTURE: &str = r#"
+name = "cairn-store-sqlite"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+fts = true
+vector = false
+graph_edges = false
+"#;
 
     #[test]
     fn parses_example_fixture() {

--- a/crates/cairn-core/src/contract/manifest.rs
+++ b/crates/cairn-core/src/contract/manifest.rs
@@ -38,6 +38,7 @@ pub enum ContractKind {
 /// Wire form: matches the TOML manifest exactly. `name` is parsed as a
 /// `String` here and validated via `PluginName::new` on the way out.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct PluginManifestWire {
     name: String,
     contract: ContractKind,
@@ -156,5 +157,69 @@ mod tests {
         "#;
         let m = PluginManifest::parse_toml(minimal).expect("valid");
         assert!(m.features.is_empty());
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_field() {
+        let bad = r#"
+            name = "good-name"
+            contract = "MemoryStore"
+            rogue_field = "boom"
+            [contract_version_range.min]
+            major = 0
+            minor = 1
+            patch = 0
+            [contract_version_range.max_exclusive]
+            major = 0
+            minor = 2
+            patch = 0
+        "#;
+        assert!(matches!(
+            PluginManifest::parse_toml(bad),
+            Err(PluginError::InvalidManifest(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_range_field() {
+        let bad = r#"
+            name = "good-name"
+            contract = "MemoryStore"
+            [contract_version_range]
+            rogue = "boom"
+            [contract_version_range.min]
+            major = 0
+            minor = 1
+            patch = 0
+            [contract_version_range.max_exclusive]
+            major = 0
+            minor = 2
+            patch = 0
+        "#;
+        assert!(matches!(
+            PluginManifest::parse_toml(bad),
+            Err(PluginError::InvalidManifest(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_version_field() {
+        let bad = r#"
+            name = "good-name"
+            contract = "MemoryStore"
+            [contract_version_range.min]
+            major = 0
+            minor = 1
+            patch = 0
+            rogue = 99
+            [contract_version_range.max_exclusive]
+            major = 0
+            minor = 2
+            patch = 0
+        "#;
+        assert!(matches!(
+            PluginManifest::parse_toml(bad),
+            Err(PluginError::InvalidManifest(_))
+        ));
     }
 }

--- a/crates/cairn-core/src/contract/manifest.rs
+++ b/crates/cairn-core/src/contract/manifest.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::contract::registry::{PluginError, PluginName};
-use crate::contract::version::VersionRange;
+use crate::contract::version::{ContractVersion, VersionRange};
 
 /// Contract enum mirroring `cairn-idl/schema/plugin/manifest.json#contract`.
 ///
@@ -33,6 +33,27 @@ pub enum ContractKind {
     FrontendAdapter,
     /// Implements `AgentProvider` contract.
     AgentProvider,
+}
+
+impl ContractKind {
+    /// Stable `&'static str` identifier matching the literal used in
+    /// [`PluginError::UnsupportedContractVersion::contract`] for the same kind.
+    ///
+    /// These strings must remain in sync with the `$contract` literals in the
+    /// `register_method!` macro in `registry.rs` — they serve as the shared
+    /// discriminator in error messages and downstream consumers.
+    #[must_use]
+    pub fn as_static_str(self) -> &'static str {
+        match self {
+            ContractKind::MemoryStore => "MemoryStore",
+            ContractKind::LLMProvider => "LLMProvider",
+            ContractKind::WorkflowOrchestrator => "WorkflowOrchestrator",
+            ContractKind::SensorIngress => "SensorIngress",
+            ContractKind::McpServer => "McpServer",
+            ContractKind::FrontendAdapter => "FrontendAdapter",
+            ContractKind::AgentProvider => "AgentProvider",
+        }
+    }
 }
 
 /// Wire form: matches the TOML manifest exactly. `name` is parsed as a
@@ -125,6 +146,29 @@ impl PluginManifest {
             contract_version_range: wire.contract_version_range,
             features: wire.features,
         })
+    }
+
+    /// Verify the manifest's `contract_version_range` accepts the supplied
+    /// host `CONTRACT_VERSION` for the same contract.
+    ///
+    /// Hosts call this before invoking a plugin's `register(&mut PluginRegistry)`
+    /// to fail closed on manifest-level version mismatch — independent of the
+    /// runtime check the registry itself performs.
+    ///
+    /// # Errors
+    /// [`PluginError::UnsupportedContractVersion`] when `host_version` is
+    /// outside `self.contract_version_range`.
+    pub fn verify_compatible_with(&self, host_version: ContractVersion) -> Result<(), PluginError> {
+        if self.contract_version_range.accepts(host_version) {
+            Ok(())
+        } else {
+            Err(PluginError::UnsupportedContractVersion {
+                contract: self.contract.as_static_str(),
+                plugin: self.name.clone(),
+                plugin_range: self.contract_version_range,
+                host: host_version,
+            })
+        }
     }
 }
 
@@ -339,4 +383,34 @@ mod tests {
     // `is_valid_feature_key` function still guards against it for callers
     // that construct the BTreeMap directly. The dot-key test above covers
     // the parser-accessible invalid-key path.
+
+    // -- Finding 2: verify_compatible_with -----------------------------------
+
+    #[test]
+    fn verify_compatible_with_accepts_host_in_range() {
+        let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
+        assert!(
+            m.verify_compatible_with(ContractVersion::new(0, 1, 0))
+                .is_ok()
+        );
+        assert!(
+            m.verify_compatible_with(ContractVersion::new(0, 1, 9))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn verify_compatible_with_rejects_host_outside_range() {
+        let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
+        let err = m
+            .verify_compatible_with(ContractVersion::new(0, 2, 0))
+            .expect_err("host outside range must fail");
+        match err {
+            PluginError::UnsupportedContractVersion { contract, host, .. } => {
+                assert_eq!(contract, "MemoryStore");
+                assert_eq!(host, ContractVersion::new(0, 2, 0));
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
 }

--- a/crates/cairn-core/src/contract/manifest.rs
+++ b/crates/cairn-core/src/contract/manifest.rs
@@ -1,0 +1,160 @@
+//! Plugin capability manifest (TOML), brief §4.1.
+//!
+//! The schema lives in `crates/cairn-idl/schema/plugin/manifest.json`; this
+//! module is the in-process parser that hosts use to validate a manifest
+//! before invoking the plugin's `register(&mut PluginRegistry)`.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::contract::registry::{PluginError, PluginName};
+use crate::contract::version::VersionRange;
+
+/// Contract enum mirroring `cairn-idl/schema/plugin/manifest.json#contract`.
+///
+/// `#[allow(clippy::upper_case_acronyms)]` — variant names match the trait
+/// names from §4.1 exactly (`LLMProvider`, `McpServer`, etc.).
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ContractKind {
+    /// Implements `MemoryStore` contract.
+    MemoryStore,
+    /// Implements `LLMProvider` contract.
+    LLMProvider,
+    /// Implements `WorkflowOrchestrator` contract.
+    WorkflowOrchestrator,
+    /// Implements `SensorIngress` contract.
+    SensorIngress,
+    /// Implements `McpServer` contract.
+    McpServer,
+    /// Implements `FrontendAdapter` contract.
+    FrontendAdapter,
+    /// Implements `AgentProvider` contract.
+    AgentProvider,
+}
+
+/// Wire form: matches the TOML manifest exactly. `name` is parsed as a
+/// `String` here and validated via `PluginName::new` on the way out.
+#[derive(Debug, Clone, Deserialize)]
+struct PluginManifestWire {
+    name: String,
+    contract: ContractKind,
+    contract_version_range: VersionRange,
+    #[serde(default)]
+    features: BTreeMap<String, bool>,
+}
+
+/// Validated, in-memory plugin capability manifest.
+///
+/// Produced by [`PluginManifest::parse_toml`] from a TOML source string.
+/// Hosts use this to gate activation before calling `register`.
+#[derive(Debug, Clone)]
+pub struct PluginManifest {
+    /// Stable plugin identifier, validated by [`PluginName`] rules.
+    pub name: PluginName,
+    /// Which contract this plugin implements.
+    pub contract: ContractKind,
+    /// Half-open version range `[min, max_exclusive)` this plugin supports.
+    pub contract_version_range: VersionRange,
+    /// Boolean feature flags this plugin advertises (may be empty).
+    pub features: BTreeMap<String, bool>,
+}
+
+impl PluginManifest {
+    /// Parse a manifest from its TOML source.
+    ///
+    /// # Errors
+    /// [`PluginError::InvalidManifest`] for syntactic errors;
+    /// [`PluginError::InvalidName`] when `name` violates `PluginName` rules.
+    pub fn parse_toml(source: &str) -> Result<Self, PluginError> {
+        let wire: PluginManifestWire =
+            toml::from_str(source).map_err(|e| PluginError::InvalidManifest(e.to_string()))?;
+        Ok(Self {
+            name: PluginName::new(wire.name)?,
+            contract: wire.contract,
+            contract_version_range: wire.contract_version_range,
+            features: wire.features,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contract::version::ContractVersion;
+
+    const FIXTURE: &str = include_str!("../../../cairn-idl/schema/plugin/example.toml");
+
+    #[test]
+    fn parses_example_fixture() {
+        let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
+        assert_eq!(m.name.as_str(), "cairn-store-sqlite");
+        assert_eq!(m.contract, ContractKind::MemoryStore);
+        assert_eq!(m.contract_version_range.min, ContractVersion::new(0, 1, 0));
+        assert_eq!(
+            m.contract_version_range.max_exclusive,
+            ContractVersion::new(0, 2, 0)
+        );
+        assert_eq!(m.features.get("fts"), Some(&true));
+    }
+
+    #[test]
+    fn rejects_invalid_name() {
+        let bad = r#"
+            name = "BAD_NAME"
+            contract = "MemoryStore"
+            [contract_version_range.min]
+            major = 0
+            minor = 1
+            patch = 0
+            [contract_version_range.max_exclusive]
+            major = 0
+            minor = 2
+            patch = 0
+        "#;
+        assert!(matches!(
+            PluginManifest::parse_toml(bad),
+            Err(PluginError::InvalidName(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_contract() {
+        let bad = r#"
+            name = "good-name"
+            contract = "Unknown"
+            [contract_version_range.min]
+            major = 0
+            minor = 1
+            patch = 0
+            [contract_version_range.max_exclusive]
+            major = 0
+            minor = 2
+            patch = 0
+        "#;
+        assert!(matches!(
+            PluginManifest::parse_toml(bad),
+            Err(PluginError::InvalidManifest(_))
+        ));
+    }
+
+    #[test]
+    fn defaults_features_to_empty() {
+        let minimal = r#"
+            name = "good-name"
+            contract = "LLMProvider"
+            [contract_version_range.min]
+            major = 0
+            minor = 1
+            patch = 0
+            [contract_version_range.max_exclusive]
+            major = 0
+            minor = 2
+            patch = 0
+        "#;
+        let m = PluginManifest::parse_toml(minimal).expect("valid");
+        assert!(m.features.is_empty());
+    }
+}

--- a/crates/cairn-core/src/contract/manifest.rs
+++ b/crates/cairn-core/src/contract/manifest.rs
@@ -14,7 +14,7 @@ use crate::contract::version::{ContractVersion, VersionRange};
 /// Contract enum mirroring `cairn-idl/schema/plugin/manifest.json#contract`.
 ///
 /// `#[allow(clippy::upper_case_acronyms)]` — variant names match the trait
-/// names from §4.1 exactly (`LLMProvider`, `McpServer`, etc.).
+/// names from §4.1 exactly (`LLMProvider`, `MCPServer`, etc.).
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -27,8 +27,8 @@ pub enum ContractKind {
     WorkflowOrchestrator,
     /// Implements `SensorIngress` contract.
     SensorIngress,
-    /// Implements `McpServer` contract.
-    McpServer,
+    /// Implements `MCPServer` contract.
+    MCPServer,
     /// Implements `FrontendAdapter` contract.
     FrontendAdapter,
     /// Implements `AgentProvider` contract.
@@ -49,7 +49,7 @@ impl ContractKind {
             ContractKind::LLMProvider => "LLMProvider",
             ContractKind::WorkflowOrchestrator => "WorkflowOrchestrator",
             ContractKind::SensorIngress => "SensorIngress",
-            ContractKind::McpServer => "McpServer",
+            ContractKind::MCPServer => "MCPServer",
             ContractKind::FrontendAdapter => "FrontendAdapter",
             ContractKind::AgentProvider => "AgentProvider",
         }
@@ -148,31 +148,39 @@ impl PluginManifest {
         })
     }
 
-    /// Verify the manifest declares `expected` contract and that
-    /// `contract_version_range` accepts the supplied host `CONTRACT_VERSION`.
+    /// Verify the manifest declares `expected_name`, the `expected_kind` contract,
+    /// and that `contract_version_range` accepts the supplied host `host_version`.
     ///
     /// Hosts call this before invoking a plugin's `register(&mut PluginRegistry)`
-    /// to fail closed on both contract-kind and version mismatches — independent
+    /// to fail closed on name, contract-kind, and version mismatches — independent
     /// of the runtime check the registry itself performs.
     ///
     /// # Errors
-    /// - [`PluginError::ContractMismatch`] when `self.contract != expected`.
+    /// - [`PluginError::ManifestNameMismatch`] when `self.name != expected_name`.
+    /// - [`PluginError::ContractMismatch`] when `self.contract != expected_kind`.
     /// - [`PluginError::UnsupportedContractVersion`] when `host_version` is
     ///   outside `self.contract_version_range`.
     pub fn verify_compatible_with(
         &self,
-        expected: ContractKind,
+        expected_name: &PluginName,
+        expected_kind: ContractKind,
         host_version: ContractVersion,
     ) -> Result<(), PluginError> {
-        if self.contract != expected {
+        if &self.name != expected_name {
+            return Err(PluginError::ManifestNameMismatch {
+                expected: expected_name.clone(),
+                manifest: self.name.clone(),
+            });
+        }
+        if self.contract != expected_kind {
             return Err(PluginError::ContractMismatch {
-                expected,
+                expected: expected_kind,
                 actual: self.contract,
             });
         }
         if !self.contract_version_range.accepts(host_version) {
             return Err(PluginError::UnsupportedContractVersion {
-                contract: expected.as_static_str(),
+                contract: expected_kind.as_static_str(),
                 plugin: self.name.clone(),
                 plugin_range: self.contract_version_range,
                 host: host_version,
@@ -399,21 +407,35 @@ mod tests {
     #[test]
     fn verify_compatible_with_accepts_host_in_range() {
         let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
+        let expected = PluginName::new("cairn-store-sqlite").expect("valid");
         assert!(
-            m.verify_compatible_with(ContractKind::MemoryStore, ContractVersion::new(0, 1, 0))
-                .is_ok()
+            m.verify_compatible_with(
+                &expected,
+                ContractKind::MemoryStore,
+                ContractVersion::new(0, 1, 0)
+            )
+            .is_ok()
         );
         assert!(
-            m.verify_compatible_with(ContractKind::MemoryStore, ContractVersion::new(0, 1, 9))
-                .is_ok()
+            m.verify_compatible_with(
+                &expected,
+                ContractKind::MemoryStore,
+                ContractVersion::new(0, 1, 9)
+            )
+            .is_ok()
         );
     }
 
     #[test]
     fn verify_compatible_with_rejects_host_outside_range() {
         let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
+        let expected = PluginName::new("cairn-store-sqlite").expect("valid");
         let err = m
-            .verify_compatible_with(ContractKind::MemoryStore, ContractVersion::new(0, 2, 0))
+            .verify_compatible_with(
+                &expected,
+                ContractKind::MemoryStore,
+                ContractVersion::new(0, 2, 0),
+            )
             .expect_err("host outside range must fail");
         match err {
             PluginError::UnsupportedContractVersion { contract, host, .. } => {
@@ -427,14 +449,39 @@ mod tests {
     #[test]
     fn verify_compatible_with_rejects_contract_mismatch() {
         let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
+        let expected = PluginName::new("cairn-store-sqlite").expect("valid");
         // Fixture is a MemoryStore manifest; verify against LLMProvider must fail.
         let err = m
-            .verify_compatible_with(ContractKind::LLMProvider, ContractVersion::new(0, 1, 0))
+            .verify_compatible_with(
+                &expected,
+                ContractKind::LLMProvider,
+                ContractVersion::new(0, 1, 0),
+            )
             .expect_err("contract kind mismatch must fail");
         match err {
             PluginError::ContractMismatch { expected, actual } => {
                 assert_eq!(expected, ContractKind::LLMProvider);
                 assert_eq!(actual, ContractKind::MemoryStore);
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verify_compatible_with_rejects_name_mismatch() {
+        let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
+        let wrong = PluginName::new("acme-other-name").expect("valid");
+        let err = m
+            .verify_compatible_with(
+                &wrong,
+                ContractKind::MemoryStore,
+                ContractVersion::new(0, 1, 0),
+            )
+            .expect_err("manifest name mismatch must fail");
+        match err {
+            PluginError::ManifestNameMismatch { expected, manifest } => {
+                assert_eq!(expected.as_str(), "acme-other-name");
+                assert_eq!(manifest.as_str(), "cairn-store-sqlite");
             }
             other => panic!("wrong variant: {other:?}"),
         }

--- a/crates/cairn-core/src/contract/manifest.rs
+++ b/crates/cairn-core/src/contract/manifest.rs
@@ -63,15 +63,62 @@ pub struct PluginManifest {
     pub features: BTreeMap<String, bool>,
 }
 
+/// Returns `true` when `range.min < range.max_exclusive` (strictly ordered).
+///
+/// JSON Schema cannot express cross-property comparison, so this check lives
+/// exclusively in the Rust parser. See the `contract_version_range` description
+/// in `manifest.json` for the documented gap.
+fn is_strictly_ordered(range: &VersionRange) -> bool {
+    let lo = (range.min.major, range.min.minor, range.min.patch);
+    let hi = (
+        range.max_exclusive.major,
+        range.max_exclusive.minor,
+        range.max_exclusive.patch,
+    );
+    lo < hi
+}
+
+/// Returns `true` when `key` satisfies the feature-key grammar:
+/// non-empty, at most 64 chars, all chars ASCII alphanumeric or `_`.
+///
+/// This mirrors the `^[A-Za-z0-9_]{1,64}$` pattern in `manifest.json`
+/// `propertyNames`.
+fn is_valid_feature_key(key: &str) -> bool {
+    !key.is_empty() && key.len() <= 64 && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 impl PluginManifest {
     /// Parse a manifest from its TOML source.
     ///
     /// # Errors
-    /// [`PluginError::InvalidManifest`] for syntactic errors;
-    /// [`PluginError::InvalidName`] when `name` violates `PluginName` rules.
+    /// - [`PluginError::InvalidManifest`] for syntactic errors, an inverted/empty
+    ///   `contract_version_range`, or an invalid feature key.
+    /// - [`PluginError::InvalidName`] when `name` violates `PluginName` rules.
     pub fn parse_toml(source: &str) -> Result<Self, PluginError> {
         let wire: PluginManifestWire =
             toml::from_str(source).map_err(|e| PluginError::InvalidManifest(e.to_string()))?;
+
+        // Semantic validation: range must be non-empty (min < max_exclusive).
+        // JSON Schema cannot enforce this cross-property invariant; the Rust
+        // parser is the gatekeeper.
+        if !is_strictly_ordered(&wire.contract_version_range) {
+            return Err(PluginError::InvalidManifest(format!(
+                "contract_version_range is empty or inverted: \
+                 min {} must be strictly less than max_exclusive {}",
+                wire.contract_version_range.min, wire.contract_version_range.max_exclusive,
+            )));
+        }
+
+        // Validate every feature key: ^[A-Za-z0-9_]{1,64}$
+        for key in wire.features.keys() {
+            if !is_valid_feature_key(key) {
+                return Err(PluginError::InvalidManifest(format!(
+                    "feature key {key:?} is invalid: \
+                     must be 1..=64 ASCII alnum + `_`",
+                )));
+            }
+        }
+
         Ok(Self {
             name: PluginName::new(wire.name)?,
             contract: wire.contract,
@@ -222,4 +269,74 @@ mod tests {
             Err(PluginError::InvalidManifest(_))
         ));
     }
+
+    // -- Finding 1: semantic range / feature-key validation ------------------
+
+    #[test]
+    fn rejects_empty_version_range() {
+        let bad = r#"
+            name = "good-name"
+            contract = "MemoryStore"
+            [contract_version_range.min]
+            major = 0
+            minor = 1
+            patch = 0
+            [contract_version_range.max_exclusive]
+            major = 0
+            minor = 1
+            patch = 0
+        "#;
+        assert!(matches!(
+            PluginManifest::parse_toml(bad),
+            Err(PluginError::InvalidManifest(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_inverted_version_range() {
+        let bad = r#"
+            name = "good-name"
+            contract = "MemoryStore"
+            [contract_version_range.min]
+            major = 1
+            minor = 0
+            patch = 0
+            [contract_version_range.max_exclusive]
+            major = 0
+            minor = 1
+            patch = 0
+        "#;
+        assert!(matches!(
+            PluginManifest::parse_toml(bad),
+            Err(PluginError::InvalidManifest(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_feature_key_with_dot() {
+        let bad = r#"
+            name = "good-name"
+            contract = "MemoryStore"
+            [contract_version_range.min]
+            major = 0
+            minor = 1
+            patch = 0
+            [contract_version_range.max_exclusive]
+            major = 0
+            minor = 2
+            patch = 0
+            [features]
+            "bad.key" = true
+        "#;
+        assert!(matches!(
+            PluginManifest::parse_toml(bad),
+            Err(PluginError::InvalidManifest(_))
+        ));
+    }
+
+    // Note: TOML does not permit empty string as a bare key, so the
+    // `"" = true` case cannot be represented in TOML syntax. The
+    // `is_valid_feature_key` function still guards against it for callers
+    // that construct the BTreeMap directly. The dot-key test above covers
+    // the parser-accessible invalid-key path.
 }

--- a/crates/cairn-core/src/contract/manifest.rs
+++ b/crates/cairn-core/src/contract/manifest.rs
@@ -72,16 +72,16 @@ struct PluginManifestWire {
 ///
 /// Produced by [`PluginManifest::parse_toml`] from a TOML source string.
 /// Hosts use this to gate activation before calling `register`.
+///
+/// Fields are private to ensure that every `PluginManifest` value has passed
+/// `parse_toml`'s semantic validation (range ordering, feature-key grammar,
+/// name pattern). Use the accessor methods to read individual fields.
 #[derive(Debug, Clone)]
 pub struct PluginManifest {
-    /// Stable plugin identifier, validated by [`PluginName`] rules.
-    pub name: PluginName,
-    /// Which contract this plugin implements.
-    pub contract: ContractKind,
-    /// Half-open version range `[min, max_exclusive)` this plugin supports.
-    pub contract_version_range: VersionRange,
-    /// Boolean feature flags this plugin advertises (may be empty).
-    pub features: BTreeMap<String, bool>,
+    name: PluginName,
+    contract: ContractKind,
+    contract_version_range: VersionRange,
+    features: BTreeMap<String, bool>,
 }
 
 /// Returns `true` when `range.min < range.max_exclusive` (strictly ordered).
@@ -109,6 +109,31 @@ fn is_valid_feature_key(key: &str) -> bool {
 }
 
 impl PluginManifest {
+    /// Stable plugin identifier as parsed from the manifest.
+    #[must_use]
+    pub fn name(&self) -> &PluginName {
+        &self.name
+    }
+
+    /// Contract kind this plugin implements.
+    #[must_use]
+    pub fn contract(&self) -> ContractKind {
+        self.contract
+    }
+
+    /// Half-open version range `[min, max_exclusive)` of host `CONTRACT_VERSION`
+    /// values this plugin accepts.
+    #[must_use]
+    pub fn contract_version_range(&self) -> VersionRange {
+        self.contract_version_range
+    }
+
+    /// Free-form boolean feature flags this plugin advertises (may be empty).
+    #[must_use]
+    pub fn features(&self) -> &BTreeMap<String, bool> {
+        &self.features
+    }
+
     /// Parse a manifest from its TOML source.
     ///
     /// # Errors
@@ -508,5 +533,18 @@ graph_edges = false
             }
             other => panic!("wrong variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn accessors_expose_parsed_values() {
+        let m = PluginManifest::parse_toml(FIXTURE).expect("fixture is valid");
+        assert_eq!(m.name().as_str(), "cairn-store-sqlite");
+        assert_eq!(m.contract(), ContractKind::MemoryStore);
+        assert_eq!(
+            m.contract_version_range(),
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0),)
+        );
+        assert_eq!(m.features().get("fts"), Some(&true));
+        assert_eq!(m.features().len(), 3);
     }
 }

--- a/crates/cairn-core/src/contract/mcp_server.rs
+++ b/crates/cairn-core/src/contract/mcp_server.rs
@@ -1,4 +1,4 @@
-//! `McpServer` contract (brief §4 row 5).
+//! `MCPServer` contract (brief §4 row 5).
 //!
 //! P0: stdio + SSE transports; eight core verbs + opt-in extensions.
 //! Implementation lives in `cairn-mcp` (#64); transports + handshake
@@ -6,15 +6,17 @@
 
 use crate::contract::version::{ContractVersion, VersionRange};
 
-/// Contract version for `McpServer`. Bumps when the trait surface changes.
+/// Contract version for `MCPServer`. Bumps when the trait surface changes.
 pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 1, 0);
 
-/// Static capability declaration for a `McpServer` impl.
+/// Static capability declaration for a `MCPServer` impl.
 // Four flags cover distinct MCP transport/extension dimensions; a state
 // machine adds indirection with no clarity gain here.
 #[allow(clippy::struct_excessive_bools)]
+// Matches brief §4 row 5 trait name; CLAUDE.md §1 says brief wins.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct McpServerCapabilities {
+pub struct MCPServerCapabilities {
     /// Whether the server supports the stdio transport.
     pub stdio: bool,
     /// Whether the server supports the SSE transport.
@@ -29,15 +31,17 @@ pub struct McpServerCapabilities {
 ///
 /// Brief §4 row 5: P0 is stdio + SSE transports (#64). HTTP streamable
 /// and extension negotiation are P1.
+// Matches brief §4 row 5 trait name; CLAUDE.md §1 says brief wins.
+#[allow(clippy::upper_case_acronyms)]
 #[async_trait::async_trait]
-pub trait McpServer: Send + Sync {
+pub trait MCPServer: Send + Sync {
     /// Stable identifier of the registered plugin instance.
     fn name(&self) -> &str;
 
     /// Static capability advertisement (brief §4.1).
-    fn capabilities(&self) -> &McpServerCapabilities;
+    fn capabilities(&self) -> &MCPServerCapabilities;
 
-    /// Range of `McpServer::CONTRACT_VERSION` values this impl accepts.
+    /// Range of `MCPServer::CONTRACT_VERSION` values this impl accepts.
     fn supported_contract_versions(&self) -> VersionRange;
 }
 
@@ -48,12 +52,12 @@ mod tests {
     struct StubMcp;
 
     #[async_trait::async_trait]
-    impl McpServer for StubMcp {
+    impl MCPServer for StubMcp {
         fn name(&self) -> &'static str {
             "stub-mcp"
         }
-        fn capabilities(&self) -> &McpServerCapabilities {
-            static CAPS: McpServerCapabilities = McpServerCapabilities {
+        fn capabilities(&self) -> &MCPServerCapabilities {
+            static CAPS: MCPServerCapabilities = MCPServerCapabilities {
                 stdio: true,
                 sse: false,
                 http_streamable: false,
@@ -68,7 +72,7 @@ mod tests {
 
     #[test]
     fn dyn_compatible() {
-        let m: Box<dyn McpServer> = Box::new(StubMcp);
+        let m: Box<dyn MCPServer> = Box::new(StubMcp);
         assert_eq!(m.name(), "stub-mcp");
         assert!(m.supported_contract_versions().accepts(CONTRACT_VERSION));
     }

--- a/crates/cairn-core/src/contract/mcp_server.rs
+++ b/crates/cairn-core/src/contract/mcp_server.rs
@@ -1,0 +1,75 @@
+//! `MCPServer` contract (brief §4 row 5).
+//!
+//! P0: stdio + SSE transports; eight core verbs + opt-in extensions.
+//! Implementation lives in `cairn-mcp` (#64); transports + handshake
+//! parity tests in #65, #66, #67.
+
+use crate::contract::version::{ContractVersion, VersionRange};
+
+/// Contract version for `McpServer`. Bumps when the trait surface changes.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 1, 0);
+
+/// Static capability declaration for a `McpServer` impl.
+// Four flags cover distinct MCP transport/extension dimensions; a state
+// machine adds indirection with no clarity gain here.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct McpServerCapabilities {
+    /// Whether the server supports the stdio transport.
+    pub stdio: bool,
+    /// Whether the server supports the SSE transport.
+    pub sse: bool,
+    /// Whether the server supports the HTTP streamable transport.
+    pub http_streamable: bool,
+    /// Whether the server supports opt-in MCP extensions.
+    pub extensions: bool,
+}
+
+/// MCP server contract — protocol binding over the eight Cairn verbs.
+///
+/// Brief §4 row 5: P0 is stdio + SSE transports (#64). HTTP streamable
+/// and extension negotiation are P1.
+#[async_trait::async_trait]
+pub trait McpServer: Send + Sync {
+    /// Stable identifier of the registered plugin instance.
+    fn name(&self) -> &str;
+
+    /// Static capability advertisement (brief §4.1).
+    fn capabilities(&self) -> &McpServerCapabilities;
+
+    /// Range of `McpServer::CONTRACT_VERSION` values this impl accepts.
+    fn supported_contract_versions(&self) -> VersionRange;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubMcp;
+
+    #[async_trait::async_trait]
+    impl McpServer for StubMcp {
+        fn name(&self) -> &'static str {
+            "stub-mcp"
+        }
+        fn capabilities(&self) -> &McpServerCapabilities {
+            static CAPS: McpServerCapabilities = McpServerCapabilities {
+                stdio: true,
+                sse: false,
+                http_streamable: false,
+                extensions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+        }
+    }
+
+    #[test]
+    fn dyn_compatible() {
+        let m: Box<dyn McpServer> = Box::new(StubMcp);
+        assert_eq!(m.name(), "stub-mcp");
+        assert!(m.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+}

--- a/crates/cairn-core/src/contract/mcp_server.rs
+++ b/crates/cairn-core/src/contract/mcp_server.rs
@@ -1,4 +1,4 @@
-//! `MCPServer` contract (brief §4 row 5).
+//! `McpServer` contract (brief §4 row 5).
 //!
 //! P0: stdio + SSE transports; eight core verbs + opt-in extensions.
 //! Implementation lives in `cairn-mcp` (#64); transports + handshake

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -1,0 +1,79 @@
+//! `MemoryStore` contract (brief §4 row 1).
+//!
+//! P0 scaffold: surface only — `name`, `capabilities`,
+//! `supported_contract_versions`. CRUD/FTS/ANN/graph methods land in #46.
+
+use crate::contract::version::{ContractVersion, VersionRange};
+
+/// Contract version for `MemoryStore`. Bumps when the trait surface changes.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 1, 0);
+
+/// Static capability declaration for a `MemoryStore` impl.
+///
+/// Cairn queries this before dispatching ANN-, FTS-, or graph-using verbs;
+/// missing capability → `CapabilityUnavailable` (brief §4.1).
+// Four capability flags mirror the four distinct store dimensions; a state
+// machine would add indirection with no gain here.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct MemoryStoreCapabilities {
+    /// Whether full-text search (FTS5) is supported.
+    pub fts: bool,
+    /// Whether vector/ANN search is supported.
+    pub vector: bool,
+    /// Whether graph edge storage and traversal is supported.
+    pub graph_edges: bool,
+    /// Whether ACID transactions are supported.
+    pub transactions: bool,
+}
+
+/// Storage contract — typed CRUD + ANN + FTS + graph over `MemoryRecord`.
+///
+/// Brief §4 row 1: P0 default is pure `SQLite` + FTS5; P1 default is the
+/// Nexus sandbox profile. Method bodies arrive in #46 once `MemoryRecord`
+/// (sub-issue #37) lands.
+#[async_trait::async_trait]
+pub trait MemoryStore: Send + Sync {
+    /// Stable identifier of the registered plugin instance.
+    fn name(&self) -> &str;
+
+    /// Static capability advertisement (brief §4.1).
+    fn capabilities(&self) -> &MemoryStoreCapabilities;
+
+    /// Range of `MemoryStore::CONTRACT_VERSION` values this impl accepts.
+    fn supported_contract_versions(&self) -> VersionRange;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubStore;
+
+    #[async_trait::async_trait]
+    impl MemoryStore for StubStore {
+        fn name(&self) -> &'static str {
+            "stub"
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: true,
+                vector: false,
+                graph_edges: false,
+                transactions: true,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+        }
+    }
+
+    #[test]
+    fn dyn_compatible() {
+        let s: Box<dyn MemoryStore> = Box::new(StubStore);
+        assert_eq!(s.name(), "stub");
+        assert!(s.capabilities().fts);
+        assert!(s.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+}

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -3,6 +3,7 @@
 //! Brief §4.1: every contract is a trait, every trait declares
 //! `CONTRACT_VERSION`, plugins register through `register_plugin!`.
 
+pub mod llm_provider;
 pub mod memory_store;
 pub mod registry;
 pub mod version;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -3,6 +3,8 @@
 //! Brief §4.1: every contract is a trait, every trait declares
 //! `CONTRACT_VERSION`, plugins register through `register_plugin!`.
 
+pub mod agent_provider;
+pub mod frontend_adapter;
 pub mod llm_provider;
 pub mod mcp_server;
 pub mod memory_store;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -3,4 +3,5 @@
 //! Brief §4.1: every contract is a trait, every trait declares
 //! `CONTRACT_VERSION`, plugins register through `register_plugin!`.
 
+pub mod registry;
 pub mod version;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -6,6 +6,7 @@
 pub mod agent_provider;
 pub mod frontend_adapter;
 pub mod llm_provider;
+pub mod macros;
 pub mod mcp_server;
 pub mod memory_store;
 pub mod registry;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -3,5 +3,6 @@
 //! Brief §4.1: every contract is a trait, every trait declares
 //! `CONTRACT_VERSION`, plugins register through `register_plugin!`.
 
+pub mod memory_store;
 pub mod registry;
 pub mod version;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -7,6 +7,7 @@ pub mod agent_provider;
 pub mod frontend_adapter;
 pub mod llm_provider;
 pub mod macros;
+pub mod manifest;
 pub mod mcp_server;
 pub mod memory_store;
 pub mod registry;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -4,6 +4,7 @@
 //! `CONTRACT_VERSION`, plugins register through `register_plugin!`.
 
 pub mod llm_provider;
+pub mod mcp_server;
 pub mod memory_store;
 pub mod registry;
 pub mod sensor_ingress;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -1,12 +1,21 @@
-//! Contract surface — traits, plugin registry, capability manifest.
+//! Cairn contract surface.
 //!
-//! Brief §4.1: every contract is a trait, every trait declares
-//! `CONTRACT_VERSION`, plugins register through `register_plugin!`.
+//! Brief §4.1 — every contract is a trait, every trait declares
+//! `CONTRACT_VERSION`, plugins register through `register_plugin!` and end
+//! up in a [`registry::PluginRegistry`] the host assembles at startup.
+//!
+//! Public surface:
+//! - [`version::ContractVersion`], [`version::VersionRange`]
+//! - [`registry::PluginRegistry`], [`registry::PluginName`],
+//!   [`registry::PluginError`]
+//! - [`manifest::PluginManifest`], [`manifest::ContractKind`]
+//! - One module per contract: [`memory_store`], [`llm_provider`],
+//!   [`workflow_orchestrator`], [`sensor_ingress`], [`mcp_server`],
+//!   [`frontend_adapter`] (P1), [`agent_provider`] (P2)
 
 pub mod agent_provider;
 pub mod frontend_adapter;
 pub mod llm_provider;
-pub mod macros;
 pub mod manifest;
 pub mod mcp_server;
 pub mod memory_store;
@@ -14,3 +23,6 @@ pub mod registry;
 pub mod sensor_ingress;
 pub mod version;
 pub mod workflow_orchestrator;
+
+#[doc(hidden)]
+pub mod macros;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -7,3 +7,4 @@ pub mod llm_provider;
 pub mod memory_store;
 pub mod registry;
 pub mod version;
+pub mod workflow_orchestrator;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -6,5 +6,6 @@
 pub mod llm_provider;
 pub mod memory_store;
 pub mod registry;
+pub mod sensor_ingress;
 pub mod version;
 pub mod workflow_orchestrator;

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -13,7 +13,7 @@
 //!   [`LLMProvider`] / [`LLMProviderCapabilities`],
 //!   [`WorkflowOrchestrator`] / [`WorkflowOrchestratorCapabilities`],
 //!   [`SensorIngress`] / [`SensorIngressCapabilities`],
-//!   [`McpServer`] / [`McpServerCapabilities`].
+//!   [`MCPServer`] / [`MCPServerCapabilities`].
 //! - Forward stubs (P1/P2, hidden until #113 / #124): `FrontendAdapter`, `AgentProvider`.
 
 pub mod agent_provider;
@@ -39,7 +39,7 @@ pub use version::{ContractVersion, VersionRange};
 pub use agent_provider::{AgentProvider, AgentProviderCapabilities};
 pub use frontend_adapter::{FrontendAdapter, FrontendAdapterCapabilities};
 pub use llm_provider::{LLMProvider, LLMProviderCapabilities};
-pub use mcp_server::{McpServer, McpServerCapabilities};
+pub use mcp_server::{MCPServer, MCPServerCapabilities};
 pub use memory_store::{MemoryStore, MemoryStoreCapabilities};
 pub use sensor_ingress::{SensorIngress, SensorIngressCapabilities};
 pub use workflow_orchestrator::{WorkflowOrchestrator, WorkflowOrchestratorCapabilities};

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -4,14 +4,17 @@
 //! `CONTRACT_VERSION`, plugins register through `register_plugin!` and end
 //! up in a [`registry::PluginRegistry`] the host assembles at startup.
 //!
-//! Public surface:
-//! - [`version::ContractVersion`], [`version::VersionRange`]
-//! - [`registry::PluginRegistry`], [`registry::PluginName`],
-//!   [`registry::PluginError`]
-//! - [`manifest::PluginManifest`], [`manifest::ContractKind`]
-//! - One module per contract: [`memory_store`], [`llm_provider`],
-//!   [`workflow_orchestrator`], [`sensor_ingress`], [`mcp_server`],
-//!   [`frontend_adapter`] (P1), [`agent_provider`] (P2)
+//! Public surface (re-exported from this module):
+//! - [`ContractVersion`], [`VersionRange`] — versioning primitives (full path: [`version`]).
+//! - [`PluginRegistry`], [`PluginName`], [`PluginError`] — runtime registry (full path: [`registry`]).
+//! - [`PluginManifest`], [`ContractKind`] — capability manifest (full path: [`manifest`]).
+//! - Five P0 contract traits + their capability structs:
+//!   [`MemoryStore`] / [`MemoryStoreCapabilities`],
+//!   [`LLMProvider`] / [`LLMProviderCapabilities`],
+//!   [`WorkflowOrchestrator`] / [`WorkflowOrchestratorCapabilities`],
+//!   [`SensorIngress`] / [`SensorIngressCapabilities`],
+//!   [`McpServer`] / [`McpServerCapabilities`].
+//! - Forward stubs (P1/P2, hidden until #113 / #124): `FrontendAdapter`, `AgentProvider`.
 
 pub mod agent_provider;
 pub mod frontend_adapter;
@@ -26,3 +29,17 @@ pub mod workflow_orchestrator;
 
 #[doc(hidden)]
 pub mod macros;
+
+// Flat re-exports so users can write `cairn_core::contract::MemoryStore`
+// instead of `cairn_core::contract::memory_store::MemoryStore`.
+pub use manifest::{ContractKind, PluginManifest};
+pub use registry::{PluginError, PluginName, PluginRegistry};
+pub use version::{ContractVersion, VersionRange};
+
+pub use agent_provider::{AgentProvider, AgentProviderCapabilities};
+pub use frontend_adapter::{FrontendAdapter, FrontendAdapterCapabilities};
+pub use llm_provider::{LLMProvider, LLMProviderCapabilities};
+pub use mcp_server::{McpServer, McpServerCapabilities};
+pub use memory_store::{MemoryStore, MemoryStoreCapabilities};
+pub use sensor_ingress::{SensorIngress, SensorIngressCapabilities};
+pub use workflow_orchestrator::{WorkflowOrchestrator, WorkflowOrchestratorCapabilities};

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -1,0 +1,6 @@
+//! Contract surface — traits, plugin registry, capability manifest.
+//!
+//! Brief §4.1: every contract is a trait, every trait declares
+//! `CONTRACT_VERSION`, plugins register through `register_plugin!`.
+
+pub mod version;

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -4,6 +4,9 @@
 //! `register(&mut PluginRegistry)` (emitted by `register_plugin!`) in a
 //! deterministic order, then assemble the active set from config.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use crate::contract::version::{ContractVersion, VersionRange};
 
 /// Stable identifier for a plugin instance. Lowercase ASCII alnum + `-`
@@ -84,9 +87,205 @@ pub enum PluginError {
     InvalidManifest(String),
 }
 
+use crate::contract::{
+    agent_provider::AgentProvider, frontend_adapter::FrontendAdapter, llm_provider::LLMProvider,
+    mcp_server::McpServer, memory_store::MemoryStore, sensor_ingress::SensorIngress,
+    workflow_orchestrator::WorkflowOrchestrator,
+};
+
+/// Active set of registered plugins, keyed per contract by `PluginName`.
+///
+/// Constructed empty by the host at startup, then populated by calling each
+/// plugin crate's `register(&mut PluginRegistry)` (emitted by
+/// `register_plugin!`). After all `register` calls, the host queries the
+/// active impl per contract from `.cairn/config.yaml` (brief §4.1).
+#[derive(Default)]
+pub struct PluginRegistry {
+    memory_stores: HashMap<PluginName, Arc<dyn MemoryStore>>,
+    llm_providers: HashMap<PluginName, Arc<dyn LLMProvider>>,
+    workflow_orchestrators: HashMap<PluginName, Arc<dyn WorkflowOrchestrator>>,
+    sensor_ingress: HashMap<PluginName, Arc<dyn SensorIngress>>,
+    mcp_servers: HashMap<PluginName, Arc<dyn McpServer>>,
+    frontend_adapters: HashMap<PluginName, Arc<dyn FrontendAdapter>>,
+    agent_providers: HashMap<PluginName, Arc<dyn AgentProvider>>,
+}
+
+impl std::fmt::Debug for PluginRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PluginRegistry")
+            .field(
+                "memory_stores",
+                &self.memory_stores.keys().collect::<Vec<_>>(),
+            )
+            .field(
+                "llm_providers",
+                &self.llm_providers.keys().collect::<Vec<_>>(),
+            )
+            .field(
+                "workflow_orchestrators",
+                &self.workflow_orchestrators.keys().collect::<Vec<_>>(),
+            )
+            .field(
+                "sensor_ingress",
+                &self.sensor_ingress.keys().collect::<Vec<_>>(),
+            )
+            .field("mcp_servers", &self.mcp_servers.keys().collect::<Vec<_>>())
+            .field(
+                "frontend_adapters",
+                &self.frontend_adapters.keys().collect::<Vec<_>>(),
+            )
+            .field(
+                "agent_providers",
+                &self.agent_providers.keys().collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+
+// Macro expansion needs absolute paths to avoid name collisions across contracts.
+#[allow(unused_qualifications)]
+macro_rules! register_method {
+    ($method:ident, $field:ident, $trait_:path, $contract:literal, $host_version:expr) => {
+        /// Register a plugin under the given contract.
+        ///
+        /// # Errors
+        /// - [`PluginError::DuplicateName`] when `name` is already registered for this contract.
+        /// - [`PluginError::UnsupportedContractVersion`] when the impl's
+        ///   `supported_contract_versions()` does not accept the host's `CONTRACT_VERSION`.
+        pub fn $method(
+            &mut self,
+            name: PluginName,
+            plugin: Arc<dyn $trait_>,
+        ) -> Result<(), PluginError> {
+            if !plugin.supported_contract_versions().accepts($host_version) {
+                return Err(PluginError::UnsupportedContractVersion {
+                    contract: $contract,
+                    plugin: name,
+                    plugin_range: plugin.supported_contract_versions(),
+                    host: $host_version,
+                });
+            }
+            if self.$field.contains_key(&name) {
+                return Err(PluginError::DuplicateName {
+                    contract: $contract,
+                    name,
+                });
+            }
+            self.$field.insert(name, plugin);
+            Ok(())
+        }
+    };
+}
+
+impl PluginRegistry {
+    /// Construct an empty `PluginRegistry`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    register_method!(
+        register_memory_store,
+        memory_stores,
+        crate::contract::memory_store::MemoryStore,
+        "MemoryStore",
+        crate::contract::memory_store::CONTRACT_VERSION
+    );
+    register_method!(
+        register_llm_provider,
+        llm_providers,
+        crate::contract::llm_provider::LLMProvider,
+        "LLMProvider",
+        crate::contract::llm_provider::CONTRACT_VERSION
+    );
+    register_method!(
+        register_workflow_orchestrator,
+        workflow_orchestrators,
+        crate::contract::workflow_orchestrator::WorkflowOrchestrator,
+        "WorkflowOrchestrator",
+        crate::contract::workflow_orchestrator::CONTRACT_VERSION
+    );
+    register_method!(
+        register_sensor_ingress,
+        sensor_ingress,
+        crate::contract::sensor_ingress::SensorIngress,
+        "SensorIngress",
+        crate::contract::sensor_ingress::CONTRACT_VERSION
+    );
+    register_method!(
+        register_mcp_server,
+        mcp_servers,
+        crate::contract::mcp_server::McpServer,
+        "McpServer",
+        crate::contract::mcp_server::CONTRACT_VERSION
+    );
+    register_method!(
+        register_frontend_adapter,
+        frontend_adapters,
+        crate::contract::frontend_adapter::FrontendAdapter,
+        "FrontendAdapter",
+        crate::contract::frontend_adapter::CONTRACT_VERSION
+    );
+    register_method!(
+        register_agent_provider,
+        agent_providers,
+        crate::contract::agent_provider::AgentProvider,
+        "AgentProvider",
+        crate::contract::agent_provider::CONTRACT_VERSION
+    );
+
+    /// Look up a registered `MemoryStore` by plugin name.
+    #[must_use]
+    pub fn memory_store(&self, name: &PluginName) -> Option<Arc<dyn MemoryStore>> {
+        self.memory_stores.get(name).cloned()
+    }
+
+    /// Look up a registered `LLMProvider` by plugin name.
+    #[must_use]
+    pub fn llm_provider(&self, name: &PluginName) -> Option<Arc<dyn LLMProvider>> {
+        self.llm_providers.get(name).cloned()
+    }
+
+    /// Look up a registered `WorkflowOrchestrator` by plugin name.
+    #[must_use]
+    pub fn workflow_orchestrator(
+        &self,
+        name: &PluginName,
+    ) -> Option<Arc<dyn WorkflowOrchestrator>> {
+        self.workflow_orchestrators.get(name).cloned()
+    }
+
+    /// Look up a registered `SensorIngress` plugin by plugin name.
+    #[must_use]
+    pub fn sensor_ingress_plugin(&self, name: &PluginName) -> Option<Arc<dyn SensorIngress>> {
+        self.sensor_ingress.get(name).cloned()
+    }
+
+    /// Look up a registered `McpServer` by plugin name.
+    #[must_use]
+    pub fn mcp_server(&self, name: &PluginName) -> Option<Arc<dyn McpServer>> {
+        self.mcp_servers.get(name).cloned()
+    }
+
+    /// Look up a registered `FrontendAdapter` by plugin name.
+    #[must_use]
+    pub fn frontend_adapter(&self, name: &PluginName) -> Option<Arc<dyn FrontendAdapter>> {
+        self.frontend_adapters.get(name).cloned()
+    }
+
+    /// Look up a registered `AgentProvider` by plugin name.
+    #[must_use]
+    pub fn agent_provider(&self, name: &PluginName) -> Option<Arc<dyn AgentProvider>> {
+        self.agent_providers.get(name).cloned()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::contract::memory_store::{CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities};
+
+    // -- PluginName tests -------------------------------------------------
 
     #[test]
     fn name_accepts_kebab_alnum() {
@@ -127,11 +326,101 @@ mod tests {
         ));
     }
 
+    // -- Registry tests ---------------------------------------------------
+
+    struct StubStore {
+        range: VersionRange,
+    }
+
+    #[async_trait::async_trait]
+    impl MemoryStore for StubStore {
+        fn name(&self) -> &'static str {
+            "stub"
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: true,
+                vector: false,
+                graph_edges: false,
+                transactions: true,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            self.range
+        }
+    }
+
+    fn compatible() -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+
+    fn incompatible() -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 2, 0), ContractVersion::new(0, 3, 0))
+    }
+
     #[test]
-    fn name_display_matches_input() {
-        let n = PluginName::new("cairn-store-sqlite").expect("valid");
-        assert_eq!(n.to_string(), "cairn-store-sqlite");
+    fn registers_and_resolves_memory_store() {
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("cairn-store-sqlite").expect("valid");
+        reg.register_memory_store(
+            name.clone(),
+            Arc::new(StubStore {
+                range: compatible(),
+            }),
+        )
+        .expect("compatible plugin registers");
+        let resolved = reg.memory_store(&name).expect("registered");
+        assert_eq!(resolved.name(), "stub");
+    }
+
+    #[test]
+    fn rejects_duplicate_name() {
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("cairn-store-sqlite").expect("valid");
+        reg.register_memory_store(
+            name.clone(),
+            Arc::new(StubStore {
+                range: compatible(),
+            }),
+        )
+        .expect("first registers");
+        let err = reg
+            .register_memory_store(
+                name,
+                Arc::new(StubStore {
+                    range: compatible(),
+                }),
+            )
+            .expect_err("duplicate must fail");
+        assert!(matches!(err, PluginError::DuplicateName { .. }));
+    }
+
+    #[test]
+    fn rejects_incompatible_contract_version() {
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("acme-store-future").expect("valid");
+        let err = reg
+            .register_memory_store(
+                name,
+                Arc::new(StubStore {
+                    range: incompatible(),
+                }),
+            )
+            .expect_err("incompatible plugin must fail closed");
+        match err {
+            PluginError::UnsupportedContractVersion { host, contract, .. } => {
+                assert_eq!(host, CONTRACT_VERSION);
+                assert_eq!(contract, "MemoryStore");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unknown_name() {
+        let reg = PluginRegistry::new();
+        let name = PluginName::new("unknown").expect("valid");
+        assert!(reg.memory_store(&name).is_none());
     }
 }
-
-// PluginRegistry struct + impl arrives in Task 10 (Batch E) once contract traits exist.

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -1,0 +1,137 @@
+//! Plugin registry: typed, in-memory, host-assembled at startup.
+//!
+//! Brief §4.1: registration is explicit. Hosts call each plugin crate's
+//! `register(&mut PluginRegistry)` (emitted by `register_plugin!`) in a
+//! deterministic order, then assemble the active set from config.
+
+use crate::contract::version::{ContractVersion, VersionRange};
+
+/// Stable identifier for a plugin instance. Lowercase ASCII alnum + `-`
+/// (matches crates.io naming), 3..=64 chars. Examples: `cairn-store-sqlite`,
+/// `cairn-llm-openai-compat`, `acme-store-qdrant`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PluginName(String);
+
+impl PluginName {
+    /// Construct a `PluginName`, validating shape.
+    ///
+    /// # Errors
+    /// [`PluginError::InvalidName`] when `raw` violates the naming rule.
+    pub fn new(raw: impl Into<String>) -> Result<Self, PluginError> {
+        let raw = raw.into();
+        let valid = raw.len() >= 3
+            && raw.len() <= 64
+            && raw
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            && !raw.starts_with('-')
+            && !raw.ends_with('-');
+        if valid {
+            Ok(Self(raw))
+        } else {
+            Err(PluginError::InvalidName(raw))
+        }
+    }
+
+    /// Returns the plugin name as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PluginName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Errors produced by the plugin registry.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum PluginError {
+    /// The supplied string is not a valid plugin name.
+    #[error("invalid plugin name: {0:?}")]
+    InvalidName(String),
+
+    /// A plugin with this name was already registered for this contract.
+    #[error("duplicate plugin name {name} for contract {contract}")]
+    DuplicateName {
+        /// The contract slot that already holds this name.
+        contract: &'static str,
+        /// The conflicting plugin name.
+        name: PluginName,
+    },
+
+    /// The plugin's accepted version range does not include the host's contract version.
+    #[error(
+        "plugin {plugin} for contract {contract} accepts {plugin_range:?} \
+         but host is {host}"
+    )]
+    UnsupportedContractVersion {
+        /// The contract whose version is mismatched.
+        contract: &'static str,
+        /// The plugin that declared incompatible version support.
+        plugin: PluginName,
+        /// The version range the plugin declared it supports.
+        plugin_range: VersionRange,
+        /// The host's current contract version.
+        host: ContractVersion,
+    },
+
+    /// The plugin manifest contains invalid or missing fields.
+    #[error("invalid plugin manifest: {0}")]
+    InvalidManifest(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_accepts_kebab_alnum() {
+        assert!(PluginName::new("cairn-store-sqlite").is_ok());
+        assert!(PluginName::new("acme-llm-2").is_ok());
+        assert!(PluginName::new("a1b").is_ok());
+    }
+
+    #[test]
+    fn name_rejects_uppercase() {
+        assert!(matches!(
+            PluginName::new("Cairn-Store"),
+            Err(PluginError::InvalidName(_))
+        ));
+    }
+
+    #[test]
+    fn name_rejects_underscore() {
+        assert!(matches!(
+            PluginName::new("cairn_store"),
+            Err(PluginError::InvalidName(_))
+        ));
+    }
+
+    #[test]
+    fn name_rejects_too_short() {
+        assert!(matches!(
+            PluginName::new("ab"),
+            Err(PluginError::InvalidName(_))
+        ));
+    }
+
+    #[test]
+    fn name_rejects_leading_hyphen() {
+        assert!(matches!(
+            PluginName::new("-cairn"),
+            Err(PluginError::InvalidName(_))
+        ));
+    }
+
+    #[test]
+    fn name_display_matches_input() {
+        let n = PluginName::new("cairn-store-sqlite").expect("valid");
+        assert_eq!(n.to_string(), "cairn-store-sqlite");
+    }
+}
+
+// PluginRegistry struct + impl arrives in Task 10 (Batch E) once contract traits exist.

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -99,6 +99,15 @@ pub enum PluginError {
     /// The plugin manifest contains invalid or missing fields.
     #[error("invalid plugin manifest: {0}")]
     InvalidManifest(String),
+
+    /// Plugin manifest declares a different contract than the host expects.
+    #[error("plugin manifest declares contract {actual:?} but host expected {expected:?}")]
+    ContractMismatch {
+        /// The contract kind the host was trying to verify against.
+        expected: crate::contract::manifest::ContractKind,
+        /// The contract kind the manifest actually declares.
+        actual: crate::contract::manifest::ContractKind,
+    },
 }
 
 use crate::contract::{

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -82,6 +82,20 @@ pub enum PluginError {
         host: ContractVersion,
     },
 
+    /// Plugin's runtime name does not match the registered identifier.
+    #[error(
+        "plugin runtime name {runtime:?} does not match registered key {registered} \
+         for contract {contract}"
+    )]
+    IdentityMismatch {
+        /// Contract under which registration was attempted.
+        contract: &'static str,
+        /// Name passed to the registry (the key).
+        registered: PluginName,
+        /// Name reported by the plugin at runtime via `name()`.
+        runtime: String,
+    },
+
     /// The plugin manifest contains invalid or missing fields.
     #[error("invalid plugin manifest: {0}")]
     InvalidManifest(String),
@@ -163,6 +177,13 @@ macro_rules! register_method {
                     plugin: name,
                     plugin_range: plugin.supported_contract_versions(),
                     host: $host_version,
+                });
+            }
+            if plugin.name() != name.as_str() {
+                return Err(PluginError::IdentityMismatch {
+                    contract: $contract,
+                    registered: name,
+                    runtime: plugin.name().to_string(),
                 });
             }
             if self.$field.contains_key(&name) {
@@ -329,13 +350,14 @@ mod tests {
     // -- Registry tests ---------------------------------------------------
 
     struct StubStore {
+        name: &'static str,
         range: VersionRange,
     }
 
     #[async_trait::async_trait]
     impl MemoryStore for StubStore {
-        fn name(&self) -> &'static str {
-            "stub"
+        fn name(&self) -> &str {
+            self.name
         }
         fn capabilities(&self) -> &MemoryStoreCapabilities {
             static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
@@ -366,12 +388,13 @@ mod tests {
         reg.register_memory_store(
             name.clone(),
             Arc::new(StubStore {
+                name: "cairn-store-sqlite",
                 range: compatible(),
             }),
         )
         .expect("compatible plugin registers");
         let resolved = reg.memory_store(&name).expect("registered");
-        assert_eq!(resolved.name(), "stub");
+        assert_eq!(resolved.name(), "cairn-store-sqlite");
     }
 
     #[test]
@@ -381,6 +404,7 @@ mod tests {
         reg.register_memory_store(
             name.clone(),
             Arc::new(StubStore {
+                name: "cairn-store-sqlite",
                 range: compatible(),
             }),
         )
@@ -389,6 +413,7 @@ mod tests {
             .register_memory_store(
                 name,
                 Arc::new(StubStore {
+                    name: "cairn-store-sqlite",
                     range: compatible(),
                 }),
             )
@@ -404,6 +429,7 @@ mod tests {
             .register_memory_store(
                 name,
                 Arc::new(StubStore {
+                    name: "acme-store-future",
                     range: incompatible(),
                 }),
             )
@@ -415,6 +441,22 @@ mod tests {
             }
             other => panic!("wrong variant: {other:?}"),
         }
+    }
+
+    #[test]
+    fn rejects_identity_mismatch() {
+        let mut reg = PluginRegistry::new();
+        let key = PluginName::new("acme-store").expect("valid");
+        let err = reg
+            .register_memory_store(
+                key,
+                Arc::new(StubStore {
+                    name: "different-runtime-name",
+                    range: compatible(),
+                }),
+            )
+            .expect_err("identity mismatch must fail closed");
+        assert!(matches!(err, PluginError::IdentityMismatch { .. }));
     }
 
     #[test]

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -108,11 +108,20 @@ pub enum PluginError {
         /// The contract kind the manifest actually declares.
         actual: crate::contract::manifest::ContractKind,
     },
+
+    /// Plugin manifest declares a different name than the host expects.
+    #[error("plugin manifest declares name {manifest:?} but host expected {expected:?}")]
+    ManifestNameMismatch {
+        /// The name the host was trying to verify against.
+        expected: PluginName,
+        /// The name the manifest actually declares.
+        manifest: PluginName,
+    },
 }
 
 use crate::contract::{
     agent_provider::AgentProvider, frontend_adapter::FrontendAdapter, llm_provider::LLMProvider,
-    mcp_server::McpServer, memory_store::MemoryStore, sensor_ingress::SensorIngress,
+    mcp_server::MCPServer, memory_store::MemoryStore, sensor_ingress::SensorIngress,
     workflow_orchestrator::WorkflowOrchestrator,
 };
 
@@ -128,7 +137,7 @@ pub struct PluginRegistry {
     llm_providers: HashMap<PluginName, Arc<dyn LLMProvider>>,
     workflow_orchestrators: HashMap<PluginName, Arc<dyn WorkflowOrchestrator>>,
     sensor_ingress: HashMap<PluginName, Arc<dyn SensorIngress>>,
-    mcp_servers: HashMap<PluginName, Arc<dyn McpServer>>,
+    mcp_servers: HashMap<PluginName, Arc<dyn MCPServer>>,
     frontend_adapters: HashMap<PluginName, Arc<dyn FrontendAdapter>>,
     agent_providers: HashMap<PluginName, Arc<dyn AgentProvider>>,
 }
@@ -245,8 +254,8 @@ impl PluginRegistry {
     register_method!(
         register_mcp_server,
         mcp_servers,
-        crate::contract::mcp_server::McpServer,
-        "McpServer",
+        crate::contract::mcp_server::MCPServer,
+        "MCPServer",
         crate::contract::mcp_server::CONTRACT_VERSION
     );
     register_method!(
@@ -291,9 +300,9 @@ impl PluginRegistry {
         self.sensor_ingress.get(name).cloned()
     }
 
-    /// Look up a registered `McpServer` by plugin name.
+    /// Look up a registered `MCPServer` by plugin name.
     #[must_use]
-    pub fn mcp_server(&self, name: &PluginName) -> Option<Arc<dyn McpServer>> {
+    pub fn mcp_server(&self, name: &PluginName) -> Option<Arc<dyn MCPServer>> {
         self.mcp_servers.get(name).cloned()
     }
 

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -131,6 +131,27 @@ use crate::contract::{
 /// plugin crate's `register(&mut PluginRegistry)` (emitted by
 /// `register_plugin!`). After all `register` calls, the host queries the
 /// active impl per contract from `.cairn/config.yaml` (brief §4.1).
+///
+/// # Trust model
+///
+/// Plugins are **compile-time dependencies** of the host binary — every
+/// `register_plugin!` call lives in a Cargo dependency the host author
+/// explicitly added. The registry is therefore **not** a sandbox: a
+/// plugin's generated `register` receives `&mut PluginRegistry` and can,
+/// in principle, call any `register_*` method or register under any
+/// `PluginName`. This is intentional. Rust crate trust is established at
+/// the build, not at the registry mutation. A single plugin may also
+/// register multiple contracts in one `register` call (e.g., a vendor
+/// suite that ships both a `MemoryStore` and a `SensorIngress` impl).
+///
+/// For deployments that want a manifest-driven gate before invoking each
+/// plugin's `register`, see [`super::manifest::PluginManifest::verify_compatible_with`].
+/// That helper validates a manifest's name + contract kind + accepted
+/// version range against the host before activation, but it is advisory:
+/// the host still calls the plugin's `register` with a full `&mut
+/// PluginRegistry`. Atomic / transactional registrars are out of P0 scope
+/// and would conflict with multi-contract plugins; revisit if a future
+/// threat model demands sandboxing (likely via WASM, not the registry).
 #[derive(Default)]
 pub struct PluginRegistry {
     memory_stores: HashMap<PluginName, Arc<dyn MemoryStore>>,

--- a/crates/cairn-core/src/contract/sensor_ingress.rs
+++ b/crates/cairn-core/src/contract/sensor_ingress.rs
@@ -1,0 +1,71 @@
+//! `SensorIngress` contract (brief §4 row 4).
+//!
+//! P0: hook sensors only (#84). IDE/clipboard/screen/web are P1; Slack/
+//! email/GitHub are P2.
+
+use crate::contract::version::{ContractVersion, VersionRange};
+
+/// Contract version for `SensorIngress`. Bumps when the trait surface changes.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 1, 0);
+
+/// Static capability declaration for a `SensorIngress` impl.
+// Three flags cover distinct sensor delivery dimensions; a state machine
+// adds indirection with no clarity gain here.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SensorIngressCapabilities {
+    /// Whether the sensor supports batched event delivery.
+    pub batches: bool,
+    /// Whether the sensor supports continuous streaming delivery.
+    pub streaming: bool,
+    /// Whether the sensor checks consent before forwarding events.
+    pub consent_aware: bool,
+}
+
+/// Sensor ingress contract — event delivery into the Cairn pipeline.
+///
+/// Brief §4 row 4: P0 is hook sensors only (#84). IDE/clipboard/screen/web
+/// are P1; Slack/email/GitHub are P2. All share this trait.
+#[async_trait::async_trait]
+pub trait SensorIngress: Send + Sync {
+    /// Stable identifier of the registered plugin instance.
+    fn name(&self) -> &str;
+
+    /// Static capability advertisement (brief §4.1).
+    fn capabilities(&self) -> &SensorIngressCapabilities;
+
+    /// Range of `SensorIngress::CONTRACT_VERSION` values this impl accepts.
+    fn supported_contract_versions(&self) -> VersionRange;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubSensor;
+
+    #[async_trait::async_trait]
+    impl SensorIngress for StubSensor {
+        fn name(&self) -> &'static str {
+            "stub-sensor"
+        }
+        fn capabilities(&self) -> &SensorIngressCapabilities {
+            static CAPS: SensorIngressCapabilities = SensorIngressCapabilities {
+                batches: true,
+                streaming: false,
+                consent_aware: true,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+        }
+    }
+
+    #[test]
+    fn dyn_compatible() {
+        let s: Box<dyn SensorIngress> = Box::new(StubSensor);
+        assert_eq!(s.name(), "stub-sensor");
+        assert!(s.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+}

--- a/crates/cairn-core/src/contract/version.rs
+++ b/crates/cairn-core/src/contract/version.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Semver-shaped contract version. `0.x` is pre-stable; bumping `minor`
 /// is a breaking change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ContractVersion {
     /// Major version component.
     pub major: u16,
@@ -36,6 +37,7 @@ impl std::fmt::Display for ContractVersion {
 
 /// Half-open range `[min, max_exclusive)` over `ContractVersion`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct VersionRange {
     /// Lower bound (inclusive).
     pub min: ContractVersion,

--- a/crates/cairn-core/src/contract/version.rs
+++ b/crates/cairn-core/src/contract/version.rs
@@ -1,0 +1,99 @@
+//! Contract versioning. Each contract module exports `CONTRACT_VERSION` of
+//! type [`ContractVersion`]. Plugins declare a [`VersionRange`] they accept;
+//! the registry rejects on mismatch (brief §4.1, "Contracts are versioned").
+
+use serde::{Deserialize, Serialize};
+
+/// Semver-shaped contract version. `0.x` is pre-stable; bumping `minor`
+/// is a breaking change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ContractVersion {
+    /// Major version component.
+    pub major: u16,
+    /// Minor version component.
+    pub minor: u16,
+    /// Patch version component.
+    pub patch: u16,
+}
+
+impl ContractVersion {
+    /// Construct a [`ContractVersion`] from its three components.
+    #[must_use]
+    pub const fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+impl std::fmt::Display for ContractVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// Half-open range `[min, max_exclusive)` over `ContractVersion`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionRange {
+    /// Lower bound (inclusive).
+    pub min: ContractVersion,
+    /// Upper bound (exclusive).
+    pub max_exclusive: ContractVersion,
+}
+
+impl VersionRange {
+    /// Construct a [`VersionRange`] with the given inclusive lower and exclusive upper bounds.
+    #[must_use]
+    pub const fn new(min: ContractVersion, max_exclusive: ContractVersion) -> Self {
+        Self { min, max_exclusive }
+    }
+
+    /// `true` iff `host` is in `[min, max_exclusive)`.
+    #[must_use]
+    pub fn accepts(&self, host: ContractVersion) -> bool {
+        let key = (host.major, host.minor, host.patch);
+        let lo = (self.min.major, self.min.minor, self.min.patch);
+        let hi = (
+            self.max_exclusive.major,
+            self.max_exclusive.minor,
+            self.max_exclusive.patch,
+        );
+        key >= lo && key < hi
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_min_inclusive() {
+        let range = VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+        assert!(range.accepts(ContractVersion::new(0, 1, 0)));
+    }
+
+    #[test]
+    fn rejects_max_exclusive() {
+        let range = VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+        assert!(!range.accepts(ContractVersion::new(0, 2, 0)));
+    }
+
+    #[test]
+    fn accepts_within_range() {
+        let range = VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+        assert!(range.accepts(ContractVersion::new(0, 1, 5)));
+    }
+
+    #[test]
+    fn rejects_below_min() {
+        let range = VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+        assert!(!range.accepts(ContractVersion::new(0, 0, 9)));
+    }
+
+    #[test]
+    fn version_display() {
+        assert_eq!(ContractVersion::new(1, 2, 3).to_string(), "1.2.3");
+    }
+}

--- a/crates/cairn-core/src/contract/workflow_orchestrator.rs
+++ b/crates/cairn-core/src/contract/workflow_orchestrator.rs
@@ -1,0 +1,71 @@
+//! `WorkflowOrchestrator` contract (brief §4 row 3).
+//!
+//! P0 default: tokio + `SQLite`-backed job table (#89). Optional Temporal
+//! adapter is a P1+ swap — same trait.
+
+use crate::contract::version::{ContractVersion, VersionRange};
+
+/// Contract version for `WorkflowOrchestrator`. Bumps when the trait surface changes.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 1, 0);
+
+/// Static capability declaration for a `WorkflowOrchestrator` impl.
+// Three flags cover distinct orchestration dimensions; a state machine adds
+// indirection with no clarity gain here.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct WorkflowOrchestratorCapabilities {
+    /// Whether the orchestrator persists job state across restarts.
+    pub durable: bool,
+    /// Whether the orchestrator can recover from a crash mid-workflow.
+    pub crash_safe: bool,
+    /// Whether the orchestrator supports cron-style recurring schedules.
+    pub cron_schedules: bool,
+}
+
+/// Workflow orchestration contract.
+///
+/// Brief §4 row 3: P0 default is tokio + `SQLite`-backed job table (#89).
+/// Optional Temporal adapter is a P1+ swap — same trait surface.
+#[async_trait::async_trait]
+pub trait WorkflowOrchestrator: Send + Sync {
+    /// Stable identifier of the registered plugin instance.
+    fn name(&self) -> &str;
+
+    /// Static capability advertisement (brief §4.1).
+    fn capabilities(&self) -> &WorkflowOrchestratorCapabilities;
+
+    /// Range of `WorkflowOrchestrator::CONTRACT_VERSION` values this impl accepts.
+    fn supported_contract_versions(&self) -> VersionRange;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubOrch;
+
+    #[async_trait::async_trait]
+    impl WorkflowOrchestrator for StubOrch {
+        fn name(&self) -> &'static str {
+            "stub-orch"
+        }
+        fn capabilities(&self) -> &WorkflowOrchestratorCapabilities {
+            static CAPS: WorkflowOrchestratorCapabilities = WorkflowOrchestratorCapabilities {
+                durable: true,
+                crash_safe: true,
+                cron_schedules: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+        }
+    }
+
+    #[test]
+    fn dyn_compatible() {
+        let o: Box<dyn WorkflowOrchestrator> = Box::new(StubOrch);
+        assert_eq!(o.name(), "stub-orch");
+        assert!(o.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+}

--- a/crates/cairn-core/src/lib.rs
+++ b/crates/cairn-core/src/lib.rs
@@ -1,6 +1,8 @@
-//! Cairn core — verb traits, domain types, and error enums.
+//! Cairn core — contract traits, domain types, and error enums.
 //!
-//! P0 scaffold. Verb behaviour, domain types, and error enums land in
-//! follow-up issues (#4, #34, #35). Core depends on no adapter crate.
+//! P0 scaffold. Domain types and verb behaviour land in follow-up issues
+//! (#4 et al.). This crate has zero dependencies on any adapter crate.
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod contract;

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -1,0 +1,110 @@
+//! Integration: a fake plugin registers via `register_plugin!`, the host
+//! looks it up, and version mismatch fails closed.
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::{
+    MemoryStore, MemoryStoreCapabilities, CONTRACT_VERSION,
+};
+use cairn_core::contract::registry::{PluginError, PluginName, PluginRegistry};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::register_plugin;
+
+mod compatible_plugin {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct FakeStore;
+
+    #[async_trait::async_trait]
+    impl MemoryStore for FakeStore {
+        fn name(&self) -> &'static str {
+            "fake-compatible"
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: true,
+                vector: false,
+                graph_edges: false,
+                transactions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            VersionRange::new(
+                ContractVersion::new(0, 1, 0),
+                ContractVersion::new(0, 2, 0),
+            )
+        }
+    }
+
+    register_plugin!(MemoryStore, FakeStore, "fake-compat");
+}
+
+mod future_plugin {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct FutureStore;
+
+    #[async_trait::async_trait]
+    impl MemoryStore for FutureStore {
+        fn name(&self) -> &'static str {
+            "fake-future"
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: false,
+                vector: false,
+                graph_edges: false,
+                transactions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            // Demands a future host version — must be rejected today.
+            VersionRange::new(
+                ContractVersion::new(9, 9, 0),
+                ContractVersion::new(10, 0, 0),
+            )
+        }
+    }
+
+    register_plugin!(MemoryStore, FutureStore, "fake-future");
+}
+
+#[test]
+fn compatible_plugin_registers_via_macro() {
+    let mut reg = PluginRegistry::new();
+    compatible_plugin::register(&mut reg).expect("compatible plugin registers");
+
+    let name = PluginName::new("fake-compat").expect("valid name");
+    let resolved = reg.memory_store(&name).expect("registered");
+    assert_eq!(resolved.name(), "fake-compatible");
+    assert!(resolved.supported_contract_versions().accepts(CONTRACT_VERSION));
+}
+
+#[test]
+fn incompatible_plugin_fails_closed() {
+    let mut reg = PluginRegistry::new();
+    let err = future_plugin::register(&mut reg)
+        .expect_err("plugin demanding future host must fail");
+    match err {
+        PluginError::UnsupportedContractVersion { contract, host, .. } => {
+            assert_eq!(contract, "MemoryStore");
+            assert_eq!(host, CONTRACT_VERSION);
+        }
+        other => panic!("wrong variant: {other:?}"),
+    }
+}
+
+#[test]
+fn keeps_arc_pointer_stable() {
+    // Two lookups return the same underlying Arc.
+    let mut reg = PluginRegistry::new();
+    compatible_plugin::register(&mut reg).expect("registers");
+    let name = PluginName::new("fake-compat").expect("valid");
+    let a = reg.memory_store(&name).expect("registered");
+    let b = reg.memory_store(&name).expect("registered");
+    assert!(Arc::ptr_eq(&a, &b));
+}

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -17,7 +17,7 @@ mod compatible_plugin {
     #[async_trait::async_trait]
     impl MemoryStore for FakeStore {
         fn name(&self) -> &'static str {
-            "fake-compatible"
+            "fake-compat"
         }
         fn capabilities(&self) -> &MemoryStoreCapabilities {
             static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
@@ -75,7 +75,7 @@ fn compatible_plugin_registers_via_macro() {
 
     let name = PluginName::new("fake-compat").expect("valid name");
     let resolved = reg.memory_store(&name).expect("registered");
-    assert_eq!(resolved.name(), "fake-compatible");
+    assert_eq!(resolved.name(), "fake-compat");
     assert!(
         resolved
             .supported_contract_versions()

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -3,9 +3,7 @@
 
 use std::sync::Arc;
 
-use cairn_core::contract::memory_store::{
-    MemoryStore, MemoryStoreCapabilities, CONTRACT_VERSION,
-};
+use cairn_core::contract::memory_store::{CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities};
 use cairn_core::contract::registry::{PluginError, PluginName, PluginRegistry};
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::register_plugin;
@@ -31,10 +29,7 @@ mod compatible_plugin {
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(
-                ContractVersion::new(0, 1, 0),
-                ContractVersion::new(0, 2, 0),
-            )
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
         }
     }
 
@@ -81,14 +76,18 @@ fn compatible_plugin_registers_via_macro() {
     let name = PluginName::new("fake-compat").expect("valid name");
     let resolved = reg.memory_store(&name).expect("registered");
     assert_eq!(resolved.name(), "fake-compatible");
-    assert!(resolved.supported_contract_versions().accepts(CONTRACT_VERSION));
+    assert!(
+        resolved
+            .supported_contract_versions()
+            .accepts(CONTRACT_VERSION)
+    );
 }
 
 #[test]
 fn incompatible_plugin_fails_closed() {
     let mut reg = PluginRegistry::new();
-    let err = future_plugin::register(&mut reg)
-        .expect_err("plugin demanding future host must fail");
+    let err =
+        future_plugin::register(&mut reg).expect_err("plugin demanding future host must fail");
     match err {
         PluginError::UnsupportedContractVersion { contract, host, .. } => {
             assert_eq!(contract, "MemoryStore");

--- a/crates/cairn-core/tests/contract_root_exports.rs
+++ b/crates/cairn-core/tests/contract_root_exports.rs
@@ -6,8 +6,8 @@
 
 use cairn_core::contract::{
     AgentProvider, AgentProviderCapabilities, ContractKind, ContractVersion, FrontendAdapter,
-    FrontendAdapterCapabilities, LLMProvider, LLMProviderCapabilities, McpServer,
-    McpServerCapabilities, MemoryStore, MemoryStoreCapabilities, PluginError, PluginManifest,
+    FrontendAdapterCapabilities, LLMProvider, LLMProviderCapabilities, MCPServer,
+    MCPServerCapabilities, MemoryStore, MemoryStoreCapabilities, PluginError, PluginManifest,
     PluginName, PluginRegistry, SensorIngress, SensorIngressCapabilities, VersionRange,
     WorkflowOrchestrator, WorkflowOrchestratorCapabilities,
 };
@@ -30,7 +30,7 @@ fn capability_structs_default() {
     let _: LLMProviderCapabilities = LLMProviderCapabilities::default();
     let _: WorkflowOrchestratorCapabilities = WorkflowOrchestratorCapabilities::default();
     let _: SensorIngressCapabilities = SensorIngressCapabilities::default();
-    let _: McpServerCapabilities = McpServerCapabilities::default();
+    let _: MCPServerCapabilities = MCPServerCapabilities::default();
     let _: FrontendAdapterCapabilities = FrontendAdapterCapabilities::default();
     let _: AgentProviderCapabilities = AgentProviderCapabilities::default();
 }
@@ -42,7 +42,7 @@ mod compile_only {
     pub fn accepts_dyn_llm_provider(_: &dyn LLMProvider) {}
     pub fn accepts_dyn_workflow_orchestrator(_: &dyn WorkflowOrchestrator) {}
     pub fn accepts_dyn_sensor_ingress(_: &dyn SensorIngress) {}
-    pub fn accepts_dyn_mcp_server(_: &dyn McpServer) {}
+    pub fn accepts_dyn_mcp_server(_: &dyn MCPServer) {}
     pub fn accepts_dyn_frontend_adapter(_: &dyn FrontendAdapter) {}
     pub fn accepts_dyn_agent_provider(_: &dyn AgentProvider) {}
 }
@@ -68,7 +68,7 @@ fn manifest_kinds_are_complete() {
         ContractKind::LLMProvider,
         ContractKind::WorkflowOrchestrator,
         ContractKind::SensorIngress,
-        ContractKind::McpServer,
+        ContractKind::MCPServer,
         ContractKind::FrontendAdapter,
         ContractKind::AgentProvider,
     ];

--- a/crates/cairn-core/tests/contract_root_exports.rs
+++ b/crates/cairn-core/tests/contract_root_exports.rs
@@ -1,0 +1,83 @@
+//! Compile-path test: every #174 acceptance trait is reachable directly from
+//! `cairn_core::contract::*` without dipping into submodules.
+
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use cairn_core::contract::{
+    AgentProvider, AgentProviderCapabilities, ContractKind, ContractVersion, FrontendAdapter,
+    FrontendAdapterCapabilities, LLMProvider, LLMProviderCapabilities, McpServer,
+    McpServerCapabilities, MemoryStore, MemoryStoreCapabilities, PluginError, PluginManifest,
+    PluginName, PluginRegistry, SensorIngress, SensorIngressCapabilities, VersionRange,
+    WorkflowOrchestrator, WorkflowOrchestratorCapabilities,
+};
+
+#[test]
+fn registry_constructible() {
+    let _: PluginRegistry = PluginRegistry::new();
+}
+
+#[test]
+fn version_constructible() {
+    let _: ContractVersion = ContractVersion::new(0, 1, 0);
+    let _: VersionRange =
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+}
+
+#[test]
+fn capability_structs_default() {
+    let _: MemoryStoreCapabilities = MemoryStoreCapabilities::default();
+    let _: LLMProviderCapabilities = LLMProviderCapabilities::default();
+    let _: WorkflowOrchestratorCapabilities = WorkflowOrchestratorCapabilities::default();
+    let _: SensorIngressCapabilities = SensorIngressCapabilities::default();
+    let _: McpServerCapabilities = McpServerCapabilities::default();
+    let _: FrontendAdapterCapabilities = FrontendAdapterCapabilities::default();
+    let _: AgentProviderCapabilities = AgentProviderCapabilities::default();
+}
+
+mod compile_only {
+    use super::*;
+
+    pub fn accepts_dyn_memory_store(_: &dyn MemoryStore) {}
+    pub fn accepts_dyn_llm_provider(_: &dyn LLMProvider) {}
+    pub fn accepts_dyn_workflow_orchestrator(_: &dyn WorkflowOrchestrator) {}
+    pub fn accepts_dyn_sensor_ingress(_: &dyn SensorIngress) {}
+    pub fn accepts_dyn_mcp_server(_: &dyn McpServer) {}
+    pub fn accepts_dyn_frontend_adapter(_: &dyn FrontendAdapter) {}
+    pub fn accepts_dyn_agent_provider(_: &dyn AgentProvider) {}
+}
+
+// Type-level proof the traits resolve via the contract root: these functions
+// compile only if the traits are re-exported from `cairn_core::contract`.
+#[test]
+fn dyn_dispatch_compiles() {
+    // Keep symbols live for clippy by taking their addresses.
+    let _ = compile_only::accepts_dyn_memory_store as fn(_);
+    let _ = compile_only::accepts_dyn_llm_provider as fn(_);
+    let _ = compile_only::accepts_dyn_workflow_orchestrator as fn(_);
+    let _ = compile_only::accepts_dyn_sensor_ingress as fn(_);
+    let _ = compile_only::accepts_dyn_mcp_server as fn(_);
+    let _ = compile_only::accepts_dyn_frontend_adapter as fn(_);
+    let _ = compile_only::accepts_dyn_agent_provider as fn(_);
+}
+
+#[test]
+fn manifest_kinds_are_complete() {
+    let kinds = [
+        ContractKind::MemoryStore,
+        ContractKind::LLMProvider,
+        ContractKind::WorkflowOrchestrator,
+        ContractKind::SensorIngress,
+        ContractKind::McpServer,
+        ContractKind::FrontendAdapter,
+        ContractKind::AgentProvider,
+    ];
+    assert_eq!(kinds.len(), 7);
+}
+
+#[test]
+fn plugin_error_constructible() {
+    // Force compile-time check: PluginError and PluginManifest are reachable.
+    let _: Result<PluginName, PluginError> = PluginName::new("good-name");
+    let _: Result<PluginManifest, PluginError> = PluginManifest::parse_toml("");
+}

--- a/crates/cairn-idl/Cargo.toml
+++ b/crates/cairn-idl/Cargo.toml
@@ -18,6 +18,11 @@ path = "src/bin/cairn-codegen.rs"
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+[dev-dependencies]
+jsonschema = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/crates/cairn-idl/schema/index.json
+++ b/crates/cairn-idl/schema/index.json
@@ -36,6 +36,9 @@
       "verbs/capture_trace.json",
       "verbs/lint.json",
       "verbs/forget.json"
+    ],
+    "plugin": [
+      "plugin/manifest.json"
     ]
   },
   "x-cairn-verb-ids": [

--- a/crates/cairn-idl/schema/plugin/example.toml
+++ b/crates/cairn-idl/schema/plugin/example.toml
@@ -1,0 +1,20 @@
+# Example plugin manifest — referenced by the cairn-core round-trip test.
+# Real plugin crates ship their own manifest alongside the binary entry point.
+
+name = "cairn-store-sqlite"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+fts = true
+vector = false
+graph_edges = false

--- a/crates/cairn-idl/schema/plugin/manifest.json
+++ b/crates/cairn-idl/schema/plugin/manifest.json
@@ -27,6 +27,7 @@
     },
     "contract_version_range": {
       "type": "object",
+      "description": "Half-open `[min, max_exclusive)`. The Rust parser additionally rejects empty/inverted ranges (min >= max_exclusive); JSON Schema cannot express this cross-property invariant.",
       "required": ["min", "max_exclusive"],
       "additionalProperties": false,
       "properties": {
@@ -37,6 +38,7 @@
     "features": {
       "type": "object",
       "description": "Free-form boolean feature flags this plugin advertises. Cairn's pipeline may consult these to gate optional behavior.",
+      "propertyNames": { "pattern": "^[A-Za-z0-9_]{1,64}$" },
       "additionalProperties": { "type": "boolean" }
     }
   },

--- a/crates/cairn-idl/schema/plugin/manifest.json
+++ b/crates/cairn-idl/schema/plugin/manifest.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/plugin/manifest.json",
+  "title": "Cairn plugin capability manifest",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "description": "Brief §4.1. Each plugin publishes one of these so the host can validate name, contract, version range, and feature flags before activation.",
+  "type": "object",
+  "required": ["name", "contract", "contract_version_range"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9](?:[a-z0-9-]{1,62}[a-z0-9])$",
+      "description": "Stable plugin identifier; same shape as PluginName in cairn-core."
+    },
+    "contract": {
+      "type": "string",
+      "enum": [
+        "MemoryStore",
+        "LLMProvider",
+        "WorkflowOrchestrator",
+        "SensorIngress",
+        "McpServer",
+        "FrontendAdapter",
+        "AgentProvider"
+      ]
+    },
+    "contract_version_range": {
+      "type": "object",
+      "required": ["min", "max_exclusive"],
+      "additionalProperties": false,
+      "properties": {
+        "min": { "$ref": "#/$defs/version" },
+        "max_exclusive": { "$ref": "#/$defs/version" }
+      }
+    },
+    "features": {
+      "type": "object",
+      "description": "Free-form boolean feature flags this plugin advertises. Cairn's pipeline may consult these to gate optional behavior.",
+      "additionalProperties": { "type": "boolean" }
+    }
+  },
+  "$defs": {
+    "version": {
+      "type": "object",
+      "required": ["major", "minor", "patch"],
+      "additionalProperties": false,
+      "properties": {
+        "major": { "type": "integer", "minimum": 0, "maximum": 65535 },
+        "minor": { "type": "integer", "minimum": 0, "maximum": 65535 },
+        "patch": { "type": "integer", "minimum": 0, "maximum": 65535 }
+      }
+    }
+  }
+}

--- a/crates/cairn-idl/schema/plugin/manifest.json
+++ b/crates/cairn-idl/schema/plugin/manifest.json
@@ -20,7 +20,7 @@
         "LLMProvider",
         "WorkflowOrchestrator",
         "SensorIngress",
-        "McpServer",
+        "MCPServer",
         "FrontendAdapter",
         "AgentProvider"
       ]

--- a/crates/cairn-idl/tests/plugin_manifest_parity.rs
+++ b/crates/cairn-idl/tests/plugin_manifest_parity.rs
@@ -62,7 +62,7 @@ fn contract_enum_lists_all_seven_kinds() {
         "AgentProvider",
         "FrontendAdapter",
         "LLMProvider",
-        "McpServer",
+        "MCPServer",
         "MemoryStore",
         "SensorIngress",
         "WorkflowOrchestrator",

--- a/crates/cairn-idl/tests/plugin_manifest_parity.rs
+++ b/crates/cairn-idl/tests/plugin_manifest_parity.rs
@@ -1,0 +1,72 @@
+//! Parity check: the patterns in `plugin/manifest.json` must match the
+//! validation rules enforced by `cairn_core::contract::manifest::PluginManifest`.
+//!
+//! We don't run a full JSON Schema validator here (that would add a heavy dep);
+//! instead we inspect the schema document and confirm the regex patterns used
+//! for `name`, `features.propertyNames`, and the version object's bounds match
+//! what the Rust parser enforces. This catches schema/Rust drift in CI.
+
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use serde_json::Value;
+
+const SCHEMA_SRC: &str = include_str!("../schema/plugin/manifest.json");
+
+#[test]
+fn name_pattern_matches_plugin_name_rules() {
+    let schema: Value = serde_json::from_str(SCHEMA_SRC).expect("schema is valid JSON");
+    let pattern = schema
+        .pointer("/properties/name/pattern")
+        .and_then(Value::as_str)
+        .expect("name pattern present");
+    // PluginName accepts: 3..=64 chars, ascii lowercase + digit + hyphen, no
+    // leading/trailing hyphen. The schema's regex must align.
+    assert_eq!(pattern, "^[a-z0-9](?:[a-z0-9-]{1,62}[a-z0-9])$");
+}
+
+#[test]
+fn feature_key_pattern_matches_rust_validator() {
+    let schema: Value = serde_json::from_str(SCHEMA_SRC).expect("schema is valid JSON");
+    let pattern = schema
+        .pointer("/properties/features/propertyNames/pattern")
+        .and_then(Value::as_str)
+        .expect("feature key pattern present");
+    // Rust validator: ^[A-Za-z0-9_]{1,64}$. Schema must agree.
+    assert_eq!(pattern, "^[A-Za-z0-9_]{1,64}$");
+}
+
+#[test]
+fn version_bounds_are_u16_compatible() {
+    let schema: Value = serde_json::from_str(SCHEMA_SRC).expect("schema is valid JSON");
+    let major = schema
+        .pointer("/$defs/version/properties/major")
+        .expect("version.major present");
+    assert_eq!(major.pointer("/minimum").and_then(Value::as_u64), Some(0));
+    assert_eq!(
+        major.pointer("/maximum").and_then(Value::as_u64),
+        Some(65535)
+    );
+}
+
+#[test]
+fn contract_enum_lists_all_seven_kinds() {
+    let schema: Value = serde_json::from_str(SCHEMA_SRC).expect("schema is valid JSON");
+    let enum_arr = schema
+        .pointer("/properties/contract/enum")
+        .and_then(Value::as_array)
+        .expect("contract enum present");
+    let mut names: Vec<&str> = enum_arr.iter().filter_map(Value::as_str).collect();
+    names.sort_unstable();
+    let mut expected = vec![
+        "AgentProvider",
+        "FrontendAdapter",
+        "LLMProvider",
+        "McpServer",
+        "MemoryStore",
+        "SensorIngress",
+        "WorkflowOrchestrator",
+    ];
+    expected.sort_unstable();
+    assert_eq!(names, expected);
+}

--- a/crates/cairn-idl/tests/plugin_manifest_validation.rs
+++ b/crates/cairn-idl/tests/plugin_manifest_validation.rs
@@ -1,0 +1,101 @@
+//! Real JSON-Schema-vs-TOML-fixture validation for `plugin/manifest.json`.
+//!
+//! Loads the schema, loads the example fixture, converts TOML to a JSON Value,
+//! and runs the fixture through `jsonschema`. Catches schema/fixture drift
+//! that the parity tests can't see.
+
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use jsonschema::Validator;
+use serde_json::Value;
+
+const SCHEMA_SRC: &str = include_str!("../schema/plugin/manifest.json");
+const FIXTURE_SRC: &str = include_str!("../schema/plugin/example.toml");
+
+fn schema() -> Validator {
+    let schema_value: Value = serde_json::from_str(SCHEMA_SRC).expect("schema is valid JSON");
+    Validator::new(&schema_value).expect("schema compiles")
+}
+
+fn fixture_as_json() -> Value {
+    let toml_value: toml::Value = toml::from_str(FIXTURE_SRC).expect("fixture is valid TOML");
+    serde_json::to_value(&toml_value).expect("toml -> json round-trip")
+}
+
+#[test]
+fn example_toml_validates_against_schema() {
+    let v = schema();
+    let fixture = fixture_as_json();
+    v.validate(&fixture).unwrap_or_else(|err| {
+        panic!("fixture failed schema validation: {err}");
+    });
+}
+
+#[test]
+fn rejects_extra_top_level_field() {
+    let v = schema();
+    let mut fixture = fixture_as_json();
+    fixture
+        .as_object_mut()
+        .expect("object")
+        .insert("rogue".to_string(), Value::String("nope".into()));
+    assert!(
+        v.validate(&fixture).is_err(),
+        "additionalProperties must reject"
+    );
+}
+
+#[test]
+fn rejects_invalid_name() {
+    let v = schema();
+    let mut fixture = fixture_as_json();
+    fixture
+        .as_object_mut()
+        .expect("object")
+        .insert("name".to_string(), Value::String("BAD_NAME".into()));
+    assert!(v.validate(&fixture).is_err(), "name pattern must reject");
+}
+
+#[test]
+fn rejects_unknown_contract() {
+    let v = schema();
+    let mut fixture = fixture_as_json();
+    fixture.as_object_mut().expect("object").insert(
+        "contract".to_string(),
+        Value::String("UnknownContract".into()),
+    );
+    assert!(v.validate(&fixture).is_err(), "contract enum must reject");
+}
+
+#[test]
+fn rejects_invalid_feature_key() {
+    let v = schema();
+    let mut fixture = fixture_as_json();
+    let features = fixture
+        .as_object_mut()
+        .expect("object")
+        .entry("features".to_string())
+        .or_insert(Value::Object(serde_json::Map::default()))
+        .as_object_mut()
+        .expect("features object");
+    features.insert("bad.key".to_string(), Value::Bool(true));
+    assert!(
+        v.validate(&fixture).is_err(),
+        "feature key propertyNames must reject"
+    );
+}
+
+#[test]
+fn rejects_out_of_range_version() {
+    let v = schema();
+    let mut fixture = fixture_as_json();
+    let major = fixture
+        .pointer_mut("/contract_version_range/min/major")
+        .expect("min.major");
+    *major = Value::Number(70_000.into()); // > 65535
+    assert!(
+        v.validate(&fixture).is_err(),
+        "version major maximum must reject"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #174.

Lands the trait surface every adapter crate needs in `cairn-core::contract`:

- 5 P0 contract traits — `MemoryStore`, `LLMProvider`, `WorkflowOrchestrator`, `SensorIngress`, `McpServer` — each with `pub const CONTRACT_VERSION` and a `*Capabilities` struct
- 2 forward stubs — `FrontendAdapter` (P1), `AgentProvider` (P2), gated `#[doc(hidden)]` until #113 / #124
- `PluginRegistry` + `PluginName` + `PluginError` with version-mismatch and duplicate-name fail-closed paths
- `register_plugin!` declarative macro emitting a per-plugin `register(&mut PluginRegistry)`
- Plugin capability manifest: JSON Schema in `cairn-idl/schema/plugin/manifest.json` + TOML parser in `cairn-core::contract::manifest`

Brief sections: §4 (contracts), §4.0 (architecture overview), §4.1 (plugin architecture).

Unblocks #46, #64, #84, #89, #143, #144.

## Invariants touched

- Brief §4.1: explicit registration, versioned contracts, capability manifests, no auto-discovery.
- Brief §4.1 also says "no distinction between built-in and third-party at runtime" — contract traits are intentionally **not** sealed.
- CLAUDE.md §6.3: contract traits use `async_trait` because the registry stores `Arc<dyn Trait>` (dyn-compat required).
- CLAUDE.md §6.10: `PluginError` is `#[non_exhaustive]`. Newtypes (`PluginName`).
- `cairn-core` stays a leaf: no `cairn-*` workspace deps, verified by `scripts/check-core-boundary.sh`. Manifest fixture is loaded via `include_str!` (compile-time path read), not a Cargo dep.

## Out of scope

- Adapter implementations (#46, #64, #84, #89, #144).
- `cairn plugins list` / `cairn plugins verify` (those land in #143 on top of this).
- Per-trait conformance suites (those ship with each adapter).

## Verification

All run locally before push:

```
cargo fmt --all --check                                           PASS
cargo clippy --workspace --all-targets --locked -- -D warnings     PASS
cargo check --workspace --all-targets --locked                     PASS
cargo nextest run --workspace --locked --no-fail-fast              52/52 PASS
cargo test --doc --workspace --locked                              PASS
./scripts/check-core-boundary.sh                                   PASS
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --locked
                                                                   PASS
cargo deny check                                                   PASS
cargo audit --deny warnings                                        0 vulns
cargo machete                                                      PASS
cargo tree -p cairn-core -e normal --depth 2 | grep '^cairn-' | grep -v '^cairn-core'
                                                                   empty (no cairn-* runtime deps)
```

## Test plan

- [ ] CI: format, lint, test (Linux + macOS), build, core-boundary, docs all green.
- [ ] CI: supply-chain (deny + audit + machete) green.
- [ ] Manual: `cargo tree -p cairn-core -e normal --depth 2` shows zero `cairn-*` deps.