### PR TITLE
feat(domain): closed-set parse/display for taxonomy enums (§6.1–6.4)

### DIFF
--- a/crates/cairn-core/src/domain/error.rs
+++ b/crates/cairn-core/src/domain/error.rs
@@ -70,6 +70,30 @@ pub enum DomainError {
         message: String,
     },
 
+    /// A [`crate::domain::MemoryKind`] string did not match any of the 19
+    /// recognized kinds (§6.1). Classifiers may not invent new kinds.
+    #[error("kind: unsupported memory kind `{value}`")]
+    UnsupportedKind {
+        /// Kind string that failed to parse.
+        value: String,
+    },
+
+    /// A [`crate::domain::MemoryClass`] string did not match any of the 4
+    /// recognized classes (§6.2).
+    #[error("class: unsupported memory class `{value}`")]
+    UnsupportedClass {
+        /// Class string that failed to parse.
+        value: String,
+    },
+
+    /// A [`crate::domain::ConfidenceBand`] string did not match `high`,
+    /// `normal`, or `uncertain` (§6.4).
+    #[error("confidence_band: unsupported value `{value}`")]
+    UnsupportedConfidenceBand {
+        /// Band string that failed to parse.
+        value: String,
+    },
+
     /// A required string field was empty (e.g., `body`, `record_id`).
     #[error("required field `{field}` must not be empty")]
     EmptyField {

--- a/crates/cairn-core/src/domain/evidence.rs
+++ b/crates/cairn-core/src/domain/evidence.rs
@@ -3,6 +3,8 @@
 //! Confidence is a single scalar in `[0.0, 1.0]`; Evidence is a four-part
 //! vector that drives promotion, expiration, and dream scheduling.
 
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 use crate::domain::DomainError;
@@ -21,6 +23,29 @@ pub enum ConfidenceBand {
 }
 
 impl ConfidenceBand {
+    /// Wire-format identifier. Stable across surfaces.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::High => "high",
+            Self::Normal => "normal",
+            Self::Uncertain => "uncertain",
+        }
+    }
+
+    /// Parse a wire-form band string. Returns
+    /// [`DomainError::UnsupportedConfidenceBand`] for unknown values.
+    pub fn parse(value: &str) -> Result<Self, DomainError> {
+        match value {
+            "high" => Ok(Self::High),
+            "normal" => Ok(Self::Normal),
+            "uncertain" => Ok(Self::Uncertain),
+            other => Err(DomainError::UnsupportedConfidenceBand {
+                value: other.to_owned(),
+            }),
+        }
+    }
+
     /// Map a confidence scalar to its band.
     #[must_use]
     pub fn from_scalar(confidence: f32) -> Self {
@@ -31,6 +56,12 @@ impl ConfidenceBand {
         } else {
             Self::Normal
         }
+    }
+}
+
+impl fmt::Display for ConfidenceBand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -93,6 +124,55 @@ mod tests {
     #[test]
     fn band_uncertain() {
         assert_eq!(ConfidenceBand::from_scalar(0.1), ConfidenceBand::Uncertain);
+    }
+
+    #[test]
+    fn band_as_str_all_3_values() {
+        assert_eq!(ConfidenceBand::High.as_str(), "high");
+        assert_eq!(ConfidenceBand::Normal.as_str(), "normal");
+        assert_eq!(ConfidenceBand::Uncertain.as_str(), "uncertain");
+    }
+
+    #[test]
+    fn band_parse_all_3_valid() {
+        assert_eq!(
+            ConfidenceBand::parse("high").expect("high"),
+            ConfidenceBand::High
+        );
+        assert_eq!(
+            ConfidenceBand::parse("normal").expect("normal"),
+            ConfidenceBand::Normal
+        );
+        assert_eq!(
+            ConfidenceBand::parse("uncertain").expect("uncertain"),
+            ConfidenceBand::Uncertain
+        );
+    }
+
+    #[test]
+    fn band_parse_rejects_invented() {
+        let err = ConfidenceBand::parse("very_high").unwrap_err();
+        assert!(matches!(err, DomainError::UnsupportedConfidenceBand { .. }));
+    }
+
+    #[test]
+    fn band_as_str_parse_round_trip() {
+        for band in [
+            ConfidenceBand::High,
+            ConfidenceBand::Normal,
+            ConfidenceBand::Uncertain,
+        ] {
+            assert_eq!(
+                ConfidenceBand::parse(band.as_str()).expect(band.as_str()),
+                band
+            );
+        }
+    }
+
+    #[test]
+    fn band_display_matches_wire_form() {
+        assert_eq!(format!("{}", ConfidenceBand::High), "high");
+        assert_eq!(format!("{}", ConfidenceBand::Uncertain), "uncertain");
     }
 
     #[test]

--- a/crates/cairn-core/src/domain/evidence.rs
+++ b/crates/cairn-core/src/domain/evidence.rs
@@ -163,7 +163,8 @@ mod tests {
             ConfidenceBand::Uncertain,
         ] {
             assert_eq!(
-                ConfidenceBand::parse(band.as_str()).expect(band.as_str()),
+                ConfidenceBand::parse(band.as_str())
+                    .unwrap_or_else(|_| panic!("{}", band.as_str())),
                 band
             );
         }

--- a/crates/cairn-core/src/domain/taxonomy.rs
+++ b/crates/cairn-core/src/domain/taxonomy.rs
@@ -287,7 +287,10 @@ mod tests {
             MemoryKind::KnowledgeGap,
         ];
         for kind in all {
-            assert_eq!(MemoryKind::parse(kind.as_str()).expect(kind.as_str()), kind);
+            assert_eq!(
+                MemoryKind::parse(kind.as_str()).unwrap_or_else(|_| panic!("{}", kind.as_str())),
+                kind
+            );
         }
     }
 
@@ -350,7 +353,7 @@ mod tests {
             MemoryClass::Graph,
         ] {
             assert_eq!(
-                MemoryClass::parse(class.as_str()).expect(class.as_str()),
+                MemoryClass::parse(class.as_str()).unwrap_or_else(|_| panic!("{}", class.as_str())),
                 class
             );
         }
@@ -424,7 +427,8 @@ mod tests {
             MemoryVisibility::Public,
         ] {
             assert_eq!(
-                MemoryVisibility::parse(vis.as_str()).expect(vis.as_str()),
+                MemoryVisibility::parse(vis.as_str())
+                    .unwrap_or_else(|_| panic!("{}", vis.as_str())),
                 vis
             );
         }

--- a/crates/cairn-core/src/domain/taxonomy.rs
+++ b/crates/cairn-core/src/domain/taxonomy.rs
@@ -4,6 +4,8 @@
 //! scope`. Three of them — `kind`, `class`, `visibility` — are closed
 //! enums; `scope` is a tuple ([`crate::domain::ScopeTuple`]).
 
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 use crate::domain::DomainError;
@@ -79,6 +81,42 @@ impl MemoryKind {
             Self::KnowledgeGap => "knowledge_gap",
         }
     }
+
+    /// Parse a wire-form kind string. Returns
+    /// [`DomainError::UnsupportedKind`] for unknown values so classifiers
+    /// cannot invent arbitrary kinds.
+    pub fn parse(value: &str) -> Result<Self, DomainError> {
+        match value {
+            "user" => Ok(Self::User),
+            "feedback" => Ok(Self::Feedback),
+            "project" => Ok(Self::Project),
+            "reference" => Ok(Self::Reference),
+            "fact" => Ok(Self::Fact),
+            "belief" => Ok(Self::Belief),
+            "opinion" => Ok(Self::Opinion),
+            "event" => Ok(Self::Event),
+            "entity" => Ok(Self::Entity),
+            "workflow" => Ok(Self::Workflow),
+            "rule" => Ok(Self::Rule),
+            "strategy_success" => Ok(Self::StrategySuccess),
+            "strategy_failure" => Ok(Self::StrategyFailure),
+            "trace" => Ok(Self::Trace),
+            "reasoning" => Ok(Self::Reasoning),
+            "playbook" => Ok(Self::Playbook),
+            "sensor_observation" => Ok(Self::SensorObservation),
+            "user_signal" => Ok(Self::UserSignal),
+            "knowledge_gap" => Ok(Self::KnowledgeGap),
+            other => Err(DomainError::UnsupportedKind {
+                value: other.to_owned(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for MemoryKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// 4 memory classes (§6.2).
@@ -94,6 +132,39 @@ pub enum MemoryClass {
     Procedural,
     /// Relationships, edges, backlinks.
     Graph,
+}
+
+impl MemoryClass {
+    /// Wire-format identifier (lower-snake-case). Stable across surfaces.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Episodic => "episodic",
+            Self::Semantic => "semantic",
+            Self::Procedural => "procedural",
+            Self::Graph => "graph",
+        }
+    }
+
+    /// Parse a wire-form class string. Returns
+    /// [`DomainError::UnsupportedClass`] for unknown values.
+    pub fn parse(value: &str) -> Result<Self, DomainError> {
+        match value {
+            "episodic" => Ok(Self::Episodic),
+            "semantic" => Ok(Self::Semantic),
+            "procedural" => Ok(Self::Procedural),
+            "graph" => Ok(Self::Graph),
+            other => Err(DomainError::UnsupportedClass {
+                value: other.to_owned(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for MemoryClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// 6 visibility tiers (§6.3). Order matters: lower index = more private.
@@ -116,6 +187,19 @@ pub enum MemoryVisibility {
 }
 
 impl MemoryVisibility {
+    /// Wire-format identifier (lower-snake-case). Stable across surfaces.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Private => "private",
+            Self::Session => "session",
+            Self::Project => "project",
+            Self::Team => "team",
+            Self::Org => "org",
+            Self::Public => "public",
+        }
+    }
+
     /// Parse a wire-form tier string. Returns
     /// [`DomainError::UnsupportedVisibility`] for unknown values.
     pub fn parse(value: &str) -> Result<Self, DomainError> {
@@ -133,6 +217,12 @@ impl MemoryVisibility {
     }
 }
 
+impl fmt::Display for MemoryVisibility {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,11 +236,159 @@ mod tests {
     }
 
     #[test]
+    fn kind_parse_all_19_valid() {
+        let all = [
+            ("user", MemoryKind::User),
+            ("feedback", MemoryKind::Feedback),
+            ("project", MemoryKind::Project),
+            ("reference", MemoryKind::Reference),
+            ("fact", MemoryKind::Fact),
+            ("belief", MemoryKind::Belief),
+            ("opinion", MemoryKind::Opinion),
+            ("event", MemoryKind::Event),
+            ("entity", MemoryKind::Entity),
+            ("workflow", MemoryKind::Workflow),
+            ("rule", MemoryKind::Rule),
+            ("strategy_success", MemoryKind::StrategySuccess),
+            ("strategy_failure", MemoryKind::StrategyFailure),
+            ("trace", MemoryKind::Trace),
+            ("reasoning", MemoryKind::Reasoning),
+            ("playbook", MemoryKind::Playbook),
+            ("sensor_observation", MemoryKind::SensorObservation),
+            ("user_signal", MemoryKind::UserSignal),
+            ("knowledge_gap", MemoryKind::KnowledgeGap),
+        ];
+        for (wire, expected) in all {
+            assert_eq!(MemoryKind::parse(wire).expect(wire), expected);
+        }
+    }
+
+    #[test]
+    fn kind_as_str_parse_round_trip() {
+        let all = [
+            MemoryKind::User,
+            MemoryKind::Feedback,
+            MemoryKind::Project,
+            MemoryKind::Reference,
+            MemoryKind::Fact,
+            MemoryKind::Belief,
+            MemoryKind::Opinion,
+            MemoryKind::Event,
+            MemoryKind::Entity,
+            MemoryKind::Workflow,
+            MemoryKind::Rule,
+            MemoryKind::StrategySuccess,
+            MemoryKind::StrategyFailure,
+            MemoryKind::Trace,
+            MemoryKind::Reasoning,
+            MemoryKind::Playbook,
+            MemoryKind::SensorObservation,
+            MemoryKind::UserSignal,
+            MemoryKind::KnowledgeGap,
+        ];
+        for kind in all {
+            assert_eq!(MemoryKind::parse(kind.as_str()).expect(kind.as_str()), kind);
+        }
+    }
+
+    #[test]
+    fn kind_parse_rejects_invented() {
+        let err = MemoryKind::parse("invented_kind").unwrap_err();
+        assert!(matches!(err, DomainError::UnsupportedKind { .. }));
+    }
+
+    #[test]
+    fn kind_display_matches_wire_form() {
+        assert_eq!(format!("{}", MemoryKind::KnowledgeGap), "knowledge_gap");
+        assert_eq!(
+            format!("{}", MemoryKind::StrategySuccess),
+            "strategy_success"
+        );
+        assert_eq!(format!("{}", MemoryKind::User), "user");
+    }
+
+    #[test]
+    fn class_as_str_all_4_values() {
+        assert_eq!(MemoryClass::Episodic.as_str(), "episodic");
+        assert_eq!(MemoryClass::Semantic.as_str(), "semantic");
+        assert_eq!(MemoryClass::Procedural.as_str(), "procedural");
+        assert_eq!(MemoryClass::Graph.as_str(), "graph");
+    }
+
+    #[test]
+    fn class_parse_all_4_valid() {
+        assert_eq!(
+            MemoryClass::parse("episodic").expect("episodic"),
+            MemoryClass::Episodic
+        );
+        assert_eq!(
+            MemoryClass::parse("semantic").expect("semantic"),
+            MemoryClass::Semantic
+        );
+        assert_eq!(
+            MemoryClass::parse("procedural").expect("procedural"),
+            MemoryClass::Procedural
+        );
+        assert_eq!(
+            MemoryClass::parse("graph").expect("graph"),
+            MemoryClass::Graph
+        );
+    }
+
+    #[test]
+    fn class_parse_rejects_invented() {
+        let err = MemoryClass::parse("invented_class").unwrap_err();
+        assert!(matches!(err, DomainError::UnsupportedClass { .. }));
+    }
+
+    #[test]
+    fn class_as_str_parse_round_trip() {
+        for class in [
+            MemoryClass::Episodic,
+            MemoryClass::Semantic,
+            MemoryClass::Procedural,
+            MemoryClass::Graph,
+        ] {
+            assert_eq!(
+                MemoryClass::parse(class.as_str()).expect(class.as_str()),
+                class
+            );
+        }
+    }
+
+    #[test]
+    fn class_display_matches_wire_form() {
+        assert_eq!(format!("{}", MemoryClass::Procedural), "procedural");
+        assert_eq!(format!("{}", MemoryClass::Graph), "graph");
+    }
+
+    #[test]
+    fn class_round_trips() {
+        let json = serde_json::to_string(&MemoryClass::Procedural).expect("serialize");
+        assert_eq!(json, "\"procedural\"");
+    }
+
+    #[test]
     fn visibility_parse_known() {
         assert_eq!(
             MemoryVisibility::parse("project").expect("known"),
             MemoryVisibility::Project
         );
+    }
+
+    #[test]
+    fn visibility_parse_all_6_tiers() {
+        let all = [
+            ("private", MemoryVisibility::Private),
+            ("session", MemoryVisibility::Session),
+            ("project", MemoryVisibility::Project),
+            ("team", MemoryVisibility::Team),
+            ("org", MemoryVisibility::Org),
+            ("public", MemoryVisibility::Public),
+        ];
+        for (wire, expected) in all {
+            assert_eq!(MemoryVisibility::parse(wire).expect(wire), expected);
+        }
     }
 
     #[test]
@@ -166,8 +404,36 @@ mod tests {
     }
 
     #[test]
-    fn class_round_trips() {
-        let json = serde_json::to_string(&MemoryClass::Procedural).expect("serialize");
-        assert_eq!(json, "\"procedural\"");
+    fn visibility_as_str_all_6_tiers() {
+        assert_eq!(MemoryVisibility::Private.as_str(), "private");
+        assert_eq!(MemoryVisibility::Session.as_str(), "session");
+        assert_eq!(MemoryVisibility::Project.as_str(), "project");
+        assert_eq!(MemoryVisibility::Team.as_str(), "team");
+        assert_eq!(MemoryVisibility::Org.as_str(), "org");
+        assert_eq!(MemoryVisibility::Public.as_str(), "public");
+    }
+
+    #[test]
+    fn visibility_as_str_parse_round_trip() {
+        for vis in [
+            MemoryVisibility::Private,
+            MemoryVisibility::Session,
+            MemoryVisibility::Project,
+            MemoryVisibility::Team,
+            MemoryVisibility::Org,
+            MemoryVisibility::Public,
+        ] {
+            assert_eq!(
+                MemoryVisibility::parse(vis.as_str()).expect(vis.as_str()),
+                vis
+            );
+        }
+    }
+
+    #[test]
+    fn visibility_display_matches_wire_form() {
+        assert_eq!(format!("{}", MemoryVisibility::Org), "org");
+        assert_eq!(format!("{}", MemoryVisibility::Public), "public");
+        assert_eq!(format!("{}", MemoryVisibility::Private), "private");
     }
 }


### PR DESCRIPTION
## Summary

- Add `parse()` + `Display` to `MemoryKind` (§6.1, 19 values) and `MemoryClass` (§6.2, 4 values)
- Add `as_str()` + `Display` to `MemoryVisibility` (§6.3, 6 tiers, already had `parse`)
- Add `as_str()`, `parse()`, `Display` to `ConfidenceBand` (§6.4)
- Add 3 new `DomainError` variants: `UnsupportedKind`, `UnsupportedClass`, `UnsupportedConfidenceBand`
- 18 new tests: every valid value, every reject case, `as_str`↔`parse` round-trips, `Display` assertions

## Acceptance Criteria

- [x] Taxonomy matches §6.1–6.4 (all 19/4/6/3 values)
- [x] `parse()` rejects invented kinds/classes/tiers/bands — classifiers cannot mint new values
- [x] Search filters and record validation share the same enum definitions

## Verification

```
cargo nextest run --workspace --locked   # 526/526 pass
cargo fmt --all --check                  # clean
cargo clippy --workspace -D warnings     # clean
cargo test --doc --workspace             # clean
RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" cargo doc ...  # clean
./scripts/check-core-boundary.sh         # OK
cargo run -p cairn-idl --bin cairn-codegen --locked -- --check  # 48 files match
```

Closes #38