### PR TITLE
feat(plugins): host wiring + cairn plugins list/verify (#143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,31 @@ jobs:
       - name: scripts/check-core-boundary.sh
         run: ./scripts/check-core-boundary.sh
 
+  plugins-verify:
+    name: plugins / cairn plugins verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install toolchain (rust-toolchain.toml)
+        run: rustup show active-toolchain || rustup toolchain install
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        with:
+          shared-key: plugins-verify
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: cairn plugins verify (default mode)
+        run: cargo run -p cairn-cli --locked -- plugins verify
+      - name: cairn plugins verify (json artifact)
+        run: cargo run -p cairn-cli --locked -- plugins verify --json > plugins-verify.json
+      - name: Upload plugins-verify.json
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: plugins-verify-${{ github.run_id }}
+          path: plugins-verify.json
+          retention-days: 14
+
   build:
     name: build / ${{ matrix.os }}
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 Cargo.lock.bak
 *.swp
 .DS_Store
+
+# Stray rustc artifact occasionally emitted at repo root by certain build
+# flows (e.g. some IDE-driven `rustc --emit=metadata` runs).
+*.rmeta

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "serde",
+ "serde_json",
  "thiserror",
  "toml",
 ]
@@ -173,9 +174,15 @@ dependencies = [
 name = "cairn-idl"
 version = "0.0.1"
 dependencies = [
+ "clap",
+ "insta",
  "jsonschema",
+ "proptest",
+ "rstest",
  "serde",
  "serde_json",
+ "tempfile",
+ "thiserror",
  "toml",
 ]
 
@@ -282,6 +289,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +324,12 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -335,6 +359,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fluent-uri"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +374,12 @@ dependencies = [
  "ref-cast",
  "serde",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -362,6 +398,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +504,12 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -509,6 +645,19 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -747,6 +896,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +921,31 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -769,6 +961,44 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -846,6 +1076,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,10 +1140,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -923,6 +1216,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1265,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1031,8 +1349,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -1045,6 +1363,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,9 +1380,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -1094,6 +1442,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-general-category"
@@ -1140,6 +1494,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"
@@ -1215,6 +1578,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
 name = "cairn-store-sqlite"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "cairn-core",
  "cairn-test-fixtures",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ name = "cairn-cli"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "cairn-core",
  "cairn-mcp",
  "cairn-sensors-local",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,8 @@ dependencies = [
  "cairn-test-fixtures",
  "cairn-workflows",
  "clap",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -163,7 +165,6 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "serde",
- "serde_json",
  "thiserror",
  "toml",
 ]
@@ -172,15 +173,9 @@ dependencies = [
 name = "cairn-idl"
 version = "0.0.1"
 dependencies = [
- "clap",
- "insta",
  "jsonschema",
- "proptest",
- "rstest",
  "serde",
  "serde_json",
- "tempfile",
- "thiserror",
  "toml",
 ]
 
@@ -259,6 +254,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -286,17 +282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "console"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
-dependencies = [
- "encode_unicode",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,12 +306,6 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -356,12 +335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "fluent-uri"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,12 +344,6 @@ dependencies = [
  "ref-cast",
  "serde",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -395,100 +362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,12 +374,6 @@ dependencies = [
  "wasip2",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -642,19 +509,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
-]
-
-[[package]]
-name = "insta"
-version = "1.47.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
-dependencies = [
- "console",
- "once_cell",
- "serde",
- "similar",
- "tempfile",
 ]
 
 [[package]]
@@ -893,24 +747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,31 +754,6 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -958,44 +769,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -1073,51 +846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rstest"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
-dependencies = [
- "futures",
- "futures-timer",
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn",
- "unicode-ident",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,28 +865,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1213,18 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,14 +963,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.27.0"
+name = "terminal_size"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "fastrand",
- "getrandom",
- "once_cell",
  "rustix",
  "windows-sys",
 ]
@@ -1336,8 +1031,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1350,15 +1045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,30 +1053,9 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.11",
+ "toml_datetime",
  "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
-dependencies = [
- "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -1429,12 +1094,6 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-general-category"
@@ -1481,15 +1140,6 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "wasip2"
@@ -1565,15 +1215,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "cairn-test-fixtures",
  "cairn-workflows",
  "clap",
+ "insta",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
 name = "cairn-mcp"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "cairn-core",
  "cairn-test-fixtures",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
 name = "cairn-workflows"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "cairn-core",
  "cairn-test-fixtures",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
 name = "cairn-sensors-local"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "cairn-core",
  "cairn-test-fixtures",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,13 @@ tokio = "1"
 tracing = "0.1"
 anyhow = "1"
 async-trait = "0.1"
-clap = { version = "4.5", features = ["derive"] }
-insta = { version = "1", features = ["json", "yaml"] }
+insta = { version = "1.40", features = ["json", "yaml"] }
 jsonschema = { version = "0.46", default-features = false }
 proptest = "1"
 rstest = "0.23"
 tempfile = "3"
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
-insta = { version = "1.40", features = ["json", "yaml"] }
 
 # Path + version on intra-workspace deps so `cargo publish` can rewrite the
 # path to a registry version without losing the constraint. The version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ proptest = "1"
 rstest = "0.23"
 tempfile = "3"
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
+insta = { version = "1.40", features = ["json", "yaml"] }
 
 # Path + version on intra-workspace deps so `cargo publish` can rewrite the
 # path to a registry version without losing the constraint. The version

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = { workspace = true }
 [dev-dependencies]
 cairn-test-fixtures = { workspace = true }
 insta = { workspace = true }
+async-trait = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 cairn-test-fixtures = { workspace = true }
+insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -22,6 +22,8 @@ cairn-sensors-local = { workspace = true }
 cairn-workflows = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 cairn-test-fixtures = { workspace = true }
@@ -29,15 +31,18 @@ cairn-test-fixtures = { workspace = true }
 [lints]
 workspace = true
 
-# Forward-declared scaffold deps. These are wired by upcoming verb-impl
-# issues; until the bodies land, machete reports them as unused. Drop an
-# entry from this list as soon as its first call site exists.
+# Forward-declared scaffold deps. anyhow/clap/serde/serde_json land their
+# first call sites in Tasks 11-13 (plugins::list, plugins::verify, and the
+# clap dispatcher in main.rs). Drop each entry once its first call site
+# exists.
 [package.metadata.cargo-machete]
 ignored = [
     "anyhow",
-    "cairn-core",
-    "cairn-mcp",
-    "cairn-sensors-local",
-    "cairn-store-sqlite",
-    "cairn-workflows",
+    "clap",
+    "serde",
+    "serde_json",
 ]
+
+[lib]
+name = "cairn_cli"
+path = "src/lib.rs"

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -32,13 +32,13 @@ insta = { workspace = true }
 [lints]
 workspace = true
 
-# Forward-declared scaffold deps. anyhow/clap/serde land their first call
-# sites in Tasks 12-13 (plugins::verify and the clap dispatcher in
-# main.rs). Drop each entry once its first call site exists.
+# Forward-declared scaffold deps. anyhow and serde land their first call
+# sites when the verb layer is wired up in a follow-up issue. clap was
+# dropped from this list in Task 17 once main.rs adopted it (Task 13).
+# Drop each remaining entry once its first call site exists.
 [package.metadata.cargo-machete]
 ignored = [
     "anyhow",
-    "clap",
     "serde",
 ]
 

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -31,16 +31,14 @@ cairn-test-fixtures = { workspace = true }
 [lints]
 workspace = true
 
-# Forward-declared scaffold deps. anyhow/clap/serde/serde_json land their
-# first call sites in Tasks 11-13 (plugins::list, plugins::verify, and the
-# clap dispatcher in main.rs). Drop each entry once its first call site
-# exists.
+# Forward-declared scaffold deps. anyhow/clap/serde land their first call
+# sites in Tasks 12-13 (plugins::verify and the clap dispatcher in
+# main.rs). Drop each entry once its first call site exists.
 [package.metadata.cargo-machete]
 ignored = [
     "anyhow",
     "clap",
     "serde",
-    "serde_json",
 ]
 
 [lib]

--- a/crates/cairn-cli/src/lib.rs
+++ b/crates/cairn-cli/src/lib.rs
@@ -1,0 +1,8 @@
+//! Library surface for the `cairn` binary. Shared between `main.rs` and
+//! integration tests in `crates/cairn-cli/tests/`.
+//!
+//! Note: this crate is not published — only `cairn-cli`'s own `main.rs`
+//! and test targets consume it. `expect()` with documented reasons is
+//! tolerated here per CLAUDE.md §6.2 (bins/tests).
+
+pub mod plugins;

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -10,6 +10,7 @@ use std::io::Write;
 use std::process::ExitCode;
 
 use cairn_cli::plugins;
+use cairn_core::contract::registry::PluginError;
 use clap::ArgMatches;
 
 mod generated;
@@ -61,7 +62,10 @@ fn main() -> ExitCode {
                 clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
                     ExitCode::SUCCESS
                 }
-                _ => ExitCode::from(2),
+                // EX_USAGE — every other clap-detected error is a usage error
+                // (unknown flag, missing required arg, invalid value, unknown
+                // subcommand, …). Spec §5.2 maps these to 64.
+                _ => ExitCode::from(64),
             };
         }
     };
@@ -87,9 +91,15 @@ fn main() -> ExitCode {
 fn run_plugins(matches: &ArgMatches) -> ExitCode {
     let registry = match plugins::host::register_all() {
         Ok(r) => r,
+        // EX_CONFIG — bundled plugin.toml failed to parse. Spec §5.2.
+        Err(PluginError::InvalidManifest(msg)) => {
+            eprintln!("cairn plugins: bundled plugin manifest invalid — {msg}");
+            return ExitCode::from(78);
+        }
+        // EX_UNAVAILABLE — registry rejected a plugin (name/contract/version
+        // mismatch, duplicate, identity error). Spec §5.2.
         Err(e) => {
             eprintln!("cairn plugins: startup failed — {e}");
-            // EX_UNAVAILABLE
             return ExitCode::from(69);
         }
     };

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -1,27 +1,127 @@
-//! Cairn CLI entry point. Subcommand tree is generated from the IDL by
-//! `cairn-codegen`; verb dispatch lands in #59 / #9. Until then, every verb
-//! exits 2 with a not-implemented message so callers cannot mistake a
-//! scaffold for a real memory operation.
+//! `cairn` binary entry point.
+//!
+//! Verb subcommands (`ingest`, `search`, …) come from the IDL-generated
+//! clap `Command` tree (`mod generated`); the `plugins` subcommand is
+//! augmented at runtime. Until the verb layer lands (#59 / #9), every
+//! verb exits 2 with a not-implemented message so callers cannot mistake
+//! a scaffold for a real memory operation.
 
+use std::io::Write;
 use std::process::ExitCode;
+
+use cairn_cli::plugins;
+use clap::ArgMatches;
 
 mod generated;
 
 fn build_command() -> clap::Command {
-    generated::command().version(env!("CARGO_PKG_VERSION"))
+    generated::command()
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("Cairn — agent memory framework")
+        .subcommand(plugins_subcommand())
+}
+
+fn plugins_subcommand() -> clap::Command {
+    clap::Command::new("plugins")
+        .about("Manage and inspect bundled plugins")
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .subcommand(
+            clap::Command::new("list")
+                .about("List loaded plugins")
+                .arg(
+                    clap::Arg::new("json")
+                        .long("json")
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Emit JSON instead of a human-readable table"),
+                ),
+        )
+        .subcommand(
+            clap::Command::new("verify")
+                .about("Run the conformance suite against every loaded plugin")
+                .arg(
+                    clap::Arg::new("strict")
+                        .long("strict")
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Treat tier-2 `pending` cases as failures"),
+                )
+                .arg(
+                    clap::Arg::new("json")
+                        .long("json")
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Emit JSON instead of a human-readable report"),
+                ),
+        )
 }
 
 fn main() -> ExitCode {
-    let matches = build_command().get_matches();
-    if let Some((verb, _sub)) = matches.subcommand() {
-        eprintln!(
-            "cairn {verb}: not yet implemented in this P0 scaffold. \
-             Verb dispatch lands in #59 / #9; no memory operation was performed."
-        );
-        ExitCode::from(2)
-    } else {
-        let _ = build_command().print_help();
-        println!();
-        ExitCode::SUCCESS
+    let matches = match build_command().try_get_matches() {
+        Ok(m) => m,
+        Err(e) => {
+            let _ = e.print();
+            return match e.kind() {
+                clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
+                    ExitCode::SUCCESS
+                }
+                _ => ExitCode::from(2),
+            };
+        }
+    };
+
+    match matches.subcommand() {
+        Some(("plugins", sub)) => run_plugins(sub),
+        Some((verb, _)) => {
+            eprintln!(
+                "cairn {verb}: not yet implemented in this P0 scaffold. \
+                 Verb dispatch lands in #59 / #9; no memory operation was \
+                 performed."
+            );
+            ExitCode::from(2)
+        }
+        None => {
+            let _ = build_command().print_help();
+            println!();
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+fn run_plugins(matches: &ArgMatches) -> ExitCode {
+    let registry = match plugins::host::register_all() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("cairn plugins: startup failed — {e}");
+            // EX_UNAVAILABLE
+            return ExitCode::from(69);
+        }
+    };
+
+    match matches.subcommand() {
+        Some(("list", sub)) => {
+            let json = sub.get_flag("json");
+            let mut stdout = std::io::stdout().lock();
+            let text = if json {
+                plugins::list::render_json(&registry)
+            } else {
+                plugins::list::render_human(&registry)
+            };
+            // Newline at end ensures the human table flushes cleanly.
+            let _ = writeln!(stdout, "{}", text.trim_end_matches('\n'));
+            ExitCode::SUCCESS
+        }
+        Some(("verify", sub)) => {
+            let strict = sub.get_flag("strict");
+            let json = sub.get_flag("json");
+            let report = plugins::verify::run(&registry);
+            let text = if json {
+                plugins::verify::render_json(&report)
+            } else {
+                plugins::verify::render_human(&report)
+            };
+            let mut stdout = std::io::stdout().lock();
+            let _ = writeln!(stdout, "{}", text.trim_end_matches('\n'));
+            ExitCode::from(plugins::verify::exit_code(&report, strict))
+        }
+        _ => unreachable!("clap subcommand_required(true) on plugins ensures a subcommand is set"),
     }
 }

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -27,14 +27,12 @@ fn plugins_subcommand() -> clap::Command {
         .subcommand_required(true)
         .arg_required_else_help(true)
         .subcommand(
-            clap::Command::new("list")
-                .about("List loaded plugins")
-                .arg(
-                    clap::Arg::new("json")
-                        .long("json")
-                        .action(clap::ArgAction::SetTrue)
-                        .help("Emit JSON instead of a human-readable table"),
-                ),
+            clap::Command::new("list").about("List loaded plugins").arg(
+                clap::Arg::new("json")
+                    .long("json")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Emit JSON instead of a human-readable table"),
+            ),
         )
         .subcommand(
             clap::Command::new("verify")

--- a/crates/cairn-cli/src/plugins/host.rs
+++ b/crates/cairn-cli/src/plugins/host.rs
@@ -1,0 +1,69 @@
+//! Plugin host: assemble the live `PluginRegistry` from bundled crates.
+
+use cairn_core::contract::registry::{PluginError, PluginRegistry};
+
+/// Register every bundled plugin in alphabetical order. Returns the
+/// populated `PluginRegistry` on success, or the first plugin error
+/// encountered (fail-closed).
+///
+/// Bundled plugins (alphabetical):
+/// - `cairn-mcp`              → `MCPServer`
+/// - `cairn-sensors-local`    → `SensorIngress`
+/// - `cairn-store-sqlite`     → `MemoryStore`
+/// - `cairn-workflows`        → `WorkflowOrchestrator`
+///
+/// # Errors
+/// Returns the first [`PluginError`] from any bundled plugin's
+/// `register()` function. The host fails closed: a single bad plugin
+/// aborts startup.
+pub fn register_all() -> Result<PluginRegistry, PluginError> {
+    let mut reg = PluginRegistry::new();
+    cairn_mcp::register(&mut reg)?;
+    cairn_sensors_local::register(&mut reg)?;
+    cairn_store_sqlite::register(&mut reg)?;
+    cairn_workflows::register(&mut reg)?;
+    Ok(reg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cairn_core::contract::registry::PluginName;
+
+    #[test]
+    fn register_all_succeeds_and_populates_four_plugins() {
+        let reg = register_all().expect("bundled plugins register");
+
+        for name in [
+            "cairn-mcp",
+            "cairn-sensors-local",
+            "cairn-store-sqlite",
+            "cairn-workflows",
+        ] {
+            let pn = PluginName::new(name).expect("valid");
+            assert!(
+                reg.parsed_manifest(&pn).is_some(),
+                "plugin {name} must be registered"
+            );
+        }
+    }
+
+    #[test]
+    fn register_all_returns_alphabetically_sorted_manifests() {
+        let reg = register_all().expect("registers");
+        let sorted: Vec<_> = reg
+            .parsed_manifests_sorted()
+            .into_iter()
+            .map(|(n, _)| n.as_str().to_string())
+            .collect();
+        assert_eq!(
+            sorted,
+            vec![
+                "cairn-mcp",
+                "cairn-sensors-local",
+                "cairn-store-sqlite",
+                "cairn-workflows",
+            ]
+        );
+    }
+}

--- a/crates/cairn-cli/src/plugins/list.rs
+++ b/crates/cairn-cli/src/plugins/list.rs
@@ -1,0 +1,1 @@
+//! `cairn plugins list` (filled in Task 11).

--- a/crates/cairn-cli/src/plugins/list.rs
+++ b/crates/cairn-cli/src/plugins/list.rs
@@ -16,7 +16,7 @@ pub fn render_human(registry: &PluginRegistry) -> String {
         .into_iter()
         .map(|(name, manifest)| HumanRow {
             name: name.as_str().to_string(),
-            contract: format!("{:?}", manifest.contract()),
+            contract: manifest.contract().as_static_str().to_string(),
             range: format!(
                 "[{}, {})",
                 manifest.contract_version_range().min,
@@ -68,7 +68,7 @@ pub fn render_json(registry: &PluginRegistry) -> String {
         .map(|(name, manifest)| {
             serde_json::json!({
                 "name": name.as_str(),
-                "contract": format!("{:?}", manifest.contract()),
+                "contract": manifest.contract().as_static_str(),
                 "contract_version_range": {
                     "min": manifest.contract_version_range().min.to_string(),
                     "max_exclusive": manifest.contract_version_range().max_exclusive.to_string(),
@@ -139,9 +139,13 @@ fn capabilities_for(
         ),
         // `LLMProvider`, `FrontendAdapter`, and `AgentProvider` have no
         // bundled implementations yet, so their capabilities render as
-        // `{}`. `ContractKind` is `#[non_exhaustive]`; the wildcard also
-        // covers any future variant until this renderer learns about it.
-        _ => serde_json::json!({}),
+        // `{}`. `ContractKind` is `#[non_exhaustive]`; the trailing `_`
+        // arm is a safety net for future variants until this renderer
+        // learns about them.
+        ContractKind::LLMProvider
+        | ContractKind::FrontendAdapter
+        | ContractKind::AgentProvider
+        | _ => serde_json::json!({}),
     }
 }
 

--- a/crates/cairn-cli/src/plugins/list.rs
+++ b/crates/cairn-cli/src/plugins/list.rs
@@ -1,1 +1,180 @@
-//! `cairn plugins list` (filled in Task 11).
+//! `cairn plugins list` — render registered plugins as a human table or JSON.
+
+use cairn_core::contract::registry::PluginRegistry;
+
+/// Render the registered plugins as a fixed-column ASCII table.
+///
+/// Columns: NAME, CONTRACT, VERSION-RANGE, SOURCE.
+/// Rows are sorted alphabetically by plugin name. Capabilities are not
+/// shown in the table — use `--json` for machine-readable detail.
+#[must_use]
+pub fn render_human(registry: &PluginRegistry) -> String {
+    use std::fmt::Write;
+
+    let rows: Vec<HumanRow> = registry
+        .parsed_manifests_sorted()
+        .into_iter()
+        .map(|(name, manifest)| HumanRow {
+            name: name.as_str().to_string(),
+            contract: format!("{:?}", manifest.contract()),
+            range: format!(
+                "[{}, {})",
+                manifest.contract_version_range().min,
+                manifest.contract_version_range().max_exclusive
+            ),
+            source: format!("bundled:{}", name.as_str()),
+        })
+        .collect();
+
+    // Static-width columns wide enough for current bundled plugin names
+    // (longest contract = "WorkflowOrchestrator" = 20 chars; longest plugin
+    // name = "cairn-sensors-local" = 19 chars; longest range = "[0.1.0, 0.2.0)" = 14
+    // chars; longest source = "bundled:cairn-sensors-local" = 27 chars).
+    // Width chosen so headers line up without dynamic measurement.
+    let col_name = 22;
+    let col_contract = 22;
+    let col_range = 18;
+
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:<col_name$}{:<col_contract$}{:<col_range$}SOURCE",
+        "NAME", "CONTRACT", "VERSION-RANGE",
+    );
+    for row in &rows {
+        let _ = writeln!(
+            out,
+            "{:<col_name$}{:<col_contract$}{:<col_range$}{}",
+            row.name, row.contract, row.range, row.source
+        );
+    }
+    out
+}
+
+struct HumanRow {
+    name: String,
+    contract: String,
+    range: String,
+    source: String,
+}
+
+/// Render the registered plugins as a JSON document with full
+/// capability detail.
+#[must_use]
+pub fn render_json(registry: &PluginRegistry) -> String {
+    let plugins: Vec<_> = registry
+        .parsed_manifests_sorted()
+        .into_iter()
+        .map(|(name, manifest)| {
+            serde_json::json!({
+                "name": name.as_str(),
+                "contract": format!("{:?}", manifest.contract()),
+                "contract_version_range": {
+                    "min": manifest.contract_version_range().min.to_string(),
+                    "max_exclusive": manifest.contract_version_range().max_exclusive.to_string(),
+                },
+                "source": format!("bundled:{}", name.as_str()),
+                "capabilities": capabilities_for(registry, name),
+            })
+        })
+        .collect();
+    serde_json::to_string_pretty(&serde_json::json!({ "plugins": plugins }))
+        .expect("json serialization is infallible for owned values")
+}
+
+fn capabilities_for(
+    registry: &PluginRegistry,
+    name: &cairn_core::contract::registry::PluginName,
+) -> serde_json::Value {
+    use cairn_core::contract::manifest::ContractKind;
+    let Some(manifest) = registry.parsed_manifest(name) else {
+        return serde_json::json!({});
+    };
+    match manifest.contract() {
+        ContractKind::MemoryStore => registry.memory_store(name).map_or_else(
+            || serde_json::json!({}),
+            |p| {
+                let c = p.capabilities();
+                serde_json::json!({
+                    "fts": c.fts,
+                    "vector": c.vector,
+                    "graph_edges": c.graph_edges,
+                    "transactions": c.transactions,
+                })
+            },
+        ),
+        ContractKind::MCPServer => registry.mcp_server(name).map_or_else(
+            || serde_json::json!({}),
+            |p| {
+                let c = p.capabilities();
+                serde_json::json!({
+                    "stdio": c.stdio,
+                    "sse": c.sse,
+                    "http_streamable": c.http_streamable,
+                    "extensions": c.extensions,
+                })
+            },
+        ),
+        ContractKind::SensorIngress => registry.sensor_ingress_plugin(name).map_or_else(
+            || serde_json::json!({}),
+            |p| {
+                let c = p.capabilities();
+                serde_json::json!({
+                    "batches": c.batches,
+                    "streaming": c.streaming,
+                    "consent_aware": c.consent_aware,
+                })
+            },
+        ),
+        ContractKind::WorkflowOrchestrator => registry.workflow_orchestrator(name).map_or_else(
+            || serde_json::json!({}),
+            |p| {
+                let c = p.capabilities();
+                serde_json::json!({
+                    "durable": c.durable,
+                    "crash_safe": c.crash_safe,
+                    "cron_schedules": c.cron_schedules,
+                })
+            },
+        ),
+        // `LLMProvider`, `FrontendAdapter`, and `AgentProvider` have no
+        // bundled implementations yet, so their capabilities render as
+        // `{}`. `ContractKind` is `#[non_exhaustive]`; the wildcard also
+        // covers any future variant until this renderer learns about it.
+        _ => serde_json::json!({}),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::host::register_all;
+
+    #[test]
+    fn human_lists_all_four_bundled_plugins() {
+        let reg = register_all().expect("registers");
+        let text = render_human(&reg);
+        assert!(text.contains("cairn-mcp"), "must list mcp");
+        assert!(text.contains("cairn-sensors-local"), "must list sensors");
+        assert!(text.contains("cairn-store-sqlite"), "must list store");
+        assert!(text.contains("cairn-workflows"), "must list workflows");
+        assert!(text.contains("MCPServer"));
+        assert!(text.contains("MemoryStore"));
+        assert!(text.contains("[0.1.0, 0.2.0)"));
+        assert!(text.contains("bundled:cairn-store-sqlite"));
+    }
+
+    #[test]
+    fn json_contains_capabilities() {
+        let reg = register_all().expect("registers");
+        let json = render_json(&reg);
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        let plugins = v["plugins"].as_array().expect("array");
+        assert_eq!(plugins.len(), 4);
+        // First plugin alphabetical = cairn-mcp.
+        assert_eq!(plugins[0]["name"], "cairn-mcp");
+        assert_eq!(plugins[0]["contract"], "MCPServer");
+        assert_eq!(plugins[0]["source"], "bundled:cairn-mcp");
+        assert!(plugins[0]["capabilities"].is_object());
+    }
+}

--- a/crates/cairn-cli/src/plugins/mod.rs
+++ b/crates/cairn-cli/src/plugins/mod.rs
@@ -1,0 +1,9 @@
+//! `cairn plugins` subcommand implementation.
+//!
+//! - [`host`] — wires bundled adapter crates into a `PluginRegistry`.
+//! - [`list`] — `cairn plugins list` (Task 11).
+//! - [`verify`] — `cairn plugins verify` (Task 12).
+
+pub mod host;
+pub mod list;
+pub mod verify;

--- a/crates/cairn-cli/src/plugins/verify.rs
+++ b/crates/cairn-cli/src/plugins/verify.rs
@@ -1,1 +1,226 @@
-//! `cairn plugins verify` (filled in Task 12).
+//! `cairn plugins verify` — run the conformance suite against every
+//! registered plugin and emit a summary.
+
+use cairn_core::contract::conformance::{CaseStatus, run_conformance_for_plugin};
+use cairn_core::contract::registry::{PluginName, PluginRegistry};
+
+/// Aggregated outcome of a verify run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyReport {
+    /// Per-plugin block of cases.
+    pub plugins: Vec<PluginReport>,
+    /// Counts.
+    pub summary: Summary,
+}
+
+/// Per-plugin sub-report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginReport {
+    /// Plugin name.
+    pub name: String,
+    /// Contract kind, stable string from `ContractKind::as_static_str()`
+    /// (matches `--json`). Same source as `plugins::list` for consistency.
+    pub contract: String,
+    /// Per-case outcomes (tier-1 first, then tier-2, declaration order).
+    pub cases: Vec<cairn_core::contract::conformance::CaseOutcome>,
+}
+
+/// Summary counts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Summary {
+    /// Cases with `CaseStatus::Ok`.
+    pub ok: usize,
+    /// Cases with `CaseStatus::Pending { .. }`.
+    pub pending: usize,
+    /// Cases with `CaseStatus::Failed { .. }`.
+    pub failed: usize,
+}
+
+/// Build a `VerifyReport` by running conformance for every registered
+/// plugin in alphabetical order.
+#[must_use]
+pub fn run(registry: &PluginRegistry) -> VerifyReport {
+    let mut plugins = Vec::new();
+    let mut summary = Summary::default();
+
+    for (name, manifest) in registry.parsed_manifests_sorted() {
+        let cases = run_conformance_for_plugin(registry, name);
+        for c in &cases {
+            match c.status {
+                CaseStatus::Ok => summary.ok += 1,
+                CaseStatus::Pending { .. } => summary.pending += 1,
+                CaseStatus::Failed { .. } => summary.failed += 1,
+            }
+        }
+        plugins.push(PluginReport {
+            name: name.as_str().to_string(),
+            contract: manifest.contract().as_static_str().to_string(),
+            cases,
+        });
+    }
+
+    VerifyReport { plugins, summary }
+}
+
+/// Exit code for the given report under the requested strictness.
+///
+/// - Default mode: exit 0 unless any case `Failed`.
+/// - Strict mode: exit 0 only if every case is `Ok`.
+///
+/// Exit code constants:
+/// - `0`  — success.
+/// - `69` (`EX_UNAVAILABLE`) — at least one case failed (or pending in
+///   strict mode).
+#[must_use]
+pub fn exit_code(report: &VerifyReport, strict: bool) -> u8 {
+    if report.summary.failed > 0 {
+        return 69;
+    }
+    if strict && report.summary.pending > 0 {
+        return 69;
+    }
+    0
+}
+
+/// Render the report as human-readable text.
+#[must_use]
+pub fn render_human(report: &VerifyReport) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    for plugin in &report.plugins {
+        let _ = writeln!(out, "{} ({})", plugin.name, plugin.contract);
+        for case in &plugin.cases {
+            let tier = match case.tier {
+                cairn_core::contract::conformance::Tier::One => "tier-1",
+                cairn_core::contract::conformance::Tier::Two => "tier-2",
+            };
+            let status = match &case.status {
+                CaseStatus::Ok => "ok".to_string(),
+                CaseStatus::Pending { reason } => format!("pending ({reason})"),
+                CaseStatus::Failed { message } => format!("FAILED ({message})"),
+            };
+            let _ = writeln!(out, "  {tier} {:<40} {status}", case.id);
+        }
+        let _ = writeln!(out);
+    }
+    let _ = writeln!(
+        out,
+        "Summary: {} plugins, {} ok, {} pending, {} failed",
+        report.plugins.len(),
+        report.summary.ok,
+        report.summary.pending,
+        report.summary.failed,
+    );
+    out
+}
+
+/// Render the report as JSON.
+#[must_use]
+pub fn render_json(report: &VerifyReport) -> String {
+    let plugins_json: Vec<_> = report
+        .plugins
+        .iter()
+        .map(|plugin| {
+            let cases: Vec<_> = plugin
+                .cases
+                .iter()
+                .map(|c| {
+                    let mut obj = serde_json::json!({
+                        "id": c.id,
+                        "tier": c.tier.as_u8(),
+                        "status": c.status.as_str(),
+                    });
+                    match &c.status {
+                        CaseStatus::Pending { reason } => {
+                            obj["reason"] = serde_json::Value::String((*reason).to_string());
+                        }
+                        CaseStatus::Failed { message } => {
+                            obj["message"] = serde_json::Value::String(message.clone());
+                        }
+                        CaseStatus::Ok => {}
+                    }
+                    obj
+                })
+                .collect();
+            serde_json::json!({
+                "name": plugin.name,
+                "contract": plugin.contract,
+                "cases": cases,
+            })
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&serde_json::json!({
+        "plugins": plugins_json,
+        "summary": {
+            "ok": report.summary.ok,
+            "pending": report.summary.pending,
+            "failed": report.summary.failed,
+        }
+    }))
+    .expect("json serialization is infallible for owned values")
+}
+
+/// Convenience: also resolve a `PluginName` for callers that need it.
+#[must_use]
+pub fn resolve_name(raw: &str) -> Option<PluginName> {
+    PluginName::new(raw).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::host::register_all;
+
+    #[test]
+    fn run_reports_four_plugins() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        assert_eq!(report.plugins.len(), 4);
+        assert_eq!(report.summary.failed, 0, "no failures expected");
+        // 4 plugins × 3 tier-1 = 12 ok minimum.
+        assert!(report.summary.ok >= 12);
+        assert!(report.summary.pending >= 4, "tier-2 stubs are pending");
+    }
+
+    #[test]
+    fn exit_code_default_zero_with_pendings() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        assert_eq!(exit_code(&report, false), 0);
+    }
+
+    #[test]
+    fn exit_code_strict_nonzero_with_pendings() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        assert_eq!(exit_code(&report, true), 69);
+    }
+
+    #[test]
+    fn human_output_contains_every_plugin_and_summary() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        let text = render_human(&report);
+        for n in [
+            "cairn-mcp",
+            "cairn-sensors-local",
+            "cairn-store-sqlite",
+            "cairn-workflows",
+        ] {
+            assert!(text.contains(n));
+        }
+        assert!(text.contains("Summary:"));
+    }
+
+    #[test]
+    fn json_output_round_trips() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        let json = render_json(&report);
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(v["plugins"].as_array().unwrap().len(), 4);
+        assert_eq!(v["summary"]["failed"], 0);
+    }
+}

--- a/crates/cairn-cli/src/plugins/verify.rs
+++ b/crates/cairn-cli/src/plugins/verify.rs
@@ -76,6 +76,51 @@ pub fn run(registry: &PluginRegistry) -> VerifyReport {
         });
     }
 
+    // Coverage gate: every typed plugin registration must carry a manifest.
+    // Plugins registered through the legacy 3-arg `register_plugin!` form
+    // (no manifest) are still a valid unit-test path, but `verify` must
+    // surface them as Failed so they cannot pass the CI gate by being
+    // invisible to `parsed_manifests_sorted`.
+    for (orphan_name, contract_label) in registry.typed_plugins_without_manifests() {
+        let case = CaseOutcome {
+            id: "manifest_present_for_typed_registration",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "typed {contract_label} plugin {orphan_name} has no parsed manifest; \
+                     register through the manifest-aware path"
+                ),
+            },
+        };
+        summary.failed += 1;
+        plugins.push(PluginReport {
+            name: orphan_name.as_str().to_string(),
+            contract: contract_label.to_string(),
+            cases: vec![case],
+        });
+    }
+
+    // Coverage gate: an empty registry means no plugins were verified at
+    // all. This must fail closed — otherwise `cairn plugins verify` would
+    // exit 0 in a misconfigured runtime where `register_all` ran but
+    // produced no plugins (e.g. all bundled crates compiled out).
+    if plugins.is_empty() {
+        summary.failed += 1;
+        plugins.push(PluginReport {
+            name: "<registry>".to_string(),
+            contract: "<none>".to_string(),
+            cases: vec![CaseOutcome {
+                id: "registry_has_at_least_one_plugin",
+                tier: Tier::One,
+                status: CaseStatus::Failed {
+                    message: "PluginRegistry has zero plugins; verify cannot \
+                              certify an empty host"
+                        .to_string(),
+                },
+            }],
+        });
+    }
+
     VerifyReport { plugins, summary }
 }
 
@@ -225,6 +270,60 @@ mod tests {
             assert!(text.contains(n));
         }
         assert!(text.contains("Summary:"));
+    }
+
+    #[test]
+    fn empty_registry_fails_closed() {
+        let reg = cairn_core::contract::registry::PluginRegistry::new();
+        let report = run(&reg);
+        assert_eq!(report.plugins.len(), 1, "synthetic registry-empty plugin");
+        assert!(report.summary.failed >= 1);
+        assert_eq!(exit_code(&report, false), 69);
+        assert_eq!(exit_code(&report, true), 69);
+    }
+
+    #[test]
+    fn typed_registration_without_manifest_is_failed() {
+        use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
+        use cairn_core::contract::registry::{PluginName, PluginRegistry};
+        use cairn_core::contract::version::{ContractVersion, VersionRange};
+
+        #[derive(Default)]
+        struct BareStore;
+
+        #[async_trait::async_trait]
+        impl MemoryStore for BareStore {
+            fn name(&self) -> &'static str {
+                "bare-store"
+            }
+            fn capabilities(&self) -> &MemoryStoreCapabilities {
+                static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                    fts: false,
+                    vector: false,
+                    graph_edges: false,
+                    transactions: false,
+                };
+                &CAPS
+            }
+            fn supported_contract_versions(&self) -> VersionRange {
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+            }
+        }
+
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("bare-store").expect("valid");
+        // Bare register (no manifest) — the legacy 3-arg path. Must still
+        // be visible to verify as a coverage failure.
+        reg.register_memory_store(name, std::sync::Arc::new(BareStore))
+            .expect("registers");
+
+        let report = run(&reg);
+        assert_eq!(report.plugins.len(), 1);
+        assert_eq!(report.plugins[0].name, "bare-store");
+        let case = &report.plugins[0].cases[0];
+        assert_eq!(case.id, "manifest_present_for_typed_registration");
+        assert!(matches!(case.status, CaseStatus::Failed { .. }));
+        assert_eq!(exit_code(&report, false), 69);
     }
 
     #[test]

--- a/crates/cairn-cli/src/plugins/verify.rs
+++ b/crates/cairn-cli/src/plugins/verify.rs
@@ -327,6 +327,111 @@ mod tests {
     }
 
     #[test]
+    fn cross_contract_same_name_orphan_is_failed() {
+        // Regression for the round-3 review finding: a single PluginName
+        // registered for two different contracts (one with a manifest,
+        // one bare) must surface the bare registration as Failed even
+        // though `manifests.contains_key(name)` is true.
+        use cairn_core::contract::manifest::PluginManifest;
+        use cairn_core::contract::mcp_server::{MCPServer, MCPServerCapabilities};
+        use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
+        use cairn_core::contract::registry::{PluginName, PluginRegistry};
+        use cairn_core::contract::version::{ContractVersion, VersionRange};
+
+        #[derive(Default)]
+        struct DualStore;
+        #[async_trait::async_trait]
+        impl MemoryStore for DualStore {
+            fn name(&self) -> &'static str {
+                "dual-plugin"
+            }
+            fn capabilities(&self) -> &MemoryStoreCapabilities {
+                static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                    fts: false,
+                    vector: false,
+                    graph_edges: false,
+                    transactions: false,
+                };
+                &CAPS
+            }
+            fn supported_contract_versions(&self) -> VersionRange {
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+            }
+        }
+
+        #[derive(Default)]
+        struct DualMcp;
+        #[async_trait::async_trait]
+        impl MCPServer for DualMcp {
+            fn name(&self) -> &'static str {
+                "dual-plugin"
+            }
+            fn capabilities(&self) -> &MCPServerCapabilities {
+                static CAPS: MCPServerCapabilities = MCPServerCapabilities {
+                    stdio: false,
+                    sse: false,
+                    http_streamable: false,
+                    extensions: false,
+                };
+                &CAPS
+            }
+            fn supported_contract_versions(&self) -> VersionRange {
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+            }
+        }
+
+        let store_manifest_toml = r#"
+name = "dual-plugin"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#;
+
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("dual-plugin").expect("valid");
+
+        // Register MemoryStore WITH a MemoryStore manifest...
+        let store_manifest =
+            PluginManifest::parse_toml(store_manifest_toml).expect("manifest parses");
+        reg.register_memory_store_with_manifest(
+            name.clone(),
+            store_manifest,
+            std::sync::Arc::new(DualStore),
+        )
+        .expect("registers");
+
+        // ...and MCPServer BARE (no manifest, same name). This is a
+        // legitimate path because the per-contract maps are independent
+        // and bare register_* only checks per-contract duplicates. The
+        // orphan gate must be contract-aware to catch the MCPServer half.
+        reg.register_mcp_server(name.clone(), std::sync::Arc::new(DualMcp))
+            .expect("bare register accepts cross-contract same name");
+
+        let report = run(&reg);
+        let orphan = report
+            .plugins
+            .iter()
+            .find(|p| p.contract == "MCPServer")
+            .expect("MCPServer orphan must appear in report");
+        assert_eq!(orphan.name, "dual-plugin");
+        assert_eq!(orphan.cases.len(), 1);
+        assert_eq!(
+            orphan.cases[0].id,
+            "manifest_present_for_typed_registration"
+        );
+        assert!(matches!(orphan.cases[0].status, CaseStatus::Failed { .. }));
+        assert_eq!(exit_code(&report, false), 69);
+    }
+
+    #[test]
     fn json_output_round_trips() {
         let reg = register_all().expect("registers");
         let report = run(&reg);

--- a/crates/cairn-cli/src/plugins/verify.rs
+++ b/crates/cairn-cli/src/plugins/verify.rs
@@ -1,0 +1,1 @@
+//! `cairn plugins verify` (filled in Task 12).

--- a/crates/cairn-cli/src/plugins/verify.rs
+++ b/crates/cairn-cli/src/plugins/verify.rs
@@ -2,7 +2,7 @@
 //! registered plugin and emit a summary.
 
 use cairn_core::contract::conformance::{CaseStatus, run_conformance_for_plugin};
-use cairn_core::contract::registry::{PluginName, PluginRegistry};
+use cairn_core::contract::registry::PluginRegistry;
 
 /// Aggregated outcome of a verify run.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -160,12 +160,6 @@ pub fn render_json(report: &VerifyReport) -> String {
         }
     }))
     .expect("json serialization is infallible for owned values")
-}
-
-/// Convenience: also resolve a `PluginName` for callers that need it.
-#[must_use]
-pub fn resolve_name(raw: &str) -> Option<PluginName> {
-    PluginName::new(raw).ok()
 }
 
 #[cfg(test)]

--- a/crates/cairn-cli/src/plugins/verify.rs
+++ b/crates/cairn-cli/src/plugins/verify.rs
@@ -1,7 +1,9 @@
 //! `cairn plugins verify` — run the conformance suite against every
 //! registered plugin and emit a summary.
 
-use cairn_core::contract::conformance::{CaseStatus, run_conformance_for_plugin};
+use cairn_core::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, run_conformance_for_plugin,
+};
 use cairn_core::contract::registry::PluginRegistry;
 
 /// Aggregated outcome of a verify run.
@@ -44,7 +46,22 @@ pub fn run(registry: &PluginRegistry) -> VerifyReport {
     let mut summary = Summary::default();
 
     for (name, manifest) in registry.parsed_manifests_sorted() {
-        let cases = run_conformance_for_plugin(registry, name);
+        let mut cases = run_conformance_for_plugin(registry, name);
+        // Defense-in-depth: if a future contract route forgets to emit any
+        // case, synthesize a `Failed` so verify cannot exit 0 against a
+        // plugin with zero coverage.
+        if cases.is_empty() {
+            cases.push(CaseOutcome {
+                id: "no_cases_emitted",
+                tier: Tier::One,
+                status: CaseStatus::Failed {
+                    message: format!(
+                        "conformance runner returned zero cases for plugin {name}; \
+                         this should never happen — file a bug"
+                    ),
+                },
+            });
+        }
         for c in &cases {
             match c.status {
                 CaseStatus::Ok => summary.ok += 1,
@@ -173,8 +190,10 @@ mod tests {
         let report = run(&reg);
         assert_eq!(report.plugins.len(), 4);
         assert_eq!(report.summary.failed, 0, "no failures expected");
-        // 4 plugins × 3 tier-1 = 12 ok minimum.
-        assert!(report.summary.ok >= 12);
+        // 4 plugins × 4 tier-1 cases (manifest_matches_host,
+        // arc_pointer_stable, capability_self_consistency_floor,
+        // manifest_features_match_capabilities) = 16 ok minimum.
+        assert!(report.summary.ok >= 16);
         assert!(report.summary.pending >= 4, "tier-2 stubs are pending");
     }
 

--- a/crates/cairn-cli/tests/cli.rs
+++ b/crates/cairn-cli/tests/cli.rs
@@ -2,9 +2,14 @@
 //! the P0 stub behaviour: help succeeds, verbs without dispatch fail closed.
 //!
 //! The CLI tree itself is generated from the IDL by `cairn-codegen`; verb
-//! dispatch lands in #59 / #9. Until then, simple verbs exit 2 with a
-//! not-implemented message and tagged-union verbs (retrieve / forget) exit 2
-//! at clap argument parsing because their target groups are required.
+//! dispatch lands in #59 / #9. Exit-code contract (spec §5.2):
+//! - simple verb stubs (`ingest`, `search`, …) reach our dispatch and exit 2
+//!   with a not-implemented marker.
+//! - clap usage errors (unknown flag, unknown subcommand, missing required
+//!   `ArgGroup`, bare invocation with `subcommand_required`) → 64
+//!   (`EX_USAGE`).
+//! - bundled `plugin.toml` parse failure → 78 (`EX_CONFIG`); registry
+//!   rejection → 69 (`EX_UNAVAILABLE`).
 
 use std::process::Command;
 
@@ -51,11 +56,11 @@ fn help_flag_lists_all_eight_verbs() {
 #[test]
 fn no_args_prints_help_and_fails_closed() {
     // Generated `command()` sets subcommand_required(true) and
-    // arg_required_else_help(true), so a bare `cairn` invocation is treated
-    // as a clap usage error: help to stderr, exit 2.
+    // arg_required_else_help(true), so a bare `cairn` invocation is a clap
+    // usage error → exit 64 (EX_USAGE) per spec §5.2.
     let out = cli().output().expect("cairn");
     assert!(!out.status.success(), "bare cairn exited OK");
-    assert_eq!(out.status.code(), Some(2));
+    assert_eq!(out.status.code(), Some(64));
     let stderr = String::from_utf8(out.stderr).expect("utf-8 stderr");
     assert!(
         stderr.contains("ingest"),
@@ -93,11 +98,11 @@ fn simple_verb_fails_closed_with_not_implemented_marker() {
 fn tagged_union_verb_requires_target_flag() {
     // `retrieve` and `forget` carry a discriminator-keyed ArgGroup with
     // `.required(true)`; clap rejects a bare invocation before our dispatch
-    // runs.
+    // runs → exit 64 (EX_USAGE).
     for verb in ["retrieve", "forget"] {
         let out = cli().arg(verb).output().expect("cairn <verb>");
         assert!(!out.status.success(), "verb {verb} exited OK");
-        assert_eq!(out.status.code(), Some(2), "verb {verb} wrong exit code");
+        assert_eq!(out.status.code(), Some(64), "verb {verb} wrong exit code");
         let stderr = String::from_utf8(out.stderr).expect("utf-8 stderr");
         assert!(
             stderr.contains("required"),
@@ -108,12 +113,13 @@ fn tagged_union_verb_requires_target_flag() {
 
 #[test]
 fn unknown_argument_fails_closed() {
+    // Clap UnknownArgument → exit 64 (EX_USAGE) per spec §5.2.
     let out = cli()
         .arg("--definitely-not-a-flag")
         .output()
         .expect("cairn");
     assert!(!out.status.success(), "exit: {:?}", out.status);
-    assert_eq!(out.status.code(), Some(2));
+    assert_eq!(out.status.code(), Some(64));
     let stderr = String::from_utf8(out.stderr).expect("utf-8 stderr");
     assert!(
         stderr.contains("unexpected argument"),

--- a/crates/cairn-cli/tests/plugins_list_snapshot.rs
+++ b/crates/cairn-cli/tests/plugins_list_snapshot.rs
@@ -1,0 +1,17 @@
+//! Snapshot test: `cairn plugins list` human + JSON outputs are stable.
+
+use cairn_cli::plugins::{host::register_all, list};
+
+#[test]
+fn list_human_snapshot() {
+    let reg = register_all().expect("registers");
+    let text = list::render_human(&reg);
+    insta::assert_snapshot!("plugins_list_human", text);
+}
+
+#[test]
+fn list_json_snapshot() {
+    let reg = register_all().expect("registers");
+    let json = list::render_json(&reg);
+    insta::assert_snapshot!("plugins_list_json", json);
+}

--- a/crates/cairn-cli/tests/plugins_verify.rs
+++ b/crates/cairn-cli/tests/plugins_verify.rs
@@ -1,0 +1,67 @@
+//! Integration: shell out to the built `cairn` binary and assert the
+//! `plugins verify --json` output. This is the CI-protective wrapper:
+//! it runs under `cargo nextest` regardless of any workflow-yaml drift.
+
+use std::process::Command;
+
+fn cairn_binary() -> std::path::PathBuf {
+    // Cargo sets CARGO_BIN_EXE_<name> for every binary in the package.
+    let raw = env!("CARGO_BIN_EXE_cairn");
+    std::path::PathBuf::from(raw)
+}
+
+#[test]
+fn plugins_verify_json_default_succeeds() {
+    let output = Command::new(cairn_binary())
+        .args(["plugins", "verify", "--json"])
+        .output()
+        .expect("spawn cairn binary");
+
+    assert!(
+        output.status.success(),
+        "cairn plugins verify --json must exit 0 in default mode; got {:?}",
+        output.status
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(v["summary"]["failed"], 0, "no tier-1 failures expected");
+    assert_eq!(
+        v["plugins"].as_array().expect("plugins array").len(),
+        4,
+        "all four bundled plugins must be reported"
+    );
+}
+
+#[test]
+fn plugins_verify_strict_exits_69_with_pendings() {
+    let output = Command::new(cairn_binary())
+        .args(["plugins", "verify", "--strict"])
+        .output()
+        .expect("spawn cairn binary");
+
+    let code = output.status.code().expect("exit code present");
+    assert_eq!(
+        code, 69,
+        "verify --strict must exit 69 while tier-2 cases are pending"
+    );
+}
+
+#[test]
+fn plugins_list_emits_alphabetical_rows() {
+    let output = Command::new(cairn_binary())
+        .args(["plugins", "list"])
+        .output()
+        .expect("spawn cairn binary");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+
+    let mcp_idx = stdout.find("cairn-mcp").expect("mcp present");
+    let sensors_idx = stdout.find("cairn-sensors-local").expect("sensors present");
+    let store_idx = stdout.find("cairn-store-sqlite").expect("store present");
+    let workflows_idx = stdout.find("cairn-workflows").expect("workflows present");
+
+    assert!(mcp_idx < sensors_idx);
+    assert!(sensors_idx < store_idx);
+    assert!(store_idx < workflows_idx);
+}

--- a/crates/cairn-cli/tests/plugins_verify_snapshot.rs
+++ b/crates/cairn-cli/tests/plugins_verify_snapshot.rs
@@ -1,0 +1,33 @@
+//! Snapshot test: `cairn plugins verify` human + JSON outputs are stable.
+
+use cairn_cli::plugins::{host::register_all, verify};
+
+#[test]
+fn verify_human_snapshot() {
+    let reg = register_all().expect("registers");
+    let report = verify::run(&reg);
+    let text = verify::render_human(&report);
+    insta::assert_snapshot!("plugins_verify_human", text);
+}
+
+#[test]
+fn verify_json_snapshot() {
+    let reg = register_all().expect("registers");
+    let report = verify::run(&reg);
+    let json = verify::render_json(&report);
+    insta::assert_snapshot!("plugins_verify_json", json);
+}
+
+#[test]
+fn verify_default_mode_exit_zero() {
+    let reg = register_all().expect("registers");
+    let report = verify::run(&reg);
+    assert_eq!(verify::exit_code(&report, false), 0);
+}
+
+#[test]
+fn verify_strict_mode_exit_69_with_pendings() {
+    let reg = register_all().expect("registers");
+    let report = verify::run(&reg);
+    assert_eq!(verify::exit_code(&report, true), 69);
+}

--- a/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_human.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_human.snap
@@ -1,0 +1,9 @@
+---
+source: crates/cairn-cli/tests/plugins_list_snapshot.rs
+expression: text
+---
+NAME                  CONTRACT              VERSION-RANGE     SOURCE
+cairn-mcp             MCPServer             [0.1.0, 0.2.0)    bundled:cairn-mcp
+cairn-sensors-local   SensorIngress         [0.1.0, 0.2.0)    bundled:cairn-sensors-local
+cairn-store-sqlite    MemoryStore           [0.1.0, 0.2.0)    bundled:cairn-store-sqlite
+cairn-workflows       WorkflowOrchestrator  [0.1.0, 0.2.0)    bundled:cairn-workflows

--- a/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
@@ -1,0 +1,66 @@
+---
+source: crates/cairn-cli/tests/plugins_list_snapshot.rs
+expression: json
+---
+{
+  "plugins": [
+    {
+      "capabilities": {
+        "extensions": false,
+        "http_streamable": false,
+        "sse": false,
+        "stdio": false
+      },
+      "contract": "MCPServer",
+      "contract_version_range": {
+        "max_exclusive": "0.2.0",
+        "min": "0.1.0"
+      },
+      "name": "cairn-mcp",
+      "source": "bundled:cairn-mcp"
+    },
+    {
+      "capabilities": {
+        "batches": false,
+        "consent_aware": false,
+        "streaming": false
+      },
+      "contract": "SensorIngress",
+      "contract_version_range": {
+        "max_exclusive": "0.2.0",
+        "min": "0.1.0"
+      },
+      "name": "cairn-sensors-local",
+      "source": "bundled:cairn-sensors-local"
+    },
+    {
+      "capabilities": {
+        "fts": false,
+        "graph_edges": false,
+        "transactions": false,
+        "vector": false
+      },
+      "contract": "MemoryStore",
+      "contract_version_range": {
+        "max_exclusive": "0.2.0",
+        "min": "0.1.0"
+      },
+      "name": "cairn-store-sqlite",
+      "source": "bundled:cairn-store-sqlite"
+    },
+    {
+      "capabilities": {
+        "crash_safe": false,
+        "cron_schedules": false,
+        "durable": false
+      },
+      "contract": "WorkflowOrchestrator",
+      "contract_version_range": {
+        "max_exclusive": "0.2.0",
+        "min": "0.1.0"
+      },
+      "name": "cairn-workflows",
+      "source": "bundled:cairn-workflows"
+    }
+  ]
+}

--- a/crates/cairn-cli/tests/snapshots/plugins_verify_snapshot__plugins_verify_human.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_verify_snapshot__plugins_verify_human.snap
@@ -6,18 +6,21 @@ cairn-mcp (MCPServer)
   tier-1 manifest_matches_host                    ok
   tier-1 arc_pointer_stable                       ok
   tier-1 capability_self_consistency_floor        ok
+  tier-1 manifest_features_match_capabilities     ok
   tier-2 initialize_and_list_tools                pending (real impl pending)
 
 cairn-sensors-local (SensorIngress)
   tier-1 manifest_matches_host                    ok
   tier-1 arc_pointer_stable                       ok
   tier-1 capability_self_consistency_floor        ok
+  tier-1 manifest_features_match_capabilities     ok
   tier-2 emits_envelope_when_poked                pending (real impl pending)
 
 cairn-store-sqlite (MemoryStore)
   tier-1 manifest_matches_host                    ok
   tier-1 arc_pointer_stable                       ok
   tier-1 capability_self_consistency_floor        ok
+  tier-1 manifest_features_match_capabilities     ok
   tier-2 put_get_roundtrip                        pending (real impl pending)
   tier-2 fts_query_returns_doc                    pending (real impl pending)
   tier-2 vector_search_when_advertised            pending (real impl pending)
@@ -26,6 +29,7 @@ cairn-workflows (WorkflowOrchestrator)
   tier-1 manifest_matches_host                    ok
   tier-1 arc_pointer_stable                       ok
   tier-1 capability_self_consistency_floor        ok
+  tier-1 manifest_features_match_capabilities     ok
   tier-2 enqueue_then_complete                    pending (real impl pending)
 
-Summary: 4 plugins, 12 ok, 6 pending, 0 failed
+Summary: 4 plugins, 16 ok, 6 pending, 0 failed

--- a/crates/cairn-cli/tests/snapshots/plugins_verify_snapshot__plugins_verify_human.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_verify_snapshot__plugins_verify_human.snap
@@ -1,0 +1,31 @@
+---
+source: crates/cairn-cli/tests/plugins_verify_snapshot.rs
+expression: text
+---
+cairn-mcp (MCPServer)
+  tier-1 manifest_matches_host                    ok
+  tier-1 arc_pointer_stable                       ok
+  tier-1 capability_self_consistency_floor        ok
+  tier-2 initialize_and_list_tools                pending (real impl pending)
+
+cairn-sensors-local (SensorIngress)
+  tier-1 manifest_matches_host                    ok
+  tier-1 arc_pointer_stable                       ok
+  tier-1 capability_self_consistency_floor        ok
+  tier-2 emits_envelope_when_poked                pending (real impl pending)
+
+cairn-store-sqlite (MemoryStore)
+  tier-1 manifest_matches_host                    ok
+  tier-1 arc_pointer_stable                       ok
+  tier-1 capability_self_consistency_floor        ok
+  tier-2 put_get_roundtrip                        pending (real impl pending)
+  tier-2 fts_query_returns_doc                    pending (real impl pending)
+  tier-2 vector_search_when_advertised            pending (real impl pending)
+
+cairn-workflows (WorkflowOrchestrator)
+  tier-1 manifest_matches_host                    ok
+  tier-1 arc_pointer_stable                       ok
+  tier-1 capability_self_consistency_floor        ok
+  tier-2 enqueue_then_complete                    pending (real impl pending)
+
+Summary: 4 plugins, 12 ok, 6 pending, 0 failed

--- a/crates/cairn-cli/tests/snapshots/plugins_verify_snapshot__plugins_verify_json.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_verify_snapshot__plugins_verify_json.snap
@@ -22,6 +22,11 @@ expression: json
           "tier": 1
         },
         {
+          "id": "manifest_features_match_capabilities",
+          "status": "ok",
+          "tier": 1
+        },
+        {
           "id": "initialize_and_list_tools",
           "reason": "real impl pending",
           "status": "pending",
@@ -49,6 +54,11 @@ expression: json
           "tier": 1
         },
         {
+          "id": "manifest_features_match_capabilities",
+          "status": "ok",
+          "tier": 1
+        },
+        {
           "id": "emits_envelope_when_poked",
           "reason": "real impl pending",
           "status": "pending",
@@ -72,6 +82,11 @@ expression: json
         },
         {
           "id": "capability_self_consistency_floor",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "manifest_features_match_capabilities",
           "status": "ok",
           "tier": 1
         },
@@ -115,6 +130,11 @@ expression: json
           "tier": 1
         },
         {
+          "id": "manifest_features_match_capabilities",
+          "status": "ok",
+          "tier": 1
+        },
+        {
           "id": "enqueue_then_complete",
           "reason": "real impl pending",
           "status": "pending",
@@ -127,7 +147,7 @@ expression: json
   ],
   "summary": {
     "failed": 0,
-    "ok": 12,
+    "ok": 16,
     "pending": 6
   }
 }

--- a/crates/cairn-cli/tests/snapshots/plugins_verify_snapshot__plugins_verify_json.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_verify_snapshot__plugins_verify_json.snap
@@ -1,0 +1,133 @@
+---
+source: crates/cairn-cli/tests/plugins_verify_snapshot.rs
+expression: json
+---
+{
+  "plugins": [
+    {
+      "cases": [
+        {
+          "id": "manifest_matches_host",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "arc_pointer_stable",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "capability_self_consistency_floor",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "initialize_and_list_tools",
+          "reason": "real impl pending",
+          "status": "pending",
+          "tier": 2
+        }
+      ],
+      "contract": "MCPServer",
+      "name": "cairn-mcp"
+    },
+    {
+      "cases": [
+        {
+          "id": "manifest_matches_host",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "arc_pointer_stable",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "capability_self_consistency_floor",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "emits_envelope_when_poked",
+          "reason": "real impl pending",
+          "status": "pending",
+          "tier": 2
+        }
+      ],
+      "contract": "SensorIngress",
+      "name": "cairn-sensors-local"
+    },
+    {
+      "cases": [
+        {
+          "id": "manifest_matches_host",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "arc_pointer_stable",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "capability_self_consistency_floor",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "put_get_roundtrip",
+          "reason": "real impl pending",
+          "status": "pending",
+          "tier": 2
+        },
+        {
+          "id": "fts_query_returns_doc",
+          "reason": "real impl pending",
+          "status": "pending",
+          "tier": 2
+        },
+        {
+          "id": "vector_search_when_advertised",
+          "reason": "real impl pending",
+          "status": "pending",
+          "tier": 2
+        }
+      ],
+      "contract": "MemoryStore",
+      "name": "cairn-store-sqlite"
+    },
+    {
+      "cases": [
+        {
+          "id": "manifest_matches_host",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "arc_pointer_stable",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "capability_self_consistency_floor",
+          "status": "ok",
+          "tier": 1
+        },
+        {
+          "id": "enqueue_then_complete",
+          "reason": "real impl pending",
+          "status": "pending",
+          "tier": 2
+        }
+      ],
+      "contract": "WorkflowOrchestrator",
+      "name": "cairn-workflows"
+    }
+  ],
+  "summary": {
+    "failed": 0,
+    "ok": 12,
+    "pending": 6
+  }
+}

--- a/crates/cairn-core/src/contract/conformance/mcp_server.rs
+++ b/crates/cairn-core/src/contract/conformance/mcp_server.rs
@@ -1,0 +1,10 @@
+//! Conformance cases for `MCPServer` plugins (filled in Task 4).
+
+use crate::contract::conformance::CaseOutcome;
+use crate::contract::registry::{PluginName, PluginRegistry};
+
+/// Run the conformance suite for this contract. Filled in Task 4.
+#[must_use]
+pub fn run(_registry: &PluginRegistry, _name: &PluginName) -> Vec<CaseOutcome> {
+    Vec::new()
+}

--- a/crates/cairn-core/src/contract/conformance/mcp_server.rs
+++ b/crates/cairn-core/src/contract/conformance/mcp_server.rs
@@ -20,7 +20,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     vec![
         // Tier 1
         tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
-        tier1_register_round_trip(registry, name, &plugin),
+        tier1_arc_pointer_stable(registry, name, &plugin),
         tier1_capability_self_consistency_floor(&*plugin),
         // Tier 2 (stub)
         CaseOutcome {
@@ -33,14 +33,14 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     ]
 }
 
-fn tier1_register_round_trip(
+fn tier1_arc_pointer_stable(
     registry: &PluginRegistry,
     name: &PluginName,
     plugin: &std::sync::Arc<dyn crate::contract::mcp_server::MCPServer>,
 ) -> CaseOutcome {
     let Some(resolved) = registry.mcp_server(name) else {
         return CaseOutcome {
-            id: "register_round_trip",
+            id: "arc_pointer_stable",
             tier: Tier::One,
             status: CaseStatus::Failed {
                 message: "lookup returned None for registered plugin".to_string(),
@@ -55,7 +55,7 @@ fn tier1_register_round_trip(
         }
     };
     CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status,
     }
@@ -66,6 +66,9 @@ fn tier1_capability_self_consistency_floor(
 ) -> CaseOutcome {
     // Floor: capabilities() must return without panic, name() non-empty,
     // supported_contract_versions() must accept the host CONTRACT_VERSION.
+    // The panic-vs-typed-error half of the spec §4.3 floor (verb methods
+    // returning `CapabilityUnavailable` for un-advertised capabilities) is
+    // deferred to per-impl PRs (#46 et al) where verb methods land.
     let caps = plugin.capabilities();
     if plugin.name().is_empty() {
         return CaseOutcome {

--- a/crates/cairn-core/src/contract/conformance/mcp_server.rs
+++ b/crates/cairn-core/src/contract/conformance/mcp_server.rs
@@ -4,7 +4,10 @@
 //! manifest/identity/version invariants. Tier-2 cases (verb behaviour)
 //! return `Pending` until per-impl PRs replace the bodies.
 
-use crate::contract::conformance::{CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host};
+use crate::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, tier1_manifest_features_match_capabilities,
+    tier1_manifest_matches_host,
+};
 use crate::contract::mcp_server::CONTRACT_VERSION;
 use crate::contract::registry::{PluginName, PluginRegistry};
 
@@ -14,14 +17,34 @@ use crate::contract::registry::{PluginName, PluginRegistry};
 #[must_use]
 pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     let Some(plugin) = registry.mcp_server(name) else {
-        return Vec::new();
+        return vec![CaseOutcome {
+            id: "typed_plugin_registered",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "manifest declared MCPServer but no MCPServer Arc \
+                     registered under name {name}"
+                ),
+            },
+        }];
     };
+    let caps = plugin.capabilities();
 
     vec![
         // Tier 1
         tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
         tier1_arc_pointer_stable(registry, name, &plugin),
         tier1_capability_self_consistency_floor(&*plugin),
+        tier1_manifest_features_match_capabilities(
+            registry,
+            name,
+            &[
+                ("stdio", caps.stdio),
+                ("sse", caps.sse),
+                ("http_streamable", caps.http_streamable),
+                ("extensions", caps.extensions),
+            ],
+        ),
         // Tier 2 (stub)
         CaseOutcome {
             id: "initialize_and_list_tools",

--- a/crates/cairn-core/src/contract/conformance/mcp_server.rs
+++ b/crates/cairn-core/src/contract/conformance/mcp_server.rs
@@ -1,10 +1,99 @@
-//! Conformance cases for `MCPServer` plugins (filled in Task 4).
+//! Conformance cases for `MCPServer` plugins.
+//!
+//! Tier-1 cases run against any registered `MCPServer` plugin and assert
+//! manifest/identity/version invariants. Tier-2 cases (verb behaviour)
+//! return `Pending` until per-impl PRs replace the bodies.
 
-use crate::contract::conformance::CaseOutcome;
+use crate::contract::conformance::{CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host};
+use crate::contract::mcp_server::CONTRACT_VERSION;
 use crate::contract::registry::{PluginName, PluginRegistry};
 
-/// Run the conformance suite for this contract. Filled in Task 4.
+/// Run tier-1 + tier-2 cases for an `MCPServer` plugin.
+///
+/// Returns an empty vec if no `MCPServer` is registered under `name`.
 #[must_use]
-pub fn run(_registry: &PluginRegistry, _name: &PluginName) -> Vec<CaseOutcome> {
-    Vec::new()
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let Some(plugin) = registry.mcp_server(name) else {
+        return Vec::new();
+    };
+
+    vec![
+        // Tier 1
+        tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
+        tier1_register_round_trip(registry, name, &plugin),
+        tier1_capability_self_consistency_floor(&*plugin),
+        // Tier 2 (stub)
+        CaseOutcome {
+            id: "initialize_and_list_tools",
+            tier: Tier::Two,
+            status: CaseStatus::Pending {
+                reason: "real impl pending",
+            },
+        },
+    ]
+}
+
+fn tier1_register_round_trip(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    plugin: &std::sync::Arc<dyn crate::contract::mcp_server::MCPServer>,
+) -> CaseOutcome {
+    let Some(resolved) = registry.mcp_server(name) else {
+        return CaseOutcome {
+            id: "register_round_trip",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "lookup returned None for registered plugin".to_string(),
+            },
+        };
+    };
+    let status = if std::sync::Arc::ptr_eq(plugin, &resolved) {
+        CaseStatus::Ok
+    } else {
+        CaseStatus::Failed {
+            message: "two lookups returned different Arcs".to_string(),
+        }
+    };
+    CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status,
+    }
+}
+
+fn tier1_capability_self_consistency_floor(
+    plugin: &dyn crate::contract::mcp_server::MCPServer,
+) -> CaseOutcome {
+    // Floor: capabilities() must return without panic, name() non-empty,
+    // supported_contract_versions() must accept the host CONTRACT_VERSION.
+    let caps = plugin.capabilities();
+    if plugin.name().is_empty() {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "plugin.name() returned empty string".to_string(),
+            },
+        };
+    }
+    if !plugin
+        .supported_contract_versions()
+        .accepts(CONTRACT_VERSION)
+    {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!("plugin does not accept host CONTRACT_VERSION {CONTRACT_VERSION}"),
+            },
+        };
+    }
+    // Touch all four bool fields so a future panicking-getter regression
+    // would surface here.
+    let _ = (caps.stdio, caps.sse, caps.http_streamable, caps.extensions);
+    CaseOutcome {
+        id: "capability_self_consistency_floor",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    }
 }

--- a/crates/cairn-core/src/contract/conformance/memory_store.rs
+++ b/crates/cairn-core/src/contract/conformance/memory_store.rs
@@ -1,10 +1,113 @@
-//! Conformance cases for `MemoryStore` plugins (filled in Task 4).
+//! Conformance cases for `MemoryStore` plugins.
+//!
+//! Tier-1 cases run against any registered `MemoryStore` plugin and assert
+//! manifest/identity/version invariants. Tier-2 cases (verb behaviour)
+//! return `Pending` until per-impl PRs replace the bodies.
 
-use crate::contract::conformance::CaseOutcome;
+use crate::contract::conformance::{CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host};
+use crate::contract::memory_store::CONTRACT_VERSION;
 use crate::contract::registry::{PluginName, PluginRegistry};
 
-/// Run the conformance suite for this contract. Filled in Task 4.
+/// Run tier-1 + tier-2 cases for a `MemoryStore` plugin.
+///
+/// Returns an empty vec if no `MemoryStore` is registered under `name`.
 #[must_use]
-pub fn run(_registry: &PluginRegistry, _name: &PluginName) -> Vec<CaseOutcome> {
-    Vec::new()
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let Some(plugin) = registry.memory_store(name) else {
+        return Vec::new();
+    };
+
+    vec![
+        // Tier 1
+        tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
+        tier1_register_round_trip(registry, name, &plugin),
+        tier1_capability_self_consistency_floor(&*plugin),
+        // Tier 2 (stubs)
+        CaseOutcome {
+            id: "put_get_roundtrip",
+            tier: Tier::Two,
+            status: CaseStatus::Pending {
+                reason: "real impl pending",
+            },
+        },
+        CaseOutcome {
+            id: "fts_query_returns_doc",
+            tier: Tier::Two,
+            status: CaseStatus::Pending {
+                reason: "real impl pending",
+            },
+        },
+        CaseOutcome {
+            id: "vector_search_when_advertised",
+            tier: Tier::Two,
+            status: CaseStatus::Pending {
+                reason: "real impl pending",
+            },
+        },
+    ]
+}
+
+fn tier1_register_round_trip(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    plugin: &std::sync::Arc<dyn crate::contract::memory_store::MemoryStore>,
+) -> CaseOutcome {
+    let Some(resolved) = registry.memory_store(name) else {
+        return CaseOutcome {
+            id: "register_round_trip",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "lookup returned None for registered plugin".to_string(),
+            },
+        };
+    };
+    let status = if std::sync::Arc::ptr_eq(plugin, &resolved) {
+        CaseStatus::Ok
+    } else {
+        CaseStatus::Failed {
+            message: "two lookups returned different Arcs".to_string(),
+        }
+    };
+    CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status,
+    }
+}
+
+fn tier1_capability_self_consistency_floor(
+    plugin: &dyn crate::contract::memory_store::MemoryStore,
+) -> CaseOutcome {
+    // Floor: capabilities() must return without panic, name() non-empty,
+    // supported_contract_versions() must accept the host CONTRACT_VERSION.
+    let caps = plugin.capabilities();
+    if plugin.name().is_empty() {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "plugin.name() returned empty string".to_string(),
+            },
+        };
+    }
+    if !plugin
+        .supported_contract_versions()
+        .accepts(CONTRACT_VERSION)
+    {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!("plugin does not accept host CONTRACT_VERSION {CONTRACT_VERSION}"),
+            },
+        };
+    }
+    // Touch all four bool fields so a future panicking-getter regression
+    // would surface here.
+    let _ = (caps.fts, caps.vector, caps.graph_edges, caps.transactions);
+    CaseOutcome {
+        id: "capability_self_consistency_floor",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    }
 }

--- a/crates/cairn-core/src/contract/conformance/memory_store.rs
+++ b/crates/cairn-core/src/contract/conformance/memory_store.rs
@@ -4,7 +4,10 @@
 //! manifest/identity/version invariants. Tier-2 cases (verb behaviour)
 //! return `Pending` until per-impl PRs replace the bodies.
 
-use crate::contract::conformance::{CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host};
+use crate::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, tier1_manifest_features_match_capabilities,
+    tier1_manifest_matches_host,
+};
 use crate::contract::memory_store::CONTRACT_VERSION;
 use crate::contract::registry::{PluginName, PluginRegistry};
 
@@ -14,14 +17,34 @@ use crate::contract::registry::{PluginName, PluginRegistry};
 #[must_use]
 pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     let Some(plugin) = registry.memory_store(name) else {
-        return Vec::new();
+        return vec![CaseOutcome {
+            id: "typed_plugin_registered",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "manifest declared MemoryStore but no MemoryStore Arc \
+                     registered under name {name}"
+                ),
+            },
+        }];
     };
+    let caps = plugin.capabilities();
 
     vec![
         // Tier 1
         tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
         tier1_arc_pointer_stable(registry, name, &plugin),
         tier1_capability_self_consistency_floor(&*plugin),
+        tier1_manifest_features_match_capabilities(
+            registry,
+            name,
+            &[
+                ("fts", caps.fts),
+                ("vector", caps.vector),
+                ("graph_edges", caps.graph_edges),
+                ("transactions", caps.transactions),
+            ],
+        ),
         // Tier 2 (stubs)
         CaseOutcome {
             id: "put_get_roundtrip",

--- a/crates/cairn-core/src/contract/conformance/memory_store.rs
+++ b/crates/cairn-core/src/contract/conformance/memory_store.rs
@@ -1,0 +1,10 @@
+//! Conformance cases for `MemoryStore` plugins (filled in Task 4).
+
+use crate::contract::conformance::CaseOutcome;
+use crate::contract::registry::{PluginName, PluginRegistry};
+
+/// Run the conformance suite for this contract. Filled in Task 4.
+#[must_use]
+pub fn run(_registry: &PluginRegistry, _name: &PluginName) -> Vec<CaseOutcome> {
+    Vec::new()
+}

--- a/crates/cairn-core/src/contract/conformance/memory_store.rs
+++ b/crates/cairn-core/src/contract/conformance/memory_store.rs
@@ -20,7 +20,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     vec![
         // Tier 1
         tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
-        tier1_register_round_trip(registry, name, &plugin),
+        tier1_arc_pointer_stable(registry, name, &plugin),
         tier1_capability_self_consistency_floor(&*plugin),
         // Tier 2 (stubs)
         CaseOutcome {
@@ -47,14 +47,14 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     ]
 }
 
-fn tier1_register_round_trip(
+fn tier1_arc_pointer_stable(
     registry: &PluginRegistry,
     name: &PluginName,
     plugin: &std::sync::Arc<dyn crate::contract::memory_store::MemoryStore>,
 ) -> CaseOutcome {
     let Some(resolved) = registry.memory_store(name) else {
         return CaseOutcome {
-            id: "register_round_trip",
+            id: "arc_pointer_stable",
             tier: Tier::One,
             status: CaseStatus::Failed {
                 message: "lookup returned None for registered plugin".to_string(),
@@ -69,7 +69,7 @@ fn tier1_register_round_trip(
         }
     };
     CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status,
     }
@@ -80,6 +80,9 @@ fn tier1_capability_self_consistency_floor(
 ) -> CaseOutcome {
     // Floor: capabilities() must return without panic, name() non-empty,
     // supported_contract_versions() must accept the host CONTRACT_VERSION.
+    // The panic-vs-typed-error half of the spec §4.3 floor (verb methods
+    // returning `CapabilityUnavailable` for un-advertised capabilities) is
+    // deferred to per-impl PRs (#46 et al) where verb methods land.
     let caps = plugin.capabilities();
     if plugin.name().is_empty() {
         return CaseOutcome {

--- a/crates/cairn-core/src/contract/conformance/mod.rs
+++ b/crates/cairn-core/src/contract/conformance/mod.rs
@@ -23,6 +23,8 @@ pub mod memory_store;
 pub mod sensor_ingress;
 pub mod workflow_orchestrator;
 
+use std::collections::BTreeSet;
+
 use crate::contract::manifest::ContractKind;
 use crate::contract::registry::{PluginError, PluginName, PluginRegistry};
 
@@ -117,9 +119,24 @@ pub fn run_conformance_for_plugin(
         ContractKind::WorkflowOrchestrator => workflow_orchestrator::run(registry, name),
         ContractKind::SensorIngress => sensor_ingress::run(registry, name),
         ContractKind::MCPServer => mcp_server::run(registry, name),
-        // P0 ships no bundled plugins for these — verify returns empty.
-        ContractKind::LLMProvider | ContractKind::FrontendAdapter | ContractKind::AgentProvider => {
-            Vec::new()
+        // P0 ships no bundled plugins for these — return a single Failed
+        // sentinel so `cairn plugins verify` cannot pass a manifest whose
+        // contract has no conformance runner. Once these contracts get
+        // bundled plugins, add per-contract `run` modules and route here.
+        kind @ (ContractKind::LLMProvider
+        | ContractKind::FrontendAdapter
+        | ContractKind::AgentProvider) => {
+            vec![CaseOutcome {
+                id: "no_conformance_runner",
+                tier: Tier::One,
+                status: CaseStatus::Failed {
+                    message: format!(
+                        "no conformance runner registered for contract {kind:?}; \
+                         add a per-contract `run` module under \
+                         `cairn-core::contract::conformance`"
+                    ),
+                },
+            }]
         }
     }
 }
@@ -169,6 +186,73 @@ pub(super) fn tier1_manifest_matches_host(
         id: "manifest_matches_host",
         tier: Tier::One,
         status,
+    }
+}
+
+/// Internal helper: tier-1 `manifest_features_match_capabilities` case.
+///
+/// Compares the manifest's `[features]` map against the runtime capability
+/// struct's named fields. The caller passes a slice of `(field_name,
+/// runtime_value)` pairs derived from the plugin's `capabilities()` return.
+///
+/// Fails if any feature key is in the manifest but not in `runtime` (or
+/// vice versa), or if any value disagrees. This catches manifest drift
+/// where a plugin advertises e.g. `fts = true` but its runtime
+/// capabilities return `fts = false`.
+pub(super) fn tier1_manifest_features_match_capabilities(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    runtime: &[(&'static str, bool)],
+) -> CaseOutcome {
+    let id = "manifest_features_match_capabilities";
+    let Some(manifest) = registry.parsed_manifest(name) else {
+        return CaseOutcome {
+            id,
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!("no manifest registered for plugin {name}"),
+            },
+        };
+    };
+    let manifest_features = manifest.features();
+    let runtime_keys: BTreeSet<&str> = runtime.iter().map(|(k, _)| *k).collect();
+    let manifest_keys: BTreeSet<&str> = manifest_features.keys().map(String::as_str).collect();
+
+    if manifest_keys != runtime_keys {
+        let only_manifest: Vec<&str> = manifest_keys.difference(&runtime_keys).copied().collect();
+        let only_runtime: Vec<&str> = runtime_keys.difference(&manifest_keys).copied().collect();
+        return CaseOutcome {
+            id,
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "feature key mismatch — only in manifest: {only_manifest:?}, \
+                     only in runtime capabilities: {only_runtime:?}"
+                ),
+            },
+        };
+    }
+
+    for (key, runtime_value) in runtime {
+        let manifest_value = manifest_features.get(*key).copied().unwrap_or(false);
+        if manifest_value != *runtime_value {
+            return CaseOutcome {
+                id,
+                tier: Tier::One,
+                status: CaseStatus::Failed {
+                    message: format!(
+                        "feature {key:?} disagrees: manifest={manifest_value}, \
+                         runtime capabilities={runtime_value}"
+                    ),
+                },
+            };
+        }
+    }
+
+    CaseOutcome {
+        id,
+        tier: Tier::One,
+        status: CaseStatus::Ok,
     }
 }
 

--- a/crates/cairn-core/src/contract/conformance/mod.rs
+++ b/crates/cairn-core/src/contract/conformance/mod.rs
@@ -131,9 +131,12 @@ pub fn run_conformance_for_plugin(
 /// and the host's `CONTRACT_VERSION` for that contract. The host version
 /// is supplied by callers (per-contract `run` functions) so this helper
 /// stays generic over contract kind.
-#[expect(
-    dead_code,
-    reason = "consumed by per-contract `run` functions added in Task 4"
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by per-contract `run` functions added in Task 4"
+    )
 )]
 pub(super) fn tier1_manifest_matches_host(
     registry: &PluginRegistry,
@@ -204,5 +207,23 @@ mod tests {
         let reg = PluginRegistry::new();
         let name = PluginName::new("does-not-exist").expect("valid");
         assert!(run_conformance_for_plugin(&reg, &name).is_empty());
+    }
+
+    #[test]
+    fn tier1_manifest_matches_host_returns_failed_when_no_manifest() {
+        use crate::contract::version::ContractVersion;
+
+        let reg = PluginRegistry::new();
+        let name = PluginName::new("missing-plugin").expect("valid");
+        let outcome = tier1_manifest_matches_host(&reg, &name, ContractVersion::new(0, 1, 0));
+        assert_eq!(outcome.id, "manifest_matches_host");
+        assert_eq!(outcome.tier, Tier::One);
+        let CaseStatus::Failed { message } = &outcome.status else {
+            panic!("expected Failed status, got {:?}", outcome.status);
+        };
+        assert!(
+            message.contains("missing-plugin"),
+            "message should mention plugin name: {message}"
+        );
     }
 }

--- a/crates/cairn-core/src/contract/conformance/mod.rs
+++ b/crates/cairn-core/src/contract/conformance/mod.rs
@@ -195,10 +195,20 @@ pub(super) fn tier1_manifest_matches_host(
 /// struct's named fields. The caller passes a slice of `(field_name,
 /// runtime_value)` pairs derived from the plugin's `capabilities()` return.
 ///
-/// Fails if any feature key is in the manifest but not in `runtime` (or
-/// vice versa), or if any value disagrees. This catches manifest drift
-/// where a plugin advertises e.g. `fts = true` but its runtime
-/// capabilities return `fts = false`.
+/// Per the manifest schema, `[features]` is optional and free-form. The
+/// validation rule is therefore asymmetric:
+///
+/// - Keys present in the manifest but NOT in `runtime` → fail (unknown
+///   feature key — typo or drift from the trait's capability struct).
+/// - Keys present in `runtime` but absent from the manifest → treated as
+///   `false` (the schema default for an unspecified feature). Compared
+///   against the runtime value.
+/// - Keys present in both → values must match.
+///
+/// This way a plugin with all-`false` runtime capabilities and no
+/// `[features]` block passes (the canonical P0 stub case), while a
+/// plugin advertising `fts = true` but returning `fts = false` at runtime
+/// still fails — manifest drift remains caught.
 pub(super) fn tier1_manifest_features_match_capabilities(
     registry: &PluginRegistry,
     name: &PluginName,
@@ -216,23 +226,29 @@ pub(super) fn tier1_manifest_features_match_capabilities(
     };
     let manifest_features = manifest.features();
     let runtime_keys: BTreeSet<&str> = runtime.iter().map(|(k, _)| *k).collect();
-    let manifest_keys: BTreeSet<&str> = manifest_features.keys().map(String::as_str).collect();
 
-    if manifest_keys != runtime_keys {
-        let only_manifest: Vec<&str> = manifest_keys.difference(&runtime_keys).copied().collect();
-        let only_runtime: Vec<&str> = runtime_keys.difference(&manifest_keys).copied().collect();
+    // Reject unknown manifest keys (typo / drift from the capability
+    // struct field set).
+    let unknown: Vec<&str> = manifest_features
+        .keys()
+        .map(String::as_str)
+        .filter(|k| !runtime_keys.contains(k))
+        .collect();
+    if !unknown.is_empty() {
         return CaseOutcome {
             id,
             tier: Tier::One,
             status: CaseStatus::Failed {
                 message: format!(
-                    "feature key mismatch — only in manifest: {only_manifest:?}, \
-                     only in runtime capabilities: {only_runtime:?}"
+                    "manifest declares unknown feature key(s) {unknown:?} \
+                     not present in the runtime capability struct"
                 ),
             },
         };
     }
 
+    // Compare each runtime capability against the manifest. Missing
+    // manifest keys default to `false` per schema.
     for (key, runtime_value) in runtime {
         let manifest_value = manifest_features.get(*key).copied().unwrap_or(false);
         if manifest_value != *runtime_value {
@@ -241,8 +257,8 @@ pub(super) fn tier1_manifest_features_match_capabilities(
                 tier: Tier::One,
                 status: CaseStatus::Failed {
                     message: format!(
-                        "feature {key:?} disagrees: manifest={manifest_value}, \
-                         runtime capabilities={runtime_value}"
+                        "feature {key:?} disagrees: manifest={manifest_value} \
+                         (or default-false if absent), runtime capabilities={runtime_value}"
                     ),
                 },
             };

--- a/crates/cairn-core/src/contract/conformance/mod.rs
+++ b/crates/cairn-core/src/contract/conformance/mod.rs
@@ -1,0 +1,208 @@
+//! Two-tier conformance suite for plugins (brief §4.1).
+//!
+//! Tier-1 cases are pure trait-surface checks: they instantiate the plugin
+//! against a fresh registry, verify name / version / manifest agreement,
+//! and assert capability self-consistency. Every plugin must pass tier-1
+//! to be considered conformant.
+//!
+//! Tier-2 cases exercise verb behaviour. They are stubbed `Pending` until
+//! per-impl PRs land — at which point each contract module's tier-2 case
+//! body is replaced with a real check.
+//!
+//! The suite lives in `cairn-core` (rather than `cairn-test-fixtures`)
+//! because `cairn plugins verify` is a production code path. All cases
+//! are pure functions: zero I/O, no adapter deps.
+//!
+//! Entry point: [`run_conformance_for_plugin`].
+//!
+//! See `docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md`
+//! §4 for the full design.
+
+pub mod mcp_server;
+pub mod memory_store;
+pub mod sensor_ingress;
+pub mod workflow_orchestrator;
+
+use crate::contract::manifest::ContractKind;
+use crate::contract::registry::{PluginError, PluginName, PluginRegistry};
+
+/// Outcome of running a single conformance case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaseOutcome {
+    /// Stable case identifier (`snake_case`, brief-aligned).
+    pub id: &'static str,
+    /// Tier this case belongs to.
+    pub tier: Tier,
+    /// Case result.
+    pub status: CaseStatus,
+}
+
+/// Conformance tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tier {
+    /// Always run; failure makes the plugin non-conformant.
+    One,
+    /// Verb-behaviour cases; stubbed `Pending` until per-impl PRs land.
+    Two,
+}
+
+impl Tier {
+    /// Numeric encoding used in JSON output (`1` or `2`).
+    #[must_use]
+    pub fn as_u8(self) -> u8 {
+        match self {
+            Tier::One => 1,
+            Tier::Two => 2,
+        }
+    }
+}
+
+/// Result of a single conformance case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CaseStatus {
+    /// Case ran to completion and the invariant held.
+    Ok,
+    /// Case body is a stub awaiting a real implementation.
+    Pending {
+        /// Static reason string explaining what's pending.
+        reason: &'static str,
+    },
+    /// Case ran and the invariant did not hold.
+    Failed {
+        /// Human-readable failure message.
+        message: String,
+    },
+}
+
+impl CaseStatus {
+    /// `true` iff this status counts as a tier-1 failure when running with
+    /// `--strict` interpreting `Pending` as failure.
+    #[must_use]
+    pub fn is_failure(&self) -> bool {
+        matches!(self, CaseStatus::Failed { .. })
+    }
+
+    /// Stable string discriminator used in JSON output.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CaseStatus::Ok => "ok",
+            CaseStatus::Pending { .. } => "pending",
+            CaseStatus::Failed { .. } => "failed",
+        }
+    }
+}
+
+/// Run the full conformance suite (tier-1 + tier-2) against the plugin
+/// identified by `name` in `registry`.
+///
+/// Returns an empty vec if the plugin is not registered. Otherwise the
+/// returned vec contains tier-1 cases first, then tier-2 cases, in
+/// declaration order.
+///
+/// # Errors
+/// This function does not return `Result`; case-level errors are encoded
+/// in `CaseStatus::Failed`. The only way this function "fails" is by
+/// returning an empty vec when `name` is not in the registry.
+#[must_use]
+pub fn run_conformance_for_plugin(
+    registry: &PluginRegistry,
+    name: &PluginName,
+) -> Vec<CaseOutcome> {
+    let Some(manifest) = registry.parsed_manifest(name) else {
+        return Vec::new();
+    };
+    match manifest.contract() {
+        ContractKind::MemoryStore => memory_store::run(registry, name),
+        ContractKind::WorkflowOrchestrator => workflow_orchestrator::run(registry, name),
+        ContractKind::SensorIngress => sensor_ingress::run(registry, name),
+        ContractKind::MCPServer => mcp_server::run(registry, name),
+        // P0 ships no bundled plugins for these — verify returns empty.
+        ContractKind::LLMProvider | ContractKind::FrontendAdapter | ContractKind::AgentProvider => {
+            Vec::new()
+        }
+    }
+}
+
+/// Internal helper: tier-1 `manifest_matches_host` case.
+///
+/// Calls [`crate::contract::manifest::PluginManifest::verify_compatible_with`]
+/// with the plugin's runtime name, the manifest's declared contract kind,
+/// and the host's `CONTRACT_VERSION` for that contract. The host version
+/// is supplied by callers (per-contract `run` functions) so this helper
+/// stays generic over contract kind.
+#[expect(
+    dead_code,
+    reason = "consumed by per-contract `run` functions added in Task 4"
+)]
+pub(super) fn tier1_manifest_matches_host(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    host_version: crate::contract::version::ContractVersion,
+) -> CaseOutcome {
+    let Some(manifest) = registry.parsed_manifest(name) else {
+        return CaseOutcome {
+            id: "manifest_matches_host",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!("no manifest registered for plugin {name}"),
+            },
+        };
+    };
+    let result = manifest.verify_compatible_with(name, manifest.contract(), host_version);
+    let status = match result {
+        Ok(()) => CaseStatus::Ok,
+        Err(PluginError::ContractMismatch { expected, actual }) => CaseStatus::Failed {
+            message: format!("manifest contract {actual:?} does not match host {expected:?}"),
+        },
+        Err(PluginError::ManifestNameMismatch { expected, manifest }) => CaseStatus::Failed {
+            message: format!("manifest name {manifest} does not match registered name {expected}"),
+        },
+        Err(PluginError::UnsupportedContractVersion {
+            host, plugin_range, ..
+        }) => CaseStatus::Failed {
+            message: format!(
+                "host CONTRACT_VERSION {host} is outside manifest range {plugin_range:?}"
+            ),
+        },
+        Err(other) => CaseStatus::Failed {
+            message: format!("verify_compatible_with failed: {other}"),
+        },
+    };
+    CaseOutcome {
+        id: "manifest_matches_host",
+        tier: Tier::One,
+        status,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_as_u8() {
+        assert_eq!(Tier::One.as_u8(), 1);
+        assert_eq!(Tier::Two.as_u8(), 2);
+    }
+
+    #[test]
+    fn case_status_str() {
+        assert_eq!(CaseStatus::Ok.as_str(), "ok");
+        assert_eq!(CaseStatus::Pending { reason: "x" }.as_str(), "pending");
+        assert_eq!(
+            CaseStatus::Failed {
+                message: "x".to_string()
+            }
+            .as_str(),
+            "failed"
+        );
+    }
+
+    #[test]
+    fn run_for_unregistered_plugin_is_empty() {
+        let reg = PluginRegistry::new();
+        let name = PluginName::new("does-not-exist").expect("valid");
+        assert!(run_conformance_for_plugin(&reg, &name).is_empty());
+    }
+}

--- a/crates/cairn-core/src/contract/conformance/mod.rs
+++ b/crates/cairn-core/src/contract/conformance/mod.rs
@@ -131,13 +131,6 @@ pub fn run_conformance_for_plugin(
 /// and the host's `CONTRACT_VERSION` for that contract. The host version
 /// is supplied by callers (per-contract `run` functions) so this helper
 /// stays generic over contract kind.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by per-contract `run` functions added in Task 4"
-    )
-)]
 pub(super) fn tier1_manifest_matches_host(
     registry: &PluginRegistry,
     name: &PluginName,

--- a/crates/cairn-core/src/contract/conformance/sensor_ingress.rs
+++ b/crates/cairn-core/src/contract/conformance/sensor_ingress.rs
@@ -20,7 +20,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     vec![
         // Tier 1
         tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
-        tier1_register_round_trip(registry, name, &plugin),
+        tier1_arc_pointer_stable(registry, name, &plugin),
         tier1_capability_self_consistency_floor(&*plugin),
         // Tier 2 (stub)
         CaseOutcome {
@@ -33,14 +33,14 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     ]
 }
 
-fn tier1_register_round_trip(
+fn tier1_arc_pointer_stable(
     registry: &PluginRegistry,
     name: &PluginName,
     plugin: &std::sync::Arc<dyn crate::contract::sensor_ingress::SensorIngress>,
 ) -> CaseOutcome {
     let Some(resolved) = registry.sensor_ingress_plugin(name) else {
         return CaseOutcome {
-            id: "register_round_trip",
+            id: "arc_pointer_stable",
             tier: Tier::One,
             status: CaseStatus::Failed {
                 message: "lookup returned None for registered plugin".to_string(),
@@ -55,7 +55,7 @@ fn tier1_register_round_trip(
         }
     };
     CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status,
     }
@@ -66,6 +66,9 @@ fn tier1_capability_self_consistency_floor(
 ) -> CaseOutcome {
     // Floor: capabilities() must return without panic, name() non-empty,
     // supported_contract_versions() must accept the host CONTRACT_VERSION.
+    // The panic-vs-typed-error half of the spec §4.3 floor (verb methods
+    // returning `CapabilityUnavailable` for un-advertised capabilities) is
+    // deferred to per-impl PRs (#46 et al) where verb methods land.
     let caps = plugin.capabilities();
     if plugin.name().is_empty() {
         return CaseOutcome {

--- a/crates/cairn-core/src/contract/conformance/sensor_ingress.rs
+++ b/crates/cairn-core/src/contract/conformance/sensor_ingress.rs
@@ -1,10 +1,99 @@
-//! Conformance cases for `SensorIngress` plugins (filled in Task 4).
+//! Conformance cases for `SensorIngress` plugins.
+//!
+//! Tier-1 cases run against any registered `SensorIngress` plugin and
+//! assert manifest/identity/version invariants. Tier-2 cases (verb
+//! behaviour) return `Pending` until per-impl PRs replace the bodies.
 
-use crate::contract::conformance::CaseOutcome;
+use crate::contract::conformance::{CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host};
 use crate::contract::registry::{PluginName, PluginRegistry};
+use crate::contract::sensor_ingress::CONTRACT_VERSION;
 
-/// Run the conformance suite for this contract. Filled in Task 4.
+/// Run tier-1 + tier-2 cases for a `SensorIngress` plugin.
+///
+/// Returns an empty vec if no `SensorIngress` is registered under `name`.
 #[must_use]
-pub fn run(_registry: &PluginRegistry, _name: &PluginName) -> Vec<CaseOutcome> {
-    Vec::new()
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let Some(plugin) = registry.sensor_ingress_plugin(name) else {
+        return Vec::new();
+    };
+
+    vec![
+        // Tier 1
+        tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
+        tier1_register_round_trip(registry, name, &plugin),
+        tier1_capability_self_consistency_floor(&*plugin),
+        // Tier 2 (stub)
+        CaseOutcome {
+            id: "emits_envelope_when_poked",
+            tier: Tier::Two,
+            status: CaseStatus::Pending {
+                reason: "real impl pending",
+            },
+        },
+    ]
+}
+
+fn tier1_register_round_trip(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    plugin: &std::sync::Arc<dyn crate::contract::sensor_ingress::SensorIngress>,
+) -> CaseOutcome {
+    let Some(resolved) = registry.sensor_ingress_plugin(name) else {
+        return CaseOutcome {
+            id: "register_round_trip",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "lookup returned None for registered plugin".to_string(),
+            },
+        };
+    };
+    let status = if std::sync::Arc::ptr_eq(plugin, &resolved) {
+        CaseStatus::Ok
+    } else {
+        CaseStatus::Failed {
+            message: "two lookups returned different Arcs".to_string(),
+        }
+    };
+    CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status,
+    }
+}
+
+fn tier1_capability_self_consistency_floor(
+    plugin: &dyn crate::contract::sensor_ingress::SensorIngress,
+) -> CaseOutcome {
+    // Floor: capabilities() must return without panic, name() non-empty,
+    // supported_contract_versions() must accept the host CONTRACT_VERSION.
+    let caps = plugin.capabilities();
+    if plugin.name().is_empty() {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "plugin.name() returned empty string".to_string(),
+            },
+        };
+    }
+    if !plugin
+        .supported_contract_versions()
+        .accepts(CONTRACT_VERSION)
+    {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!("plugin does not accept host CONTRACT_VERSION {CONTRACT_VERSION}"),
+            },
+        };
+    }
+    // Touch all three bool fields so a future panicking-getter regression
+    // would surface here.
+    let _ = (caps.batches, caps.streaming, caps.consent_aware);
+    CaseOutcome {
+        id: "capability_self_consistency_floor",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    }
 }

--- a/crates/cairn-core/src/contract/conformance/sensor_ingress.rs
+++ b/crates/cairn-core/src/contract/conformance/sensor_ingress.rs
@@ -1,0 +1,10 @@
+//! Conformance cases for `SensorIngress` plugins (filled in Task 4).
+
+use crate::contract::conformance::CaseOutcome;
+use crate::contract::registry::{PluginName, PluginRegistry};
+
+/// Run the conformance suite for this contract. Filled in Task 4.
+#[must_use]
+pub fn run(_registry: &PluginRegistry, _name: &PluginName) -> Vec<CaseOutcome> {
+    Vec::new()
+}

--- a/crates/cairn-core/src/contract/conformance/sensor_ingress.rs
+++ b/crates/cairn-core/src/contract/conformance/sensor_ingress.rs
@@ -4,7 +4,10 @@
 //! assert manifest/identity/version invariants. Tier-2 cases (verb
 //! behaviour) return `Pending` until per-impl PRs replace the bodies.
 
-use crate::contract::conformance::{CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host};
+use crate::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, tier1_manifest_features_match_capabilities,
+    tier1_manifest_matches_host,
+};
 use crate::contract::registry::{PluginName, PluginRegistry};
 use crate::contract::sensor_ingress::CONTRACT_VERSION;
 
@@ -14,14 +17,33 @@ use crate::contract::sensor_ingress::CONTRACT_VERSION;
 #[must_use]
 pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     let Some(plugin) = registry.sensor_ingress_plugin(name) else {
-        return Vec::new();
+        return vec![CaseOutcome {
+            id: "typed_plugin_registered",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "manifest declared SensorIngress but no SensorIngress \
+                     Arc registered under name {name}"
+                ),
+            },
+        }];
     };
+    let caps = plugin.capabilities();
 
     vec![
         // Tier 1
         tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
         tier1_arc_pointer_stable(registry, name, &plugin),
         tier1_capability_self_consistency_floor(&*plugin),
+        tier1_manifest_features_match_capabilities(
+            registry,
+            name,
+            &[
+                ("batches", caps.batches),
+                ("streaming", caps.streaming),
+                ("consent_aware", caps.consent_aware),
+            ],
+        ),
         // Tier 2 (stub)
         CaseOutcome {
             id: "emits_envelope_when_poked",

--- a/crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs
+++ b/crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs
@@ -1,10 +1,100 @@
-//! Conformance cases for `WorkflowOrchestrator` plugins (filled in Task 4).
+//! Conformance cases for `WorkflowOrchestrator` plugins.
+//!
+//! Tier-1 cases run against any registered `WorkflowOrchestrator` plugin
+//! and assert manifest/identity/version invariants. Tier-2 cases (verb
+//! behaviour) return `Pending` until per-impl PRs replace the bodies.
 
-use crate::contract::conformance::CaseOutcome;
+use crate::contract::conformance::{CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host};
 use crate::contract::registry::{PluginName, PluginRegistry};
+use crate::contract::workflow_orchestrator::CONTRACT_VERSION;
 
-/// Run the conformance suite for this contract. Filled in Task 4.
+/// Run tier-1 + tier-2 cases for a `WorkflowOrchestrator` plugin.
+///
+/// Returns an empty vec if no `WorkflowOrchestrator` is registered under
+/// `name`.
 #[must_use]
-pub fn run(_registry: &PluginRegistry, _name: &PluginName) -> Vec<CaseOutcome> {
-    Vec::new()
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let Some(plugin) = registry.workflow_orchestrator(name) else {
+        return Vec::new();
+    };
+
+    vec![
+        // Tier 1
+        tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
+        tier1_register_round_trip(registry, name, &plugin),
+        tier1_capability_self_consistency_floor(&*plugin),
+        // Tier 2 (stub)
+        CaseOutcome {
+            id: "enqueue_then_complete",
+            tier: Tier::Two,
+            status: CaseStatus::Pending {
+                reason: "real impl pending",
+            },
+        },
+    ]
+}
+
+fn tier1_register_round_trip(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    plugin: &std::sync::Arc<dyn crate::contract::workflow_orchestrator::WorkflowOrchestrator>,
+) -> CaseOutcome {
+    let Some(resolved) = registry.workflow_orchestrator(name) else {
+        return CaseOutcome {
+            id: "register_round_trip",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "lookup returned None for registered plugin".to_string(),
+            },
+        };
+    };
+    let status = if std::sync::Arc::ptr_eq(plugin, &resolved) {
+        CaseStatus::Ok
+    } else {
+        CaseStatus::Failed {
+            message: "two lookups returned different Arcs".to_string(),
+        }
+    };
+    CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status,
+    }
+}
+
+fn tier1_capability_self_consistency_floor(
+    plugin: &dyn crate::contract::workflow_orchestrator::WorkflowOrchestrator,
+) -> CaseOutcome {
+    // Floor: capabilities() must return without panic, name() non-empty,
+    // supported_contract_versions() must accept the host CONTRACT_VERSION.
+    let caps = plugin.capabilities();
+    if plugin.name().is_empty() {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "plugin.name() returned empty string".to_string(),
+            },
+        };
+    }
+    if !plugin
+        .supported_contract_versions()
+        .accepts(CONTRACT_VERSION)
+    {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!("plugin does not accept host CONTRACT_VERSION {CONTRACT_VERSION}"),
+            },
+        };
+    }
+    // Touch all three bool fields so a future panicking-getter regression
+    // would surface here.
+    let _ = (caps.durable, caps.crash_safe, caps.cron_schedules);
+    CaseOutcome {
+        id: "capability_self_consistency_floor",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    }
 }

--- a/crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs
+++ b/crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs
@@ -1,0 +1,10 @@
+//! Conformance cases for `WorkflowOrchestrator` plugins (filled in Task 4).
+
+use crate::contract::conformance::CaseOutcome;
+use crate::contract::registry::{PluginName, PluginRegistry};
+
+/// Run the conformance suite for this contract. Filled in Task 4.
+#[must_use]
+pub fn run(_registry: &PluginRegistry, _name: &PluginName) -> Vec<CaseOutcome> {
+    Vec::new()
+}

--- a/crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs
+++ b/crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs
@@ -4,7 +4,10 @@
 //! and assert manifest/identity/version invariants. Tier-2 cases (verb
 //! behaviour) return `Pending` until per-impl PRs replace the bodies.
 
-use crate::contract::conformance::{CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host};
+use crate::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, tier1_manifest_features_match_capabilities,
+    tier1_manifest_matches_host,
+};
 use crate::contract::registry::{PluginName, PluginRegistry};
 use crate::contract::workflow_orchestrator::CONTRACT_VERSION;
 
@@ -15,14 +18,33 @@ use crate::contract::workflow_orchestrator::CONTRACT_VERSION;
 #[must_use]
 pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     let Some(plugin) = registry.workflow_orchestrator(name) else {
-        return Vec::new();
+        return vec![CaseOutcome {
+            id: "typed_plugin_registered",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "manifest declared WorkflowOrchestrator but no \
+                     WorkflowOrchestrator Arc registered under name {name}"
+                ),
+            },
+        }];
     };
+    let caps = plugin.capabilities();
 
     vec![
         // Tier 1
         tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
         tier1_arc_pointer_stable(registry, name, &plugin),
         tier1_capability_self_consistency_floor(&*plugin),
+        tier1_manifest_features_match_capabilities(
+            registry,
+            name,
+            &[
+                ("durable", caps.durable),
+                ("crash_safe", caps.crash_safe),
+                ("cron_schedules", caps.cron_schedules),
+            ],
+        ),
         // Tier 2 (stub)
         CaseOutcome {
             id: "enqueue_then_complete",

--- a/crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs
+++ b/crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs
@@ -21,7 +21,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     vec![
         // Tier 1
         tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
-        tier1_register_round_trip(registry, name, &plugin),
+        tier1_arc_pointer_stable(registry, name, &plugin),
         tier1_capability_self_consistency_floor(&*plugin),
         // Tier 2 (stub)
         CaseOutcome {
@@ -34,14 +34,14 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     ]
 }
 
-fn tier1_register_round_trip(
+fn tier1_arc_pointer_stable(
     registry: &PluginRegistry,
     name: &PluginName,
     plugin: &std::sync::Arc<dyn crate::contract::workflow_orchestrator::WorkflowOrchestrator>,
 ) -> CaseOutcome {
     let Some(resolved) = registry.workflow_orchestrator(name) else {
         return CaseOutcome {
-            id: "register_round_trip",
+            id: "arc_pointer_stable",
             tier: Tier::One,
             status: CaseStatus::Failed {
                 message: "lookup returned None for registered plugin".to_string(),
@@ -56,7 +56,7 @@ fn tier1_register_round_trip(
         }
     };
     CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status,
     }
@@ -67,6 +67,9 @@ fn tier1_capability_self_consistency_floor(
 ) -> CaseOutcome {
     // Floor: capabilities() must return without panic, name() non-empty,
     // supported_contract_versions() must accept the host CONTRACT_VERSION.
+    // The panic-vs-typed-error half of the spec §4.3 floor (verb methods
+    // returning `CapabilityUnavailable` for un-advertised capabilities) is
+    // deferred to per-impl PRs (#46 et al) where verb methods land.
     let caps = plugin.capabilities();
     if plugin.name().is_empty() {
         return CaseOutcome {

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -67,8 +67,63 @@
 /// let mut reg = cairn_core::contract::registry::PluginRegistry::new();
 /// register(&mut reg).expect("compatible plugin registers");
 /// ```
+///
+/// # Manifest-aware form (preferred for bundled plugins)
+///
+/// ```
+/// # use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
+/// # use cairn_core::contract::version::{ContractVersion, VersionRange};
+/// use cairn_core::register_plugin;
+///
+/// const MANIFEST_TOML: &str = r#"
+/// name = "acme-store"
+/// contract = "MemoryStore"
+///
+/// [contract_version_range.min]
+/// major = 0
+/// minor = 1
+/// patch = 0
+///
+/// [contract_version_range.max_exclusive]
+/// major = 0
+/// minor = 2
+/// patch = 0
+/// "#;
+///
+/// #[derive(Default)]
+/// struct MyStore;
+///
+/// #[async_trait::async_trait]
+/// impl MemoryStore for MyStore {
+///     fn name(&self) -> &str { "acme-store" }
+///     fn capabilities(&self) -> &MemoryStoreCapabilities {
+///         static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+///             fts: false,
+///             vector: false,
+///             graph_edges: false,
+///             transactions: false,
+///         };
+///         &CAPS
+///     }
+///     fn supported_contract_versions(&self) -> VersionRange {
+///         VersionRange::new(
+///             ContractVersion::new(0, 1, 0),
+///             ContractVersion::new(0, 2, 0),
+///         )
+///     }
+/// }
+///
+/// register_plugin!(MemoryStore, MyStore, "acme-store", MANIFEST_TOML);
+///
+/// let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+/// register(&mut reg).expect("compatible plugin registers");
+/// assert!(reg.parsed_manifest(
+///     &cairn_core::contract::registry::PluginName::new("acme-store").unwrap()
+/// ).is_some());
+/// ```
 #[macro_export]
 macro_rules! register_plugin {
+    // 3-arg form: legacy / unit-test path with no manifest.
     (MemoryStore, $impl:ty, $name:literal) => {
         $crate::__register_plugin_helper!(register_memory_store, $impl, $name);
     };
@@ -90,6 +145,65 @@ macro_rules! register_plugin {
     (AgentProvider, $impl:ty, $name:literal) => {
         $crate::__register_plugin_helper!(register_agent_provider, $impl, $name);
     };
+
+    // 4-arg form: manifest-aware. `$manifest` is an expression producing a
+    // `&'static str` (typically a `pub const MANIFEST_TOML: &str = include_str!(...)`).
+    (MemoryStore, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_memory_store_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (LLMProvider, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_llm_provider_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (WorkflowOrchestrator, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_workflow_orchestrator_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (SensorIngress, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_sensor_ingress_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (MCPServer, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_mcp_server_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (FrontendAdapter, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_frontend_adapter_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (AgentProvider, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_agent_provider_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
 }
 
 #[doc(hidden)]
@@ -108,6 +222,32 @@ macro_rules! __register_plugin_helper {
             let name = $crate::contract::registry::PluginName::new($name)?;
             reg.$method(
                 name,
+                ::std::sync::Arc::new(<$impl as ::core::default::Default>::default()),
+            )
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_plugin_with_manifest_helper {
+    ($method:ident, $impl:ty, $name:literal, $manifest:expr) => {
+        /// Plugin entry point with manifest-aware registration.
+        ///
+        /// # Errors
+        /// Returns [`cairn_core::contract::registry::PluginError`] when the
+        /// name is invalid, the manifest fails to parse, the manifest
+        /// disagrees with the registered name / contract / host version,
+        /// or another plugin already holds this name.
+        pub fn register(
+            reg: &mut $crate::contract::registry::PluginRegistry,
+        ) -> ::core::result::Result<(), $crate::contract::registry::PluginError> {
+            let name = $crate::contract::registry::PluginName::new($name)?;
+            let manifest =
+                $crate::contract::manifest::PluginManifest::parse_toml($manifest)?;
+            reg.$method(
+                name,
+                manifest,
                 ::std::sync::Arc::new(<$impl as ::core::default::Default>::default()),
             )
         }

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -243,8 +243,7 @@ macro_rules! __register_plugin_with_manifest_helper {
             reg: &mut $crate::contract::registry::PluginRegistry,
         ) -> ::core::result::Result<(), $crate::contract::registry::PluginError> {
             let name = $crate::contract::registry::PluginName::new($name)?;
-            let manifest =
-                $crate::contract::manifest::PluginManifest::parse_toml($manifest)?;
+            let manifest = $crate::contract::manifest::PluginManifest::parse_toml($manifest)?;
             reg.$method(
                 name,
                 manifest,

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -17,6 +17,7 @@
 //! - Forward stubs (P1/P2, hidden until #113 / #124): `FrontendAdapter`, `AgentProvider`.
 
 pub mod agent_provider;
+pub mod conformance;
 pub mod frontend_adapter;
 pub mod llm_provider;
 pub mod manifest;
@@ -32,6 +33,7 @@ pub mod macros;
 
 // Flat re-exports so users can write `cairn_core::contract::MemoryStore`
 // instead of `cairn_core::contract::memory_store::MemoryStore`.
+pub use conformance::{CaseOutcome, CaseStatus, Tier, run_conformance_for_plugin};
 pub use manifest::{ContractKind, PluginManifest};
 pub use registry::{PluginError, PluginName, PluginRegistry};
 pub use version::{ContractVersion, VersionRange};

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -645,8 +645,7 @@ patch = 0
     fn register_with_manifest_inserts_into_both_maps() {
         let mut reg = PluginRegistry::new();
         let name = PluginName::new("cairn-store-sqlite").expect("valid");
-        let manifest =
-            PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
+        let manifest = PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
         reg.register_memory_store_with_manifest(
             name.clone(),
             manifest,
@@ -658,10 +657,7 @@ patch = 0
         .expect("manifest-aware registration succeeds");
 
         assert!(reg.memory_store(&name).is_some(), "store registered");
-        assert!(
-            reg.parsed_manifest(&name).is_some(),
-            "manifest registered"
-        );
+        assert!(reg.parsed_manifest(&name).is_some(), "manifest registered");
         assert_eq!(
             reg.parsed_manifest(&name).unwrap().contract(),
             ContractKind::MemoryStore
@@ -697,8 +693,7 @@ patch = 0
 
         let mut reg = PluginRegistry::new();
         let name = PluginName::new("cairn-store-sqlite").expect("valid");
-        let manifest =
-            PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
+        let manifest = PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
         let err = reg
             .register_llm_provider_with_manifest(
                 name,
@@ -716,8 +711,7 @@ patch = 0
     fn register_with_manifest_rejects_global_duplicate_name() {
         let mut reg = PluginRegistry::new();
         let name = PluginName::new("cairn-store-sqlite").expect("valid");
-        let manifest =
-            PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
+        let manifest = PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
         reg.register_memory_store_with_manifest(
             name.clone(),
             manifest.clone(),

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -161,6 +161,10 @@ pub struct PluginRegistry {
     mcp_servers: HashMap<PluginName, Arc<dyn MCPServer>>,
     frontend_adapters: HashMap<PluginName, Arc<dyn FrontendAdapter>>,
     agent_providers: HashMap<PluginName, Arc<dyn AgentProvider>>,
+    /// Per-name manifest, populated by `register_*_with_manifest`. Global
+    /// across contracts: a single `PluginName` cannot have two manifests
+    /// even if the impl side allows reusing the name across contracts.
+    manifests: HashMap<PluginName, crate::contract::manifest::PluginManifest>,
 }
 
 impl std::fmt::Debug for PluginRegistry {
@@ -191,6 +195,7 @@ impl std::fmt::Debug for PluginRegistry {
                 "agent_providers",
                 &self.agent_providers.keys().collect::<Vec<_>>(),
             )
+            .field("manifests", &self.manifests.keys().collect::<Vec<_>>())
             .finish()
     }
 }
@@ -232,6 +237,41 @@ macro_rules! register_method {
                 });
             }
             self.$field.insert(name, plugin);
+            Ok(())
+        }
+    };
+}
+
+// Manifest-aware sibling. Verifies the manifest matches the contract kind
+// and host version, enforces global manifest-name uniqueness, then delegates
+// to the bare `register_<contract>` method.
+macro_rules! register_method_with_manifest {
+    ($method:ident, $bare:ident, $trait_:path, $contract:literal, $kind:expr, $host_version:expr) => {
+        /// Manifest-aware registration.
+        ///
+        /// # Errors
+        /// - [`PluginError::ContractMismatch`] / [`PluginError::ManifestNameMismatch`] /
+        ///   [`PluginError::UnsupportedContractVersion`] from
+        ///   [`crate::contract::manifest::PluginManifest::verify_compatible_with`].
+        /// - [`PluginError::DuplicateName`] when another plugin already
+        ///   holds this name globally (across all contracts).
+        /// - Plus any error returned by the bare `register_<contract>`
+        ///   method (identity / per-contract duplicate / version).
+        pub fn $method(
+            &mut self,
+            name: PluginName,
+            manifest: crate::contract::manifest::PluginManifest,
+            plugin: Arc<dyn $trait_>,
+        ) -> Result<(), PluginError> {
+            manifest.verify_compatible_with(&name, $kind, $host_version)?;
+            if self.manifests.contains_key(&name) {
+                return Err(PluginError::DuplicateName {
+                    contract: $contract,
+                    name,
+                });
+            }
+            self.$bare(name.clone(), plugin)?;
+            self.manifests.insert(name, manifest);
             Ok(())
         }
     };
@@ -293,6 +333,83 @@ impl PluginRegistry {
         "AgentProvider",
         crate::contract::agent_provider::CONTRACT_VERSION
     );
+
+    register_method_with_manifest!(
+        register_memory_store_with_manifest,
+        register_memory_store,
+        crate::contract::memory_store::MemoryStore,
+        "MemoryStore",
+        crate::contract::manifest::ContractKind::MemoryStore,
+        crate::contract::memory_store::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_llm_provider_with_manifest,
+        register_llm_provider,
+        crate::contract::llm_provider::LLMProvider,
+        "LLMProvider",
+        crate::contract::manifest::ContractKind::LLMProvider,
+        crate::contract::llm_provider::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_workflow_orchestrator_with_manifest,
+        register_workflow_orchestrator,
+        crate::contract::workflow_orchestrator::WorkflowOrchestrator,
+        "WorkflowOrchestrator",
+        crate::contract::manifest::ContractKind::WorkflowOrchestrator,
+        crate::contract::workflow_orchestrator::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_sensor_ingress_with_manifest,
+        register_sensor_ingress,
+        crate::contract::sensor_ingress::SensorIngress,
+        "SensorIngress",
+        crate::contract::manifest::ContractKind::SensorIngress,
+        crate::contract::sensor_ingress::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_mcp_server_with_manifest,
+        register_mcp_server,
+        crate::contract::mcp_server::MCPServer,
+        "MCPServer",
+        crate::contract::manifest::ContractKind::MCPServer,
+        crate::contract::mcp_server::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_frontend_adapter_with_manifest,
+        register_frontend_adapter,
+        crate::contract::frontend_adapter::FrontendAdapter,
+        "FrontendAdapter",
+        crate::contract::manifest::ContractKind::FrontendAdapter,
+        crate::contract::frontend_adapter::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_agent_provider_with_manifest,
+        register_agent_provider,
+        crate::contract::agent_provider::AgentProvider,
+        "AgentProvider",
+        crate::contract::manifest::ContractKind::AgentProvider,
+        crate::contract::agent_provider::CONTRACT_VERSION
+    );
+
+    /// Look up the parsed manifest for a registered plugin by name.
+    #[must_use]
+    pub fn parsed_manifest(
+        &self,
+        name: &PluginName,
+    ) -> Option<&crate::contract::manifest::PluginManifest> {
+        self.manifests.get(name)
+    }
+
+    /// Iterate every parsed manifest in alphabetical order by plugin name.
+    /// Used by `cairn plugins list`/`verify` for stable output.
+    #[must_use]
+    pub fn parsed_manifests_sorted(
+        &self,
+    ) -> Vec<(&PluginName, &crate::contract::manifest::PluginManifest)> {
+        let mut v: Vec<_> = self.manifests.iter().collect();
+        v.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+        v
+    }
 
     /// Look up a registered `MemoryStore` by plugin name.
     #[must_use]
@@ -503,5 +620,124 @@ mod tests {
         let reg = PluginRegistry::new();
         let name = PluginName::new("unknown").expect("valid");
         assert!(reg.memory_store(&name).is_none());
+    }
+
+    use crate::contract::manifest::{ContractKind, PluginManifest};
+
+    fn store_manifest_text() -> &'static str {
+        r#"
+name = "cairn-store-sqlite"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#
+    }
+
+    #[test]
+    fn register_with_manifest_inserts_into_both_maps() {
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("cairn-store-sqlite").expect("valid");
+        let manifest =
+            PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
+        reg.register_memory_store_with_manifest(
+            name.clone(),
+            manifest,
+            Arc::new(StubStore {
+                name: "cairn-store-sqlite",
+                range: compatible(),
+            }),
+        )
+        .expect("manifest-aware registration succeeds");
+
+        assert!(reg.memory_store(&name).is_some(), "store registered");
+        assert!(
+            reg.parsed_manifest(&name).is_some(),
+            "manifest registered"
+        );
+        assert_eq!(
+            reg.parsed_manifest(&name).unwrap().contract(),
+            ContractKind::MemoryStore
+        );
+    }
+
+    #[test]
+    fn register_with_manifest_rejects_kind_mismatch() {
+        // Manifest declares MemoryStore; we try to register through the
+        // LLMProvider sibling — verify_compatible_with must trip.
+        struct StubLlm {
+            name: &'static str,
+            range: VersionRange,
+        }
+        #[async_trait::async_trait]
+        impl crate::contract::llm_provider::LLMProvider for StubLlm {
+            fn name(&self) -> &str {
+                self.name
+            }
+            fn capabilities(&self) -> &crate::contract::llm_provider::LLMProviderCapabilities {
+                static CAPS: crate::contract::llm_provider::LLMProviderCapabilities =
+                    crate::contract::llm_provider::LLMProviderCapabilities {
+                        json_mode: false,
+                        streaming: false,
+                        tool_calls: false,
+                    };
+                &CAPS
+            }
+            fn supported_contract_versions(&self) -> VersionRange {
+                self.range
+            }
+        }
+
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("cairn-store-sqlite").expect("valid");
+        let manifest =
+            PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
+        let err = reg
+            .register_llm_provider_with_manifest(
+                name,
+                manifest,
+                Arc::new(StubLlm {
+                    name: "cairn-store-sqlite",
+                    range: compatible(),
+                }),
+            )
+            .expect_err("kind mismatch must fail closed");
+        assert!(matches!(err, PluginError::ContractMismatch { .. }));
+    }
+
+    #[test]
+    fn register_with_manifest_rejects_global_duplicate_name() {
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("cairn-store-sqlite").expect("valid");
+        let manifest =
+            PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
+        reg.register_memory_store_with_manifest(
+            name.clone(),
+            manifest.clone(),
+            Arc::new(StubStore {
+                name: "cairn-store-sqlite",
+                range: compatible(),
+            }),
+        )
+        .expect("first registration succeeds");
+
+        let err = reg
+            .register_memory_store_with_manifest(
+                name,
+                manifest,
+                Arc::new(StubStore {
+                    name: "cairn-store-sqlite",
+                    range: compatible(),
+                }),
+            )
+            .expect_err("global duplicate must fail");
+        assert!(matches!(err, PluginError::DuplicateName { .. }));
     }
 }

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -411,56 +411,70 @@ impl PluginRegistry {
         v
     }
 
-    /// Return every typed plugin registration whose `PluginName` does NOT
-    /// have a corresponding entry in the manifest map. Each tuple is
-    /// `(plugin_name, contract_label)` where `contract_label` matches the
-    /// `$contract` literal used in the per-contract `register_*` methods
-    /// (e.g. `"MemoryStore"`). Result is alphabetical by name.
+    /// Return every typed plugin registration NOT covered by a manifest of
+    /// the matching contract kind. Each tuple is `(plugin_name,
+    /// contract_label)` where `contract_label` matches the `$contract`
+    /// literal used in the per-contract `register_*` methods
+    /// (e.g. `"MemoryStore"`). Result is sorted by `(name, contract)`.
     ///
     /// This exists so `cairn plugins verify` can enforce "every typed
-    /// registration must carry a manifest" as a tier-1 gate. The 3-arg
-    /// `register_plugin!` macro path (manifest-less) is still public for
-    /// unit tests; without this helper it could pass `verify` silently by
-    /// not appearing in `parsed_manifests_sorted()`.
+    /// registration must carry a matching manifest" as a tier-1 gate.
+    /// The 3-arg `register_plugin!` macro path (manifest-less) is still
+    /// public for unit tests; the bare `register_*` per-contract methods
+    /// are also public. Without this helper, both would pass `verify` by
+    /// being invisible to `parsed_manifests_sorted()`.
+    ///
+    /// The check is contract-aware: a plugin registered for `MemoryStore`
+    /// with a manifest AND for `MCPServer` bare under the same name will
+    /// surface the bare `MCPServer` registration here, because the
+    /// manifest's `contract()` is `MemoryStore`, not `MCPServer`.
     #[must_use]
     pub fn typed_plugins_without_manifests(&self) -> Vec<(&PluginName, &'static str)> {
+        use crate::contract::manifest::ContractKind;
+
+        let covers = |name: &PluginName, expected: ContractKind| {
+            self.manifests
+                .get(name)
+                .is_some_and(|m| m.contract() == expected)
+        };
+
         let mut out: Vec<(&PluginName, &'static str)> = Vec::new();
         for n in self.memory_stores.keys() {
-            if !self.manifests.contains_key(n) {
+            if !covers(n, ContractKind::MemoryStore) {
                 out.push((n, "MemoryStore"));
             }
         }
         for n in self.llm_providers.keys() {
-            if !self.manifests.contains_key(n) {
+            if !covers(n, ContractKind::LLMProvider) {
                 out.push((n, "LLMProvider"));
             }
         }
         for n in self.workflow_orchestrators.keys() {
-            if !self.manifests.contains_key(n) {
+            if !covers(n, ContractKind::WorkflowOrchestrator) {
                 out.push((n, "WorkflowOrchestrator"));
             }
         }
         for n in self.sensor_ingress.keys() {
-            if !self.manifests.contains_key(n) {
+            if !covers(n, ContractKind::SensorIngress) {
                 out.push((n, "SensorIngress"));
             }
         }
         for n in self.mcp_servers.keys() {
-            if !self.manifests.contains_key(n) {
+            if !covers(n, ContractKind::MCPServer) {
                 out.push((n, "MCPServer"));
             }
         }
         for n in self.frontend_adapters.keys() {
-            if !self.manifests.contains_key(n) {
+            if !covers(n, ContractKind::FrontendAdapter) {
                 out.push((n, "FrontendAdapter"));
             }
         }
         for n in self.agent_providers.keys() {
-            if !self.manifests.contains_key(n) {
+            if !covers(n, ContractKind::AgentProvider) {
                 out.push((n, "AgentProvider"));
             }
         }
-        out.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+        out.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()).then_with(|| a.1.cmp(b.1)));
         out
     }
 

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -740,4 +740,77 @@ patch = 0
             .expect_err("global duplicate must fail");
         assert!(matches!(err, PluginError::DuplicateName { .. }));
     }
+
+    #[test]
+    fn register_with_manifest_rejects_cross_contract_duplicate_name() {
+        // Same `PluginName` registered first as MemoryStore, then again as
+        // LLMProvider. The per-contract dup check cannot fire (different
+        // contract maps), so this exercises the global manifest dup-key
+        // check exclusively.
+        struct StubLlm {
+            name: &'static str,
+            range: VersionRange,
+        }
+        #[async_trait::async_trait]
+        impl crate::contract::llm_provider::LLMProvider for StubLlm {
+            fn name(&self) -> &str {
+                self.name
+            }
+            fn capabilities(&self) -> &crate::contract::llm_provider::LLMProviderCapabilities {
+                static CAPS: crate::contract::llm_provider::LLMProviderCapabilities =
+                    crate::contract::llm_provider::LLMProviderCapabilities {
+                        json_mode: false,
+                        streaming: false,
+                        tool_calls: false,
+                    };
+                &CAPS
+            }
+            fn supported_contract_versions(&self) -> VersionRange {
+                self.range
+            }
+        }
+
+        let llm_manifest_text = r#"
+name = "cairn-store-sqlite"
+contract = "LLMProvider"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#;
+
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("cairn-store-sqlite").expect("valid");
+        let store_manifest =
+            PluginManifest::parse_toml(store_manifest_text()).expect("store manifest parses");
+        reg.register_memory_store_with_manifest(
+            name.clone(),
+            store_manifest,
+            Arc::new(StubStore {
+                name: "cairn-store-sqlite",
+                range: compatible(),
+            }),
+        )
+        .expect("memory store registers");
+
+        let llm_manifest =
+            PluginManifest::parse_toml(llm_manifest_text).expect("llm manifest parses");
+        let err = reg
+            .register_llm_provider_with_manifest(
+                name,
+                llm_manifest,
+                Arc::new(StubLlm {
+                    name: "cairn-store-sqlite",
+                    range: compatible(),
+                }),
+            )
+            .expect_err("cross-contract duplicate must fail");
+        assert!(matches!(err, PluginError::DuplicateName { .. }));
+    }
 }

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -411,6 +411,59 @@ impl PluginRegistry {
         v
     }
 
+    /// Return every typed plugin registration whose `PluginName` does NOT
+    /// have a corresponding entry in the manifest map. Each tuple is
+    /// `(plugin_name, contract_label)` where `contract_label` matches the
+    /// `$contract` literal used in the per-contract `register_*` methods
+    /// (e.g. `"MemoryStore"`). Result is alphabetical by name.
+    ///
+    /// This exists so `cairn plugins verify` can enforce "every typed
+    /// registration must carry a manifest" as a tier-1 gate. The 3-arg
+    /// `register_plugin!` macro path (manifest-less) is still public for
+    /// unit tests; without this helper it could pass `verify` silently by
+    /// not appearing in `parsed_manifests_sorted()`.
+    #[must_use]
+    pub fn typed_plugins_without_manifests(&self) -> Vec<(&PluginName, &'static str)> {
+        let mut out: Vec<(&PluginName, &'static str)> = Vec::new();
+        for n in self.memory_stores.keys() {
+            if !self.manifests.contains_key(n) {
+                out.push((n, "MemoryStore"));
+            }
+        }
+        for n in self.llm_providers.keys() {
+            if !self.manifests.contains_key(n) {
+                out.push((n, "LLMProvider"));
+            }
+        }
+        for n in self.workflow_orchestrators.keys() {
+            if !self.manifests.contains_key(n) {
+                out.push((n, "WorkflowOrchestrator"));
+            }
+        }
+        for n in self.sensor_ingress.keys() {
+            if !self.manifests.contains_key(n) {
+                out.push((n, "SensorIngress"));
+            }
+        }
+        for n in self.mcp_servers.keys() {
+            if !self.manifests.contains_key(n) {
+                out.push((n, "MCPServer"));
+            }
+        }
+        for n in self.frontend_adapters.keys() {
+            if !self.manifests.contains_key(n) {
+                out.push((n, "FrontendAdapter"));
+            }
+        }
+        for n in self.agent_providers.keys() {
+            if !self.manifests.contains_key(n) {
+                out.push((n, "AgentProvider"));
+            }
+        }
+        out.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+        out
+    }
+
     /// Look up a registered `MemoryStore` by plugin name.
     #[must_use]
     pub fn memory_store(&self, name: &PluginName) -> Option<Arc<dyn MemoryStore>> {

--- a/crates/cairn-core/src/contract/version.rs
+++ b/crates/cairn-core/src/contract/version.rs
@@ -54,15 +54,19 @@ impl VersionRange {
 
     /// `true` iff `host` is in `[min, max_exclusive)`.
     #[must_use]
-    pub fn accepts(&self, host: ContractVersion) -> bool {
-        let key = (host.major, host.minor, host.patch);
-        let lo = (self.min.major, self.min.minor, self.min.patch);
-        let hi = (
-            self.max_exclusive.major,
-            self.max_exclusive.minor,
-            self.max_exclusive.patch,
-        );
-        key >= lo && key < hi
+    pub const fn accepts(&self, host: ContractVersion) -> bool {
+        // Hand-unfolded lexicographic compare: tuple `PartialOrd` is not yet
+        // stable in const context, so we cannot use `(a, b, c) >= (..)` here.
+        let ge_min = host.major > self.min.major
+            || (host.major == self.min.major
+                && (host.minor > self.min.minor
+                    || (host.minor == self.min.minor && host.patch >= self.min.patch)));
+        let lt_max = host.major < self.max_exclusive.major
+            || (host.major == self.max_exclusive.major
+                && (host.minor < self.max_exclusive.minor
+                    || (host.minor == self.max_exclusive.minor
+                        && host.patch < self.max_exclusive.patch)));
+        ge_min && lt_max
     }
 }
 

--- a/crates/cairn-core/tests/conformance_tier1.rs
+++ b/crates/cairn-core/tests/conformance_tier1.rs
@@ -1,0 +1,75 @@
+//! Tier-1 conformance: ensure the three core cases pass against a
+//! well-formed stub plugin registered with a matching manifest.
+
+use std::sync::Arc;
+
+use cairn_core::contract::conformance::{CaseStatus, Tier, run_conformance_for_plugin};
+use cairn_core::contract::manifest::PluginManifest;
+use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
+use cairn_core::contract::registry::{PluginName, PluginRegistry};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+
+const STORE_MANIFEST: &str = r#"
+name = "stub-store"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#;
+
+#[derive(Default)]
+struct StubStore;
+
+#[async_trait::async_trait]
+impl MemoryStore for StubStore {
+    fn name(&self) -> &'static str {
+        "stub-store"
+    }
+    fn capabilities(&self) -> &MemoryStoreCapabilities {
+        // `Default::default()` is not const, so use an explicit literal.
+        static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+            fts: false,
+            vector: false,
+            graph_edges: false,
+            transactions: false,
+        };
+        &CAPS
+    }
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+}
+
+#[test]
+fn tier1_cases_pass_for_well_formed_memory_store() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-store").expect("valid");
+    let manifest = PluginManifest::parse_toml(STORE_MANIFEST).expect("manifest parses");
+    reg.register_memory_store_with_manifest(name.clone(), manifest, Arc::new(StubStore))
+        .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+
+    let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
+    assert_eq!(tier1.len(), 3, "expect 3 tier-1 cases");
+    for outcome in &tier1 {
+        assert!(
+            matches!(outcome.status, CaseStatus::Ok),
+            "tier-1 case {} must pass, got {:?}",
+            outcome.id,
+            outcome.status
+        );
+    }
+
+    let ids: Vec<_> = tier1.iter().map(|o| o.id).collect();
+    assert!(ids.contains(&"manifest_matches_host"));
+    assert!(ids.contains(&"register_round_trip"));
+    assert!(ids.contains(&"capability_self_consistency_floor"));
+}

--- a/crates/cairn-core/tests/conformance_tier1.rs
+++ b/crates/cairn-core/tests/conformance_tier1.rs
@@ -1,5 +1,8 @@
-//! Tier-1 conformance: ensure the three core cases pass against a
-//! well-formed stub plugin registered with a matching manifest.
+//! Tier-1 conformance: ensure the four core cases pass against a
+//! well-formed stub plugin registered with a matching manifest. The
+//! cases are: `manifest_matches_host`, `arc_pointer_stable`,
+//! `capability_self_consistency_floor`,
+//! `manifest_features_match_capabilities`.
 
 use std::sync::Arc;
 
@@ -27,6 +30,12 @@ patch = 0
 major = 0
 minor = 2
 patch = 0
+
+[features]
+fts = false
+vector = false
+graph_edges = false
+transactions = false
 "#;
 
 #[derive(Default)]
@@ -63,7 +72,7 @@ fn tier1_cases_pass_for_well_formed_memory_store() {
     let outcomes = run_conformance_for_plugin(&reg, &name);
 
     let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
-    assert_eq!(tier1.len(), 3, "expect 3 tier-1 cases");
+    assert_eq!(tier1.len(), 4, "expect 4 tier-1 cases");
     for outcome in &tier1 {
         assert!(
             matches!(outcome.status, CaseStatus::Ok),
@@ -77,6 +86,7 @@ fn tier1_cases_pass_for_well_formed_memory_store() {
     assert!(ids.contains(&"manifest_matches_host"));
     assert!(ids.contains(&"arc_pointer_stable"));
     assert!(ids.contains(&"capability_self_consistency_floor"));
+    assert!(ids.contains(&"manifest_features_match_capabilities"));
 }
 
 const MCP_MANIFEST: &str = r#"
@@ -92,6 +102,12 @@ patch = 0
 major = 0
 minor = 2
 patch = 0
+
+[features]
+stdio = true
+sse = false
+http_streamable = false
+extensions = false
 "#;
 
 #[derive(Default)]
@@ -127,7 +143,7 @@ fn tier1_cases_pass_for_well_formed_mcp_server() {
     let outcomes = run_conformance_for_plugin(&reg, &name);
 
     let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
-    assert_eq!(tier1.len(), 3, "expect 3 tier-1 cases");
+    assert_eq!(tier1.len(), 4, "expect 4 tier-1 cases");
     for outcome in &tier1 {
         assert!(
             matches!(outcome.status, CaseStatus::Ok),
@@ -141,6 +157,7 @@ fn tier1_cases_pass_for_well_formed_mcp_server() {
     assert!(ids.contains(&"manifest_matches_host"));
     assert!(ids.contains(&"arc_pointer_stable"));
     assert!(ids.contains(&"capability_self_consistency_floor"));
+    assert!(ids.contains(&"manifest_features_match_capabilities"));
 }
 
 const SENSOR_MANIFEST: &str = r#"
@@ -156,6 +173,11 @@ patch = 0
 major = 0
 minor = 2
 patch = 0
+
+[features]
+batches = true
+streaming = false
+consent_aware = true
 "#;
 
 #[derive(Default)]
@@ -190,7 +212,7 @@ fn tier1_cases_pass_for_well_formed_sensor_ingress() {
     let outcomes = run_conformance_for_plugin(&reg, &name);
 
     let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
-    assert_eq!(tier1.len(), 3, "expect 3 tier-1 cases");
+    assert_eq!(tier1.len(), 4, "expect 4 tier-1 cases");
     for outcome in &tier1 {
         assert!(
             matches!(outcome.status, CaseStatus::Ok),
@@ -204,6 +226,7 @@ fn tier1_cases_pass_for_well_formed_sensor_ingress() {
     assert!(ids.contains(&"manifest_matches_host"));
     assert!(ids.contains(&"arc_pointer_stable"));
     assert!(ids.contains(&"capability_self_consistency_floor"));
+    assert!(ids.contains(&"manifest_features_match_capabilities"));
 }
 
 const WORKFLOW_MANIFEST: &str = r#"
@@ -219,6 +242,11 @@ patch = 0
 major = 0
 minor = 2
 patch = 0
+
+[features]
+durable = true
+crash_safe = true
+cron_schedules = false
 "#;
 
 #[derive(Default)]
@@ -257,7 +285,7 @@ fn tier1_cases_pass_for_well_formed_workflow_orchestrator() {
     let outcomes = run_conformance_for_plugin(&reg, &name);
 
     let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
-    assert_eq!(tier1.len(), 3, "expect 3 tier-1 cases");
+    assert_eq!(tier1.len(), 4, "expect 4 tier-1 cases");
     for outcome in &tier1 {
         assert!(
             matches!(outcome.status, CaseStatus::Ok),
@@ -271,4 +299,5 @@ fn tier1_cases_pass_for_well_formed_workflow_orchestrator() {
     assert!(ids.contains(&"manifest_matches_host"));
     assert!(ids.contains(&"arc_pointer_stable"));
     assert!(ids.contains(&"capability_self_consistency_floor"));
+    assert!(ids.contains(&"manifest_features_match_capabilities"));
 }

--- a/crates/cairn-core/tests/conformance_tier1.rs
+++ b/crates/cairn-core/tests/conformance_tier1.rs
@@ -5,9 +5,14 @@ use std::sync::Arc;
 
 use cairn_core::contract::conformance::{CaseStatus, Tier, run_conformance_for_plugin};
 use cairn_core::contract::manifest::PluginManifest;
+use cairn_core::contract::mcp_server::{MCPServer, MCPServerCapabilities};
 use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
 use cairn_core::contract::registry::{PluginName, PluginRegistry};
+use cairn_core::contract::sensor_ingress::{SensorIngress, SensorIngressCapabilities};
 use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::contract::workflow_orchestrator::{
+    WorkflowOrchestrator, WorkflowOrchestratorCapabilities,
+};
 
 const STORE_MANIFEST: &str = r#"
 name = "stub-store"
@@ -70,6 +75,200 @@ fn tier1_cases_pass_for_well_formed_memory_store() {
 
     let ids: Vec<_> = tier1.iter().map(|o| o.id).collect();
     assert!(ids.contains(&"manifest_matches_host"));
-    assert!(ids.contains(&"register_round_trip"));
+    assert!(ids.contains(&"arc_pointer_stable"));
+    assert!(ids.contains(&"capability_self_consistency_floor"));
+}
+
+const MCP_MANIFEST: &str = r#"
+name = "stub-mcp"
+contract = "MCPServer"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#;
+
+#[derive(Default)]
+struct StubMcpServer;
+
+#[async_trait::async_trait]
+impl MCPServer for StubMcpServer {
+    fn name(&self) -> &'static str {
+        "stub-mcp"
+    }
+    fn capabilities(&self) -> &MCPServerCapabilities {
+        static CAPS: MCPServerCapabilities = MCPServerCapabilities {
+            stdio: true,
+            sse: false,
+            http_streamable: false,
+            extensions: false,
+        };
+        &CAPS
+    }
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+}
+
+#[test]
+fn tier1_cases_pass_for_well_formed_mcp_server() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-mcp").expect("valid");
+    let manifest = PluginManifest::parse_toml(MCP_MANIFEST).expect("manifest parses");
+    reg.register_mcp_server_with_manifest(name.clone(), manifest, Arc::new(StubMcpServer))
+        .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+
+    let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
+    assert_eq!(tier1.len(), 3, "expect 3 tier-1 cases");
+    for outcome in &tier1 {
+        assert!(
+            matches!(outcome.status, CaseStatus::Ok),
+            "tier-1 case {} must pass, got {:?}",
+            outcome.id,
+            outcome.status
+        );
+    }
+
+    let ids: Vec<_> = tier1.iter().map(|o| o.id).collect();
+    assert!(ids.contains(&"manifest_matches_host"));
+    assert!(ids.contains(&"arc_pointer_stable"));
+    assert!(ids.contains(&"capability_self_consistency_floor"));
+}
+
+const SENSOR_MANIFEST: &str = r#"
+name = "stub-sensor"
+contract = "SensorIngress"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#;
+
+#[derive(Default)]
+struct StubSensor;
+
+#[async_trait::async_trait]
+impl SensorIngress for StubSensor {
+    fn name(&self) -> &'static str {
+        "stub-sensor"
+    }
+    fn capabilities(&self) -> &SensorIngressCapabilities {
+        static CAPS: SensorIngressCapabilities = SensorIngressCapabilities {
+            batches: true,
+            streaming: false,
+            consent_aware: true,
+        };
+        &CAPS
+    }
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+}
+
+#[test]
+fn tier1_cases_pass_for_well_formed_sensor_ingress() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-sensor").expect("valid");
+    let manifest = PluginManifest::parse_toml(SENSOR_MANIFEST).expect("manifest parses");
+    reg.register_sensor_ingress_with_manifest(name.clone(), manifest, Arc::new(StubSensor))
+        .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+
+    let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
+    assert_eq!(tier1.len(), 3, "expect 3 tier-1 cases");
+    for outcome in &tier1 {
+        assert!(
+            matches!(outcome.status, CaseStatus::Ok),
+            "tier-1 case {} must pass, got {:?}",
+            outcome.id,
+            outcome.status
+        );
+    }
+
+    let ids: Vec<_> = tier1.iter().map(|o| o.id).collect();
+    assert!(ids.contains(&"manifest_matches_host"));
+    assert!(ids.contains(&"arc_pointer_stable"));
+    assert!(ids.contains(&"capability_self_consistency_floor"));
+}
+
+const WORKFLOW_MANIFEST: &str = r#"
+name = "stub-workflow"
+contract = "WorkflowOrchestrator"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#;
+
+#[derive(Default)]
+struct StubWorkflow;
+
+#[async_trait::async_trait]
+impl WorkflowOrchestrator for StubWorkflow {
+    fn name(&self) -> &'static str {
+        "stub-workflow"
+    }
+    fn capabilities(&self) -> &WorkflowOrchestratorCapabilities {
+        static CAPS: WorkflowOrchestratorCapabilities = WorkflowOrchestratorCapabilities {
+            durable: true,
+            crash_safe: true,
+            cron_schedules: false,
+        };
+        &CAPS
+    }
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+}
+
+#[test]
+fn tier1_cases_pass_for_well_formed_workflow_orchestrator() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-workflow").expect("valid");
+    let manifest = PluginManifest::parse_toml(WORKFLOW_MANIFEST).expect("manifest parses");
+    reg.register_workflow_orchestrator_with_manifest(
+        name.clone(),
+        manifest,
+        Arc::new(StubWorkflow),
+    )
+    .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+
+    let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
+    assert_eq!(tier1.len(), 3, "expect 3 tier-1 cases");
+    for outcome in &tier1 {
+        assert!(
+            matches!(outcome.status, CaseStatus::Ok),
+            "tier-1 case {} must pass, got {:?}",
+            outcome.id,
+            outcome.status
+        );
+    }
+
+    let ids: Vec<_> = tier1.iter().map(|o| o.id).collect();
+    assert!(ids.contains(&"manifest_matches_host"));
+    assert!(ids.contains(&"arc_pointer_stable"));
     assert!(ids.contains(&"capability_self_consistency_floor"));
 }

--- a/crates/cairn-core/tests/conformance_types.rs
+++ b/crates/cairn-core/tests/conformance_types.rs
@@ -12,8 +12,13 @@ fn case_outcome_constructs_pending() {
         },
     };
     assert_eq!(outcome.id, "put_get_roundtrip");
-    matches!(outcome.tier, Tier::Two);
-    matches!(outcome.status, CaseStatus::Pending { .. });
+    assert_eq!(outcome.tier, Tier::Two);
+    assert!(matches!(
+        outcome.status,
+        CaseStatus::Pending {
+            reason: "real impl pending"
+        }
+    ));
 }
 
 #[test]
@@ -23,8 +28,9 @@ fn case_outcome_constructs_ok() {
         tier: Tier::One,
         status: CaseStatus::Ok,
     };
-    matches!(outcome.tier, Tier::One);
-    matches!(outcome.status, CaseStatus::Ok);
+    assert_eq!(outcome.id, "register_round_trip");
+    assert_eq!(outcome.tier, Tier::One);
+    assert!(matches!(outcome.status, CaseStatus::Ok));
 }
 
 #[test]
@@ -36,5 +42,9 @@ fn case_outcome_constructs_failed() {
             message: "version mismatch".to_string(),
         },
     };
-    matches!(outcome.status, CaseStatus::Failed { .. });
+    assert_eq!(outcome.id, "manifest_matches_host");
+    assert_eq!(outcome.tier, Tier::One);
+    assert!(
+        matches!(&outcome.status, CaseStatus::Failed { message } if message == "version mismatch")
+    );
 }

--- a/crates/cairn-core/tests/conformance_types.rs
+++ b/crates/cairn-core/tests/conformance_types.rs
@@ -24,11 +24,11 @@ fn case_outcome_constructs_pending() {
 #[test]
 fn case_outcome_constructs_ok() {
     let outcome = CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status: CaseStatus::Ok,
     };
-    assert_eq!(outcome.id, "register_round_trip");
+    assert_eq!(outcome.id, "arc_pointer_stable");
     assert_eq!(outcome.tier, Tier::One);
     assert!(matches!(outcome.status, CaseStatus::Ok));
 }

--- a/crates/cairn-core/tests/conformance_types.rs
+++ b/crates/cairn-core/tests/conformance_types.rs
@@ -1,0 +1,40 @@
+//! Smoke test for conformance types — they exist and are constructible.
+
+use cairn_core::contract::conformance::{CaseOutcome, CaseStatus, Tier};
+
+#[test]
+fn case_outcome_constructs_pending() {
+    let outcome = CaseOutcome {
+        id: "put_get_roundtrip",
+        tier: Tier::Two,
+        status: CaseStatus::Pending {
+            reason: "real impl pending",
+        },
+    };
+    assert_eq!(outcome.id, "put_get_roundtrip");
+    matches!(outcome.tier, Tier::Two);
+    matches!(outcome.status, CaseStatus::Pending { .. });
+}
+
+#[test]
+fn case_outcome_constructs_ok() {
+    let outcome = CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    };
+    matches!(outcome.tier, Tier::One);
+    matches!(outcome.status, CaseStatus::Ok);
+}
+
+#[test]
+fn case_outcome_constructs_failed() {
+    let outcome = CaseOutcome {
+        id: "manifest_matches_host",
+        tier: Tier::One,
+        status: CaseStatus::Failed {
+            message: "version mismatch".to_string(),
+        },
+    };
+    matches!(outcome.status, CaseStatus::Failed { .. });
+}

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -107,3 +107,60 @@ fn keeps_arc_pointer_stable() {
     let b = reg.memory_store(&name).expect("registered");
     assert!(Arc::ptr_eq(&a, &b));
 }
+
+mod manifest_aware_plugin {
+    use super::*;
+
+    pub const MANIFEST_TOML: &str = r#"
+name = "fake-with-manifest"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#;
+
+    #[derive(Default)]
+    pub struct FakeStore;
+
+    #[async_trait::async_trait]
+    impl MemoryStore for FakeStore {
+        fn name(&self) -> &'static str {
+            "fake-with-manifest"
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: false,
+                vector: false,
+                graph_edges: false,
+                transactions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+        }
+    }
+
+    register_plugin!(MemoryStore, FakeStore, "fake-with-manifest", MANIFEST_TOML);
+}
+
+#[test]
+fn manifest_aware_macro_registers_with_manifest() {
+    let mut reg = PluginRegistry::new();
+    manifest_aware_plugin::register(&mut reg).expect("manifest-aware register succeeds");
+
+    let name = PluginName::new("fake-with-manifest").expect("valid");
+    assert!(reg.memory_store(&name).is_some(), "trait registered");
+    assert!(reg.parsed_manifest(&name).is_some(), "manifest registered");
+    assert_eq!(
+        reg.parsed_manifest(&name).unwrap().contract(),
+        cairn_core::contract::manifest::ContractKind::MemoryStore
+    );
+}

--- a/crates/cairn-mcp/Cargo.toml
+++ b/crates/cairn-mcp/Cargo.toml
@@ -12,6 +12,7 @@ description = "MCP adapter surface for the Cairn verb layer."
 
 [dependencies]
 cairn-core = { workspace = true }
+async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/cairn-mcp/plugin.toml
+++ b/crates/cairn-mcp/plugin.toml
@@ -1,0 +1,18 @@
+name = "cairn-mcp"
+contract = "MCPServer"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+stdio = false
+sse = false
+http_streamable = false
+extensions = false

--- a/crates/cairn-mcp/src/lib.rs
+++ b/crates/cairn-mcp/src/lib.rs
@@ -1,9 +1,63 @@
-//! Cairn MCP adapter — exposes the verb layer over MCP transports.
+//! Cairn MCP adapter (P0 scaffold).
 //!
-//! P0 scaffold. Transport wiring lands in follow-up issues.
+//! P0: no transports yet — this crate ships the IDL-generated `generated`
+//! submodule, the plugin manifest, a stub `MCPServer` impl with all
+//! capability flags `false`, and a `register()` entry point. Real stdio +
+//! SSE wiring lands in #64.
 //!
 //! The `generated` submodule is produced by `cairn-codegen` from the IDL.
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod generated;
+
+use cairn_core::contract::mcp_server::{CONTRACT_VERSION, MCPServer, MCPServerCapabilities};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::register_plugin;
+
+/// Stable plugin name. Matches `name = ...` in `plugin.toml`.
+pub const PLUGIN_NAME: &str = "cairn-mcp";
+
+/// Plugin capability manifest TOML (parsed at registration time).
+pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// Accepted host contract version range. Single source of truth for both the
+/// trait impl's `supported_contract_versions()` and the const-eval guard.
+pub const ACCEPTED_RANGE: VersionRange =
+    VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+
+/// P0 stub `MCPServer`. All capability flags are `false`; transport
+/// wiring lands in #64.
+#[derive(Default)]
+pub struct CairnMcpServer;
+
+#[async_trait::async_trait]
+impl MCPServer for CairnMcpServer {
+    fn name(&self) -> &str {
+        PLUGIN_NAME
+    }
+
+    fn capabilities(&self) -> &MCPServerCapabilities {
+        static CAPS: MCPServerCapabilities = MCPServerCapabilities {
+            stdio: false,
+            sse: false,
+            http_streamable: false,
+            extensions: false,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        ACCEPTED_RANGE
+    }
+}
+
+// Compile-time guard: this crate's accepted range must include the host
+// CONTRACT_VERSION. If we ever bump CONTRACT_VERSION without bumping
+// ACCEPTED_RANGE, this assertion fires at build time.
+const _: () = assert!(
+    ACCEPTED_RANGE.accepts(CONTRACT_VERSION),
+    "host CONTRACT_VERSION outside this crate's declared range"
+);
+
+register_plugin!(MCPServer, CairnMcpServer, "cairn-mcp", MANIFEST_TOML);

--- a/crates/cairn-mcp/tests/manifest_validates.rs
+++ b/crates/cairn-mcp/tests/manifest_validates.rs
@@ -1,0 +1,29 @@
+//! Integration: the bundled plugin.toml parses through the manifest
+//! parser and matches the host contract version + name.
+
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use cairn_core::contract::manifest::{ContractKind, PluginManifest};
+use cairn_core::contract::mcp_server::CONTRACT_VERSION;
+use cairn_core::contract::registry::PluginName;
+
+#[test]
+fn manifest_parses_and_matches_host() {
+    let manifest = PluginManifest::parse_toml(cairn_mcp::MANIFEST_TOML).expect("manifest parses");
+    assert_eq!(manifest.name().as_str(), "cairn-mcp");
+    assert_eq!(manifest.contract(), ContractKind::MCPServer);
+    let expected = PluginName::new("cairn-mcp").expect("valid");
+    manifest
+        .verify_compatible_with(&expected, ContractKind::MCPServer, CONTRACT_VERSION)
+        .expect("manifest matches host");
+}
+
+#[test]
+fn register_populates_registry() {
+    let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+    cairn_mcp::register(&mut reg).expect("registers");
+    let name = PluginName::new("cairn-mcp").expect("valid");
+    assert!(reg.mcp_server(&name).is_some());
+    assert!(reg.parsed_manifest(&name).is_some());
+}

--- a/crates/cairn-sensors-local/Cargo.toml
+++ b/crates/cairn-sensors-local/Cargo.toml
@@ -12,6 +12,7 @@ description = "Local sensors (IDE hook, terminal, clipboard, voice, screen) for 
 
 [dependencies]
 cairn-core = { workspace = true }
+async-trait = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
@@ -22,4 +23,4 @@ workspace = true
 
 # Forward-declared scaffold deps. Drop entries as their first call site lands.
 [package.metadata.cargo-machete]
-ignored = ["cairn-core", "tracing"]
+ignored = ["tracing"]

--- a/crates/cairn-sensors-local/plugin.toml
+++ b/crates/cairn-sensors-local/plugin.toml
@@ -1,0 +1,17 @@
+name = "cairn-sensors-local"
+contract = "SensorIngress"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+batches = false
+streaming = false
+consent_aware = false

--- a/crates/cairn-sensors-local/src/lib.rs
+++ b/crates/cairn-sensors-local/src/lib.rs
@@ -1,5 +1,62 @@
-//! Local sensors for Cairn — IDE hook, terminal, clipboard, voice, and screen.
+//! Local sensors for Cairn — IDE hook, terminal, clipboard, voice, screen.
 //!
-//! P0 scaffold. Real capture lands in follow-up issues.
+//! P0 scaffold: stub `SensorIngress` impl with all capability flags
+//! `false`. Real capture lands per-sensor in #84 and follow-ups.
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+use cairn_core::contract::sensor_ingress::{
+    CONTRACT_VERSION, SensorIngress, SensorIngressCapabilities,
+};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::register_plugin;
+
+/// Stable plugin name. Matches `name = ...` in `plugin.toml`.
+pub const PLUGIN_NAME: &str = "cairn-sensors-local";
+
+/// Plugin capability manifest TOML (parsed at registration time).
+pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// Accepted host contract version range. Single source of truth for both the
+/// trait impl's `supported_contract_versions()` and the const-eval guard.
+pub const ACCEPTED_RANGE: VersionRange =
+    VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+
+/// P0 stub `SensorIngress`. All capability flags are `false`.
+#[derive(Default)]
+pub struct LocalSensorIngress;
+
+#[async_trait::async_trait]
+impl SensorIngress for LocalSensorIngress {
+    fn name(&self) -> &str {
+        PLUGIN_NAME
+    }
+
+    fn capabilities(&self) -> &SensorIngressCapabilities {
+        static CAPS: SensorIngressCapabilities = SensorIngressCapabilities {
+            batches: false,
+            streaming: false,
+            consent_aware: false,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        ACCEPTED_RANGE
+    }
+}
+
+// Compile-time guard: this crate's accepted range must include the host
+// CONTRACT_VERSION. If we ever bump CONTRACT_VERSION without bumping
+// ACCEPTED_RANGE, this assertion fires at build time.
+const _: () = assert!(
+    ACCEPTED_RANGE.accepts(CONTRACT_VERSION),
+    "host CONTRACT_VERSION outside this crate's declared range"
+);
+
+register_plugin!(
+    SensorIngress,
+    LocalSensorIngress,
+    "cairn-sensors-local",
+    MANIFEST_TOML
+);

--- a/crates/cairn-sensors-local/tests/manifest_validates.rs
+++ b/crates/cairn-sensors-local/tests/manifest_validates.rs
@@ -1,0 +1,29 @@
+#![allow(missing_docs)]
+//! Integration: the bundled plugin.toml parses through the manifest
+//! parser, matches the host contract version + name, and registration
+//! populates both per-contract and global manifest maps.
+
+use cairn_core::contract::manifest::{ContractKind, PluginManifest};
+use cairn_core::contract::registry::PluginName;
+use cairn_core::contract::sensor_ingress::CONTRACT_VERSION;
+
+#[test]
+fn manifest_parses_and_matches_host() {
+    let manifest =
+        PluginManifest::parse_toml(cairn_sensors_local::MANIFEST_TOML).expect("manifest parses");
+    assert_eq!(manifest.name().as_str(), "cairn-sensors-local");
+    assert_eq!(manifest.contract(), ContractKind::SensorIngress);
+    let expected = PluginName::new("cairn-sensors-local").expect("valid");
+    manifest
+        .verify_compatible_with(&expected, ContractKind::SensorIngress, CONTRACT_VERSION)
+        .expect("manifest matches host");
+}
+
+#[test]
+fn register_populates_registry() {
+    let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+    cairn_sensors_local::register(&mut reg).expect("registers");
+    let name = PluginName::new("cairn-sensors-local").expect("valid");
+    assert!(reg.sensor_ingress_plugin(&name).is_some());
+    assert!(reg.parsed_manifest(&name).is_some());
+}

--- a/crates/cairn-store-sqlite/Cargo.toml
+++ b/crates/cairn-store-sqlite/Cargo.toml
@@ -12,6 +12,7 @@ description = "SQLite + FTS5 + sqlite-vec record store adapter for Cairn."
 
 [dependencies]
 cairn-core = { workspace = true }
+async-trait = { workspace = true }
 thiserror = { workspace = true }
 # NOTE: rusqlite (with `bundled` feature) is intentionally held out of the P0
 # scaffold. Pulling libsqlite3-sys/cc into every workspace build widens the
@@ -26,4 +27,4 @@ workspace = true
 
 # Forward-declared scaffold deps. Drop entries as their first call site lands.
 [package.metadata.cargo-machete]
-ignored = ["cairn-core", "thiserror"]
+ignored = ["thiserror"]

--- a/crates/cairn-store-sqlite/Cargo.toml
+++ b/crates/cairn-store-sqlite/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = { workspace = true }
 # NOTE: rusqlite (with `bundled` feature) is intentionally held out of the P0
 # scaffold. Pulling libsqlite3-sys/cc into every workspace build widens the
 # native-compilation surface before any storage code uses it. The real dep
-# lands with the storage implementation in issue #6.
+# lands with the storage implementation in issue #46.
 
 [dev-dependencies]
 cairn-test-fixtures = { workspace = true }

--- a/crates/cairn-store-sqlite/plugin.toml
+++ b/crates/cairn-store-sqlite/plugin.toml
@@ -1,0 +1,18 @@
+name = "cairn-store-sqlite"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+fts = false
+vector = false
+graph_edges = false
+transactions = false

--- a/crates/cairn-store-sqlite/src/lib.rs
+++ b/crates/cairn-store-sqlite/src/lib.rs
@@ -18,6 +18,12 @@ pub const PLUGIN_NAME: &str = "cairn-store-sqlite";
 /// Plugin capability manifest TOML (parsed at registration time).
 pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
 
+/// Contract-version range this crate accepts. Shared by the trait impl and
+/// the compile-time guard below so the manifest range and the trait surface
+/// derive from one binding.
+pub const ACCEPTED_RANGE: VersionRange =
+    VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+
 /// P0 stub `MemoryStore`. All capability flags are `false`; verb methods
 /// land with the storage implementation in #46.
 #[derive(Default)]
@@ -40,27 +46,17 @@ impl MemoryStore for SqliteMemoryStore {
     }
 
     fn supported_contract_versions(&self) -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+        ACCEPTED_RANGE
     }
 }
 
 // Compile-time guard: this crate's accepted range must include the host
 // CONTRACT_VERSION. If we ever bump CONTRACT_VERSION without bumping the
 // range, the const evaluation here panics at build.
-const _: () = {
-    let lo = (0u16, 1u16, 0u16);
-    let hi = (0u16, 2u16, 0u16);
-    let v = (
-        CONTRACT_VERSION.major,
-        CONTRACT_VERSION.minor,
-        CONTRACT_VERSION.patch,
-    );
-    assert!(
-        (v.0 > lo.0 || (v.0 == lo.0 && (v.1 > lo.1 || (v.1 == lo.1 && v.2 >= lo.2))))
-            && (v.0 < hi.0 || (v.0 == hi.0 && (v.1 < hi.1 || (v.1 == hi.1 && v.2 < hi.2)))),
-        "host CONTRACT_VERSION outside this crate's declared range"
-    );
-};
+const _: () = assert!(
+    ACCEPTED_RANGE.accepts(CONTRACT_VERSION),
+    "host CONTRACT_VERSION outside this crate's declared range"
+);
 
 register_plugin!(
     MemoryStore,

--- a/crates/cairn-store-sqlite/src/lib.rs
+++ b/crates/cairn-store-sqlite/src/lib.rs
@@ -1,6 +1,70 @@
-//! `SQLite` record store for Cairn.
+//! `SQLite` record store for Cairn (P0 scaffold).
 //!
-//! P0 scaffold. Schema, migrations, FTS5 and sqlite-vec integration arrive in
-//! follow-up issues (#6 and later).
+//! Schema, migrations, FTS5 and sqlite-vec integration arrive in
+//! follow-up issues (#46 and later). For now this crate ships only the
+//! plugin manifest, a stub `MemoryStore` impl with all capability flags
+//! `false`, and a `register()` entry point so the host can include it
+//! in `cairn plugins list/verify`.
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+use cairn_core::contract::memory_store::{CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::register_plugin;
+
+/// Stable plugin name. Matches `name = ...` in `plugin.toml`.
+pub const PLUGIN_NAME: &str = "cairn-store-sqlite";
+
+/// Plugin capability manifest TOML (parsed at registration time).
+pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// P0 stub `MemoryStore`. All capability flags are `false`; verb methods
+/// land with the storage implementation in #46.
+#[derive(Default)]
+pub struct SqliteMemoryStore;
+
+#[async_trait::async_trait]
+impl MemoryStore for SqliteMemoryStore {
+    fn name(&self) -> &str {
+        PLUGIN_NAME
+    }
+
+    fn capabilities(&self) -> &MemoryStoreCapabilities {
+        static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+            fts: false,
+            vector: false,
+            graph_edges: false,
+            transactions: false,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+}
+
+// Compile-time guard: this crate's accepted range must include the host
+// CONTRACT_VERSION. If we ever bump CONTRACT_VERSION without bumping the
+// range, the const evaluation here panics at build.
+const _: () = {
+    let lo = (0u16, 1u16, 0u16);
+    let hi = (0u16, 2u16, 0u16);
+    let v = (
+        CONTRACT_VERSION.major,
+        CONTRACT_VERSION.minor,
+        CONTRACT_VERSION.patch,
+    );
+    assert!(
+        (v.0 > lo.0 || (v.0 == lo.0 && (v.1 > lo.1 || (v.1 == lo.1 && v.2 >= lo.2))))
+            && (v.0 < hi.0 || (v.0 == hi.0 && (v.1 < hi.1 || (v.1 == hi.1 && v.2 < hi.2)))),
+        "host CONTRACT_VERSION outside this crate's declared range"
+    );
+};
+
+register_plugin!(
+    MemoryStore,
+    SqliteMemoryStore,
+    "cairn-store-sqlite",
+    MANIFEST_TOML
+);

--- a/crates/cairn-store-sqlite/tests/manifest_validates.rs
+++ b/crates/cairn-store-sqlite/tests/manifest_validates.rs
@@ -1,0 +1,30 @@
+//! Integration: the bundled plugin.toml parses, validates against the
+//! IDL JSON schema, and matches the host contract version + name.
+
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use cairn_core::contract::manifest::{ContractKind, PluginManifest};
+use cairn_core::contract::memory_store::CONTRACT_VERSION;
+use cairn_core::contract::registry::PluginName;
+
+#[test]
+fn manifest_parses_and_matches_host() {
+    let manifest =
+        PluginManifest::parse_toml(cairn_store_sqlite::MANIFEST_TOML).expect("manifest parses");
+    assert_eq!(manifest.name().as_str(), "cairn-store-sqlite");
+    assert_eq!(manifest.contract(), ContractKind::MemoryStore);
+    let expected = PluginName::new("cairn-store-sqlite").expect("valid");
+    manifest
+        .verify_compatible_with(&expected, ContractKind::MemoryStore, CONTRACT_VERSION)
+        .expect("manifest matches host");
+}
+
+#[test]
+fn register_populates_registry() {
+    let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+    cairn_store_sqlite::register(&mut reg).expect("registers");
+    let name = PluginName::new("cairn-store-sqlite").expect("valid");
+    assert!(reg.memory_store(&name).is_some());
+    assert!(reg.parsed_manifest(&name).is_some());
+}

--- a/crates/cairn-store-sqlite/tests/manifest_validates.rs
+++ b/crates/cairn-store-sqlite/tests/manifest_validates.rs
@@ -1,5 +1,5 @@
-//! Integration: the bundled plugin.toml parses, validates against the
-//! IDL JSON schema, and matches the host contract version + name.
+//! Integration: the bundled plugin.toml parses through the manifest
+//! parser and matches the host contract version + name.
 
 // Integration test files are not public API; doc-comments are not required.
 #![allow(missing_docs)]

--- a/crates/cairn-workflows/Cargo.toml
+++ b/crates/cairn-workflows/Cargo.toml
@@ -12,6 +12,7 @@ description = "Background workflows host (consolidate, promote, expire, evaluate
 
 [dependencies]
 cairn-core = { workspace = true }
+async-trait = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing = { workspace = true }
 
@@ -23,4 +24,4 @@ workspace = true
 
 # Forward-declared scaffold deps. Drop entries as their first call site lands.
 [package.metadata.cargo-machete]
-ignored = ["cairn-core", "tokio", "tracing"]
+ignored = ["tokio", "tracing"]

--- a/crates/cairn-workflows/plugin.toml
+++ b/crates/cairn-workflows/plugin.toml
@@ -1,0 +1,17 @@
+name = "cairn-workflows"
+contract = "WorkflowOrchestrator"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+durable = false
+crash_safe = false
+cron_schedules = false

--- a/crates/cairn-workflows/src/lib.rs
+++ b/crates/cairn-workflows/src/lib.rs
@@ -1,6 +1,59 @@
-//! Cairn background workflows host.
+//! Cairn background workflows host (P0 scaffold).
 //!
-//! P0 scaffold. Ships only the in-process runner shape; Temporal integration
-//! is deferred to a later issue.
+//! P0: no runner yet — stub `WorkflowOrchestrator` with all capability
+//! flags `false`. Tokio + SQLite-backed job table lands in #89.
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::contract::workflow_orchestrator::{
+    CONTRACT_VERSION, WorkflowOrchestrator, WorkflowOrchestratorCapabilities,
+};
+use cairn_core::register_plugin;
+
+/// Stable plugin name. Matches `name = ...` in `plugin.toml`.
+pub const PLUGIN_NAME: &str = "cairn-workflows";
+
+/// Plugin capability manifest TOML (parsed at registration time).
+pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// Accepted host contract version range. Single source of truth for both the
+/// trait impl's `supported_contract_versions()` and the const-eval guard.
+pub const ACCEPTED_RANGE: VersionRange =
+    VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+
+/// P0 stub `WorkflowOrchestrator`. All capability flags are `false`.
+#[derive(Default)]
+pub struct InProcessOrchestrator;
+
+#[async_trait::async_trait]
+impl WorkflowOrchestrator for InProcessOrchestrator {
+    fn name(&self) -> &str {
+        PLUGIN_NAME
+    }
+
+    fn capabilities(&self) -> &WorkflowOrchestratorCapabilities {
+        static CAPS: WorkflowOrchestratorCapabilities = WorkflowOrchestratorCapabilities {
+            durable: false,
+            crash_safe: false,
+            cron_schedules: false,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        ACCEPTED_RANGE
+    }
+}
+
+const _: () = assert!(
+    ACCEPTED_RANGE.accepts(CONTRACT_VERSION),
+    "host CONTRACT_VERSION outside this crate's declared range"
+);
+
+register_plugin!(
+    WorkflowOrchestrator,
+    InProcessOrchestrator,
+    "cairn-workflows",
+    MANIFEST_TOML
+);

--- a/crates/cairn-workflows/tests/manifest_validates.rs
+++ b/crates/cairn-workflows/tests/manifest_validates.rs
@@ -1,0 +1,33 @@
+#![allow(missing_docs)]
+//! Integration: the bundled plugin.toml parses through the manifest
+//! parser, matches the host contract version + name, and registration
+//! populates both per-contract and global manifest maps.
+
+use cairn_core::contract::manifest::{ContractKind, PluginManifest};
+use cairn_core::contract::registry::PluginName;
+use cairn_core::contract::workflow_orchestrator::CONTRACT_VERSION;
+
+#[test]
+fn manifest_parses_and_matches_host() {
+    let manifest =
+        PluginManifest::parse_toml(cairn_workflows::MANIFEST_TOML).expect("manifest parses");
+    assert_eq!(manifest.name().as_str(), "cairn-workflows");
+    assert_eq!(manifest.contract(), ContractKind::WorkflowOrchestrator);
+    let expected = PluginName::new("cairn-workflows").expect("valid");
+    manifest
+        .verify_compatible_with(
+            &expected,
+            ContractKind::WorkflowOrchestrator,
+            CONTRACT_VERSION,
+        )
+        .expect("manifest matches host");
+}
+
+#[test]
+fn register_populates_registry() {
+    let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+    cairn_workflows::register(&mut reg).expect("registers");
+    let name = PluginName::new("cairn-workflows").expect("valid");
+    assert!(reg.workflow_orchestrator(&name).is_some());
+    assert!(reg.parsed_manifest(&name).is_some());
+}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -36,6 +36,7 @@ must be updated in the same PR.
 | `build / macos-latest` (`ci.yml`) | ✅ required | Same on macOS. |
 | `invariant / cairn-core dep-freeness` (`ci.yml`) | ✅ required | Enforces brief §4 plugin boundary. Adapter or runtime crates depending into core fail closed. |
 | `codegen / no drift` (`ci.yml`) | ✅ required | Runs `cargo run -p cairn-idl --bin cairn-codegen -- --check`; fails when generated CLI/MCP/SDK/skill artefacts disagree with the IDL. |
+| `plugins / cairn plugins verify` (`ci.yml`) | ✅ required | Runs the bundled-plugin conformance suite (`cairn plugins verify`) and uploads the JSON report as a build artifact. |
 | `docs / cargo doc` (`docs.yml`) | ✅ required | Broken intra-doc links fail. |
 | `deny / licenses + bans + sources` (`supply-chain.yml`) | ✅ required | Runs on every PR — workflow-level path filtering would leave the required check Pending on non-manifest PRs and either deadlock merges or silently miss manifest-only changes. Cache makes this cheap. |
 | `audit / RUSTSEC advisories` (`supply-chain.yml`) | ✅ required | Same reasoning as `deny`. Daily cron catches advisories disclosed after merge. |
@@ -134,6 +135,7 @@ CI is split so the failed job tells you which kind of bug you have:
 | `build` (Ubuntu or macOS) | Compile failure on a target you didn't test. Build matrix exists exactly for this. |
 | `invariant / cairn-core dep-freeness` | Adapter or runtime crate crept into core. Move it to the right crate; see CLAUDE.md §3. |
 | `codegen / no drift` | IDL changed without re-running codegen, or a generated file was hand-edited. Run `cargo run -p cairn-idl --bin cairn-codegen` and commit the diff. |
+| `plugins / cairn plugins verify` | Bundled-plugin conformance regression. Reproduce with `cargo run -p cairn-cli -- plugins verify --strict`. |
 | `docs / cargo doc` | Broken intra-doc link or missing-docs lint. |
 | `deny` | License or banned crate. Update the manifest or `deny.toml` (with a justification in the PR). |
 | `audit` | RUSTSEC advisory on a transitive dep. Update the lockfile or pin a patched version. |
@@ -206,6 +208,7 @@ Configure under **Settings → Rules → Rulesets → Branch ruleset → main**:
    build / macos-latest
    invariant / cairn-core dep-freeness
    codegen / no drift
+   plugins / cairn plugins verify
    docs / cargo doc
    deny / licenses + bans + sources
    audit / RUSTSEC advisories

--- a/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
+++ b/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
@@ -705,11 +705,11 @@ fn case_outcome_constructs_pending() {
 #[test]
 fn case_outcome_constructs_ok() {
     let outcome = CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status: CaseStatus::Ok,
     };
-    assert_eq!(outcome.id, "register_round_trip");
+    assert_eq!(outcome.id, "arc_pointer_stable");
     assert_eq!(outcome.tier, Tier::One);
     assert!(matches!(outcome.status, CaseStatus::Ok));
 }
@@ -1126,7 +1126,7 @@ fn tier1_cases_pass_for_well_formed_memory_store() {
 
     let ids: Vec<_> = tier1.iter().map(|o| o.id).collect();
     assert!(ids.contains(&"manifest_matches_host"));
-    assert!(ids.contains(&"register_round_trip"));
+    assert!(ids.contains(&"arc_pointer_stable"));
     assert!(ids.contains(&"capability_self_consistency_floor"));
 }
 ```
@@ -1168,7 +1168,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
 
     // Tier 1
     out.push(tier1_manifest_matches_host(registry, name, CONTRACT_VERSION));
-    out.push(tier1_register_round_trip(registry, name, &plugin));
+    out.push(tier1_arc_pointer_stable(registry, name, &plugin));
     out.push(tier1_capability_self_consistency_floor(&*plugin));
 
     // Tier 2 (stubs)
@@ -1197,7 +1197,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     out
 }
 
-fn tier1_register_round_trip(
+fn tier1_arc_pointer_stable(
     registry: &PluginRegistry,
     name: &PluginName,
     plugin: &std::sync::Arc<dyn crate::contract::memory_store::MemoryStore>,
@@ -1206,7 +1206,7 @@ fn tier1_register_round_trip(
         Some(p) => p,
         None => {
             return CaseOutcome {
-                id: "register_round_trip",
+                id: "arc_pointer_stable",
                 tier: Tier::One,
                 status: CaseStatus::Failed {
                     message: "lookup returned None for registered plugin".to_string(),
@@ -1222,7 +1222,7 @@ fn tier1_register_round_trip(
         }
     };
     CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status,
     }
@@ -1287,7 +1287,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
 
     let mut out = Vec::with_capacity(4);
     out.push(tier1_manifest_matches_host(registry, name, CONTRACT_VERSION));
-    out.push(tier1_register_round_trip(registry, name, &plugin));
+    out.push(tier1_arc_pointer_stable(registry, name, &plugin));
     out.push(tier1_capability_self_consistency_floor(&*plugin));
     out.push(CaseOutcome {
         id: "initialize_and_list_tools",
@@ -1299,7 +1299,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     out
 }
 
-fn tier1_register_round_trip(
+fn tier1_arc_pointer_stable(
     registry: &PluginRegistry,
     name: &PluginName,
     plugin: &std::sync::Arc<dyn crate::contract::mcp_server::MCPServer>,
@@ -1308,7 +1308,7 @@ fn tier1_register_round_trip(
         Some(p) => p,
         None => {
             return CaseOutcome {
-                id: "register_round_trip",
+                id: "arc_pointer_stable",
                 tier: Tier::One,
                 status: CaseStatus::Failed {
                     message: "lookup returned None for registered plugin".to_string(),
@@ -1324,7 +1324,7 @@ fn tier1_register_round_trip(
         }
     };
     CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status,
     }
@@ -1385,7 +1385,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
 
     let mut out = Vec::with_capacity(4);
     out.push(tier1_manifest_matches_host(registry, name, CONTRACT_VERSION));
-    out.push(tier1_register_round_trip(registry, name, &plugin));
+    out.push(tier1_arc_pointer_stable(registry, name, &plugin));
     out.push(tier1_capability_self_consistency_floor(&*plugin));
     out.push(CaseOutcome {
         id: "emits_envelope_when_poked",
@@ -1397,7 +1397,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     out
 }
 
-fn tier1_register_round_trip(
+fn tier1_arc_pointer_stable(
     registry: &PluginRegistry,
     name: &PluginName,
     plugin: &std::sync::Arc<dyn crate::contract::sensor_ingress::SensorIngress>,
@@ -1406,7 +1406,7 @@ fn tier1_register_round_trip(
         Some(p) => p,
         None => {
             return CaseOutcome {
-                id: "register_round_trip",
+                id: "arc_pointer_stable",
                 tier: Tier::One,
                 status: CaseStatus::Failed {
                     message: "lookup returned None for registered plugin".to_string(),
@@ -1422,7 +1422,7 @@ fn tier1_register_round_trip(
         }
     };
     CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status,
     }
@@ -1483,7 +1483,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
 
     let mut out = Vec::with_capacity(4);
     out.push(tier1_manifest_matches_host(registry, name, CONTRACT_VERSION));
-    out.push(tier1_register_round_trip(registry, name, &plugin));
+    out.push(tier1_arc_pointer_stable(registry, name, &plugin));
     out.push(tier1_capability_self_consistency_floor(&*plugin));
     out.push(CaseOutcome {
         id: "enqueue_then_complete",
@@ -1495,7 +1495,7 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
     out
 }
 
-fn tier1_register_round_trip(
+fn tier1_arc_pointer_stable(
     registry: &PluginRegistry,
     name: &PluginName,
     plugin: &std::sync::Arc<dyn crate::contract::workflow_orchestrator::WorkflowOrchestrator>,
@@ -1504,7 +1504,7 @@ fn tier1_register_round_trip(
         Some(p) => p,
         None => {
             return CaseOutcome {
-                id: "register_round_trip",
+                id: "arc_pointer_stable",
                 tier: Tier::One,
                 status: CaseStatus::Failed {
                     message: "lookup returned None for registered plugin".to_string(),
@@ -1520,7 +1520,7 @@ fn tier1_register_round_trip(
         }
     };
     CaseOutcome {
-        id: "register_round_trip",
+        id: "arc_pointer_stable",
         tier: Tier::One,
         status,
     }
@@ -1580,7 +1580,7 @@ Each of the four bundled-plugin contracts (MemoryStore, MCPServer,
 SensorIngress, WorkflowOrchestrator) gets:
 
   - tier-1 manifest_matches_host    (delegates to verify_compatible_with)
-  - tier-1 register_round_trip      (Arc::ptr_eq across two lookups)
+  - tier-1 arc_pointer_stable      (Arc::ptr_eq across two lookups)
   - tier-1 capability_self_consistency_floor (name non-empty, version
                                               accepts host, all cap
                                               fields readable)

--- a/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
+++ b/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
@@ -2814,7 +2814,8 @@ pub struct VerifyReport {
 pub struct PluginReport {
     /// Plugin name.
     pub name: String,
-    /// Contract kind, formatted as `Debug` (matches `--json`).
+    /// Contract kind, stable string from `ContractKind::as_static_str()`
+    /// (matches `--json`). Same source as `plugins::list` for consistency.
     pub contract: String,
     /// Per-case outcomes (tier-1 first, then tier-2, declaration order).
     pub cases: Vec<cairn_core::contract::conformance::CaseOutcome>,
@@ -2849,7 +2850,7 @@ pub fn run(registry: &PluginRegistry) -> VerifyReport {
         }
         plugins.push(PluginReport {
             name: name.as_str().to_string(),
-            contract: format!("{:?}", manifest.contract()),
+            contract: manifest.contract().as_static_str().to_string(),
             cases,
         });
     }

--- a/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
+++ b/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
@@ -2384,11 +2384,13 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 ```
 
-Replace the machete-ignored block with the empty one (drop all entries — every dep has a real call site after this PR):
+Drop the four bundled-adapter-crate names (`cairn-mcp`, `cairn-sensors-local`, `cairn-store-sqlite`, `cairn-workflows`) from the machete-ignored block — they become real call sites in `plugins/host.rs` this task. Keep `anyhow`, `clap`, `serde`, `serde_json` ignored until Tasks 11–13 wire their call sites:
 
 ```toml
+# Forward-declared scaffold deps. anyhow + clap wired by Task 13's main.rs.
+# serde + serde_json wired by Tasks 11/12's list/verify renderers.
 [package.metadata.cargo-machete]
-ignored = []
+ignored = ["anyhow", "clap", "serde", "serde_json"]
 ```
 
 - [ ] **Step 2: Create the `plugins` module skeleton** — `crates/cairn-cli/src/plugins/mod.rs`:

--- a/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
+++ b/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
@@ -693,8 +693,13 @@ fn case_outcome_constructs_pending() {
         },
     };
     assert_eq!(outcome.id, "put_get_roundtrip");
-    matches!(outcome.tier, Tier::Two);
-    matches!(outcome.status, CaseStatus::Pending { .. });
+    assert_eq!(outcome.tier, Tier::Two);
+    assert!(matches!(
+        outcome.status,
+        CaseStatus::Pending {
+            reason: "real impl pending"
+        }
+    ));
 }
 
 #[test]
@@ -704,8 +709,9 @@ fn case_outcome_constructs_ok() {
         tier: Tier::One,
         status: CaseStatus::Ok,
     };
-    matches!(outcome.tier, Tier::One);
-    matches!(outcome.status, CaseStatus::Ok);
+    assert_eq!(outcome.id, "register_round_trip");
+    assert_eq!(outcome.tier, Tier::One);
+    assert!(matches!(outcome.status, CaseStatus::Ok));
 }
 
 #[test]
@@ -717,7 +723,11 @@ fn case_outcome_constructs_failed() {
             message: "version mismatch".to_string(),
         },
     };
-    matches!(outcome.status, CaseStatus::Failed { .. });
+    assert_eq!(outcome.id, "manifest_matches_host");
+    assert_eq!(outcome.tier, Tier::One);
+    assert!(
+        matches!(&outcome.status, CaseStatus::Failed { message } if message == "version mismatch")
+    );
 }
 ```
 

--- a/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
+++ b/docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md
@@ -1,0 +1,3622 @@
+# Plugin Host + `cairn plugins list/verify` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining acceptance criteria of issue #143 by wiring a live plugin host into `cairn-cli`, adding `cairn plugins list` + `cairn plugins verify`, shipping a two-tier conformance suite in `cairn-core`, and integrating verify into CI.
+
+**Architecture:** Bundled adapter crates (`cairn-store-sqlite`, `cairn-mcp`, `cairn-sensors-local`, `cairn-workflows`) each ship a `plugin.toml` + `register()` function emitted by the `register_plugin!` macro (extended to a manifest-aware four-arg form). `cairn-cli` calls each `register()` in alphabetical order from `plugins::host::register_all()`, populates a `PluginRegistry`, and serves `plugins list`/`plugins verify` against it. Tier-1 cases (manifest match, register round-trip, capability self-consistency) live in `cairn-core::contract::conformance` as pure code; tier-2 stubs return `Pending` until per-impl PRs land.
+
+**Tech Stack:** Rust 2024 edition, `clap` 4.5 (derive), `serde`/`serde_json` (JSON output), `toml` (manifest parsing — already a workspace dep), `insta` (snapshot tests), `cargo nextest` (test runner).
+
+**Spec:** `docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md`
+
+---
+
+## File Structure
+
+**Created:**
+- `crates/cairn-core/src/contract/conformance/mod.rs`
+- `crates/cairn-core/src/contract/conformance/memory_store.rs`
+- `crates/cairn-core/src/contract/conformance/mcp_server.rs`
+- `crates/cairn-core/src/contract/conformance/sensor_ingress.rs`
+- `crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs`
+- `crates/cairn-cli/src/plugins/mod.rs`
+- `crates/cairn-cli/src/plugins/host.rs`
+- `crates/cairn-cli/src/plugins/list.rs`
+- `crates/cairn-cli/src/plugins/verify.rs`
+- `crates/cairn-cli/tests/plugins_list_snapshot.rs`
+- `crates/cairn-cli/tests/plugins_verify_snapshot.rs`
+- `crates/cairn-cli/tests/plugins_verify.rs`
+- `crates/cairn-store-sqlite/plugin.toml`
+- `crates/cairn-store-sqlite/tests/manifest_validates.rs`
+- `crates/cairn-mcp/plugin.toml`
+- `crates/cairn-mcp/tests/manifest_validates.rs`
+- `crates/cairn-sensors-local/plugin.toml`
+- `crates/cairn-sensors-local/tests/manifest_validates.rs`
+- `crates/cairn-workflows/plugin.toml`
+- `crates/cairn-workflows/tests/manifest_validates.rs`
+
+**Modified:**
+- `Cargo.toml` (workspace) — add `clap`, `insta` workspace deps
+- `crates/cairn-core/src/contract/registry.rs` — add `register_*_with_manifest` siblings + global manifest map + `parsed_manifest` accessor
+- `crates/cairn-core/src/contract/macros.rs` — extend each arm with 4-arg manifest-aware variant
+- `crates/cairn-core/src/contract/mod.rs` — re-export `conformance`
+- `crates/cairn-cli/Cargo.toml` — add `clap`, `serde`, `serde_json` deps; drop machete ignores for now-used crates
+- `crates/cairn-cli/src/main.rs` — replace argv matcher with clap dispatch
+- `crates/cairn-store-sqlite/Cargo.toml` — drop `cairn-core` from machete ignored
+- `crates/cairn-store-sqlite/src/lib.rs` — stub `MemoryStore` impl + `register()`
+- `crates/cairn-mcp/Cargo.toml` — add `cairn-core` dep + drop machete ignored once used
+- `crates/cairn-mcp/src/lib.rs` — stub `MCPServer` impl + `register()`
+- `crates/cairn-sensors-local/Cargo.toml` — add `cairn-core` dep
+- `crates/cairn-sensors-local/src/lib.rs` — stub `SensorIngress` impl + `register()`
+- `crates/cairn-workflows/Cargo.toml` — add `cairn-core` dep
+- `crates/cairn-workflows/src/lib.rs` — stub `WorkflowOrchestrator` impl + `register()`
+- `.github/workflows/ci.yml` — add `cairn plugins verify` step + JSON artifact upload
+
+---
+
+## Task 1: Registry — global manifest map + `_with_manifest` siblings
+
+**Files:**
+- Modify: `crates/cairn-core/src/contract/registry.rs`
+- Test: `crates/cairn-core/src/contract/registry.rs` (existing `mod tests`)
+
+- [ ] **Step 1: Write failing test** — `crates/cairn-core/src/contract/registry.rs`
+
+Append to the `#[cfg(test)] mod tests` block (after the existing `lookup_returns_none_for_unknown_name` test):
+
+```rust
+    use crate::contract::manifest::{ContractKind, PluginManifest};
+
+    fn store_manifest_text() -> &'static str {
+        r#"
+name = "cairn-store-sqlite"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#
+    }
+
+    #[test]
+    fn register_with_manifest_inserts_into_both_maps() {
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("cairn-store-sqlite").expect("valid");
+        let manifest =
+            PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
+        reg.register_memory_store_with_manifest(
+            name.clone(),
+            manifest,
+            Arc::new(StubStore {
+                name: "cairn-store-sqlite",
+                range: compatible(),
+            }),
+        )
+        .expect("manifest-aware registration succeeds");
+
+        assert!(reg.memory_store(&name).is_some(), "store registered");
+        assert!(
+            reg.parsed_manifest(&name).is_some(),
+            "manifest registered"
+        );
+        assert_eq!(
+            reg.parsed_manifest(&name).unwrap().contract(),
+            ContractKind::MemoryStore
+        );
+    }
+
+    #[test]
+    fn register_with_manifest_rejects_kind_mismatch() {
+        // Manifest declares MemoryStore; we try to register through the
+        // LLMProvider sibling — verify_compatible_with must trip.
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("cairn-store-sqlite").expect("valid");
+        let manifest =
+            PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
+
+        // We stub an LLMProvider impl in registry tests by reusing StubStore
+        // is impossible (different trait). Use an existing stub from the
+        // contract registry — fall back to building a custom stub for this
+        // test directly below.
+        struct StubLlm {
+            name: &'static str,
+            range: VersionRange,
+        }
+        #[async_trait::async_trait]
+        impl crate::contract::llm_provider::LLMProvider for StubLlm {
+            fn name(&self) -> &str {
+                self.name
+            }
+            fn capabilities(&self) -> &crate::contract::llm_provider::LLMProviderCapabilities {
+                static CAPS: crate::contract::llm_provider::LLMProviderCapabilities =
+                    crate::contract::llm_provider::LLMProviderCapabilities {
+                        streaming: false,
+                        tool_use: false,
+                        vision: false,
+                    };
+                &CAPS
+            }
+            fn supported_contract_versions(&self) -> VersionRange {
+                self.range
+            }
+        }
+        let err = reg
+            .register_llm_provider_with_manifest(
+                name,
+                manifest,
+                Arc::new(StubLlm {
+                    name: "cairn-store-sqlite",
+                    range: compatible(),
+                }),
+            )
+            .expect_err("kind mismatch must fail closed");
+        assert!(matches!(err, PluginError::ContractMismatch { .. }));
+    }
+
+    #[test]
+    fn register_with_manifest_rejects_global_duplicate_name() {
+        let mut reg = PluginRegistry::new();
+        let name = PluginName::new("cairn-store-sqlite").expect("valid");
+        let manifest =
+            PluginManifest::parse_toml(store_manifest_text()).expect("manifest parses");
+        reg.register_memory_store_with_manifest(
+            name.clone(),
+            manifest.clone(),
+            Arc::new(StubStore {
+                name: "cairn-store-sqlite",
+                range: compatible(),
+            }),
+        )
+        .expect("first registration succeeds");
+
+        let err = reg
+            .register_memory_store_with_manifest(
+                name,
+                manifest,
+                Arc::new(StubStore {
+                    name: "cairn-store-sqlite",
+                    range: compatible(),
+                }),
+            )
+            .expect_err("global duplicate must fail");
+        assert!(matches!(err, PluginError::DuplicateName { .. }));
+    }
+```
+
+Note: tests use the existing `StubStore` defined earlier in the same `mod tests` block (lines ~390–413).
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cargo test -p cairn-core --lib contract::registry::tests -- --nocapture`
+Expected: compile error (`register_memory_store_with_manifest` does not exist; `parsed_manifest` does not exist).
+
+- [ ] **Step 3: Add the global manifest map**
+
+In `crates/cairn-core/src/contract/registry.rs`, modify the `PluginRegistry` struct (around line 156):
+
+```rust
+#[derive(Default)]
+pub struct PluginRegistry {
+    memory_stores: HashMap<PluginName, Arc<dyn MemoryStore>>,
+    llm_providers: HashMap<PluginName, Arc<dyn LLMProvider>>,
+    workflow_orchestrators: HashMap<PluginName, Arc<dyn WorkflowOrchestrator>>,
+    sensor_ingress: HashMap<PluginName, Arc<dyn SensorIngress>>,
+    mcp_servers: HashMap<PluginName, Arc<dyn MCPServer>>,
+    frontend_adapters: HashMap<PluginName, Arc<dyn FrontendAdapter>>,
+    agent_providers: HashMap<PluginName, Arc<dyn AgentProvider>>,
+    /// Per-name manifest, populated by `register_*_with_manifest`. Global
+    /// across contracts: a single `PluginName` cannot have two manifests
+    /// even if the impl side allows reusing the name across contracts.
+    manifests: HashMap<PluginName, crate::contract::manifest::PluginManifest>,
+}
+```
+
+Add `manifests` to the manual `Debug` impl too (line ~166):
+
+```rust
+            .field("manifests", &self.manifests.keys().collect::<Vec<_>>())
+```
+
+- [ ] **Step 4: Add a `register_method_with_manifest!` helper macro**
+
+Below the existing `register_method!` macro (around line 200), add:
+
+```rust
+// Manifest-aware sibling. Verifies the manifest matches the contract kind
+// and host version, enforces global manifest-name uniqueness, then delegates
+// to the bare `register_<contract>` method.
+macro_rules! register_method_with_manifest {
+    ($method:ident, $bare:ident, $trait_:path, $contract:literal, $kind:expr, $host_version:expr) => {
+        /// Manifest-aware registration.
+        ///
+        /// # Errors
+        /// - [`PluginError::ContractMismatch`] / [`PluginError::ManifestNameMismatch`] /
+        ///   [`PluginError::UnsupportedContractVersion`] from
+        ///   [`crate::contract::manifest::PluginManifest::verify_compatible_with`].
+        /// - [`PluginError::DuplicateName`] when another plugin already
+        ///   holds this name globally (across all contracts).
+        /// - Plus any error returned by the bare `register_<contract>`
+        ///   method (identity / per-contract duplicate / version).
+        pub fn $method(
+            &mut self,
+            name: PluginName,
+            manifest: crate::contract::manifest::PluginManifest,
+            plugin: Arc<dyn $trait_>,
+        ) -> Result<(), PluginError> {
+            manifest.verify_compatible_with(&name, $kind, $host_version)?;
+            if self.manifests.contains_key(&name) {
+                return Err(PluginError::DuplicateName {
+                    contract: $contract,
+                    name,
+                });
+            }
+            self.$bare(name.clone(), plugin)?;
+            self.manifests.insert(name, manifest);
+            Ok(())
+        }
+    };
+}
+```
+
+- [ ] **Step 5: Wire each `_with_manifest` method**
+
+Inside the existing `impl PluginRegistry` block (after the seven `register_method!` invocations near line 247), add:
+
+```rust
+    register_method_with_manifest!(
+        register_memory_store_with_manifest,
+        register_memory_store,
+        crate::contract::memory_store::MemoryStore,
+        "MemoryStore",
+        crate::contract::manifest::ContractKind::MemoryStore,
+        crate::contract::memory_store::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_llm_provider_with_manifest,
+        register_llm_provider,
+        crate::contract::llm_provider::LLMProvider,
+        "LLMProvider",
+        crate::contract::manifest::ContractKind::LLMProvider,
+        crate::contract::llm_provider::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_workflow_orchestrator_with_manifest,
+        register_workflow_orchestrator,
+        crate::contract::workflow_orchestrator::WorkflowOrchestrator,
+        "WorkflowOrchestrator",
+        crate::contract::manifest::ContractKind::WorkflowOrchestrator,
+        crate::contract::workflow_orchestrator::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_sensor_ingress_with_manifest,
+        register_sensor_ingress,
+        crate::contract::sensor_ingress::SensorIngress,
+        "SensorIngress",
+        crate::contract::manifest::ContractKind::SensorIngress,
+        crate::contract::sensor_ingress::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_mcp_server_with_manifest,
+        register_mcp_server,
+        crate::contract::mcp_server::MCPServer,
+        "MCPServer",
+        crate::contract::manifest::ContractKind::MCPServer,
+        crate::contract::mcp_server::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_frontend_adapter_with_manifest,
+        register_frontend_adapter,
+        crate::contract::frontend_adapter::FrontendAdapter,
+        "FrontendAdapter",
+        crate::contract::manifest::ContractKind::FrontendAdapter,
+        crate::contract::frontend_adapter::CONTRACT_VERSION
+    );
+    register_method_with_manifest!(
+        register_agent_provider_with_manifest,
+        register_agent_provider,
+        crate::contract::agent_provider::AgentProvider,
+        "AgentProvider",
+        crate::contract::manifest::ContractKind::AgentProvider,
+        crate::contract::agent_provider::CONTRACT_VERSION
+    );
+
+    /// Look up the parsed manifest for a registered plugin by name.
+    #[must_use]
+    pub fn parsed_manifest(
+        &self,
+        name: &PluginName,
+    ) -> Option<&crate::contract::manifest::PluginManifest> {
+        self.manifests.get(name)
+    }
+
+    /// Iterate every parsed manifest in alphabetical order by plugin name.
+    /// Used by `cairn plugins list`/`verify` for stable output.
+    pub fn parsed_manifests_sorted(
+        &self,
+    ) -> Vec<(&PluginName, &crate::contract::manifest::PluginManifest)> {
+        let mut v: Vec<_> = self.manifests.iter().collect();
+        v.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+        v
+    }
+```
+
+- [ ] **Step 6: Run test, expect pass**
+
+Run: `cargo test -p cairn-core --lib contract::registry::tests`
+Expected: PASS, including the three new tests + all existing tests.
+
+- [ ] **Step 7: Lint clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cairn-core/src/contract/registry.rs
+git commit -m "feat(core): add register_*_with_manifest siblings + parsed_manifest accessor (#143)
+
+Brief §4.1: hosts gate plugin activation on a parsed PluginManifest.
+The new sibling methods verify the manifest's name+kind+version against
+the host before delegating to the bare register_<contract> method, and
+populate a global manifests map so 'cairn plugins list'/'verify' can
+read the manifest for each registered plugin.
+
+A global manifest map enforces name-uniqueness across contracts, which
+is brief-aligned (one PluginName per crate)."
+```
+
+---
+
+## Task 2: Macro extension — 4-arg manifest-aware variant
+
+**Files:**
+- Modify: `crates/cairn-core/src/contract/macros.rs`
+- Test: `crates/cairn-core/tests/contract_registry.rs` (new test cases)
+
+- [ ] **Step 1: Write failing test** — add to `crates/cairn-core/tests/contract_registry.rs`
+
+Append to the bottom of the file:
+
+```rust
+mod manifest_aware_plugin {
+    use super::*;
+    use cairn_core::contract::manifest::PluginManifest;
+
+    pub const MANIFEST_TOML: &str = r#"
+name = "fake-with-manifest"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#;
+
+    #[derive(Default)]
+    pub struct FakeStore;
+
+    #[async_trait::async_trait]
+    impl MemoryStore for FakeStore {
+        fn name(&self) -> &'static str {
+            "fake-with-manifest"
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: false,
+                vector: false,
+                graph_edges: false,
+                transactions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+        }
+    }
+
+    register_plugin!(MemoryStore, FakeStore, "fake-with-manifest", MANIFEST_TOML);
+
+    // Also build the parsed manifest at module scope so tests can compare.
+    pub fn parsed_manifest() -> PluginManifest {
+        PluginManifest::parse_toml(MANIFEST_TOML).expect("manifest parses")
+    }
+}
+
+#[test]
+fn manifest_aware_macro_registers_with_manifest() {
+    let mut reg = PluginRegistry::new();
+    manifest_aware_plugin::register(&mut reg).expect("manifest-aware register succeeds");
+
+    let name = PluginName::new("fake-with-manifest").expect("valid");
+    assert!(reg.memory_store(&name).is_some(), "trait registered");
+    assert!(reg.parsed_manifest(&name).is_some(), "manifest registered");
+    assert_eq!(
+        reg.parsed_manifest(&name).unwrap().contract(),
+        cairn_core::contract::manifest::ContractKind::MemoryStore
+    );
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cargo test -p cairn-core --test contract_registry`
+Expected: compile error — `register_plugin!` does not accept four arguments.
+
+- [ ] **Step 3: Extend the macro**
+
+In `crates/cairn-core/src/contract/macros.rs`, replace each existing arm with a *pair* of arms (3-arg + 4-arg) and add the manifest-aware helper.
+
+Replace the entire `register_plugin!` macro (lines 70–93) with:
+
+```rust
+#[macro_export]
+macro_rules! register_plugin {
+    // 3-arg form: legacy / unit-test path with no manifest.
+    (MemoryStore, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_memory_store, $impl, $name);
+    };
+    (LLMProvider, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_llm_provider, $impl, $name);
+    };
+    (WorkflowOrchestrator, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_workflow_orchestrator, $impl, $name);
+    };
+    (SensorIngress, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_sensor_ingress, $impl, $name);
+    };
+    (MCPServer, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_mcp_server, $impl, $name);
+    };
+    (FrontendAdapter, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_frontend_adapter, $impl, $name);
+    };
+    (AgentProvider, $impl:ty, $name:literal) => {
+        $crate::__register_plugin_helper!(register_agent_provider, $impl, $name);
+    };
+
+    // 4-arg form: manifest-aware. `$manifest` is an expression producing a
+    // `&'static str` (typically a `pub const MANIFEST_TOML: &str = include_str!(...)`).
+    (MemoryStore, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_memory_store_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (LLMProvider, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_llm_provider_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (WorkflowOrchestrator, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_workflow_orchestrator_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (SensorIngress, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_sensor_ingress_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (MCPServer, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_mcp_server_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (FrontendAdapter, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_frontend_adapter_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+    (AgentProvider, $impl:ty, $name:literal, $manifest:expr) => {
+        $crate::__register_plugin_with_manifest_helper!(
+            register_agent_provider_with_manifest,
+            $impl,
+            $name,
+            $manifest
+        );
+    };
+}
+```
+
+Then add the manifest-aware helper macro at the bottom of the file:
+
+```rust
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_plugin_with_manifest_helper {
+    ($method:ident, $impl:ty, $name:literal, $manifest:expr) => {
+        /// Plugin entry point with manifest-aware registration.
+        ///
+        /// # Errors
+        /// Returns [`cairn_core::contract::registry::PluginError`] when the
+        /// name is invalid, the manifest fails to parse, the manifest
+        /// disagrees with the registered name / contract / host version,
+        /// or another plugin already holds this name.
+        pub fn register(
+            reg: &mut $crate::contract::registry::PluginRegistry,
+        ) -> ::core::result::Result<(), $crate::contract::registry::PluginError> {
+            let name = $crate::contract::registry::PluginName::new($name)?;
+            let manifest =
+                $crate::contract::manifest::PluginManifest::parse_toml($manifest)?;
+            reg.$method(
+                name,
+                manifest,
+                ::std::sync::Arc::new(<$impl as ::core::default::Default>::default()),
+            )
+        }
+    };
+}
+```
+
+- [ ] **Step 4: Update macro doc-comment**
+
+In the doc-comment block at the top of `register_plugin!` (lines 11–69), add an additional `# Examples` section showing the 4-arg form:
+
+```rust
+///
+/// # Manifest-aware form (preferred for bundled plugins)
+///
+/// ```
+/// # use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
+/// # use cairn_core::contract::version::{ContractVersion, VersionRange};
+/// use cairn_core::register_plugin;
+///
+/// const MANIFEST_TOML: &str = r#"
+/// name = "acme-store"
+/// contract = "MemoryStore"
+///
+/// [contract_version_range.min]
+/// major = 0
+/// minor = 1
+/// patch = 0
+///
+/// [contract_version_range.max_exclusive]
+/// major = 0
+/// minor = 2
+/// patch = 0
+/// "#;
+///
+/// #[derive(Default)]
+/// struct MyStore;
+///
+/// #[async_trait::async_trait]
+/// impl MemoryStore for MyStore {
+///     fn name(&self) -> &str { "acme-store" }
+///     fn capabilities(&self) -> &MemoryStoreCapabilities {
+///         static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+///             fts: false,
+///             vector: false,
+///             graph_edges: false,
+///             transactions: false,
+///         };
+///         &CAPS
+///     }
+///     fn supported_contract_versions(&self) -> VersionRange {
+///         VersionRange::new(
+///             ContractVersion::new(0, 1, 0),
+///             ContractVersion::new(0, 2, 0),
+///         )
+///     }
+/// }
+///
+/// register_plugin!(MemoryStore, MyStore, "acme-store", MANIFEST_TOML);
+///
+/// let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+/// register(&mut reg).expect("compatible plugin registers");
+/// assert!(reg.parsed_manifest(
+///     &cairn_core::contract::registry::PluginName::new("acme-store").unwrap()
+/// ).is_some());
+/// ```
+```
+
+- [ ] **Step 5: Convert `PluginManifest::parse_toml` errors to `PluginError`**
+
+Open `crates/cairn-core/src/contract/manifest.rs` and confirm `parse_toml` returns `Result<Self, PluginError>` (it already does — see line 143 of the existing code). The `?` in the macro body relies on this; no change needed.
+
+- [ ] **Step 6: Run test, expect pass**
+
+Run: `cargo test -p cairn-core --test contract_registry` and `cargo test -p cairn-core --doc`
+Expected: PASS for all tests in both targets.
+
+- [ ] **Step 7: Lint clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cairn-core/src/contract/macros.rs crates/cairn-core/tests/contract_registry.rs
+git commit -m "feat(core): register_plugin! 4-arg manifest-aware form (#143)
+
+The new fourth argument is the manifest TOML &'static str (typically
+include_str!(\"../plugin.toml\")). The expansion parses the manifest,
+forwards the parsed PluginManifest into register_<contract>_with_manifest,
+and fails closed on parse / kind / version mismatch before construction.
+
+Existing 3-arg call sites are kept for unit tests that don't need a
+manifest; bundled plugins use the 4-arg form."
+```
+
+---
+
+## Task 3: Conformance — types module
+
+**Files:**
+- Create: `crates/cairn-core/src/contract/conformance/mod.rs`
+- Modify: `crates/cairn-core/src/contract/mod.rs`
+
+- [ ] **Step 1: Write failing test** — temporarily add to `crates/cairn-core/src/contract/conformance/mod.rs` once it exists. For now, write the test stub in `crates/cairn-core/tests/conformance_types.rs` (new file):
+
+```rust
+//! Smoke test for conformance types — they exist and are constructible.
+
+use cairn_core::contract::conformance::{CaseOutcome, CaseStatus, Tier};
+
+#[test]
+fn case_outcome_constructs_pending() {
+    let outcome = CaseOutcome {
+        id: "put_get_roundtrip",
+        tier: Tier::Two,
+        status: CaseStatus::Pending {
+            reason: "real impl pending",
+        },
+    };
+    assert_eq!(outcome.id, "put_get_roundtrip");
+    matches!(outcome.tier, Tier::Two);
+    matches!(outcome.status, CaseStatus::Pending { .. });
+}
+
+#[test]
+fn case_outcome_constructs_ok() {
+    let outcome = CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    };
+    matches!(outcome.tier, Tier::One);
+    matches!(outcome.status, CaseStatus::Ok);
+}
+
+#[test]
+fn case_outcome_constructs_failed() {
+    let outcome = CaseOutcome {
+        id: "manifest_matches_host",
+        tier: Tier::One,
+        status: CaseStatus::Failed {
+            message: "version mismatch".to_string(),
+        },
+    };
+    matches!(outcome.status, CaseStatus::Failed { .. });
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cargo test -p cairn-core --test conformance_types`
+Expected: compile error — module `conformance` does not exist.
+
+- [ ] **Step 3: Create the conformance module**
+
+Create `crates/cairn-core/src/contract/conformance/mod.rs`:
+
+```rust
+//! Two-tier conformance suite for plugins (brief §4.1).
+//!
+//! Tier-1 cases are pure trait-surface checks: they instantiate the plugin
+//! against a fresh registry, verify name / version / manifest agreement,
+//! and assert capability self-consistency. Every plugin must pass tier-1
+//! to be considered conformant.
+//!
+//! Tier-2 cases exercise verb behaviour. They are stubbed `Pending` until
+//! per-impl PRs land — at which point each contract module's tier-2 case
+//! body is replaced with a real check.
+//!
+//! The suite lives in `cairn-core` (rather than `cairn-test-fixtures`)
+//! because `cairn plugins verify` is a production code path. All cases
+//! are pure functions: zero I/O, no adapter deps.
+//!
+//! Entry point: [`run_conformance_for_plugin`].
+//!
+//! See `docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md`
+//! §4 for the full design.
+
+pub mod memory_store;
+pub mod mcp_server;
+pub mod sensor_ingress;
+pub mod workflow_orchestrator;
+
+use crate::contract::manifest::ContractKind;
+use crate::contract::registry::{PluginError, PluginName, PluginRegistry};
+
+/// Outcome of running a single conformance case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaseOutcome {
+    /// Stable case identifier (snake_case, brief-aligned).
+    pub id: &'static str,
+    /// Tier this case belongs to.
+    pub tier: Tier,
+    /// Case result.
+    pub status: CaseStatus,
+}
+
+/// Conformance tier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tier {
+    /// Always run; failure makes the plugin non-conformant.
+    One,
+    /// Verb-behaviour cases; stubbed `Pending` until per-impl PRs land.
+    Two,
+}
+
+impl Tier {
+    /// Numeric encoding used in JSON output (`1` or `2`).
+    #[must_use]
+    pub fn as_u8(self) -> u8 {
+        match self {
+            Tier::One => 1,
+            Tier::Two => 2,
+        }
+    }
+}
+
+/// Result of a single conformance case.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CaseStatus {
+    /// Case ran to completion and the invariant held.
+    Ok,
+    /// Case body is a stub awaiting a real implementation.
+    Pending {
+        /// Static reason string explaining what's pending.
+        reason: &'static str,
+    },
+    /// Case ran and the invariant did not hold.
+    Failed {
+        /// Human-readable failure message.
+        message: String,
+    },
+}
+
+impl CaseStatus {
+    /// `true` iff this status counts as a tier-1 failure when running with
+    /// `--strict` interpreting `Pending` as failure.
+    #[must_use]
+    pub fn is_failure(&self) -> bool {
+        matches!(self, CaseStatus::Failed { .. })
+    }
+
+    /// Stable string discriminator used in JSON output.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CaseStatus::Ok => "ok",
+            CaseStatus::Pending { .. } => "pending",
+            CaseStatus::Failed { .. } => "failed",
+        }
+    }
+}
+
+/// Run the full conformance suite (tier-1 + tier-2) against the plugin
+/// identified by `name` in `registry`.
+///
+/// Returns an empty vec if the plugin is not registered. Otherwise the
+/// returned vec contains tier-1 cases first, then tier-2 cases, in
+/// declaration order.
+///
+/// # Errors
+/// This function does not return `Result`; case-level errors are encoded
+/// in `CaseStatus::Failed`. The only way this function "fails" is by
+/// returning an empty vec when `name` is not in the registry.
+#[must_use]
+pub fn run_conformance_for_plugin(
+    registry: &PluginRegistry,
+    name: &PluginName,
+) -> Vec<CaseOutcome> {
+    let Some(manifest) = registry.parsed_manifest(name) else {
+        return Vec::new();
+    };
+    match manifest.contract() {
+        ContractKind::MemoryStore => memory_store::run(registry, name),
+        ContractKind::WorkflowOrchestrator => workflow_orchestrator::run(registry, name),
+        ContractKind::SensorIngress => sensor_ingress::run(registry, name),
+        ContractKind::MCPServer => mcp_server::run(registry, name),
+        // P0 ships no bundled plugins for these — verify returns empty.
+        ContractKind::LLMProvider
+        | ContractKind::FrontendAdapter
+        | ContractKind::AgentProvider => Vec::new(),
+    }
+}
+
+/// Internal helper: tier-1 `manifest_matches_host` case.
+///
+/// Calls [`crate::contract::manifest::PluginManifest::verify_compatible_with`]
+/// with the plugin's runtime name, the manifest's declared contract kind,
+/// and the host's `CONTRACT_VERSION` for that contract. The host version
+/// is supplied by callers (per-contract `run` functions) so this helper
+/// stays generic over contract kind.
+pub(super) fn tier1_manifest_matches_host(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    host_version: crate::contract::version::ContractVersion,
+) -> CaseOutcome {
+    let Some(manifest) = registry.parsed_manifest(name) else {
+        return CaseOutcome {
+            id: "manifest_matches_host",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!("no manifest registered for plugin {name}"),
+            },
+        };
+    };
+    let result = manifest.verify_compatible_with(name, manifest.contract(), host_version);
+    let status = match result {
+        Ok(()) => CaseStatus::Ok,
+        Err(PluginError::ContractMismatch { expected, actual }) => CaseStatus::Failed {
+            message: format!("manifest contract {actual:?} does not match host {expected:?}"),
+        },
+        Err(PluginError::ManifestNameMismatch { expected, manifest }) => CaseStatus::Failed {
+            message: format!(
+                "manifest name {manifest} does not match registered name {expected}"
+            ),
+        },
+        Err(PluginError::UnsupportedContractVersion {
+            host, plugin_range, ..
+        }) => CaseStatus::Failed {
+            message: format!(
+                "host CONTRACT_VERSION {host} is outside manifest range {plugin_range:?}"
+            ),
+        },
+        Err(other) => CaseStatus::Failed {
+            message: format!("verify_compatible_with failed: {other}"),
+        },
+    };
+    CaseOutcome {
+        id: "manifest_matches_host",
+        tier: Tier::One,
+        status,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_as_u8() {
+        assert_eq!(Tier::One.as_u8(), 1);
+        assert_eq!(Tier::Two.as_u8(), 2);
+    }
+
+    #[test]
+    fn case_status_str() {
+        assert_eq!(CaseStatus::Ok.as_str(), "ok");
+        assert_eq!(
+            CaseStatus::Pending {
+                reason: "x"
+            }
+            .as_str(),
+            "pending"
+        );
+        assert_eq!(
+            CaseStatus::Failed {
+                message: "x".to_string()
+            }
+            .as_str(),
+            "failed"
+        );
+    }
+
+    #[test]
+    fn run_for_unregistered_plugin_is_empty() {
+        let reg = PluginRegistry::new();
+        let name = PluginName::new("does-not-exist").expect("valid");
+        assert!(run_conformance_for_plugin(&reg, &name).is_empty());
+    }
+}
+```
+
+- [ ] **Step 4: Re-export from `contract/mod.rs`**
+
+Edit `crates/cairn-core/src/contract/mod.rs`:
+
+Add to the module list (after `pub mod agent_provider;` block around line 19):
+
+```rust
+pub mod conformance;
+```
+
+And to the flat re-exports section (around line 35, after `pub use manifest::...`):
+
+```rust
+pub use conformance::{CaseOutcome, CaseStatus, Tier, run_conformance_for_plugin};
+```
+
+- [ ] **Step 5: Create empty per-contract module files**
+
+Create four empty files so the `pub mod` lines compile:
+
+`crates/cairn-core/src/contract/conformance/memory_store.rs`:
+```rust
+//! Conformance cases for `MemoryStore` plugins (filled in Task 4).
+```
+
+`crates/cairn-core/src/contract/conformance/mcp_server.rs`:
+```rust
+//! Conformance cases for `MCPServer` plugins (filled in Task 4).
+```
+
+`crates/cairn-core/src/contract/conformance/sensor_ingress.rs`:
+```rust
+//! Conformance cases for `SensorIngress` plugins (filled in Task 4).
+```
+
+`crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs`:
+```rust
+//! Conformance cases for `WorkflowOrchestrator` plugins (filled in Task 4).
+```
+
+- [ ] **Step 6: Run test, expect compile failure on per-contract `run` functions**
+
+Run: `cargo test -p cairn-core --lib`
+Expected: compile error — `memory_store::run`, `mcp_server::run`, `sensor_ingress::run`, `workflow_orchestrator::run` not found.
+
+- [ ] **Step 7: Stub each per-contract `run` to satisfy the dispatch**
+
+In each of the four files, append:
+
+```rust
+use crate::contract::conformance::CaseOutcome;
+use crate::contract::registry::{PluginName, PluginRegistry};
+
+/// Run the conformance suite for this contract. Filled in Task 4.
+#[must_use]
+pub fn run(_registry: &PluginRegistry, _name: &PluginName) -> Vec<CaseOutcome> {
+    Vec::new()
+}
+```
+
+- [ ] **Step 8: Run test, expect pass**
+
+Run: `cargo test -p cairn-core` (lib + integration + doc)
+Expected: all tests pass, including `conformance_types` integration test.
+
+- [ ] **Step 9: Lint clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/cairn-core/src/contract/conformance \
+        crates/cairn-core/src/contract/mod.rs \
+        crates/cairn-core/tests/conformance_types.rs
+git commit -m "feat(core): conformance type module skeleton (#143)
+
+Adds CaseOutcome, CaseStatus, Tier and the run_conformance_for_plugin
+dispatcher. Per-contract case modules ship empty 'run()' stubs returning
+Vec::new() — bodies fill in the next task."
+```
+
+---
+
+## Task 4: Conformance — tier-1 cases per contract
+
+**Files:**
+- Modify: `crates/cairn-core/src/contract/conformance/memory_store.rs`
+- Modify: `crates/cairn-core/src/contract/conformance/mcp_server.rs`
+- Modify: `crates/cairn-core/src/contract/conformance/sensor_ingress.rs`
+- Modify: `crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs`
+- Test: `crates/cairn-core/tests/conformance_tier1.rs` (new)
+
+- [ ] **Step 1: Write failing test** — create `crates/cairn-core/tests/conformance_tier1.rs`:
+
+```rust
+//! Tier-1 conformance: ensure the three core cases pass against a
+//! well-formed stub plugin registered with a matching manifest.
+
+use std::sync::Arc;
+
+use cairn_core::contract::conformance::{
+    CaseStatus, Tier, run_conformance_for_plugin,
+};
+use cairn_core::contract::manifest::PluginManifest;
+use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
+use cairn_core::contract::registry::{PluginName, PluginRegistry};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+
+const STORE_MANIFEST: &str = r#"
+name = "stub-store"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+"#;
+
+#[derive(Default)]
+struct StubStore;
+
+#[async_trait::async_trait]
+impl MemoryStore for StubStore {
+    fn name(&self) -> &'static str {
+        "stub-store"
+    }
+    fn capabilities(&self) -> &MemoryStoreCapabilities {
+        // `Default::default()` is not const, so use an explicit literal.
+        static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+            fts: false,
+            vector: false,
+            graph_edges: false,
+            transactions: false,
+        };
+        &CAPS
+    }
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+}
+
+#[test]
+fn tier1_cases_pass_for_well_formed_memory_store() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-store").expect("valid");
+    let manifest = PluginManifest::parse_toml(STORE_MANIFEST).expect("manifest parses");
+    reg.register_memory_store_with_manifest(name.clone(), manifest, Arc::new(StubStore))
+        .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+
+    let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
+    assert_eq!(tier1.len(), 3, "expect 3 tier-1 cases");
+    for outcome in &tier1 {
+        assert!(
+            matches!(outcome.status, CaseStatus::Ok),
+            "tier-1 case {} must pass, got {:?}",
+            outcome.id,
+            outcome.status
+        );
+    }
+
+    let ids: Vec<_> = tier1.iter().map(|o| o.id).collect();
+    assert!(ids.contains(&"manifest_matches_host"));
+    assert!(ids.contains(&"register_round_trip"));
+    assert!(ids.contains(&"capability_self_consistency_floor"));
+}
+```
+
+Note: this test uses `MemoryStoreCapabilities::default()`. The struct already derives `Default` (verified at line 18 of `memory_store.rs`).
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cargo test -p cairn-core --test conformance_tier1`
+Expected: compile passes (modules exist) but assertion fails — `tier1.len() == 0` because per-contract `run()` stubs return empty vecs.
+
+- [ ] **Step 3: Implement `MemoryStore` tier-1 cases**
+
+Replace `crates/cairn-core/src/contract/conformance/memory_store.rs` with:
+
+```rust
+//! Conformance cases for `MemoryStore` plugins.
+//!
+//! Tier-1 cases run against any registered `MemoryStore` plugin and assert
+//! manifest/identity/version invariants. Tier-2 cases (verb behaviour)
+//! return `Pending` until per-impl PRs replace the bodies.
+
+use crate::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host,
+};
+use crate::contract::memory_store::CONTRACT_VERSION;
+use crate::contract::registry::{PluginName, PluginRegistry};
+
+/// Run tier-1 + tier-2 cases for a `MemoryStore` plugin.
+///
+/// Returns an empty vec if no `MemoryStore` is registered under `name`.
+#[must_use]
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let Some(plugin) = registry.memory_store(name) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::with_capacity(6);
+
+    // Tier 1
+    out.push(tier1_manifest_matches_host(registry, name, CONTRACT_VERSION));
+    out.push(tier1_register_round_trip(registry, name, &plugin));
+    out.push(tier1_capability_self_consistency_floor(&*plugin));
+
+    // Tier 2 (stubs)
+    out.push(CaseOutcome {
+        id: "put_get_roundtrip",
+        tier: Tier::Two,
+        status: CaseStatus::Pending {
+            reason: "real impl pending",
+        },
+    });
+    out.push(CaseOutcome {
+        id: "fts_query_returns_doc",
+        tier: Tier::Two,
+        status: CaseStatus::Pending {
+            reason: "real impl pending",
+        },
+    });
+    out.push(CaseOutcome {
+        id: "vector_search_when_advertised",
+        tier: Tier::Two,
+        status: CaseStatus::Pending {
+            reason: "real impl pending",
+        },
+    });
+
+    out
+}
+
+fn tier1_register_round_trip(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    plugin: &std::sync::Arc<dyn crate::contract::memory_store::MemoryStore>,
+) -> CaseOutcome {
+    let resolved = match registry.memory_store(name) {
+        Some(p) => p,
+        None => {
+            return CaseOutcome {
+                id: "register_round_trip",
+                tier: Tier::One,
+                status: CaseStatus::Failed {
+                    message: "lookup returned None for registered plugin".to_string(),
+                },
+            };
+        }
+    };
+    let status = if std::sync::Arc::ptr_eq(plugin, &resolved) {
+        CaseStatus::Ok
+    } else {
+        CaseStatus::Failed {
+            message: "two lookups returned different Arcs".to_string(),
+        }
+    };
+    CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status,
+    }
+}
+
+fn tier1_capability_self_consistency_floor(
+    plugin: &dyn crate::contract::memory_store::MemoryStore,
+) -> CaseOutcome {
+    // Floor: capabilities() must return without panic, name() non-empty,
+    // supported_contract_versions() must accept the host CONTRACT_VERSION.
+    let caps = plugin.capabilities();
+    if plugin.name().is_empty() {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "plugin.name() returned empty string".to_string(),
+            },
+        };
+    }
+    if !plugin.supported_contract_versions().accepts(CONTRACT_VERSION) {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "plugin does not accept host CONTRACT_VERSION {CONTRACT_VERSION}"
+                ),
+            },
+        };
+    }
+    // Touch all four bool fields so a future panicking-getter regression
+    // would surface here.
+    let _ = (caps.fts, caps.vector, caps.graph_edges, caps.transactions);
+    CaseOutcome {
+        id: "capability_self_consistency_floor",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    }
+}
+```
+
+- [ ] **Step 4: Implement `MCPServer` tier-1 cases**
+
+Replace `crates/cairn-core/src/contract/conformance/mcp_server.rs` with:
+
+```rust
+//! Conformance cases for `MCPServer` plugins.
+
+use crate::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host,
+};
+use crate::contract::mcp_server::CONTRACT_VERSION;
+use crate::contract::registry::{PluginName, PluginRegistry};
+
+/// Run tier-1 + tier-2 cases for an `MCPServer` plugin.
+#[must_use]
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let Some(plugin) = registry.mcp_server(name) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::with_capacity(4);
+    out.push(tier1_manifest_matches_host(registry, name, CONTRACT_VERSION));
+    out.push(tier1_register_round_trip(registry, name, &plugin));
+    out.push(tier1_capability_self_consistency_floor(&*plugin));
+    out.push(CaseOutcome {
+        id: "initialize_and_list_tools",
+        tier: Tier::Two,
+        status: CaseStatus::Pending {
+            reason: "real impl pending",
+        },
+    });
+    out
+}
+
+fn tier1_register_round_trip(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    plugin: &std::sync::Arc<dyn crate::contract::mcp_server::MCPServer>,
+) -> CaseOutcome {
+    let resolved = match registry.mcp_server(name) {
+        Some(p) => p,
+        None => {
+            return CaseOutcome {
+                id: "register_round_trip",
+                tier: Tier::One,
+                status: CaseStatus::Failed {
+                    message: "lookup returned None for registered plugin".to_string(),
+                },
+            };
+        }
+    };
+    let status = if std::sync::Arc::ptr_eq(plugin, &resolved) {
+        CaseStatus::Ok
+    } else {
+        CaseStatus::Failed {
+            message: "two lookups returned different Arcs".to_string(),
+        }
+    };
+    CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status,
+    }
+}
+
+fn tier1_capability_self_consistency_floor(
+    plugin: &dyn crate::contract::mcp_server::MCPServer,
+) -> CaseOutcome {
+    let caps = plugin.capabilities();
+    if plugin.name().is_empty() {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "plugin.name() returned empty string".to_string(),
+            },
+        };
+    }
+    if !plugin.supported_contract_versions().accepts(CONTRACT_VERSION) {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "plugin does not accept host CONTRACT_VERSION {CONTRACT_VERSION}"
+                ),
+            },
+        };
+    }
+    let _ = (caps.stdio, caps.sse, caps.http_streamable, caps.extensions);
+    CaseOutcome {
+        id: "capability_self_consistency_floor",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    }
+}
+```
+
+- [ ] **Step 5: Implement `SensorIngress` tier-1 cases**
+
+Replace `crates/cairn-core/src/contract/conformance/sensor_ingress.rs` with:
+
+```rust
+//! Conformance cases for `SensorIngress` plugins.
+
+use crate::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host,
+};
+use crate::contract::registry::{PluginName, PluginRegistry};
+use crate::contract::sensor_ingress::CONTRACT_VERSION;
+
+/// Run tier-1 + tier-2 cases for a `SensorIngress` plugin.
+#[must_use]
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let Some(plugin) = registry.sensor_ingress_plugin(name) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::with_capacity(4);
+    out.push(tier1_manifest_matches_host(registry, name, CONTRACT_VERSION));
+    out.push(tier1_register_round_trip(registry, name, &plugin));
+    out.push(tier1_capability_self_consistency_floor(&*plugin));
+    out.push(CaseOutcome {
+        id: "emits_envelope_when_poked",
+        tier: Tier::Two,
+        status: CaseStatus::Pending {
+            reason: "real impl pending",
+        },
+    });
+    out
+}
+
+fn tier1_register_round_trip(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    plugin: &std::sync::Arc<dyn crate::contract::sensor_ingress::SensorIngress>,
+) -> CaseOutcome {
+    let resolved = match registry.sensor_ingress_plugin(name) {
+        Some(p) => p,
+        None => {
+            return CaseOutcome {
+                id: "register_round_trip",
+                tier: Tier::One,
+                status: CaseStatus::Failed {
+                    message: "lookup returned None for registered plugin".to_string(),
+                },
+            };
+        }
+    };
+    let status = if std::sync::Arc::ptr_eq(plugin, &resolved) {
+        CaseStatus::Ok
+    } else {
+        CaseStatus::Failed {
+            message: "two lookups returned different Arcs".to_string(),
+        }
+    };
+    CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status,
+    }
+}
+
+fn tier1_capability_self_consistency_floor(
+    plugin: &dyn crate::contract::sensor_ingress::SensorIngress,
+) -> CaseOutcome {
+    let caps = plugin.capabilities();
+    if plugin.name().is_empty() {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "plugin.name() returned empty string".to_string(),
+            },
+        };
+    }
+    if !plugin.supported_contract_versions().accepts(CONTRACT_VERSION) {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "plugin does not accept host CONTRACT_VERSION {CONTRACT_VERSION}"
+                ),
+            },
+        };
+    }
+    let _ = (caps.batches, caps.streaming, caps.consent_aware);
+    CaseOutcome {
+        id: "capability_self_consistency_floor",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    }
+}
+```
+
+- [ ] **Step 6: Implement `WorkflowOrchestrator` tier-1 cases**
+
+Replace `crates/cairn-core/src/contract/conformance/workflow_orchestrator.rs` with:
+
+```rust
+//! Conformance cases for `WorkflowOrchestrator` plugins.
+
+use crate::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, tier1_manifest_matches_host,
+};
+use crate::contract::registry::{PluginName, PluginRegistry};
+use crate::contract::workflow_orchestrator::CONTRACT_VERSION;
+
+/// Run tier-1 + tier-2 cases for a `WorkflowOrchestrator` plugin.
+#[must_use]
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let Some(plugin) = registry.workflow_orchestrator(name) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::with_capacity(4);
+    out.push(tier1_manifest_matches_host(registry, name, CONTRACT_VERSION));
+    out.push(tier1_register_round_trip(registry, name, &plugin));
+    out.push(tier1_capability_self_consistency_floor(&*plugin));
+    out.push(CaseOutcome {
+        id: "enqueue_then_complete",
+        tier: Tier::Two,
+        status: CaseStatus::Pending {
+            reason: "real impl pending",
+        },
+    });
+    out
+}
+
+fn tier1_register_round_trip(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    plugin: &std::sync::Arc<dyn crate::contract::workflow_orchestrator::WorkflowOrchestrator>,
+) -> CaseOutcome {
+    let resolved = match registry.workflow_orchestrator(name) {
+        Some(p) => p,
+        None => {
+            return CaseOutcome {
+                id: "register_round_trip",
+                tier: Tier::One,
+                status: CaseStatus::Failed {
+                    message: "lookup returned None for registered plugin".to_string(),
+                },
+            };
+        }
+    };
+    let status = if std::sync::Arc::ptr_eq(plugin, &resolved) {
+        CaseStatus::Ok
+    } else {
+        CaseStatus::Failed {
+            message: "two lookups returned different Arcs".to_string(),
+        }
+    };
+    CaseOutcome {
+        id: "register_round_trip",
+        tier: Tier::One,
+        status,
+    }
+}
+
+fn tier1_capability_self_consistency_floor(
+    plugin: &dyn crate::contract::workflow_orchestrator::WorkflowOrchestrator,
+) -> CaseOutcome {
+    let caps = plugin.capabilities();
+    if plugin.name().is_empty() {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "plugin.name() returned empty string".to_string(),
+            },
+        };
+    }
+    if !plugin.supported_contract_versions().accepts(CONTRACT_VERSION) {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "plugin does not accept host CONTRACT_VERSION {CONTRACT_VERSION}"
+                ),
+            },
+        };
+    }
+    let _ = (caps.durable, caps.crash_safe, caps.cron_schedules);
+    CaseOutcome {
+        id: "capability_self_consistency_floor",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    }
+}
+```
+
+- [ ] **Step 7: Run test, expect pass**
+
+Run: `cargo test -p cairn-core` (lib + integration tests + doctests).
+Expected: PASS, including `conformance_tier1` showing all three tier-1 cases as `Ok`.
+
+- [ ] **Step 8: Lint clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/cairn-core/src/contract/conformance \
+        crates/cairn-core/tests/conformance_tier1.rs
+git commit -m "feat(core): tier-1 conformance cases per contract (#143)
+
+Each of the four bundled-plugin contracts (MemoryStore, MCPServer,
+SensorIngress, WorkflowOrchestrator) gets:
+
+  - tier-1 manifest_matches_host    (delegates to verify_compatible_with)
+  - tier-1 register_round_trip      (Arc::ptr_eq across two lookups)
+  - tier-1 capability_self_consistency_floor (name non-empty, version
+                                              accepts host, all cap
+                                              fields readable)
+  - tier-2 verb-behaviour stubs returning Pending('real impl pending')
+
+LLMProvider/FrontendAdapter/AgentProvider have no bundled plugins in
+P0 — verify returns an empty vec for them."
+```
+
+---
+
+## Task 5: Bundled plugin — `cairn-store-sqlite`
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/plugin.toml`
+- Modify: `crates/cairn-store-sqlite/src/lib.rs`
+- Modify: `crates/cairn-store-sqlite/Cargo.toml`
+- Create: `crates/cairn-store-sqlite/tests/manifest_validates.rs`
+
+- [ ] **Step 1: Write failing test** — create `crates/cairn-store-sqlite/tests/manifest_validates.rs`:
+
+```rust
+//! Integration: the bundled plugin.toml parses, validates against the
+//! IDL JSON schema, and matches the host contract version + name.
+
+use cairn_core::contract::manifest::{ContractKind, PluginManifest};
+use cairn_core::contract::memory_store::CONTRACT_VERSION;
+use cairn_core::contract::registry::PluginName;
+
+#[test]
+fn manifest_parses_and_matches_host() {
+    let manifest =
+        PluginManifest::parse_toml(cairn_store_sqlite::MANIFEST_TOML).expect("manifest parses");
+    assert_eq!(manifest.name().as_str(), "cairn-store-sqlite");
+    assert_eq!(manifest.contract(), ContractKind::MemoryStore);
+    let expected = PluginName::new("cairn-store-sqlite").expect("valid");
+    manifest
+        .verify_compatible_with(&expected, ContractKind::MemoryStore, CONTRACT_VERSION)
+        .expect("manifest matches host");
+}
+
+#[test]
+fn register_populates_registry() {
+    let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+    cairn_store_sqlite::register(&mut reg).expect("registers");
+    let name = PluginName::new("cairn-store-sqlite").expect("valid");
+    assert!(reg.memory_store(&name).is_some());
+    assert!(reg.parsed_manifest(&name).is_some());
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cargo test -p cairn-store-sqlite --test manifest_validates`
+Expected: compile error — `MANIFEST_TOML` and `register` not found in crate root.
+
+- [ ] **Step 3: Create `plugin.toml`** — `crates/cairn-store-sqlite/plugin.toml`:
+
+```toml
+name = "cairn-store-sqlite"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+fts = false
+vector = false
+graph_edges = false
+transactions = false
+```
+
+- [ ] **Step 4: Add a stub `MemoryStore` impl + `register()`**
+
+Replace `crates/cairn-store-sqlite/src/lib.rs` with:
+
+```rust
+//! `SQLite` record store for Cairn (P0 scaffold).
+//!
+//! Schema, migrations, FTS5 and sqlite-vec integration arrive in
+//! follow-up issues (#46 and later). For now this crate ships only the
+//! plugin manifest, a stub `MemoryStore` impl with all capability flags
+//! `false`, and a `register()` entry point so the host can include it
+//! in `cairn plugins list/verify`.
+
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+use cairn_core::contract::memory_store::{
+    CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities,
+};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::register_plugin;
+
+/// Stable plugin name. Matches `name = ...` in `plugin.toml`.
+pub const PLUGIN_NAME: &str = "cairn-store-sqlite";
+
+/// Plugin capability manifest TOML (parsed at registration time).
+pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// P0 stub `MemoryStore`. All capability flags are `false`; verb methods
+/// land with the storage implementation in #46.
+#[derive(Default)]
+pub struct SqliteMemoryStore;
+
+#[async_trait::async_trait]
+impl MemoryStore for SqliteMemoryStore {
+    fn name(&self) -> &str {
+        PLUGIN_NAME
+    }
+
+    fn capabilities(&self) -> &MemoryStoreCapabilities {
+        static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+            fts: false,
+            vector: false,
+            graph_edges: false,
+            transactions: false,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(
+            ContractVersion::new(0, 1, 0),
+            ContractVersion::new(0, 2, 0),
+        )
+    }
+}
+
+// Compile-time guard: this crate's accepted range must include the host
+// CONTRACT_VERSION. If we ever bump CONTRACT_VERSION without bumping the
+// range, the const evaluation here panics at build.
+const _: () = {
+    let lo = (0u16, 1u16, 0u16);
+    let hi = (0u16, 2u16, 0u16);
+    let v = (
+        CONTRACT_VERSION.major,
+        CONTRACT_VERSION.minor,
+        CONTRACT_VERSION.patch,
+    );
+    assert!(
+        (v.0 > lo.0 || (v.0 == lo.0 && (v.1 > lo.1 || (v.1 == lo.1 && v.2 >= lo.2))))
+            && (v.0 < hi.0 || (v.0 == hi.0 && (v.1 < hi.1 || (v.1 == hi.1 && v.2 < hi.2)))),
+        "host CONTRACT_VERSION outside this crate's declared range"
+    );
+};
+
+register_plugin!(MemoryStore, SqliteMemoryStore, "cairn-store-sqlite", MANIFEST_TOML);
+```
+
+- [ ] **Step 5: Update `Cargo.toml`** — `crates/cairn-store-sqlite/Cargo.toml`:
+
+Two minimal edits to the existing file:
+
+(a) Add `async-trait` to `[dependencies]` (the trait impl uses it). The block becomes:
+
+```toml
+[dependencies]
+cairn-core = { workspace = true }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+# NOTE: rusqlite (with `bundled`) lands with the storage implementation in #46.
+```
+
+(b) Update `[package.metadata.cargo-machete]` to drop `cairn-core` (now used) and keep `thiserror`:
+
+```toml
+[package.metadata.cargo-machete]
+ignored = ["thiserror"]
+```
+
+- [ ] **Step 6: Run test, expect pass**
+
+Run: `cargo test -p cairn-store-sqlite`
+Expected: PASS for both new tests.
+
+- [ ] **Step 7: Lint clean**
+
+Run: `cargo clippy -p cairn-store-sqlite --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Manifest schema validation**
+
+Run: `cargo test -p cairn-idl --test plugin_manifest_validation` (existing test that validates every TOML in `crates/cairn-idl/schema/plugin/`).
+
+If this test does not pick up the new `crates/cairn-store-sqlite/plugin.toml`, *and* if the existing test only globs the `cairn-idl` schema dir, defer real CI-level schema validation to the manifest-aware Rust parser (which is identical content). No additional action needed unless the existing test framework is a globbing one — confirm by reading `crates/cairn-idl/tests/plugin_manifest_validation.rs` first. If a glob exists, extend it to include `crates/*/plugin.toml`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/cairn-store-sqlite
+git commit -m "feat(store-sqlite): plugin.toml + stub register() (#143)
+
+P0 scaffold for the bundled SQLite MemoryStore plugin. Registers a
+stub SqliteMemoryStore with all capability flags false so 'cairn
+plugins list' / 'verify' can include it. Real schema, FTS5, and
+sqlite-vec integration land in #46.
+
+A const-eval guard catches drift between the host CONTRACT_VERSION
+and the manifest's declared accepted range at build time."
+```
+
+---
+
+## Task 6: Bundled plugin — `cairn-mcp`
+
+**Files:**
+- Create: `crates/cairn-mcp/plugin.toml`
+- Modify: `crates/cairn-mcp/src/lib.rs`
+- Modify: `crates/cairn-mcp/Cargo.toml`
+- Create: `crates/cairn-mcp/tests/manifest_validates.rs`
+
+- [ ] **Step 1: Write failing test** — create `crates/cairn-mcp/tests/manifest_validates.rs`:
+
+```rust
+//! Integration: the bundled plugin.toml parses and matches host contract.
+
+use cairn_core::contract::manifest::{ContractKind, PluginManifest};
+use cairn_core::contract::mcp_server::CONTRACT_VERSION;
+use cairn_core::contract::registry::PluginName;
+
+#[test]
+fn manifest_parses_and_matches_host() {
+    let manifest =
+        PluginManifest::parse_toml(cairn_mcp::MANIFEST_TOML).expect("manifest parses");
+    assert_eq!(manifest.name().as_str(), "cairn-mcp");
+    assert_eq!(manifest.contract(), ContractKind::MCPServer);
+    let expected = PluginName::new("cairn-mcp").expect("valid");
+    manifest
+        .verify_compatible_with(&expected, ContractKind::MCPServer, CONTRACT_VERSION)
+        .expect("manifest matches host");
+}
+
+#[test]
+fn register_populates_registry() {
+    let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+    cairn_mcp::register(&mut reg).expect("registers");
+    let name = PluginName::new("cairn-mcp").expect("valid");
+    assert!(reg.mcp_server(&name).is_some());
+    assert!(reg.parsed_manifest(&name).is_some());
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cargo test -p cairn-mcp --test manifest_validates`
+Expected: compile error.
+
+- [ ] **Step 3: Create `plugin.toml`** — `crates/cairn-mcp/plugin.toml`:
+
+```toml
+name = "cairn-mcp"
+contract = "MCPServer"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+stdio = false
+sse = false
+http_streamable = false
+extensions = false
+```
+
+- [ ] **Step 4: Add stub impl + `register()`** — replace `crates/cairn-mcp/src/lib.rs`:
+
+```rust
+//! Cairn MCP adapter (P0 scaffold).
+//!
+//! P0: no transports yet — this crate ships only the plugin manifest,
+//! a stub `MCPServer` impl with all capability flags `false`, and a
+//! `register()` entry point. Real stdio + SSE wiring lands in #64.
+
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+use cairn_core::contract::mcp_server::{CONTRACT_VERSION, MCPServer, MCPServerCapabilities};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::register_plugin;
+
+/// Stable plugin name. Matches `name = ...` in `plugin.toml`.
+pub const PLUGIN_NAME: &str = "cairn-mcp";
+
+/// Plugin capability manifest TOML (parsed at registration time).
+pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// P0 stub `MCPServer`. All capability flags are `false`; transport
+/// wiring lands in #64.
+#[derive(Default)]
+pub struct CairnMcpServer;
+
+#[async_trait::async_trait]
+impl MCPServer for CairnMcpServer {
+    fn name(&self) -> &str {
+        PLUGIN_NAME
+    }
+
+    fn capabilities(&self) -> &MCPServerCapabilities {
+        static CAPS: MCPServerCapabilities = MCPServerCapabilities {
+            stdio: false,
+            sse: false,
+            http_streamable: false,
+            extensions: false,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(
+            ContractVersion::new(0, 1, 0),
+            ContractVersion::new(0, 2, 0),
+        )
+    }
+}
+
+const _: () = {
+    let lo = (0u16, 1u16, 0u16);
+    let hi = (0u16, 2u16, 0u16);
+    let v = (
+        CONTRACT_VERSION.major,
+        CONTRACT_VERSION.minor,
+        CONTRACT_VERSION.patch,
+    );
+    assert!(
+        (v.0 > lo.0 || (v.0 == lo.0 && (v.1 > lo.1 || (v.1 == lo.1 && v.2 >= lo.2))))
+            && (v.0 < hi.0 || (v.0 == hi.0 && (v.1 < hi.1 || (v.1 == hi.1 && v.2 < hi.2)))),
+        "host CONTRACT_VERSION outside this crate's declared range"
+    );
+};
+
+register_plugin!(MCPServer, CairnMcpServer, "cairn-mcp", MANIFEST_TOML);
+```
+
+- [ ] **Step 5: Update `Cargo.toml`** — `crates/cairn-mcp/Cargo.toml`:
+
+Two minimal edits:
+
+(a) Add `async-trait` to `[dependencies]`:
+
+```toml
+[dependencies]
+cairn-core = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+```
+
+(b) Leave `[package.metadata.cargo-machete] ignored = ["serde", "serde_json"]`
+unchanged — those deps remain forward-declared until the MCP transport
+work in #64 lands.
+
+- [ ] **Step 6: Run test, expect pass**
+
+Run: `cargo test -p cairn-mcp`
+Expected: PASS.
+
+- [ ] **Step 7: Lint clean**
+
+Run: `cargo clippy -p cairn-mcp --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cairn-mcp
+git commit -m "feat(mcp): plugin.toml + stub register() (#143)
+
+P0 scaffold for the bundled MCP plugin. Stub CairnMcpServer with all
+transport flags false; real stdio + SSE wiring lands in #64."
+```
+
+---
+
+## Task 7: Bundled plugin — `cairn-sensors-local`
+
+**Files:**
+- Create: `crates/cairn-sensors-local/plugin.toml`
+- Modify: `crates/cairn-sensors-local/src/lib.rs`
+- Modify: `crates/cairn-sensors-local/Cargo.toml`
+- Create: `crates/cairn-sensors-local/tests/manifest_validates.rs`
+
+- [ ] **Step 1: Write failing test** — create `crates/cairn-sensors-local/tests/manifest_validates.rs`:
+
+```rust
+//! Integration: the bundled plugin.toml parses and matches host contract.
+
+use cairn_core::contract::manifest::{ContractKind, PluginManifest};
+use cairn_core::contract::registry::PluginName;
+use cairn_core::contract::sensor_ingress::CONTRACT_VERSION;
+
+#[test]
+fn manifest_parses_and_matches_host() {
+    let manifest =
+        PluginManifest::parse_toml(cairn_sensors_local::MANIFEST_TOML).expect("manifest parses");
+    assert_eq!(manifest.name().as_str(), "cairn-sensors-local");
+    assert_eq!(manifest.contract(), ContractKind::SensorIngress);
+    let expected = PluginName::new("cairn-sensors-local").expect("valid");
+    manifest
+        .verify_compatible_with(&expected, ContractKind::SensorIngress, CONTRACT_VERSION)
+        .expect("manifest matches host");
+}
+
+#[test]
+fn register_populates_registry() {
+    let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+    cairn_sensors_local::register(&mut reg).expect("registers");
+    let name = PluginName::new("cairn-sensors-local").expect("valid");
+    assert!(reg.sensor_ingress_plugin(&name).is_some());
+    assert!(reg.parsed_manifest(&name).is_some());
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cargo test -p cairn-sensors-local --test manifest_validates`
+Expected: compile error.
+
+- [ ] **Step 3: Create `plugin.toml`** — `crates/cairn-sensors-local/plugin.toml`:
+
+```toml
+name = "cairn-sensors-local"
+contract = "SensorIngress"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+batches = false
+streaming = false
+consent_aware = false
+```
+
+- [ ] **Step 4: Add stub impl + `register()`** — replace `crates/cairn-sensors-local/src/lib.rs`:
+
+```rust
+//! Local sensors for Cairn — IDE hook, terminal, clipboard, voice, screen.
+//!
+//! P0 scaffold: stub `SensorIngress` impl with all capability flags
+//! `false`. Real capture lands per-sensor in #84 and follow-ups.
+
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+use cairn_core::contract::sensor_ingress::{
+    CONTRACT_VERSION, SensorIngress, SensorIngressCapabilities,
+};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::register_plugin;
+
+/// Stable plugin name.
+pub const PLUGIN_NAME: &str = "cairn-sensors-local";
+
+/// Plugin capability manifest TOML.
+pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// P0 stub `SensorIngress`. All capability flags are `false`.
+#[derive(Default)]
+pub struct LocalSensorIngress;
+
+#[async_trait::async_trait]
+impl SensorIngress for LocalSensorIngress {
+    fn name(&self) -> &str {
+        PLUGIN_NAME
+    }
+
+    fn capabilities(&self) -> &SensorIngressCapabilities {
+        static CAPS: SensorIngressCapabilities = SensorIngressCapabilities {
+            batches: false,
+            streaming: false,
+            consent_aware: false,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(
+            ContractVersion::new(0, 1, 0),
+            ContractVersion::new(0, 2, 0),
+        )
+    }
+}
+
+const _: () = {
+    let lo = (0u16, 1u16, 0u16);
+    let hi = (0u16, 2u16, 0u16);
+    let v = (
+        CONTRACT_VERSION.major,
+        CONTRACT_VERSION.minor,
+        CONTRACT_VERSION.patch,
+    );
+    assert!(
+        (v.0 > lo.0 || (v.0 == lo.0 && (v.1 > lo.1 || (v.1 == lo.1 && v.2 >= lo.2))))
+            && (v.0 < hi.0 || (v.0 == hi.0 && (v.1 < hi.1 || (v.1 == hi.1 && v.2 < hi.2)))),
+        "host CONTRACT_VERSION outside this crate's declared range"
+    );
+};
+
+register_plugin!(SensorIngress, LocalSensorIngress, "cairn-sensors-local", MANIFEST_TOML);
+```
+
+- [ ] **Step 5: Update `Cargo.toml`** — `crates/cairn-sensors-local/Cargo.toml`:
+
+Two minimal edits:
+
+(a) Add `async-trait` to `[dependencies]`:
+
+```toml
+[dependencies]
+cairn-core = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+```
+
+(b) Update `[package.metadata.cargo-machete]` to drop `cairn-core` (now used):
+
+```toml
+[package.metadata.cargo-machete]
+ignored = ["tracing"]
+```
+
+- [ ] **Step 6: Run test, expect pass**
+
+Run: `cargo test -p cairn-sensors-local`
+Expected: PASS.
+
+- [ ] **Step 7: Lint clean**
+
+Run: `cargo clippy -p cairn-sensors-local --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cairn-sensors-local
+git commit -m "feat(sensors-local): plugin.toml + stub register() (#143)
+
+P0 scaffold for the bundled sensor plugin. Real per-sensor capture
+lands in #84 and follow-ups."
+```
+
+---
+
+## Task 8: Bundled plugin — `cairn-workflows`
+
+**Files:**
+- Create: `crates/cairn-workflows/plugin.toml`
+- Modify: `crates/cairn-workflows/src/lib.rs`
+- Modify: `crates/cairn-workflows/Cargo.toml`
+- Create: `crates/cairn-workflows/tests/manifest_validates.rs`
+
+- [ ] **Step 1: Write failing test** — create `crates/cairn-workflows/tests/manifest_validates.rs`:
+
+```rust
+//! Integration: the bundled plugin.toml parses and matches host contract.
+
+use cairn_core::contract::manifest::{ContractKind, PluginManifest};
+use cairn_core::contract::registry::PluginName;
+use cairn_core::contract::workflow_orchestrator::CONTRACT_VERSION;
+
+#[test]
+fn manifest_parses_and_matches_host() {
+    let manifest =
+        PluginManifest::parse_toml(cairn_workflows::MANIFEST_TOML).expect("manifest parses");
+    assert_eq!(manifest.name().as_str(), "cairn-workflows");
+    assert_eq!(manifest.contract(), ContractKind::WorkflowOrchestrator);
+    let expected = PluginName::new("cairn-workflows").expect("valid");
+    manifest
+        .verify_compatible_with(
+            &expected,
+            ContractKind::WorkflowOrchestrator,
+            CONTRACT_VERSION,
+        )
+        .expect("manifest matches host");
+}
+
+#[test]
+fn register_populates_registry() {
+    let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+    cairn_workflows::register(&mut reg).expect("registers");
+    let name = PluginName::new("cairn-workflows").expect("valid");
+    assert!(reg.workflow_orchestrator(&name).is_some());
+    assert!(reg.parsed_manifest(&name).is_some());
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cargo test -p cairn-workflows --test manifest_validates`
+Expected: compile error.
+
+- [ ] **Step 3: Create `plugin.toml`** — `crates/cairn-workflows/plugin.toml`:
+
+```toml
+name = "cairn-workflows"
+contract = "WorkflowOrchestrator"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+durable = false
+crash_safe = false
+cron_schedules = false
+```
+
+- [ ] **Step 4: Add stub impl + `register()`** — replace `crates/cairn-workflows/src/lib.rs`:
+
+```rust
+//! Cairn background workflows host (P0 scaffold).
+//!
+//! P0: no runner yet — stub `WorkflowOrchestrator` with all capability
+//! flags `false`. Tokio + SQLite-backed job table lands in #89.
+
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::contract::workflow_orchestrator::{
+    CONTRACT_VERSION, WorkflowOrchestrator, WorkflowOrchestratorCapabilities,
+};
+use cairn_core::register_plugin;
+
+/// Stable plugin name.
+pub const PLUGIN_NAME: &str = "cairn-workflows";
+
+/// Plugin capability manifest TOML.
+pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// P0 stub `WorkflowOrchestrator`. All capability flags are `false`.
+#[derive(Default)]
+pub struct InProcessOrchestrator;
+
+#[async_trait::async_trait]
+impl WorkflowOrchestrator for InProcessOrchestrator {
+    fn name(&self) -> &str {
+        PLUGIN_NAME
+    }
+
+    fn capabilities(&self) -> &WorkflowOrchestratorCapabilities {
+        static CAPS: WorkflowOrchestratorCapabilities = WorkflowOrchestratorCapabilities {
+            durable: false,
+            crash_safe: false,
+            cron_schedules: false,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(
+            ContractVersion::new(0, 1, 0),
+            ContractVersion::new(0, 2, 0),
+        )
+    }
+}
+
+const _: () = {
+    let lo = (0u16, 1u16, 0u16);
+    let hi = (0u16, 2u16, 0u16);
+    let v = (
+        CONTRACT_VERSION.major,
+        CONTRACT_VERSION.minor,
+        CONTRACT_VERSION.patch,
+    );
+    assert!(
+        (v.0 > lo.0 || (v.0 == lo.0 && (v.1 > lo.1 || (v.1 == lo.1 && v.2 >= lo.2))))
+            && (v.0 < hi.0 || (v.0 == hi.0 && (v.1 < hi.1 || (v.1 == hi.1 && v.2 < hi.2)))),
+        "host CONTRACT_VERSION outside this crate's declared range"
+    );
+};
+
+register_plugin!(
+    WorkflowOrchestrator,
+    InProcessOrchestrator,
+    "cairn-workflows",
+    MANIFEST_TOML
+);
+```
+
+- [ ] **Step 5: Update `Cargo.toml`** — `crates/cairn-workflows/Cargo.toml`:
+
+Two minimal edits:
+
+(a) Add `async-trait` to `[dependencies]`:
+
+```toml
+[dependencies]
+cairn-core = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }
+tracing = { workspace = true }
+```
+
+(b) Update `[package.metadata.cargo-machete]` to drop `cairn-core` (now used):
+
+```toml
+[package.metadata.cargo-machete]
+ignored = ["tokio", "tracing"]
+```
+
+- [ ] **Step 6: Run test, expect pass**
+
+Run: `cargo test -p cairn-workflows`
+Expected: PASS.
+
+- [ ] **Step 7: Lint clean**
+
+Run: `cargo clippy -p cairn-workflows --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cairn-workflows
+git commit -m "feat(workflows): plugin.toml + stub register() (#143)
+
+P0 scaffold for the bundled workflow orchestrator plugin. Tokio +
+SQLite-backed job table lands in #89."
+```
+
+---
+
+## Task 9: Workspace deps — add `clap`, `serde_json`, `insta`
+
+**Files:**
+- Modify: `Cargo.toml` (workspace)
+
+- [ ] **Step 1: Add to `[workspace.dependencies]`**
+
+Edit `Cargo.toml` `[workspace.dependencies]` block (lines 15–24). Append:
+
+```toml
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
+insta = { version = "1.40", features = ["json", "yaml"] }
+```
+
+`serde_json` is already present (line 17). No further changes here.
+
+- [ ] **Step 2: Verify the workspace still builds**
+
+Run: `cargo check --workspace --locked`
+Expected: PASS (no consumers yet, but workspace metadata must be valid).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Cargo.toml
+git commit -m "build: add clap and insta as workspace deps (#143)
+
+Used in the next task by cairn-cli for the plugins subcommand and
+snapshot tests."
+```
+
+---
+
+## Task 10: `cairn-cli` deps + `plugins::host::register_all()`
+
+**Files:**
+- Modify: `crates/cairn-cli/Cargo.toml`
+- Create: `crates/cairn-cli/src/plugins/mod.rs`
+- Create: `crates/cairn-cli/src/plugins/host.rs`
+- Test: in-file `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Update `crates/cairn-cli/Cargo.toml`**
+
+Replace the `[dependencies]` block:
+
+```toml
+[dependencies]
+cairn-core = { workspace = true }
+cairn-mcp = { workspace = true }
+cairn-store-sqlite = { workspace = true }
+cairn-sensors-local = { workspace = true }
+cairn-workflows = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+```
+
+Replace the machete-ignored block with the empty one (drop all entries — every dep has a real call site after this PR):
+
+```toml
+[package.metadata.cargo-machete]
+ignored = []
+```
+
+- [ ] **Step 2: Create the `plugins` module skeleton** — `crates/cairn-cli/src/plugins/mod.rs`:
+
+```rust
+//! `cairn plugins` subcommand implementation.
+//!
+//! - [`host`] — wires bundled adapter crates into a `PluginRegistry`.
+//! - [`list`] — `cairn plugins list` (Task 11).
+//! - [`verify`] — `cairn plugins verify` (Task 12).
+
+pub mod host;
+pub mod list;
+pub mod verify;
+```
+
+- [ ] **Step 3: Write failing test** — create `crates/cairn-cli/src/plugins/host.rs`:
+
+```rust
+//! Plugin host: assemble the live `PluginRegistry` from bundled crates.
+
+use cairn_core::contract::registry::{PluginError, PluginRegistry};
+
+/// Register every bundled plugin in alphabetical order. Returns the
+/// populated `PluginRegistry` on success, or the first plugin error
+/// encountered (fail-closed).
+///
+/// Bundled plugins (alphabetical):
+/// - `cairn-mcp`              → `MCPServer`
+/// - `cairn-sensors-local`    → `SensorIngress`
+/// - `cairn-store-sqlite`     → `MemoryStore`
+/// - `cairn-workflows`        → `WorkflowOrchestrator`
+///
+/// # Errors
+/// Returns the first [`PluginError`] from any bundled plugin's
+/// `register()` function. The host fails closed: a single bad plugin
+/// aborts startup.
+pub fn register_all() -> Result<PluginRegistry, PluginError> {
+    let mut reg = PluginRegistry::new();
+    cairn_mcp::register(&mut reg)?;
+    cairn_sensors_local::register(&mut reg)?;
+    cairn_store_sqlite::register(&mut reg)?;
+    cairn_workflows::register(&mut reg)?;
+    Ok(reg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cairn_core::contract::registry::PluginName;
+
+    #[test]
+    fn register_all_succeeds_and_populates_four_plugins() {
+        let reg = register_all().expect("bundled plugins register");
+
+        for name in [
+            "cairn-mcp",
+            "cairn-sensors-local",
+            "cairn-store-sqlite",
+            "cairn-workflows",
+        ] {
+            let pn = PluginName::new(name).expect("valid");
+            assert!(
+                reg.parsed_manifest(&pn).is_some(),
+                "plugin {name} must be registered"
+            );
+        }
+    }
+
+    #[test]
+    fn register_all_returns_alphabetically_sorted_manifests() {
+        let reg = register_all().expect("registers");
+        let sorted: Vec<_> = reg
+            .parsed_manifests_sorted()
+            .into_iter()
+            .map(|(n, _)| n.as_str().to_string())
+            .collect();
+        assert_eq!(
+            sorted,
+            vec![
+                "cairn-mcp",
+                "cairn-sensors-local",
+                "cairn-store-sqlite",
+                "cairn-workflows",
+            ]
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Run test, expect compile failure**
+
+`cairn-cli/src/main.rs` does not yet import the `plugins` module, so the host module won't be reachable from `main.rs` for the binary build. The test still runs against the lib target — except `cairn-cli` is currently a binary-only crate (`[[bin]]` in Cargo.toml, no `[lib]`).
+
+Add a library target alongside the binary. Append to `crates/cairn-cli/Cargo.toml` (after the existing `[[bin]]` block):
+
+```toml
+[lib]
+name = "cairn_cli"
+path = "src/lib.rs"
+```
+
+Create `crates/cairn-cli/src/lib.rs`:
+
+```rust
+//! Library surface for the `cairn` binary. Shared between `main.rs` and
+//! integration tests in `crates/cairn-cli/tests/`.
+//!
+//! Note: this crate is not published — only `cairn-cli`'s own `main.rs`
+//! and test targets consume it. `expect()` with documented reasons is
+//! tolerated here per CLAUDE.md §6.2 (bins/tests).
+
+pub mod plugins;
+```
+
+- [ ] **Step 5: Re-run test**
+
+Run: `cargo test -p cairn-cli --lib plugins::host`
+Expected: PASS (both new tests).
+
+- [ ] **Step 6: Lint clean**
+
+Run: `cargo clippy -p cairn-cli --all-targets --locked -- -D warnings`
+Expected: no warnings (note: `list` and `verify` modules are still empty stubs at this point but compile fine).
+
+Add the empty stubs first to satisfy the `pub mod` lines:
+
+`crates/cairn-cli/src/plugins/list.rs`:
+```rust
+//! `cairn plugins list` (filled in Task 11).
+```
+
+`crates/cairn-cli/src/plugins/verify.rs`:
+```rust
+//! `cairn plugins verify` (filled in Task 12).
+```
+
+Re-run clippy.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cairn-cli/Cargo.toml crates/cairn-cli/src/lib.rs \
+        crates/cairn-cli/src/plugins
+git commit -m "feat(cli): plugin host wiring (#143)
+
+cairn-cli grows a [lib] target so plugin module code is reachable from
+both main.rs and integration tests. host::register_all() calls each
+bundled crate's register() in alphabetical order and fails closed on
+the first error."
+```
+
+---
+
+## Task 11: `plugins::list` — formatter + JSON
+
+**Files:**
+- Modify: `crates/cairn-cli/src/plugins/list.rs`
+
+- [ ] **Step 1: Write failing test** — replace `crates/cairn-cli/src/plugins/list.rs` content with a test-first scaffold:
+
+```rust
+//! `cairn plugins list` — render registered plugins as a human table or JSON.
+
+use cairn_core::contract::registry::PluginRegistry;
+
+/// Render the registered plugins as a fixed-column ASCII table.
+///
+/// Columns: NAME, CONTRACT, VERSION-RANGE, SOURCE.
+/// Rows are sorted alphabetically by plugin name. Capabilities are not
+/// shown in the table — use `--json` for machine-readable detail.
+#[must_use]
+pub fn render_human(registry: &PluginRegistry) -> String {
+    let _ = registry;
+    String::new()
+}
+
+/// Render the registered plugins as a JSON document with full
+/// capability detail.
+#[must_use]
+pub fn render_json(registry: &PluginRegistry) -> String {
+    let _ = registry;
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::host::register_all;
+
+    #[test]
+    fn human_lists_all_four_bundled_plugins() {
+        let reg = register_all().expect("registers");
+        let text = render_human(&reg);
+        assert!(text.contains("cairn-mcp"), "must list mcp");
+        assert!(text.contains("cairn-sensors-local"), "must list sensors");
+        assert!(text.contains("cairn-store-sqlite"), "must list store");
+        assert!(text.contains("cairn-workflows"), "must list workflows");
+        assert!(text.contains("MCPServer"));
+        assert!(text.contains("MemoryStore"));
+        assert!(text.contains("[0.1.0, 0.2.0)"));
+        assert!(text.contains("bundled:cairn-store-sqlite"));
+    }
+
+    #[test]
+    fn json_contains_capabilities() {
+        let reg = register_all().expect("registers");
+        let json = render_json(&reg);
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        let plugins = v["plugins"].as_array().expect("array");
+        assert_eq!(plugins.len(), 4);
+        // First plugin alphabetical = cairn-mcp.
+        assert_eq!(plugins[0]["name"], "cairn-mcp");
+        assert_eq!(plugins[0]["contract"], "MCPServer");
+        assert_eq!(plugins[0]["source"], "bundled:cairn-mcp");
+        assert!(plugins[0]["capabilities"].is_object());
+    }
+}
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cargo test -p cairn-cli --lib plugins::list`
+Expected: tests fail (empty strings).
+
+- [ ] **Step 3: Implement `render_human`**
+
+Replace the `render_human` body:
+
+```rust
+#[must_use]
+pub fn render_human(registry: &PluginRegistry) -> String {
+    use std::fmt::Write;
+
+    let rows: Vec<HumanRow> = registry
+        .parsed_manifests_sorted()
+        .into_iter()
+        .map(|(name, manifest)| HumanRow {
+            name: name.as_str().to_string(),
+            contract: format!("{:?}", manifest.contract()),
+            range: format!(
+                "[{}, {})",
+                manifest.contract_version_range().min,
+                manifest.contract_version_range().max_exclusive
+            ),
+            source: format!("bundled:{}", name.as_str()),
+        })
+        .collect();
+
+    // Static-width columns wide enough for current bundled plugin names
+    // (longest contract = "WorkflowOrchestrator" = 20 chars; longest plugin
+    // name = "cairn-sensors-local" = 19 chars; longest range = "[0.1.0, 0.2.0)" = 14
+    // chars; longest source = "bundled:cairn-sensors-local" = 27 chars).
+    // Width chosen so headers line up without dynamic measurement.
+    let col_name = 22;
+    let col_contract = 22;
+    let col_range = 18;
+
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:<col_name$}{:<col_contract$}{:<col_range$}{}",
+        "NAME", "CONTRACT", "VERSION-RANGE", "SOURCE"
+    );
+    for row in &rows {
+        let _ = writeln!(
+            out,
+            "{:<col_name$}{:<col_contract$}{:<col_range$}{}",
+            row.name, row.contract, row.range, row.source
+        );
+    }
+    out
+}
+
+struct HumanRow {
+    name: String,
+    contract: String,
+    range: String,
+    source: String,
+}
+```
+
+- [ ] **Step 4: Implement `render_json`**
+
+Replace the `render_json` body:
+
+```rust
+#[must_use]
+pub fn render_json(registry: &PluginRegistry) -> String {
+    let plugins: Vec<_> = registry
+        .parsed_manifests_sorted()
+        .into_iter()
+        .map(|(name, manifest)| {
+            serde_json::json!({
+                "name": name.as_str(),
+                "contract": format!("{:?}", manifest.contract()),
+                "contract_version_range": {
+                    "min": manifest.contract_version_range().min.to_string(),
+                    "max_exclusive": manifest.contract_version_range().max_exclusive.to_string(),
+                },
+                "source": format!("bundled:{}", name.as_str()),
+                "capabilities": capabilities_for(registry, name),
+            })
+        })
+        .collect();
+    serde_json::to_string_pretty(&serde_json::json!({"plugins": plugins}))
+        .expect("json serialization is infallible for owned values")
+}
+
+fn capabilities_for(
+    registry: &PluginRegistry,
+    name: &cairn_core::contract::registry::PluginName,
+) -> serde_json::Value {
+    use cairn_core::contract::manifest::ContractKind;
+    let Some(manifest) = registry.parsed_manifest(name) else {
+        return serde_json::json!({});
+    };
+    match manifest.contract() {
+        ContractKind::MemoryStore => registry.memory_store(name).map_or_else(
+            || serde_json::json!({}),
+            |p| {
+                let c = p.capabilities();
+                serde_json::json!({
+                    "fts": c.fts,
+                    "vector": c.vector,
+                    "graph_edges": c.graph_edges,
+                    "transactions": c.transactions,
+                })
+            },
+        ),
+        ContractKind::MCPServer => registry.mcp_server(name).map_or_else(
+            || serde_json::json!({}),
+            |p| {
+                let c = p.capabilities();
+                serde_json::json!({
+                    "stdio": c.stdio,
+                    "sse": c.sse,
+                    "http_streamable": c.http_streamable,
+                    "extensions": c.extensions,
+                })
+            },
+        ),
+        ContractKind::SensorIngress => registry.sensor_ingress_plugin(name).map_or_else(
+            || serde_json::json!({}),
+            |p| {
+                let c = p.capabilities();
+                serde_json::json!({
+                    "batches": c.batches,
+                    "streaming": c.streaming,
+                    "consent_aware": c.consent_aware,
+                })
+            },
+        ),
+        ContractKind::WorkflowOrchestrator => registry.workflow_orchestrator(name).map_or_else(
+            || serde_json::json!({}),
+            |p| {
+                let c = p.capabilities();
+                serde_json::json!({
+                    "durable": c.durable,
+                    "crash_safe": c.crash_safe,
+                    "cron_schedules": c.cron_schedules,
+                })
+            },
+        ),
+        ContractKind::LLMProvider
+        | ContractKind::FrontendAdapter
+        | ContractKind::AgentProvider => serde_json::json!({}),
+    }
+}
+```
+
+The `expect("json serialization is infallible for owned values")` is the
+documented exception in CLAUDE.md §6.2: invariant must hold at runtime
+because we're serializing an owned `serde_json::Value` tree with no
+custom `Serialize` impls.
+
+- [ ] **Step 5: Run test, expect pass**
+
+Run: `cargo test -p cairn-cli --lib plugins::list`
+Expected: PASS.
+
+- [ ] **Step 6: Lint clean**
+
+Run: `cargo clippy -p cairn-cli --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cairn-cli/src/plugins/list.rs
+git commit -m "feat(cli): cairn plugins list human + JSON renderers (#143)"
+```
+
+---
+
+## Task 12: `plugins::verify` — runner, exit codes, JSON
+
+**Files:**
+- Modify: `crates/cairn-cli/src/plugins/verify.rs`
+
+- [ ] **Step 1: Write failing test** — replace `crates/cairn-cli/src/plugins/verify.rs`:
+
+```rust
+//! `cairn plugins verify` — run the conformance suite against every
+//! registered plugin and emit a summary.
+
+use cairn_core::contract::conformance::{CaseStatus, run_conformance_for_plugin};
+use cairn_core::contract::registry::{PluginName, PluginRegistry};
+
+/// Aggregated outcome of a verify run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyReport {
+    /// Per-plugin block of cases.
+    pub plugins: Vec<PluginReport>,
+    /// Counts.
+    pub summary: Summary,
+}
+
+/// Per-plugin sub-report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginReport {
+    /// Plugin name.
+    pub name: String,
+    /// Contract kind, formatted as `Debug` (matches `--json`).
+    pub contract: String,
+    /// Per-case outcomes (tier-1 first, then tier-2, declaration order).
+    pub cases: Vec<cairn_core::contract::conformance::CaseOutcome>,
+}
+
+/// Summary counts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Summary {
+    /// Cases with `CaseStatus::Ok`.
+    pub ok: usize,
+    /// Cases with `CaseStatus::Pending { .. }`.
+    pub pending: usize,
+    /// Cases with `CaseStatus::Failed { .. }`.
+    pub failed: usize,
+}
+
+/// Build a `VerifyReport` by running conformance for every registered
+/// plugin in alphabetical order.
+#[must_use]
+pub fn run(registry: &PluginRegistry) -> VerifyReport {
+    let mut plugins = Vec::new();
+    let mut summary = Summary::default();
+
+    for (name, manifest) in registry.parsed_manifests_sorted() {
+        let cases = run_conformance_for_plugin(registry, name);
+        for c in &cases {
+            match c.status {
+                CaseStatus::Ok => summary.ok += 1,
+                CaseStatus::Pending { .. } => summary.pending += 1,
+                CaseStatus::Failed { .. } => summary.failed += 1,
+            }
+        }
+        plugins.push(PluginReport {
+            name: name.as_str().to_string(),
+            contract: format!("{:?}", manifest.contract()),
+            cases,
+        });
+    }
+
+    VerifyReport { plugins, summary }
+}
+
+/// Exit code for the given report under the requested strictness.
+///
+/// - Default mode: exit 0 unless any case `Failed`.
+/// - Strict mode: exit 0 only if every case is `Ok`.
+///
+/// Exit code constants:
+/// - `0`  — success.
+/// - `69` (`EX_UNAVAILABLE`) — at least one case failed (or pending in
+///   strict mode).
+#[must_use]
+pub fn exit_code(report: &VerifyReport, strict: bool) -> u8 {
+    if report.summary.failed > 0 {
+        return 69;
+    }
+    if strict && report.summary.pending > 0 {
+        return 69;
+    }
+    0
+}
+
+/// Render the report as human-readable text.
+#[must_use]
+pub fn render_human(report: &VerifyReport) -> String {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    for plugin in &report.plugins {
+        let _ = writeln!(out, "{} ({})", plugin.name, plugin.contract);
+        for case in &plugin.cases {
+            let tier = match case.tier {
+                cairn_core::contract::conformance::Tier::One => "tier-1",
+                cairn_core::contract::conformance::Tier::Two => "tier-2",
+            };
+            let status = match &case.status {
+                CaseStatus::Ok => "ok".to_string(),
+                CaseStatus::Pending { reason } => format!("pending ({reason})"),
+                CaseStatus::Failed { message } => format!("FAILED ({message})"),
+            };
+            let _ = writeln!(out, "  {tier} {:<40} {status}", case.id);
+        }
+        let _ = writeln!(out);
+    }
+    let _ = writeln!(
+        out,
+        "Summary: {} plugins, {} ok, {} pending, {} failed",
+        report.plugins.len(),
+        report.summary.ok,
+        report.summary.pending,
+        report.summary.failed,
+    );
+    out
+}
+
+/// Render the report as JSON.
+#[must_use]
+pub fn render_json(report: &VerifyReport) -> String {
+    let plugins_json: Vec<_> = report
+        .plugins
+        .iter()
+        .map(|plugin| {
+            let cases: Vec<_> = plugin
+                .cases
+                .iter()
+                .map(|c| {
+                    let mut obj = serde_json::json!({
+                        "id": c.id,
+                        "tier": c.tier.as_u8(),
+                        "status": c.status.as_str(),
+                    });
+                    match &c.status {
+                        CaseStatus::Pending { reason } => {
+                            obj["reason"] = serde_json::Value::String((*reason).to_string());
+                        }
+                        CaseStatus::Failed { message } => {
+                            obj["message"] = serde_json::Value::String(message.clone());
+                        }
+                        CaseStatus::Ok => {}
+                    }
+                    obj
+                })
+                .collect();
+            serde_json::json!({
+                "name": plugin.name,
+                "contract": plugin.contract,
+                "cases": cases,
+            })
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&serde_json::json!({
+        "plugins": plugins_json,
+        "summary": {
+            "ok": report.summary.ok,
+            "pending": report.summary.pending,
+            "failed": report.summary.failed,
+        }
+    }))
+    .expect("json serialization is infallible for owned values")
+}
+
+/// Convenience: also resolve a `PluginName` for callers that need it.
+#[must_use]
+pub fn resolve_name(raw: &str) -> Option<PluginName> {
+    PluginName::new(raw).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::host::register_all;
+
+    #[test]
+    fn run_reports_four_plugins() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        assert_eq!(report.plugins.len(), 4);
+        assert_eq!(report.summary.failed, 0, "no failures expected");
+        // 4 plugins × 3 tier-1 = 12 ok minimum.
+        assert!(report.summary.ok >= 12);
+        assert!(report.summary.pending >= 4, "tier-2 stubs are pending");
+    }
+
+    #[test]
+    fn exit_code_default_zero_with_pendings() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        assert_eq!(exit_code(&report, false), 0);
+    }
+
+    #[test]
+    fn exit_code_strict_nonzero_with_pendings() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        assert_eq!(exit_code(&report, true), 69);
+    }
+
+    #[test]
+    fn human_output_contains_every_plugin_and_summary() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        let text = render_human(&report);
+        for n in [
+            "cairn-mcp",
+            "cairn-sensors-local",
+            "cairn-store-sqlite",
+            "cairn-workflows",
+        ] {
+            assert!(text.contains(n));
+        }
+        assert!(text.contains("Summary:"));
+    }
+
+    #[test]
+    fn json_output_round_trips() {
+        let reg = register_all().expect("registers");
+        let report = run(&reg);
+        let json = render_json(&report);
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(v["plugins"].as_array().unwrap().len(), 4);
+        assert_eq!(v["summary"]["failed"], 0);
+    }
+}
+```
+
+- [ ] **Step 2: Run test, expect pass**
+
+Run: `cargo test -p cairn-cli --lib plugins::verify`
+Expected: PASS.
+
+- [ ] **Step 3: Lint clean**
+
+Run: `cargo clippy -p cairn-cli --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-cli/src/plugins/verify.rs
+git commit -m "feat(cli): cairn plugins verify runner + exit codes (#143)
+
+Default mode exits 0 with pendings allowed; --strict flips pending
+to failure. JSON output matches the spec's schema."
+```
+
+---
+
+## Task 13: `cairn-cli/src/main.rs` — clap dispatch
+
+**Files:**
+- Modify: `crates/cairn-cli/src/main.rs`
+
+- [ ] **Step 1: Write failing test** — defer all CLI-level testing to the snapshot tests in Task 14. Implementation comes first here because main.rs has no test surface of its own; snapshot tests verify the full dispatch.
+
+- [ ] **Step 2: Replace `crates/cairn-cli/src/main.rs`**
+
+```rust
+//! `cairn` binary entry point.
+//!
+//! Adopts `clap` for the `plugins` subcommand. Verb subcommands
+//! (`ingest`, `search`, …) remain stubs that exit 2 — they wire into
+//! real verb-layer code in a follow-up issue.
+
+use std::io::Write;
+use std::process::ExitCode;
+
+use cairn_cli::plugins;
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(name = "cairn", version, about = "Cairn — agent memory framework")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Manage and inspect bundled plugins.
+    Plugins {
+        #[command(subcommand)]
+        action: PluginsAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum PluginsAction {
+    /// List loaded plugins.
+    List {
+        /// Emit JSON instead of a human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Run the conformance suite against every loaded plugin.
+    Verify {
+        /// Treat tier-2 `pending` cases as failures.
+        #[arg(long)]
+        strict: bool,
+        /// Emit JSON instead of a human-readable report.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+fn main() -> ExitCode {
+    let cli = match Cli::try_parse() {
+        Ok(c) => c,
+        Err(e) => {
+            // Clap prints the error itself; map its exit code through.
+            let _ = e.print();
+            return match e.kind() {
+                clap::error::ErrorKind::DisplayHelp
+                | clap::error::ErrorKind::DisplayVersion => ExitCode::SUCCESS,
+                _ => ExitCode::from(2),
+            };
+        }
+    };
+
+    match cli.command {
+        None => {
+            // No subcommand: clap printed nothing; emulate the previous scaffold's
+            // help shape so existing test expectations don't drift more than needed.
+            print_help();
+            ExitCode::SUCCESS
+        }
+        Some(Commands::Plugins { action }) => run_plugins(action),
+    }
+}
+
+fn run_plugins(action: PluginsAction) -> ExitCode {
+    let registry = match plugins::host::register_all() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("cairn plugins: startup failed — {e}");
+            // EX_UNAVAILABLE
+            return ExitCode::from(69);
+        }
+    };
+
+    match action {
+        PluginsAction::List { json } => {
+            let mut stdout = std::io::stdout().lock();
+            let text = if json {
+                plugins::list::render_json(&registry)
+            } else {
+                plugins::list::render_human(&registry)
+            };
+            // Newline at end ensures the human table flushes cleanly.
+            let _ = writeln!(stdout, "{}", text.trim_end_matches('\n'));
+            ExitCode::SUCCESS
+        }
+        PluginsAction::Verify { strict, json } => {
+            let report = plugins::verify::run(&registry);
+            let text = if json {
+                plugins::verify::render_json(&report)
+            } else {
+                plugins::verify::render_human(&report)
+            };
+            let mut stdout = std::io::stdout().lock();
+            let _ = writeln!(stdout, "{}", text.trim_end_matches('\n'));
+            ExitCode::from(plugins::verify::exit_code(&report, strict))
+        }
+    }
+}
+
+fn print_help() {
+    println!("cairn {} — P0 scaffold", env!("CARGO_PKG_VERSION"));
+    println!();
+    println!("Subcommands:");
+    println!("  cairn plugins list       List loaded plugins");
+    println!("  cairn plugins verify     Run plugin conformance suite");
+    println!();
+    println!("Verbs (not yet implemented — every verb exits 2):");
+    for v in [
+        "ingest",
+        "search",
+        "retrieve",
+        "summarize",
+        "assemble_hot",
+        "capture_trace",
+        "lint",
+        "forget",
+    ] {
+        println!("  cairn {v}");
+    }
+}
+```
+
+- [ ] **Step 3: Build and smoke-test by hand**
+
+Run:
+```
+cargo build -p cairn-cli --locked
+./target/debug/cairn plugins list
+./target/debug/cairn plugins list --json
+./target/debug/cairn plugins verify
+echo "verify exit: $?"
+./target/debug/cairn plugins verify --strict
+echo "strict exit: $?"
+```
+Expected:
+- `list` shows four rows alphabetical: cairn-mcp, cairn-sensors-local, cairn-store-sqlite, cairn-workflows.
+- `list --json` emits valid JSON with 4 plugins.
+- `verify` exits 0 (pending cases allowed).
+- `verify --strict` exits 69.
+
+- [ ] **Step 4: Run cargo check + clippy on workspace**
+
+Run: `cargo clippy --workspace --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-cli/src/main.rs
+git commit -m "feat(cli): clap dispatch for cairn plugins subcommand (#143)
+
+Replaces the hand-rolled argv matcher with clap. Verb stubs still
+exit 2 via the no-subcommand path; only --help, --version, and
+'cairn plugins {list,verify}' are wired."
+```
+
+---
+
+## Task 14: Snapshot tests for `list` and `verify`
+
+**Files:**
+- Modify: `crates/cairn-cli/Cargo.toml` (add `insta` dev-dep)
+- Create: `crates/cairn-cli/tests/plugins_list_snapshot.rs`
+- Create: `crates/cairn-cli/tests/plugins_verify_snapshot.rs`
+- Create: `crates/cairn-cli/tests/snapshots/` (auto-generated by insta)
+
+- [ ] **Step 1: Add `insta` as dev-dep**
+
+Append to `[dev-dependencies]` in `crates/cairn-cli/Cargo.toml`:
+
+```toml
+insta = { workspace = true }
+```
+
+- [ ] **Step 2: Create `plugins_list_snapshot.rs`**
+
+```rust
+//! Snapshot test: `cairn plugins list` human + JSON outputs are stable.
+
+use cairn_cli::plugins::{host::register_all, list};
+
+#[test]
+fn list_human_snapshot() {
+    let reg = register_all().expect("registers");
+    let text = list::render_human(&reg);
+    insta::assert_snapshot!("plugins_list_human", text);
+}
+
+#[test]
+fn list_json_snapshot() {
+    let reg = register_all().expect("registers");
+    let json = list::render_json(&reg);
+    insta::assert_snapshot!("plugins_list_json", json);
+}
+```
+
+- [ ] **Step 3: Create `plugins_verify_snapshot.rs`**
+
+```rust
+//! Snapshot test: `cairn plugins verify` human + JSON outputs are stable.
+
+use cairn_cli::plugins::{host::register_all, verify};
+
+#[test]
+fn verify_human_snapshot() {
+    let reg = register_all().expect("registers");
+    let report = verify::run(&reg);
+    let text = verify::render_human(&report);
+    insta::assert_snapshot!("plugins_verify_human", text);
+}
+
+#[test]
+fn verify_json_snapshot() {
+    let reg = register_all().expect("registers");
+    let report = verify::run(&reg);
+    let json = verify::render_json(&report);
+    insta::assert_snapshot!("plugins_verify_json", json);
+}
+
+#[test]
+fn verify_default_mode_exit_zero() {
+    let reg = register_all().expect("registers");
+    let report = verify::run(&reg);
+    assert_eq!(verify::exit_code(&report, false), 0);
+}
+
+#[test]
+fn verify_strict_mode_exit_69_with_pendings() {
+    let reg = register_all().expect("registers");
+    let report = verify::run(&reg);
+    assert_eq!(verify::exit_code(&report, true), 69);
+}
+```
+
+- [ ] **Step 4: Run the tests once with `INSTA_UPDATE=auto` to create the initial snapshots**
+
+Run: `INSTA_UPDATE=auto cargo test -p cairn-cli --test plugins_list_snapshot --test plugins_verify_snapshot`
+Expected: PASS — snapshots are created in `crates/cairn-cli/tests/snapshots/`.
+
+- [ ] **Step 5: Inspect the generated snapshots**
+
+Read the four `.snap` files in `crates/cairn-cli/tests/snapshots/`. Confirm:
+- Human list: 4 rows, alphabetical.
+- JSON list: 4 plugins with capabilities objects.
+- Human verify: each plugin block, summary line `4 plugins, ≥12 ok, ≥4 pending, 0 failed`.
+- JSON verify: matches the schema in the spec.
+
+If any snapshot looks wrong, fix the renderer; do not edit the snapshot by hand.
+
+- [ ] **Step 6: Re-run without `INSTA_UPDATE`**
+
+Run: `cargo test -p cairn-cli --test plugins_list_snapshot --test plugins_verify_snapshot`
+Expected: PASS — snapshots match.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cairn-cli/Cargo.toml \
+        crates/cairn-cli/tests/plugins_list_snapshot.rs \
+        crates/cairn-cli/tests/plugins_verify_snapshot.rs \
+        crates/cairn-cli/tests/snapshots/
+git commit -m "test(cli): insta snapshots for plugins list/verify (#143)"
+```
+
+---
+
+## Task 15: Cargo-test wrapper that shells out to the binary
+
+**Files:**
+- Create: `crates/cairn-cli/tests/plugins_verify.rs`
+
+- [ ] **Step 1: Create the test**
+
+Create `crates/cairn-cli/tests/plugins_verify.rs`:
+
+```rust
+//! Integration: shell out to the built `cairn` binary and assert the
+//! `plugins verify --json` output. This is the CI-protective wrapper:
+//! it runs under `cargo nextest` regardless of any workflow-yaml drift.
+
+use std::process::Command;
+
+fn cairn_binary() -> std::path::PathBuf {
+    // Cargo sets CARGO_BIN_EXE_<name> for every binary in the package.
+    let raw = env!("CARGO_BIN_EXE_cairn");
+    std::path::PathBuf::from(raw)
+}
+
+#[test]
+fn plugins_verify_json_default_succeeds() {
+    let output = Command::new(cairn_binary())
+        .args(["plugins", "verify", "--json"])
+        .output()
+        .expect("spawn cairn binary");
+
+    assert!(
+        output.status.success(),
+        "cairn plugins verify --json must exit 0 in default mode; got {:?}",
+        output.status
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(v["summary"]["failed"], 0, "no tier-1 failures expected");
+    assert_eq!(
+        v["plugins"].as_array().expect("plugins array").len(),
+        4,
+        "all four bundled plugins must be reported"
+    );
+}
+
+#[test]
+fn plugins_verify_strict_exits_69_with_pendings() {
+    let output = Command::new(cairn_binary())
+        .args(["plugins", "verify", "--strict"])
+        .output()
+        .expect("spawn cairn binary");
+
+    let code = output.status.code().expect("exit code present");
+    assert_eq!(
+        code, 69,
+        "verify --strict must exit 69 while tier-2 cases are pending"
+    );
+}
+
+#[test]
+fn plugins_list_emits_alphabetical_rows() {
+    let output = Command::new(cairn_binary())
+        .args(["plugins", "list"])
+        .output()
+        .expect("spawn cairn binary");
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+
+    let mcp_idx = stdout.find("cairn-mcp").expect("mcp present");
+    let sensors_idx = stdout
+        .find("cairn-sensors-local")
+        .expect("sensors present");
+    let store_idx = stdout.find("cairn-store-sqlite").expect("store present");
+    let workflows_idx = stdout.find("cairn-workflows").expect("workflows present");
+
+    assert!(mcp_idx < sensors_idx);
+    assert!(sensors_idx < store_idx);
+    assert!(store_idx < workflows_idx);
+}
+```
+
+This test relies on `serde_json` being a dev-dep — it's already a regular
+dep of `cairn-cli` (Task 10), and Cargo allows tests to use regular deps.
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p cairn-cli --test plugins_verify`
+Expected: PASS.
+
+- [ ] **Step 3: Lint clean**
+
+Run: `cargo clippy --workspace --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-cli/tests/plugins_verify.rs
+git commit -m "test(cli): shell out to built cairn binary for plugins verify (#143)
+
+Catches regressions in the CLI dispatch + exit-code mapping under
+'cargo nextest run', so workflow-yaml edits cannot silently drop
+the verify gate."
+```
+
+---
+
+## Task 16: CI integration — `.github/workflows/ci.yml`
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Read the current workflow**
+
+Run: `cat .github/workflows/ci.yml`
+
+Identify the step that runs `cargo nextest run --workspace` (or similar).
+
+- [ ] **Step 2: Add `plugins verify` steps after the test step**
+
+Insert these YAML stanzas immediately after the existing `cargo nextest run` step (preserve indentation under the matching job's `steps:` list):
+
+```yaml
+      - name: cairn plugins verify (default mode)
+        run: cargo run -p cairn-cli --locked -- plugins verify
+      - name: cairn plugins verify (json artifact)
+        run: cargo run -p cairn-cli --locked -- plugins verify --json > plugins-verify.json
+      - name: Upload plugins-verify.json
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugins-verify-${{ github.run_id }}
+          path: plugins-verify.json
+          retention-days: 14
+```
+
+The default `plugins verify` step uses non-strict mode so the build stays
+green while tier-2 cases are `Pending`. The JSON artifact captures the
+full report for review.
+
+- [ ] **Step 3: Verify the workflow file is valid YAML**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo OK`
+Expected: `OK`.
+
+(If `python` is not available, run `yq '.' .github/workflows/ci.yml > /dev/null` instead.)
+
+- [ ] **Step 4: Smoke-test the new commands locally**
+
+Run:
+```
+cargo run -p cairn-cli --locked -- plugins verify
+cargo run -p cairn-cli --locked -- plugins verify --json > /tmp/plugins-verify.json
+jq '.summary' /tmp/plugins-verify.json
+```
+Expected: human run prints summary + exit 0; JSON file parses with `jq`.
+
+- [ ] **Step 5: Run full local verification checklist** (CLAUDE.md §8)
+
+Run:
+```
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo check --workspace --all-targets --locked
+cargo nextest run --workspace --locked --no-fail-fast
+cargo test --doc --workspace --locked
+./scripts/check-core-boundary.sh
+```
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run cairn plugins verify in CI + upload JSON artifact (#143)
+
+Default-mode invocation gates the build on tier-1 conformance pass
+across all bundled plugins. JSON artifact (plugins-verify-<run_id>.json)
+captures the full per-case report for reviewer access."
+```
+
+---
+
+## Task 17: Final integration sweep + PR
+
+**Files:** none (sweep only)
+
+- [ ] **Step 1: Run the full CLAUDE.md §8 verification checklist**
+
+```
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo check --workspace --all-targets --locked
+cargo nextest run --workspace --locked --no-fail-fast
+cargo test --doc --workspace --locked
+./scripts/check-core-boundary.sh
+
+RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" \
+  cargo doc --workspace --no-deps --document-private-items --locked
+
+cargo deny check
+cargo audit --deny warnings
+cargo machete
+```
+
+Expected: every command exits 0. If `cargo machete` flags any leftover ignored entry, drop it from the relevant `[package.metadata.cargo-machete]`.
+
+- [ ] **Step 2: Smoke the binary one last time**
+
+```
+cargo run -p cairn-cli --locked -- --version
+cargo run -p cairn-cli --locked -- --help
+cargo run -p cairn-cli --locked -- plugins list
+cargo run -p cairn-cli --locked -- plugins list --json | jq '.plugins | length'
+cargo run -p cairn-cli --locked -- plugins verify
+echo "default exit: $?"
+cargo run -p cairn-cli --locked -- plugins verify --strict
+echo "strict exit: $?"
+```
+
+Expected:
+- `--version` prints `cairn 0.0.1`.
+- `--help` lists `plugins` subcommand and verb stubs.
+- `plugins list --json | jq '.plugins | length'` prints `4`.
+- Default verify exit is `0`; strict verify exit is `69`.
+
+- [ ] **Step 3: Open the PR**
+
+Push the branch and run:
+
+```bash
+gh pr create --title "feat(plugins): host wiring + cairn plugins list/verify (#143)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Live plugin host: bundled crates register through `register_plugin!` (now manifest-aware) into `PluginRegistry` at startup of `plugins`-subcommand commands.
+- `cairn plugins list` (human + `--json`) and `cairn plugins verify` (`--strict`/`--json`).
+- Two-tier conformance suite in `cairn-core::contract::conformance`: tier-1 pass for all four bundled stubs; tier-2 cases stub `Pending` until per-impl PRs land.
+- CI runs `plugins verify` in default mode and uploads JSON artifact.
+- `cargo`-test wrapper at `crates/cairn-cli/tests/plugins_verify.rs` keeps the verify gate in `cargo nextest`.
+
+## Brief sections
+- §4.0 Contracts
+- §4.1 Plugin architecture
+- §13.3 Commands
+
+## Invariants touched (CLAUDE.md §4)
+- 1 (harness-agnostic) — preserved; sensors stub keeps no harness assumptions.
+- 4 (seven contracts, pure functions) — extended `cairn-core` with conformance helpers (pure).
+- 6 (fail closed on capability) — `cairn plugins verify --strict` exits 69 on pendings; default mode keeps CI green during P0 build-out.
+- 7 (`#![forbid(unsafe_code)]`) — preserved.
+
+## Test plan
+- [ ] `cargo nextest run --workspace --locked` passes locally.
+- [ ] `cargo run -p cairn-cli -- plugins list --json | jq '.plugins | length'` returns 4.
+- [ ] `cargo run -p cairn-cli -- plugins verify` exits 0.
+- [ ] `cargo run -p cairn-cli -- plugins verify --strict` exits 69.
+- [ ] CI step uploads `plugins-verify-<run_id>.json` artifact.
+- [ ] `cargo deny check`, `cargo audit`, `cargo machete` all clean.
+
+## Out of scope (follow-up issues)
+- Real `MemoryStore` / `MCPServer` / `WorkflowOrchestrator` / `SensorIngress` impls (#46, #64, #84, #89).
+- `LLMProvider` bundled plugin (no crate yet).
+- `.cairn/config.yaml` loader and active-set selection.
+- Verb dispatch invoking `register_all()` (lands with verb-layer issue).
+
+Spec: `docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md`
+EOF
+)"
+```
+
+- [ ] **Step 4: Mark plan complete**
+
+The plan ends here. PR review then drives any follow-up adjustments.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- §3.1 crate diagram → Tasks 5–8 + 10.
+- §3.2 hard-coded discovery → Task 10 (`register_all`).
+- §3.3 manifest convention → Tasks 5–8 each create `plugin.toml` + `MANIFEST_TOML`.
+- §3.4 registry extension → Task 1.
+- §3.5 CLI clap structure → Task 13.
+- §3.6 startup wiring scope → Task 13 (only `plugins` subcommand calls `register_all`).
+- §4 conformance suite → Tasks 3–4.
+- §5 CLI command outputs → Tasks 11, 12, 14.
+- §6.1 macro extension → Task 2.
+- §6.3 tests → unit tests in each task + Tasks 14, 15.
+- §7 CI integration → Task 16.
+
+**Type / signature consistency check:**
+- `register_*_with_manifest(name, manifest, plugin)` argument order — used consistently across Tasks 1, 2, 5–8.
+- `parsed_manifest(&PluginName) -> Option<&PluginManifest>` and `parsed_manifests_sorted()` — defined Task 1, used in Tasks 4, 11, 12.
+- `CaseOutcome { id, tier, status }` — defined Task 3, used in Tasks 4, 12.
+- `CaseStatus` variants `Ok`/`Pending { reason }`/`Failed { message }` — defined Task 3, matched in Tasks 4, 12.
+- `Tier::as_u8()` — defined Task 3, used in Task 12 (`render_json`).
+- `MANIFEST_TOML` const — defined per-crate in Tasks 5–8, consumed in Task 14 macro expansion.
+- `PluginRegistry::sensor_ingress_plugin` — name confirmed against `crates/cairn-core/src/contract/registry.rs:320`.
+
+**Out-of-scope guardrails:**
+- No verb-layer code touched.
+- No real adapter implementation logic added — every adapter trait method returns the static capability struct only.
+- `cairn-test-fixtures` not on the production dep graph.

--- a/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
+++ b/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
@@ -327,7 +327,7 @@ cairn-store-sqlite (MemoryStore)
 
 …
 
-Summary: 4 plugins, 12 ok, 7 pending, 0 failed
+Summary: 4 plugins, 12 ok, 6 pending, 0 failed
 ```
 
 `--json`:
@@ -345,7 +345,7 @@ Summary: 4 plugins, 12 ok, 7 pending, 0 failed
       ]
     }
   ],
-  "summary": { "ok": 12, "pending": 7, "failed": 0 }
+  "summary": { "ok": 12, "pending": 6, "failed": 0 }
 }
 ```
 

--- a/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
+++ b/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
@@ -1,0 +1,516 @@
+# Plugin host, `cairn plugins list`, and `cairn plugins verify`
+
+**Issue:** [#143](https://github.com/windoliver/cairn/issues/143) — *[P0] Implement
+plugin registration, capability manifests, and `cairn plugins verify`*.
+
+**Brief sections:** §4.0 Contracts, §4.1 Plugin architecture, §13.3 Commands.
+
+**Status:** Design — drafted 2026-04-25.
+
+---
+
+## 1. Goal
+
+Close the remaining acceptance criteria of issue #143 by:
+
+1. Wiring a live, in-process plugin host into `cairn-cli` so the four
+   already-existing bundled adapter crates register themselves through
+   `PluginRegistry` at startup of plugin-using commands.
+2. Adding two CLI commands: `cairn plugins list` and `cairn plugins verify`.
+3. Adding a two-tier conformance suite in `cairn-core::contract::conformance` that the
+   `verify` command runs against every registered plugin.
+4. Wiring `cairn plugins verify` into CI so a regression in any bundled
+   plugin's manifest, identity, version range, or capability self-consistency
+   breaks the build.
+
+The existing landed work (PR #174 / commit `f74b0c8`) provides contract
+traits, `CONTRACT_VERSION` constants, `PluginRegistry`, `register_plugin!`,
+and `PluginManifest`. This design builds on that foundation only — it does
+not modify it.
+
+## 2. Scope
+
+### 2.1 In scope
+
+- New `crates/cairn-cli/src/plugins/` module: host, list, verify.
+- A `clap`-derived subcommand tree on `cairn-cli` introducing the
+  `plugins {list, verify}` subcommands. **`clap` is added as a new
+  workspace dependency by this PR** (no current `Cargo.toml` mention).
+  The existing scaffold's argv matching is replaced by `clap` only for
+  the `plugins` subtree; help and version remain trivial.
+- Per-bundled-crate work: `plugin.toml`, `register()` function emitted
+  through `register_plugin!`, stub trait impl exposing honest capability
+  flags and `CapabilityUnavailable`-returning verb methods. Four crates:
+  `cairn-store-sqlite`, `cairn-sensors-local`, `cairn-mcp`,
+  `cairn-workflows`.
+- New `cairn-core::contract::conformance` module with one submodule per
+  contract, two tiers of cases. *(Lives in `cairn-core` rather than
+  `cairn-test-fixtures` because `cairn plugins verify` is a production
+  code path and CLAUDE.md §3 forbids `cairn-test-fixtures` as a non-dev
+  dep. The conformance suite is pure functions — no I/O — so it
+  satisfies the `cairn-core` purity rule.)*
+- CI integration in `.github/workflows/ci.yml` plus a `cargo`-test wrapper
+  in `crates/cairn-cli/tests/plugins_verify.rs`.
+- `PluginRegistry` accessor `parsed_manifest(&PluginName)` so `verify` can
+  reach the manifest the host parsed at registration time.
+
+### 2.2 Out of scope (deferred to dedicated issues)
+
+- Real `MemoryStore` / `MCPServer` / `WorkflowOrchestrator` /
+  `SensorIngress` implementations beyond what tier-1 cases require.
+- `LLMProvider` bundled plugin (no crate exists yet).
+- `.cairn/config.yaml` loader and active-set selection between competing
+  plugins for one contract.
+- Verb dispatch calling `register_all()` (lands when the verb layer does).
+- Third-party plugin discovery, signing, or sandboxing.
+
+## 3. Architecture
+
+### 3.1 Crate diagram
+
+```
+cairn-cli ──┬─ depends-on ──> cairn-core (PluginRegistry, contract traits)
+            ├─ depends-on ──> cairn-store-sqlite       (calls register())
+            ├─ depends-on ──> cairn-sensors-local      (calls register())
+            ├─ depends-on ──> cairn-mcp                (calls register())
+            └─ depends-on ──> cairn-workflows          (calls register())
+
+each adapter crate ─ depends-on ─> cairn-core (contract traits, register_plugin!)
+
+cairn-test-fixtures stays dev-only (CLAUDE.md §3) — not on the
+production dep graph above.
+```
+
+Only `cairn-cli` gains direct deps on the four adapter crates. No adapter
+crate depends on another. `cairn-core` retains its zero-workspace-dep
+invariant.
+
+### 3.2 Discovery: hard-coded deps
+
+`cairn-cli/src/plugins/host.rs` calls each adapter crate's public
+`register(&mut PluginRegistry)` function in alphabetical order:
+
+```rust
+pub fn register_all() -> Result<PluginRegistry, PluginError> {
+    let mut reg = PluginRegistry::new();
+    cairn_mcp::register(&mut reg)?;
+    cairn_sensors_local::register(&mut reg)?;
+    cairn_store_sqlite::register(&mut reg)?;
+    cairn_workflows::register(&mut reg)?;
+    Ok(reg)
+}
+```
+
+No `inventory`, no build-script codegen. Adding a fifth bundled plugin
+edits this function and `Cargo.toml`. The brief invariant "registration is
+explicit" (§4.1) is satisfied at the source level.
+
+### 3.3 Manifest convention per adapter crate
+
+Each bundled crate gains:
+
+- `crates/<crate>/plugin.toml` — TOML manifest, schema-validated by
+  `crates/cairn-idl/schema/plugin/manifest.json`.
+- `pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");` — the
+  manifest is baked into the binary. No filesystem access at runtime.
+- A single `pub fn register(reg: &mut PluginRegistry) -> Result<(),
+  PluginError>` emitted by `register_plugin!`. The macro is extended to
+  accept the `MANIFEST_TOML` constant and forward the parsed
+  `PluginManifest` into the registry alongside the `Arc<dyn Trait>`.
+
+### 3.4 Registry extension
+
+`PluginRegistry` gains a parallel `HashMap<PluginName, PluginManifest>`
+per contract, populated alongside the `Arc<dyn Trait>` map. New accessor:
+
+```rust
+impl PluginRegistry {
+    pub fn parsed_manifest(&self, name: &PluginName) -> Option<&PluginManifest>;
+}
+```
+
+The existing seven `register_<contract>()` methods are **kept unchanged**
+to preserve the public API just shipped by PR #174. Each gets a sibling
+`register_<contract>_with_manifest(name, manifest, plugin)` method that
+performs the same registration and additionally stores the parsed
+manifest. The macro-emitted four-arg form (§6.1) calls the
+`_with_manifest` variant; the three-arg form keeps calling the original.
+
+This avoids a churn-y signature change and lets unit tests that don't
+care about manifests stay terse, while the bundled-plugin path always
+carries a manifest.
+
+### 3.5 CLI structure
+
+`cairn-cli/src/main.rs` stops being a hand-rolled argv matcher. It
+adopts `clap` 4.5 — added as a new workspace dependency by this PR
+per CLAUDE.md §6.5 — with a minimal command tree:
+
+```
+cairn
+├── --help / -h           (skips register_all)
+├── --version / -V        (skips register_all)
+└── plugins
+    ├── list  [--json]
+    └── verify [--strict] [--json]
+```
+
+Future verb subcommands (`ingest`, `search`, …) slot in alongside
+`plugins`. They are out of scope here. The existing scaffold's behaviour
+of refusing unknown verbs is preserved by `clap`'s usage error (exit 2).
+
+### 3.6 Startup wiring
+
+`register_all()` is invoked **only** by the `plugins` subcommand. `--help`,
+`--version`, and unknown commands do not trigger plugin registration.
+This matches the AC ("startup fails closed when a plugin contract version
+is incompatible") for any command that does work, without bricking
+trivial commands.
+
+## 4. Conformance suite (two tiers)
+
+### 4.1 Layout
+
+```
+crates/cairn-core/src/contract/conformance/
+├── mod.rs                  -- CaseOutcome, CaseStatus, Tier,
+│                              run_conformance_for_plugin entry point
+├── memory_store.rs
+├── workflow_orchestrator.rs
+├── sensor_ingress.rs
+└── mcp_server.rs
+   -- llm_provider.rs deferred until an LLM bundled crate exists.
+   -- frontend_adapter.rs / agent_provider.rs deferred (P1/P2).
+```
+
+The module is `pub` from `cairn-core::contract`. `cairn-cli` consumes it
+directly. `cairn-core`'s no-I/O rule is preserved because every case is
+either a pure trait-method call or returns `Pending`.
+
+### 4.2 Public types
+
+```rust
+pub struct CaseOutcome {
+    pub id: &'static str,
+    pub tier: Tier,
+    pub status: CaseStatus,
+}
+
+pub enum Tier { One, Two }
+
+pub enum CaseStatus {
+    Ok,
+    Pending { reason: &'static str },
+    Failed { message: String },
+}
+```
+
+### 4.3 Per-contract case set
+
+Tier-1 cases are identical across contracts (defined once and reused with
+generic helpers); tier-2 cases are contract-specific function stubs.
+
+| Contract | Tier-1 (always run) | Tier-2 (`Pending` until impl) |
+|---|---|---|
+| `MemoryStore` | `manifest_matches_host`, `register_round_trip`, `capability_self_consistency_floor` | `put_get_roundtrip`, `fts_query_returns_doc`, `vector_search_when_advertised` |
+| `WorkflowOrchestrator` | (same three) | `enqueue_then_complete` |
+| `SensorIngress` | (same three) | `emits_envelope_when_poked` |
+| `MCPServer` | (same three) | `initialize_and_list_tools` |
+
+Tier-1 specifics:
+
+- `manifest_matches_host` — call `PluginManifest::verify_compatible_with`
+  with the plugin's runtime `name()`, contract kind, and host
+  `CONTRACT_VERSION`.
+- `register_round_trip` — instantiate a fresh `PluginRegistry`, call the
+  plugin's `register()`, look up by name, assert `Arc::ptr_eq` against
+  the original.
+- `capability_self_consistency_floor` — every public field of the
+  capability struct is readable; the trait's runtime methods do not panic
+  when called for a capability the plugin does **not** advertise (they
+  must return a typed `CapabilityUnavailable` error). This is the
+  minimum floor; per-contract invariants (e.g.,
+  `caps.fts == true ⇒ supports_fts() == true`) tighten in the per-impl
+  PRs.
+
+Tier-2 stubs are real Rust functions in
+`cairn-core::contract::conformance::<contract>` whose bodies return
+`CaseStatus::Pending { reason: "real impl pending" }` until a follow-up
+PR replaces them. Real tier-2 bodies that need adapter-specific I/O
+(e.g., a SQLite round-trip beyond the trait surface) are not surfaced
+through this entry point — they live in per-adapter integration tests
+and are run by `cargo nextest`, not by `cairn plugins verify`. The
+conformance suite is the lowest-common-denominator surface that runs
+against any plugin via the trait alone.
+
+### 4.4 Entry point
+
+```rust
+pub fn run_conformance_for_plugin(
+    registry: &PluginRegistry,
+    name: &PluginName,
+) -> Vec<CaseOutcome>;
+```
+
+This is the function `cairn plugins verify` calls. It dispatches by
+contract kind (read from the parsed manifest) to the per-contract case
+runner.
+
+## 5. CLI commands
+
+### 5.1 `cairn plugins list`
+
+Default output:
+
+```
+NAME                  CONTRACT              VERSION-RANGE      SOURCE
+cairn-mcp             MCPServer             [0.1.0, 0.2.0)     bundled:cairn-mcp
+cairn-sensors-local   SensorIngress         [0.1.0, 0.2.0)     bundled:cairn-sensors-local
+cairn-store-sqlite    MemoryStore           [0.1.0, 0.2.0)     bundled:cairn-store-sqlite
+cairn-workflows       WorkflowOrchestrator  [0.1.0, 0.2.0)     bundled:cairn-workflows
+```
+
+`--json`:
+
+```json
+{
+  "plugins": [
+    {
+      "name": "cairn-mcp",
+      "contract": "MCPServer",
+      "contract_version_range": {
+        "min": "0.1.0",
+        "max_exclusive": "0.2.0"
+      },
+      "source": "bundled:cairn-mcp",
+      "capabilities": { "stdio": true, "http": false }
+    }
+  ]
+}
+```
+
+`source` is `bundled:<crate-name>` for every plugin in P0. The shape is
+forward-compatible with `config:.cairn/config.yaml` once the config
+loader lands.
+
+Capabilities are hidden from the human table to keep it narrow but
+present in `--json`. A future `cairn plugins describe <name>` command
+can surface them in human form; out of scope here.
+
+### 5.2 `cairn plugins verify`
+
+Default output (one block per plugin):
+
+```
+cairn-store-sqlite (MemoryStore)
+  tier-1 manifest_matches_host                    ok
+  tier-1 register_round_trip                      ok
+  tier-1 capability_self_consistency_floor        ok
+  tier-2 put_get_roundtrip                        pending (real impl pending)
+  tier-2 fts_query_returns_doc                    pending (real impl pending)
+  tier-2 vector_search_when_advertised            pending (real impl pending)
+
+…
+
+Summary: 4 plugins, 12 ok, 7 pending, 0 failed
+```
+
+`--json`:
+
+```json
+{
+  "plugins": [
+    {
+      "name": "cairn-store-sqlite",
+      "contract": "MemoryStore",
+      "cases": [
+        { "id": "manifest_matches_host", "tier": 1, "status": "ok" },
+        { "id": "put_get_roundtrip", "tier": 2, "status": "pending",
+          "reason": "real impl pending" }
+      ]
+    }
+  ],
+  "summary": { "ok": 12, "pending": 7, "failed": 0 }
+}
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0`  | No tier-1 failure (default; `pending` cases allowed). |
+| `64` | Clap usage error (`EX_USAGE`). |
+| `69` | A tier-1 case failed or `register_all` rejected a plugin (`EX_UNAVAILABLE`). |
+| `78` | A bundled `plugin.toml` failed to parse (`EX_CONFIG`). |
+
+`--strict` flips: any `pending` case becomes a tier-2 failure → exit `69`.
+This is the mode used by ad-hoc local invocations; CI uses default mode
+so the build stays green until per-contract impls land.
+
+## 6. Implementation notes
+
+### 6.1 `register_plugin!` macro extension
+
+The macro currently expands to
+`register_plugin!(<Contract>, <Impl>, "<name>")` per
+`crates/cairn-core/src/contract/macros.rs`. We extend each arm to accept
+an optional fourth argument — the manifest TOML constant:
+
+```rust
+// existing form (kept for tests that don't need a manifest):
+register_plugin!(MemoryStore, MyStore, "acme-store");
+
+// new manifest-aware form (required for bundled plugins):
+register_plugin!(
+    MemoryStore,
+    MyStore,
+    "cairn-store-sqlite",
+    MANIFEST_TOML,
+);
+```
+
+Implementation: add a second arm to `__register_plugin_helper!` that
+accepts `$manifest:expr` and emits a `register()` body which:
+
+1. Parses `MANIFEST_TOML` via `PluginManifest::parse_toml`, surfacing
+   `PluginError::InvalidManifest` on failure.
+2. Calls `PluginManifest::verify_compatible_with(name, contract_kind,
+   <contract>::CONTRACT_VERSION)` to fail closed before construction.
+3. Calls `reg.<register_method>_with_manifest(name, manifest, Arc::new(<impl>::default()))`.
+
+The four-arg form is used by every bundled plugin in this PR. The
+three-arg form remains for unit tests in `cairn-core` that don't need
+to exercise the manifest path.
+
+### 6.2 Stub trait implementations
+
+Every bundled crate ships a stub struct implementing its contract trait.
+Required methods (`name`, `capabilities`, `supported_contract_versions`)
+return real values. Verb-shaped methods that exist on the trait return
+`Err(PluginError::CapabilityUnavailable { … })` or the per-trait
+equivalent. The stubs exist solely so `register_all()` succeeds and
+tier-1 cases pass; per-impl issues replace them with real logic.
+
+Capability flag values for stubs:
+
+- `MemoryStore`: `fts=false, vector=false, graph_edges=false, transactions=false`.
+- `WorkflowOrchestrator`: empty workflow set.
+- `SensorIngress`: empty sensor set.
+- `MCPServer`: `stdio=false, http=false` *(real flags flip to true in
+  the MCP impl issue)*.
+
+These are honest defaults — the stubs do not advertise capability they
+do not have.
+
+### 6.3 Tests
+
+Unit (in-crate):
+
+- `cairn-cli/src/plugins/host.rs`: `register_all` happy path; failure
+  path synthesised by injecting a `BadPlugin` registering before the
+  bundled set (test-only feature `test-utils` exposing a helper).
+- `cairn-cli/src/plugins/list.rs`: pure formatter unit tests.
+- `cairn-cli/src/plugins/verify.rs`: pure exit-code mapping tests.
+
+Integration (`crates/cairn-cli/tests/`):
+
+- `plugins_list_snapshot.rs` — `insta` snapshot of human + JSON output.
+- `plugins_verify_snapshot.rs` — `insta` snapshot of human + JSON
+  output; asserts default mode exits 0, `--strict` exits 69.
+- `plugins_verify.rs` — shells out to the built `cairn` binary,
+  parses JSON, asserts `summary.failed == 0`, `summary.ok >= 12` (4
+  plugins × 3 tier-1 cases). This is the CI-protective wrapper that
+  runs under `cargo nextest` regardless of workflow changes.
+
+Per-bundled-crate (`crates/<crate>/tests/`):
+
+- `manifest_validates.rs` — load `plugin.toml`, run JSON-Schema
+  validation via `cairn-idl`, run Rust-level `PluginManifest::parse_toml`,
+  call `verify_compatible_with` with the host's `CONTRACT_VERSION`.
+
+### 6.4 Trade-off — sibling method vs signature change
+
+§3.4 picks the **sibling method** form
+(`register_<contract>_with_manifest(...)`) over changing the existing
+seven `register_<contract>(...)` signatures. Reasons:
+
+1. PR #174 just shipped the existing signatures; changing them within
+   the same release cycle churns the public API for no behavioural
+   gain.
+2. The macro is the bundled-plugin entry point; it emits the
+   manifest-aware variant unconditionally, so end-users never call the
+   bare form except in unit tests.
+3. The sibling form composes: a future `register_with_manifest_and_config`
+   can be added without breaking either of the existing two.
+
+Cost: two near-identical methods per contract (14 total). Mitigation:
+`_with_manifest` delegates to the bare form internally, so the
+duplication is one `self.<contract>_manifests.insert(...)` line per
+contract.
+
+## 7. CI integration
+
+### 7.1 `.github/workflows/ci.yml`
+
+After the existing `cargo nextest run` step, add:
+
+```yaml
+- name: cairn plugins verify (default)
+  run: cargo run -p cairn-cli --locked -- plugins verify
+- name: cairn plugins verify (json artifact)
+  run: cargo run -p cairn-cli --locked -- plugins verify --json > plugins-verify.json
+- uses: actions/upload-artifact@v4
+  with:
+    name: plugins-verify
+    path: plugins-verify.json
+```
+
+Default mode keeps CI green while tier-2 cases are still `Pending`. The
+JSON artifact is consumed by future dashboards / reviewers.
+
+### 7.2 Cargo-test wrapper
+
+`crates/cairn-cli/tests/plugins_verify.rs` shells out to the built
+binary inside a `#[test]`. This means even if a contributor edits
+`ci.yml` and removes the verify step, `cargo nextest run --workspace`
+still catches a regression.
+
+## 8. Acceptance-criteria mapping
+
+| AC | How this design satisfies it |
+|---|---|
+| Startup fails closed when a plugin contract version is incompatible | `host::register_all()` propagates `PluginError::UnsupportedContractVersion`; the existing registry guard fires. Synthesized failure path covered by `host.rs` unit test. |
+| `cairn plugins list` reports loaded plugins, versions, capabilities, and selected config source | §5.1 — name, contract, version range, source column; capabilities in `--json`. |
+| `cairn plugins verify` can run conformance tests against active bundled plugins in CI | §5.2 + §7. CI runs default mode + uploads JSON artifact; cargo-test wrapper guards against workflow drift. |
+
+## 9. Risks and follow-ups
+
+- **Macro complexity.** Extending `register_plugin!` to handle manifests
+  inflates the macro surface. If review pushes back, fall back to the
+  alternative in §6.4 (separate `register_manifest` call).
+- **Adopting clap mid-scaffold.** Bringing in `clap` for one subcommand
+  invites scope creep. Mitigation: only the `plugins` subtree is
+  defined; verbs remain unwired and exit 2 via the existing scaffold
+  path or `clap`'s default error.
+- **Tier-2 surface lock-in.** Tier-2 case names defined here become an
+  API contract for per-impl PRs. Renaming a case later means renaming a
+  function across two crates. Mitigation: the case names map directly
+  to brief §5 verb behaviour; they should not need to churn.
+- **Stub plugin semantics.** Stubs ship in production binaries until
+  per-impl issues land. Risk that a user runs `cairn ingest` and gets a
+  `CapabilityUnavailable` error. This is desired behaviour for the
+  current scaffold phase but should be documented in `--help` output.
+
+## 10. Definition of done
+
+- [ ] All four bundled crates ship `plugin.toml` + `register()` + stub
+      trait impl. Each crate's `manifest_validates.rs` test passes.
+- [ ] `PluginRegistry` exposes `parsed_manifest()`; macro emits the
+      manifest-aware `register()` form.
+- [ ] `cairn plugins list` and `cairn plugins verify` exist, snapshot
+      tests committed, exit codes match §5.2.
+- [ ] `cairn-core::contract::conformance` ships tier-1 cases (working)
+      and tier-2 stubs (`Pending`).
+- [ ] CI workflow runs `plugins verify` and uploads JSON artifact;
+      cargo-test wrapper passes locally and in CI.
+- [ ] PR description cites brief §4.0, §4.1, §13.3 + this spec.

--- a/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
+++ b/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
@@ -226,7 +226,7 @@ generic helpers); tier-2 cases are contract-specific function stubs.
 
 | Contract | Tier-1 (always run) | Tier-2 (`Pending` until impl) |
 |---|---|---|
-| `MemoryStore` | `manifest_matches_host`, `register_round_trip`, `capability_self_consistency_floor` | `put_get_roundtrip`, `fts_query_returns_doc`, `vector_search_when_advertised` |
+| `MemoryStore` | `manifest_matches_host`, `arc_pointer_stable`, `capability_self_consistency_floor` | `put_get_roundtrip`, `fts_query_returns_doc`, `vector_search_when_advertised` |
 | `WorkflowOrchestrator` | (same three) | `enqueue_then_complete` |
 | `SensorIngress` | (same three) | `emits_envelope_when_poked` |
 | `MCPServer` | (same three) | `initialize_and_list_tools` |
@@ -236,9 +236,10 @@ Tier-1 specifics:
 - `manifest_matches_host` — call `PluginManifest::verify_compatible_with`
   with the plugin's runtime `name()`, contract kind, and host
   `CONTRACT_VERSION`.
-- `register_round_trip` — instantiate a fresh `PluginRegistry`, call the
-  plugin's `register()`, look up by name, assert `Arc::ptr_eq` against
-  the original.
+- `arc_pointer_stable` — after registration, look up the plugin by name
+  twice and assert `Arc::ptr_eq` between the two results. Verifies the
+  registry returns a stable pointer to the same plugin instance across
+  lookups (the underlying `HashMap::get(name).cloned()` invariant).
 - `capability_self_consistency_floor` — every public field of the
   capability struct is readable; the trait's runtime methods do not panic
   when called for a capability the plugin does **not** advertise (they
@@ -318,7 +319,7 @@ Default output (one block per plugin):
 ```
 cairn-store-sqlite (MemoryStore)
   tier-1 manifest_matches_host                    ok
-  tier-1 register_round_trip                      ok
+  tier-1 arc_pointer_stable                       ok
   tier-1 capability_self_consistency_floor        ok
   tier-2 put_get_roundtrip                        pending (real impl pending)
   tier-2 fts_query_returns_doc                    pending (real impl pending)

--- a/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
+++ b/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
@@ -170,8 +170,10 @@ cairn
 ```
 
 Future verb subcommands (`ingest`, `search`, …) slot in alongside
-`plugins`. They are out of scope here. The existing scaffold's behaviour
-of refusing unknown verbs is preserved by `clap`'s usage error (exit 2).
+`plugins`. They are out of scope here. Verb stubs that reach our dispatch
+exit 2 with a not-implemented marker; clap usage errors (unknown
+subcommand, missing required ArgGroup, unknown flag) exit 64
+(`EX_USAGE`) per §5.2.
 
 ### 3.6 Startup wiring
 
@@ -226,10 +228,10 @@ generic helpers); tier-2 cases are contract-specific function stubs.
 
 | Contract | Tier-1 (always run) | Tier-2 (`Pending` until impl) |
 |---|---|---|
-| `MemoryStore` | `manifest_matches_host`, `arc_pointer_stable`, `capability_self_consistency_floor` | `put_get_roundtrip`, `fts_query_returns_doc`, `vector_search_when_advertised` |
-| `WorkflowOrchestrator` | (same three) | `enqueue_then_complete` |
-| `SensorIngress` | (same three) | `emits_envelope_when_poked` |
-| `MCPServer` | (same three) | `initialize_and_list_tools` |
+| `MemoryStore` | `manifest_matches_host`, `arc_pointer_stable`, `capability_self_consistency_floor`, `manifest_features_match_capabilities` | `put_get_roundtrip`, `fts_query_returns_doc`, `vector_search_when_advertised` |
+| `WorkflowOrchestrator` | (same four) | `enqueue_then_complete` |
+| `SensorIngress` | (same four) | `emits_envelope_when_poked` |
+| `MCPServer` | (same four) | `initialize_and_list_tools` |
 
 Tier-1 specifics:
 
@@ -247,6 +249,13 @@ Tier-1 specifics:
   minimum floor; per-contract invariants (e.g.,
   `caps.fts == true ⇒ supports_fts() == true`) tighten in the per-impl
   PRs.
+- `manifest_features_match_capabilities` — compare the manifest's
+  `[features]` map against the runtime capability struct field set.
+  Fails on unknown manifest keys (typo / drift) or value disagreement;
+  manifest keys absent from the capability struct default to `false`
+  (matches the schema's optional/free-form `[features]` semantics).
+  Catches the case where a plugin advertises e.g. `fts = true` in
+  `plugin.toml` but its runtime `capabilities()` returns `fts = false`.
 
 Tier-2 stubs are real Rust functions in
 `cairn-core::contract::conformance::<contract>` whose bodies return
@@ -321,13 +330,14 @@ cairn-store-sqlite (MemoryStore)
   tier-1 manifest_matches_host                    ok
   tier-1 arc_pointer_stable                       ok
   tier-1 capability_self_consistency_floor        ok
+  tier-1 manifest_features_match_capabilities     ok
   tier-2 put_get_roundtrip                        pending (real impl pending)
   tier-2 fts_query_returns_doc                    pending (real impl pending)
   tier-2 vector_search_when_advertised            pending (real impl pending)
 
 …
 
-Summary: 4 plugins, 12 ok, 6 pending, 0 failed
+Summary: 4 plugins, 16 ok, 6 pending, 0 failed
 ```
 
 `--json`:
@@ -345,7 +355,7 @@ Summary: 4 plugins, 12 ok, 6 pending, 0 failed
       ]
     }
   ],
-  "summary": { "ok": 12, "pending": 6, "failed": 0 }
+  "summary": { "ok": 16, "pending": 6, "failed": 0 }
 }
 ```
 

--- a/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
+++ b/docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md
@@ -120,20 +120,34 @@ Each bundled crate gains:
 
 ### 3.4 Registry extension
 
-`PluginRegistry` gains a parallel `HashMap<PluginName, PluginManifest>`
-per contract, populated alongside the `Arc<dyn Trait>` map. New accessor:
+`PluginRegistry` gains a single global `HashMap<PluginName,
+PluginManifest>`, populated alongside whichever per-contract `Arc<dyn
+Trait>` map the plugin registers into. One global map (rather than one
+parallel map per contract) enforces global `PluginName` uniqueness:
+even if the per-contract impl maps would tolerate the same name in two
+contract slots, the global manifest map rejects the second
+`register_*_with_manifest` call with `PluginError::DuplicateName`. This
+matches the brief's "stable identifier of a plugin instance" framing
+(§4.1) — a `PluginName` identifies one plugin, not one (plugin,
+contract) pair. New accessors:
 
 ```rust
 impl PluginRegistry {
     pub fn parsed_manifest(&self, name: &PluginName) -> Option<&PluginManifest>;
+    pub fn parsed_manifests_sorted(&self) -> Vec<(&PluginName, &PluginManifest)>;
 }
 ```
+
+`parsed_manifests_sorted` returns alphabetically-ordered manifests so
+`cairn plugins list` / `verify` get stable output without reaching into
+the underlying `HashMap`.
 
 The existing seven `register_<contract>()` methods are **kept unchanged**
 to preserve the public API just shipped by PR #174. Each gets a sibling
 `register_<contract>_with_manifest(name, manifest, plugin)` method that
 performs the same registration and additionally stores the parsed
-manifest. The macro-emitted four-arg form (§6.1) calls the
+manifest in the global map (failing closed if the name is already
+present there). The macro-emitted four-arg form (§6.1) calls the
 `_with_manifest` variant; the three-arg form keeps calling the original.
 
 This avoids a churn-y signature change and lets unit tests that don't


### PR DESCRIPTION
## Summary
- Live plugin host: bundled crates register through `register_plugin!` (now manifest-aware) into `PluginRegistry` at startup of `plugins`-subcommand commands.
- `cairn plugins list` (human + `--json`) and `cairn plugins verify` (`--strict` / `--json`) — built on top of the IDL-generated clap tree.
- Two-tier conformance suite in `cairn-core::contract::conformance`: tier-1 (`manifest_matches_host`, `arc_pointer_stable`, `capability_self_consistency_floor`) passes for all four bundled stubs; tier-2 cases stub `Pending` until per-impl PRs land.
- CI runs `plugins verify` in default mode and uploads the JSON report as an artifact (`plugins-verify-<run_id>.json`, 14-day retention).
- Cargo-test wrapper at `crates/cairn-cli/tests/plugins_verify.rs` keeps the verify gate inside `cargo nextest`, independent of workflow-yaml drift.
- `docs/ci.md` registers the new `plugins / cairn plugins verify` job for branch protection.

Closes #143.

## Brief sections
- §4.0 Contracts
- §4.1 Plugin architecture
- §13.3 Commands

## Invariants touched (CLAUDE.md §4)
- 1 (harness-agnostic) — preserved; bundled stubs make no harness assumption.
- 4 (seven contracts, pure functions) — extended `cairn-core` with `conformance` helpers (pure, no I/O).
- 6 (fail closed on capability) — `cairn plugins verify --strict` exits 69 on pendings; default mode keeps CI green during P0 build-out.
- 7 (`#![forbid(unsafe_code)]`) — preserved.

## Test plan
- [x] `cargo nextest run --workspace --locked` — 377 tests pass.
- [x] `cargo test --doc --workspace --locked` — 2 doctests pass (8 suites).
- [x] `cargo run -p cairn-cli -- plugins list --json | jq '.plugins | length'` returns 4.
- [x] `cargo run -p cairn-cli -- plugins verify` exits 0; `--strict` exits 69.
- [x] `cargo deny check` / `cargo audit` / `cargo machete` clean.
- [x] CI job `plugins / cairn plugins verify` uploads `plugins-verify-<run_id>.json`.

## Note on commits
Branch is 32 commits, including 5 in-flight correction commits from the per-task review loop (Task 11 fix-up, Task 12 fix-up, three plan/spec patches). They are intentionally preserved rather than squashed so the review trail stays auditable. If you'd prefer a squashed history, happy to interactive-rebase.

Cross-cutting follow-ups (intentionally out of scope):
- `cairn --help` advertises generated verb subcommands but not the `plugins` subcommand prominently — could be tightened with a `long_about`.
- Real `MemoryStore` / `MCPServer` / `WorkflowOrchestrator` / `SensorIngress` impls (#46, #64, #84, #89).
- `LLMProvider` bundled plugin (no crate yet).
- `.cairn/config.yaml` loader and active-set selection.
- Verb dispatch invoking `register_all()` (lands with verb-layer issue).

Spec: `docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md`
Plan: `docs/superpowers/plans/2026-04-25-plugin-host-list-verify.md`