### PR TITLE
feat(domain): filter DSL validation + SQL compiler (§8.0.c/§8.0.d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "async-trait",
  "insta",
  "proptest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -272,6 +273,16 @@ dependencies = [
  "cairn-test-fixtures",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -416,6 +427,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +468,12 @@ dependencies = [
  "uncased",
  "version_check",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fluent-uri"
@@ -624,6 +653,15 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -647,6 +685,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -862,6 +909,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1112,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1310,6 +1374,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1520,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "similar"
@@ -1746,6 +1830,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ figment = { version = "0.10", features = ["yaml", "env"] }
 regex = { version = "1", default-features = false, features = ["std"] }
 serde_yaml = "0.9"
 temp-env = "0.3"
+rusqlite = { version = "0.32", features = ["bundled"] }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 
 # Path + version on intra-workspace deps so `cargo publish` can rewrite the

--- a/crates/cairn-core/Cargo.toml
+++ b/crates/cairn-core/Cargo.toml
@@ -22,6 +22,7 @@ sha2 = { workspace = true }
 async-trait = { workspace = true }
 proptest = { workspace = true }
 insta = { workspace = true }
+rusqlite = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -21,12 +21,17 @@ use crate::generated::verbs::search::SearchArgsFilters;
 pub enum FieldType {
     /// Single string value (`kind`, `class`, `visibility`, `path`, `title`, `category`, …).
     Str,
-    /// Numeric value (`priority`, `version`, `created_at`, `confidence`).
+    /// Numeric value (`priority`, `version`, `confidence`).
     Number,
     /// Boolean flag (`is_static`, `tombstoned`, `active`).
     Boolean,
     /// JSON-array column (`tags`, `actor_chain`, `backlinks`).
     Array,
+    /// RFC3339 timestamp (`created_at`). Only exact/membership ops are valid;
+    /// range ordering over raw RFC3339 strings is unreliable due to timezone
+    /// offsets, so `lt/lte/gt/gte/between` are rejected until a normalized
+    /// epoch column is available in the store.
+    Timestamp,
 }
 
 impl FieldType {
@@ -36,12 +41,19 @@ impl FieldType {
             Self::Number => "number",
             Self::Boolean => "boolean",
             Self::Array => "array",
+            Self::Timestamp => "timestamp",
         }
     }
 }
 
 // Ordered list of (field_name, type) pairs.  All P0 allowlisted fields are here;
 // any field not in this list is rejected by `validate_filter`.
+//
+// P0 contract: every field listed here MUST exist as a same-named physical column
+// (or addressable expression) on the `records` table in `cairn-store-sqlite`.
+// When the store migration is implemented, this list must be reconciled with the
+// actual schema; fields stored inside a JSON blob need an explicit expression in
+// `field_col` rather than the identity mapping.
 const KNOWN_FIELDS: &[(&str, FieldType)] = &[
     // String fields — direct `records` table columns.
     ("kind", FieldType::Str),
@@ -54,15 +66,13 @@ const KNOWN_FIELDS: &[(&str, FieldType)] = &[
     ("priority", FieldType::Number),
     ("version", FieldType::Number),
     ("confidence", FieldType::Number),
-    // Timestamp field — stored as RFC3339 text; ISO8601 is lexicographically
-    // sortable, so string ops (eq/neq/in/nin/string_contains/starts_with) work
-    // correctly against the stored representation.
-    ("created_at", FieldType::Str),
+    // Timestamp — stored as RFC3339 text; only exact/membership ops accepted.
+    ("created_at", FieldType::Timestamp),
     // Boolean fields.
     ("is_static", FieldType::Boolean),
     ("tombstoned", FieldType::Boolean),
     ("active", FieldType::Boolean),
-    // Array fields — stored as JSON columns.
+    // Array fields — stored as JSON text columns.
     ("tags", FieldType::Array),
     ("actor_chain", FieldType::Array),
     ("backlinks", FieldType::Array),
@@ -185,6 +195,9 @@ fn validate_op_for_type(field: &str, op: &str, ft: FieldType) -> Result<(), Filt
             op,
             "array_contains" | "array_contains_any" | "array_contains_all" | "array_size_eq"
         ),
+        // Range ops are rejected for Timestamp until a normalized epoch column
+        // exists in the store; raw RFC3339 strings are not reliably ordered.
+        FieldType::Timestamp => matches!(op, "eq" | "neq" | "in" | "nin"),
     };
     if valid {
         Ok(())
@@ -268,6 +281,25 @@ fn validate_value_shape(
             .then_some(())
             .ok_or_else(|| scalar_err("boolean")),
         FieldType::Array => validate_array_field_value(field, op, value, scalar_err),
+        // Timestamp: eq/neq require a single string; in/nin require array of strings.
+        FieldType::Timestamp => match op {
+            "in" | "nin" => {
+                let arr = value
+                    .as_array()
+                    .ok_or_else(|| scalar_err("array of RFC3339 strings"))?;
+                require_array_of(
+                    field,
+                    op,
+                    arr,
+                    "array of RFC3339 strings",
+                    serde_json::Value::is_string,
+                )
+            }
+            _ => value
+                .is_string()
+                .then_some(())
+                .ok_or_else(|| scalar_err("RFC3339 string")),
+        },
     }
 }
 
@@ -413,19 +445,6 @@ fn compile_leaf(v: &serde_json::Value, params: &mut Vec<serde_json::Value>) -> S
     }
 }
 
-/// Escape `%` and `_` in a LIKE operand so they are treated as literals.
-/// The caller must also emit `ESCAPE '\'` in the SQL fragment.
-fn escape_like(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        if matches!(ch, '%' | '_' | '\\') {
-            out.push('\\');
-        }
-        out.push(ch);
-    }
-    out
-}
-
 fn compile_scalar_op(
     col: &str,
     op: &str,
@@ -493,20 +512,19 @@ fn compile_scalar_op(
             format!("instr({col}, ?) > 0")
         }
         "string_starts_with" => {
-            let Some(s) = value.as_str() else {
-                unreachable!("string_starts_with value is a string after validation");
-            };
-            let escaped = escape_like(s);
-            params.push(serde_json::Value::String(format!("{escaped}%")));
-            format!("{col} LIKE ? ESCAPE '\\'")
+            // Use substr/length for case-sensitive, metachar-safe prefix matching
+            // consistent with instr() used by string_contains.
+            params.push(value.clone());
+            params.push(value.clone());
+            format!("substr({col}, 1, length(?)) = ?")
         }
         "string_ends_with" => {
-            let Some(s) = value.as_str() else {
-                unreachable!("string_ends_with value is a string after validation");
-            };
-            let escaped = escape_like(s);
-            params.push(serde_json::Value::String(format!("%{escaped}")));
-            format!("{col} LIKE ? ESCAPE '\\'")
+            // Use substr/length for case-sensitive, metachar-safe suffix matching.
+            // Three ?'s: length(?) twice, then the equality value.
+            params.push(value.clone());
+            params.push(value.clone());
+            params.push(value.clone());
+            format!("substr({col}, -length(?), length(?)) = ?")
         }
         _ => unreachable!("op was validated by validate_filter before compile_filter"),
     }

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -1,0 +1,410 @@
+//! Metadata filter DSL validation and SQL compilation (§8.0.d).
+//!
+//! Two-step pipeline:
+//! 1. [`validate_filter`] — walks the parsed [`SearchArgsFilters`] tree,
+//!    checks every leaf field against the P0 allowlist, and ensures the op
+//!    is valid for that field's type. Rejects with [`FilterError`] before any
+//!    store is touched.
+//! 2. [`compile_filter`] — converts a validated tree into a parameterized
+//!    [`CompiledFilter`] (`sql` fragment + positional `params`). All user
+//!    values land in `params`; the `sql` string contains only structure and
+//!    `?` placeholders, so SQL injection via field values is impossible.
+
+use thiserror::Error;
+
+use crate::generated::verbs::search::SearchArgsFilters;
+
+// ── Field allowlist ───────────────────────────────────────────────────────────
+
+/// Type classification of a P0 filter field (§8.0.d table).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldType {
+    /// Single string value (`kind`, `class`, `visibility`, `path`, `title`, `category`, …).
+    Str,
+    /// Numeric value (`priority`, `version`, `created_at`, `confidence`).
+    Number,
+    /// Boolean flag (`is_static`, `tombstoned`, `active`).
+    Boolean,
+    /// JSON-array column (`tags`, `actor_chain`, `backlinks`).
+    Array,
+}
+
+impl FieldType {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Str => "string",
+            Self::Number => "number",
+            Self::Boolean => "boolean",
+            Self::Array => "array",
+        }
+    }
+}
+
+// Ordered list of (field_name, type) pairs.  All P0 allowlisted fields are here;
+// any field not in this list is rejected by `validate_filter`.
+const KNOWN_FIELDS: &[(&str, FieldType)] = &[
+    // String fields — direct `records` table columns.
+    ("kind", FieldType::Str),
+    ("class", FieldType::Str),
+    ("visibility", FieldType::Str),
+    ("path", FieldType::Str),
+    ("title", FieldType::Str),
+    ("category", FieldType::Str),
+    // Numeric fields.
+    ("priority", FieldType::Number),
+    ("version", FieldType::Number),
+    ("created_at", FieldType::Number),
+    ("confidence", FieldType::Number),
+    // Boolean fields.
+    ("is_static", FieldType::Boolean),
+    ("tombstoned", FieldType::Boolean),
+    ("active", FieldType::Boolean),
+    // Array fields — stored as JSON columns.
+    ("tags", FieldType::Array),
+    ("actor_chain", FieldType::Array),
+    ("backlinks", FieldType::Array),
+];
+
+/// Return the declared [`FieldType`] for a filter field name, or `None` if the
+/// field is not in the P0 allowlist.
+#[must_use]
+pub fn field_type(name: &str) -> Option<FieldType> {
+    KNOWN_FIELDS
+        .iter()
+        .find(|(k, _)| *k == name)
+        .map(|(_, t)| *t)
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+/// Failure from filter validation.
+///
+/// Produced by [`validate_filter`] and surfaced to the caller so it can
+/// translate to an `InvalidFilter` wire error before touching `SQLite`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum FilterError {
+    /// The filter references a field not in the P0 allowlist (§8.0.d).
+    #[error("unknown filter field `{0}` — only P0 allowlisted fields are accepted")]
+    UnknownField(String),
+
+    /// The operator is not valid for the declared type of the field (§8.0.d table).
+    #[error("op `{op}` is not supported for field `{field}` of type {field_type}")]
+    UnsupportedOp {
+        /// Field that was queried.
+        field: String,
+        /// Operator that was rejected.
+        op: String,
+        /// Human-readable field type ("string", "number", "boolean", "array").
+        field_type: &'static str,
+    },
+}
+
+// ── validate_filter ───────────────────────────────────────────────────────────
+
+/// Validate a parsed [`SearchArgsFilters`] tree against the P0 field allowlist
+/// and per-type operator rules (§8.0.d).
+///
+/// Call this before [`compile_filter`] and before dispatching to any store.
+/// Returns the first [`FilterError`] found, depth-first left-to-right.
+pub fn validate_filter(filter: &SearchArgsFilters) -> Result<(), FilterError> {
+    match filter {
+        SearchArgsFilters::And { and } => {
+            for child in and {
+                validate_filter(child)?;
+            }
+            Ok(())
+        }
+        SearchArgsFilters::Or { or } => {
+            for child in or {
+                validate_filter(child)?;
+            }
+            Ok(())
+        }
+        SearchArgsFilters::Not { not } => validate_filter(not),
+        SearchArgsFilters::Leaf(v) => validate_leaf(v),
+    }
+}
+
+/// Validate a single leaf.  The serde parser (`validate_filter_leaf_shape`)
+/// already verified that `field`, `op`, and `value` are present and that the
+/// op is shape-valid; here we enforce the field allowlist and type-op matrix.
+fn validate_leaf(v: &serde_json::Value) -> Result<(), FilterError> {
+    let Some(obj) = v.as_object() else {
+        unreachable!("leaf is always a JSON object after parsing");
+    };
+    let Some(field) = obj["field"].as_str() else {
+        unreachable!("field is always a string after parsing");
+    };
+    let Some(op) = obj["op"].as_str() else {
+        unreachable!("op is always a string after parsing");
+    };
+
+    let ft = field_type(field).ok_or_else(|| FilterError::UnknownField(field.to_owned()))?;
+    validate_op_for_type(field, op, ft)
+}
+
+fn validate_op_for_type(field: &str, op: &str, ft: FieldType) -> Result<(), FilterError> {
+    let valid = match ft {
+        FieldType::Str => matches!(
+            op,
+            "eq" | "neq"
+                | "in"
+                | "nin"
+                | "string_contains"
+                | "string_starts_with"
+                | "string_ends_with"
+        ),
+        FieldType::Number => {
+            matches!(
+                op,
+                "eq" | "neq" | "lt" | "lte" | "gt" | "gte" | "between" | "in" | "nin"
+            )
+        }
+        FieldType::Boolean => op == "eq",
+        FieldType::Array => matches!(
+            op,
+            "array_contains" | "array_contains_any" | "array_contains_all" | "array_size_eq"
+        ),
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(FilterError::UnsupportedOp {
+            field: field.to_owned(),
+            op: op.to_owned(),
+            field_type: ft.as_str(),
+        })
+    }
+}
+
+// ── compile_filter ────────────────────────────────────────────────────────────
+
+/// A compiled filter: a SQL fragment using `?` placeholders and the matching
+/// positional parameters.
+///
+/// Embed `sql` directly inside a `WHERE` clause and bind `params` in order.
+/// No user values are ever interpolated into `sql`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompiledFilter {
+    /// SQL fragment for use inside a `WHERE` clause. Uses `?` placeholders.
+    pub sql: String,
+    /// Values to bind at the `?` positions, in order.
+    pub params: Vec<serde_json::Value>,
+}
+
+/// Compile a validated [`SearchArgsFilters`] tree to a parameterized `SQLite`
+/// `WHERE` fragment.
+///
+/// # Caller contract
+/// [`validate_filter`] must have returned `Ok` for `filter` before calling
+/// this function.  Calling on an unvalidated filter may produce incorrect SQL
+/// for unknown fields (they pass through as column names) or `unreachable!`
+/// for unexpected op values.
+#[must_use]
+pub fn compile_filter(filter: &SearchArgsFilters) -> CompiledFilter {
+    let mut params = Vec::new();
+    let sql = compile_node(filter, &mut params);
+    CompiledFilter { sql, params }
+}
+
+fn compile_node(filter: &SearchArgsFilters, params: &mut Vec<serde_json::Value>) -> String {
+    match filter {
+        SearchArgsFilters::And { and } => {
+            let parts: Vec<String> = and.iter().map(|f| compile_node(f, params)).collect();
+            format!("({})", parts.join(" AND "))
+        }
+        SearchArgsFilters::Or { or } => {
+            let parts: Vec<String> = or.iter().map(|f| compile_node(f, params)).collect();
+            format!("({})", parts.join(" OR "))
+        }
+        SearchArgsFilters::Not { not } => {
+            format!("(NOT {})", compile_node(not, params))
+        }
+        SearchArgsFilters::Leaf(v) => compile_leaf(v, params),
+    }
+}
+
+/// Map a validated field name to its SQL column expression in the `records` table.
+fn field_col(name: &str) -> &str {
+    // All P0 allowlisted fields map 1-to-1 to same-named columns on the
+    // `records` table.  Array fields (`tags`, `actor_chain`, `backlinks`) are
+    // stored as JSON text columns; array ops use `json_each()` sub-selects.
+    name
+}
+
+fn compile_leaf(v: &serde_json::Value, params: &mut Vec<serde_json::Value>) -> String {
+    let Some(obj) = v.as_object() else {
+        unreachable!("leaf is always a JSON object; validate_filter must be called first");
+    };
+    let Some(field) = obj["field"].as_str() else {
+        unreachable!("leaf field is always a string; validate_filter must be called first");
+    };
+    let Some(op) = obj["op"].as_str() else {
+        unreachable!("leaf op is always a string; validate_filter must be called first");
+    };
+    let value = &obj["value"];
+    let col = field_col(field);
+
+    let ft = field_type(field).unwrap_or_else(|| {
+        unreachable!("field is in allowlist; validate_filter must be called before compile_filter")
+    });
+
+    match ft {
+        FieldType::Array => compile_array_op(col, op, value, params),
+        _ => compile_scalar_op(col, op, value, params),
+    }
+}
+
+fn compile_scalar_op(
+    col: &str,
+    op: &str,
+    value: &serde_json::Value,
+    params: &mut Vec<serde_json::Value>,
+) -> String {
+    match op {
+        "eq" => {
+            params.push(value.clone());
+            format!("{col} = ?")
+        }
+        "neq" => {
+            params.push(value.clone());
+            format!("{col} != ?")
+        }
+        "lt" => {
+            params.push(value.clone());
+            format!("{col} < ?")
+        }
+        "lte" => {
+            params.push(value.clone());
+            format!("{col} <= ?")
+        }
+        "gt" => {
+            params.push(value.clone());
+            format!("{col} > ?")
+        }
+        "gte" => {
+            params.push(value.clone());
+            format!("{col} >= ?")
+        }
+        "in" => {
+            let Some(arr) = value.as_array() else {
+                unreachable!("in value is array after validation");
+            };
+            let placeholders = "?, ".repeat(arr.len());
+            let placeholders = placeholders.trim_end_matches(", ");
+            for v in arr {
+                params.push(v.clone());
+            }
+            format!("{col} IN ({placeholders})")
+        }
+        "nin" => {
+            let Some(arr) = value.as_array() else {
+                unreachable!("nin value is array after validation");
+            };
+            let placeholders = "?, ".repeat(arr.len());
+            let placeholders = placeholders.trim_end_matches(", ");
+            for v in arr {
+                params.push(v.clone());
+            }
+            format!("{col} NOT IN ({placeholders})")
+        }
+        "between" => {
+            let Some(arr) = value.as_array() else {
+                unreachable!("between value is 2-element array after validation");
+            };
+            params.push(arr[0].clone());
+            params.push(arr[1].clone());
+            format!("{col} BETWEEN ? AND ?")
+        }
+        "string_contains" => {
+            // Use `instr()` for substring matching — avoids `LIKE` special-char escaping.
+            params.push(value.clone());
+            format!("instr({col}, ?) > 0")
+        }
+        "string_starts_with" => {
+            // Append `%` to the value to build a `LIKE` prefix pattern.
+            // `LIKE` metacharacters (`%`, `_`) in the value itself are NOT escaped
+            // at P0; escaping is a P1 hardening.
+            let Some(s) = value.as_str() else {
+                unreachable!("string_starts_with value is a string after validation");
+            };
+            params.push(serde_json::Value::String(format!("{s}%")));
+            format!("{col} LIKE ?")
+        }
+        "string_ends_with" => {
+            let Some(s) = value.as_str() else {
+                unreachable!("string_ends_with value is a string after validation");
+            };
+            params.push(serde_json::Value::String(format!("%{s}")));
+            format!("{col} LIKE ?")
+        }
+        _ => unreachable!("op was validated by validate_filter before compile_filter"),
+    }
+}
+
+fn compile_array_op(
+    col: &str,
+    op: &str,
+    value: &serde_json::Value,
+    params: &mut Vec<serde_json::Value>,
+) -> String {
+    match op {
+        "array_contains" => {
+            params.push(value.clone());
+            format!("EXISTS (SELECT 1 FROM json_each({col}) WHERE value = ?)")
+        }
+        "array_contains_any" => {
+            let Some(arr) = value.as_array() else {
+                unreachable!("array_contains_any value is array after validation");
+            };
+            let placeholders = "?, ".repeat(arr.len());
+            let placeholders = placeholders.trim_end_matches(", ");
+            for v in arr {
+                params.push(v.clone());
+            }
+            format!("EXISTS (SELECT 1 FROM json_each({col}) WHERE value IN ({placeholders}))")
+        }
+        "array_contains_all" => {
+            let Some(arr) = value.as_array() else {
+                unreachable!("array_contains_all value is array after validation");
+            };
+            let n = arr.len();
+            let placeholders = "?, ".repeat(n);
+            let placeholders = placeholders.trim_end_matches(", ");
+            for v in arr {
+                params.push(v.clone());
+            }
+            params.push(serde_json::Value::Number(serde_json::Number::from(
+                n as u64,
+            )));
+            format!(
+                "(SELECT COUNT(DISTINCT value) FROM json_each({col}) WHERE value IN ({placeholders})) = ?"
+            )
+        }
+        "array_size_eq" => {
+            params.push(value.clone());
+            format!("json_array_length({col}) = ?")
+        }
+        _ => unreachable!("op was validated by validate_filter before compile_filter"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn field_type_lookup_known() {
+        assert_eq!(field_type("kind"), Some(FieldType::Str));
+        assert_eq!(field_type("priority"), Some(FieldType::Number));
+        assert_eq!(field_type("is_static"), Some(FieldType::Boolean));
+        assert_eq!(field_type("tags"), Some(FieldType::Array));
+    }
+
+    #[test]
+    fn field_type_lookup_unknown() {
+        assert_eq!(field_type("not_a_real_field"), None);
+        assert_eq!(field_type(""), None);
+    }
+}

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -191,10 +191,19 @@ const MAX_TOTAL_PARAMS: usize = 500;
 /// Enforces the same depth/fanout caps as the serde parser so that
 /// programmatically constructed trees cannot cause stack exhaustion or
 /// unbounded SQL generation.
-pub fn validate_filter(filter: &SearchArgsFilters) -> Result<(), FilterError> {
+pub fn validate_filter(filter: &SearchArgsFilters) -> Result<ValidatedFilter<'_>, FilterError> {
     let mut param_budget = MAX_TOTAL_PARAMS;
-    validate_filter_inner(filter, 0, &mut param_budget)
+    validate_filter_inner(filter, 0, &mut param_budget)?;
+    Ok(ValidatedFilter(filter))
 }
+
+/// A filter that has passed all [`validate_filter`] checks.
+///
+/// The only way to produce a `ValidatedFilter` is through [`validate_filter`].
+/// [`compile_filter`] requires this type so the budget and semantic checks
+/// cannot be bypassed through the public API.
+#[derive(Clone, Copy, Debug)]
+pub struct ValidatedFilter<'a>(&'a SearchArgsFilters);
 
 fn validate_filter_inner(
     filter: &SearchArgsFilters,
@@ -599,18 +608,15 @@ pub struct CompiledFilter {
     pub params: Vec<serde_json::Value>,
 }
 
-/// Compile a validated [`SearchArgsFilters`] tree to a parameterized `SQLite`
-/// `WHERE` fragment.
+/// Compile a [`ValidatedFilter`] to a parameterized `SQLite` `WHERE` fragment.
 ///
-/// # Caller contract
-/// [`validate_filter`] must have returned `Ok` for `filter` before calling
-/// this function.  Calling on an unvalidated filter may produce incorrect SQL
-/// for unknown fields (they pass through as column names) or `unreachable!`
-/// for unexpected op values.
+/// Accepts only a [`ValidatedFilter`] produced by [`validate_filter`],
+/// guaranteeing that all semantic checks and the parameter budget have
+/// already passed.
 #[must_use]
-pub fn compile_filter(filter: &SearchArgsFilters) -> CompiledFilter {
+pub fn compile_filter(filter: ValidatedFilter<'_>) -> CompiledFilter {
     let mut params = Vec::new();
-    let sql = compile_node(filter, &mut params);
+    let sql = compile_node(filter.0, &mut params);
     CompiledFilter { sql, params }
 }
 

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -175,9 +175,12 @@ const MAX_FILTER_DEPTH: usize = 8;
 /// Maximum fanout for `and` / `or` nodes (matches the serde-layer cap).
 const MAX_FILTER_FANOUT: usize = 32;
 /// Maximum number of items in a set operand (`in`, `nin`, `array_contains_any`,
-/// `array_contains_all`). Keeps compiled `?` placeholder counts well below
-/// SQLite's default variable limit (999) even under heavy nesting.
+/// `array_contains_all`). Per-leaf limit; total params across the whole filter
+/// are further capped by `MAX_TOTAL_PARAMS`.
 const MAX_SET_OPERAND_SIZE: usize = 64;
+/// Maximum total `?` parameters compiled across the entire filter tree.
+/// Stays well below the `SQLITE_MAX_VARIABLE_NUMBER` default of `999`.
+const MAX_TOTAL_PARAMS: usize = 500;
 
 /// Validate a parsed [`SearchArgsFilters`] tree against the P0 field allowlist
 /// and per-type operator rules (§8.0.d).
@@ -189,10 +192,15 @@ const MAX_SET_OPERAND_SIZE: usize = 64;
 /// programmatically constructed trees cannot cause stack exhaustion or
 /// unbounded SQL generation.
 pub fn validate_filter(filter: &SearchArgsFilters) -> Result<(), FilterError> {
-    validate_filter_inner(filter, 0)
+    let mut param_budget = MAX_TOTAL_PARAMS;
+    validate_filter_inner(filter, 0, &mut param_budget)
 }
 
-fn validate_filter_inner(filter: &SearchArgsFilters, depth: usize) -> Result<(), FilterError> {
+fn validate_filter_inner(
+    filter: &SearchArgsFilters,
+    depth: usize,
+    param_budget: &mut usize,
+) -> Result<(), FilterError> {
     if depth > MAX_FILTER_DEPTH {
         return Err(FilterError::MalformedLeaf(format!(
             "filter tree exceeds maximum nesting depth of {MAX_FILTER_DEPTH}"
@@ -210,7 +218,7 @@ fn validate_filter_inner(filter: &SearchArgsFilters, depth: usize) -> Result<(),
                 )));
             }
             for child in and {
-                validate_filter_inner(child, depth + 1)?;
+                validate_filter_inner(child, depth + 1, param_budget)?;
             }
             Ok(())
         }
@@ -225,19 +233,22 @@ fn validate_filter_inner(filter: &SearchArgsFilters, depth: usize) -> Result<(),
                 )));
             }
             for child in or {
-                validate_filter_inner(child, depth + 1)?;
+                validate_filter_inner(child, depth + 1, param_budget)?;
             }
             Ok(())
         }
-        SearchArgsFilters::Not { not } => validate_filter_inner(not, depth + 1),
-        SearchArgsFilters::Leaf(v) => validate_leaf(v),
+        SearchArgsFilters::Not { not } => validate_filter_inner(not, depth + 1, param_budget),
+        SearchArgsFilters::Leaf(v) => validate_leaf_with_budget(v, param_budget),
     }
 }
 
-/// Validate a single leaf.  Callers using the serde path will always receive
-/// well-formed leaves; callers constructing `SearchArgsFilters::Leaf` directly
-/// receive graceful `FilterError::MalformedLeaf` rather than a panic.
-fn validate_leaf(v: &serde_json::Value) -> Result<(), FilterError> {
+/// Validate a single leaf, also deducting its expected `?` parameter count
+/// from `param_budget`. Returns `FilterError::MalformedLeaf` when the budget
+/// would go negative.
+fn validate_leaf_with_budget(
+    v: &serde_json::Value,
+    param_budget: &mut usize,
+) -> Result<(), FilterError> {
     let Some(obj) = v.as_object() else {
         return Err(FilterError::MalformedLeaf(
             "leaf value is not a JSON object".into(),
@@ -261,7 +272,32 @@ fn validate_leaf(v: &serde_json::Value) -> Result<(), FilterError> {
 
     let ft = field_type(field).ok_or_else(|| FilterError::UnknownField(field.to_owned()))?;
     validate_op_for_type(field, op, ft)?;
-    validate_value_shape(field, op, ft, value)
+    validate_value_shape(field, op, ft, value)?;
+
+    let cost = leaf_param_count(op, value);
+    if cost > *param_budget {
+        return Err(FilterError::MalformedLeaf(format!(
+            "filter would require more than {MAX_TOTAL_PARAMS} total SQL parameters"
+        )));
+    }
+    *param_budget -= cost;
+    Ok(())
+}
+
+/// Estimate the number of `?` placeholders `compile_leaf` will emit for `op`.
+fn leaf_param_count(op: &str, value: &serde_json::Value) -> usize {
+    match op {
+        "in" | "nin" | "array_contains_any" => value.as_array().map_or(1, Vec::len),
+        "array_contains_all" => {
+            // N items + 1 count param
+            value.as_array().map_or(2, |a| a.len() + 1)
+        }
+        // between → 2 params; string_starts_with → substr(col, 1, length(?)) = ? → 2 params
+        "between" | "string_starts_with" => 2,
+        // substr(col, -length(?), length(?)) = ? → 3 params
+        "string_ends_with" => 3,
+        _ => 1, // eq, neq, lt, lte, gt, gte, string_contains, array_contains, array_size_eq
+    }
 }
 
 fn validate_op_for_type(field: &str, op: &str, ft: FieldType) -> Result<(), FilterError> {

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -158,6 +158,14 @@ pub enum FilterError {
         /// The offending value.
         value: String,
     },
+
+    /// An `and` or `or` node has an empty children array.
+    #[error("`{0}` node must contain at least one child filter")]
+    EmptyOperator(&'static str),
+
+    /// A leaf node is structurally invalid (missing or wrong-typed `field`/`op`/`value`).
+    #[error("malformed leaf filter: {0}")]
+    MalformedLeaf(String),
 }
 
 // ── validate_filter ───────────────────────────────────────────────────────────
@@ -170,12 +178,18 @@ pub enum FilterError {
 pub fn validate_filter(filter: &SearchArgsFilters) -> Result<(), FilterError> {
     match filter {
         SearchArgsFilters::And { and } => {
+            if and.is_empty() {
+                return Err(FilterError::EmptyOperator("and"));
+            }
             for child in and {
                 validate_filter(child)?;
             }
             Ok(())
         }
         SearchArgsFilters::Or { or } => {
+            if or.is_empty() {
+                return Err(FilterError::EmptyOperator("or"));
+            }
             for child in or {
                 validate_filter(child)?;
             }
@@ -186,21 +200,30 @@ pub fn validate_filter(filter: &SearchArgsFilters) -> Result<(), FilterError> {
     }
 }
 
-/// Validate a single leaf.  The serde parser (`validate_filter_leaf_shape`)
-/// already verified that `field`, `op`, and `value` are present and that the
-/// op is shape-valid; here we enforce the field allowlist, type-op matrix,
-/// and value-shape compatibility.
+/// Validate a single leaf.  Callers using the serde path will always receive
+/// well-formed leaves; callers constructing `SearchArgsFilters::Leaf` directly
+/// receive graceful `FilterError::MalformedLeaf` rather than a panic.
 fn validate_leaf(v: &serde_json::Value) -> Result<(), FilterError> {
     let Some(obj) = v.as_object() else {
-        unreachable!("leaf is always a JSON object after parsing");
+        return Err(FilterError::MalformedLeaf(
+            "leaf value is not a JSON object".into(),
+        ));
     };
-    let Some(field) = obj["field"].as_str() else {
-        unreachable!("field is always a string after parsing");
+    let Some(field) = obj.get("field").and_then(|f| f.as_str()) else {
+        return Err(FilterError::MalformedLeaf(
+            "leaf missing string `field` key".into(),
+        ));
     };
-    let Some(op) = obj["op"].as_str() else {
-        unreachable!("op is always a string after parsing");
+    let Some(op) = obj.get("op").and_then(|o| o.as_str()) else {
+        return Err(FilterError::MalformedLeaf(
+            "leaf missing string `op` key".into(),
+        ));
     };
-    let value = &obj["value"];
+    let Some(value) = obj.get("value") else {
+        return Err(FilterError::MalformedLeaf(
+            "leaf missing `value` key".into(),
+        ));
+    };
 
     let ft = field_type(field).ok_or_else(|| FilterError::UnknownField(field.to_owned()))?;
     validate_op_for_type(field, op, ft)?;

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -637,12 +637,50 @@ fn compile_node(filter: &SearchArgsFilters, params: &mut Vec<serde_json::Value>)
     }
 }
 
-/// Map a validated field name to its SQL column expression in the `records` table.
-fn field_col(name: &str) -> &str {
-    // All P0 allowlisted fields map 1-to-1 to same-named columns on the
-    // `records` table.  Array fields (`tags`, `actor_chain`, `backlinks`) are
-    // stored as JSON text columns; array ops use `json_each()` sub-selects.
-    name
+/// Map a validated field name to its SQL column/expression in the `records` table.
+///
+/// Fields that are direct scalar columns on `MemoryRecord` map 1-to-1.
+/// Fields nested inside JSON blobs or stored in `extra_frontmatter` emit the
+/// appropriate `json_extract(...)` expression so the SQL is immediately correct
+/// when `cairn-store-sqlite` (#46) creates the schema. The store may additionally
+/// create indexed computed columns or partial indexes over these expressions
+/// for query performance — the filter SQL works with both approaches.
+fn field_col(name: &str) -> &'static str {
+    match name {
+        // ── Direct MemoryRecord scalar columns ────────────────────────────
+        "kind" => "kind",
+        "class" => "class",
+        "visibility" => "visibility",
+        "confidence" => "confidence",
+
+        // ── Nested inside the `provenance` JSON column ────────────────────
+        // `provenance.created_at` is the RFC3339 creation timestamp.
+        "created_at" => "json_extract(provenance, '$.created_at')",
+
+        // ── Direct JSON-array columns on MemoryRecord ─────────────────────
+        // `tags` is Vec<String> — flat string array; standard json_each works.
+        // `actor_chain` is Vec<ActorChainEntry> — struct array; see compile_array_op.
+        "tags" => "tags",
+        "actor_chain" => "actor_chain",
+
+        // ── Fields stored in the `extra_frontmatter` JSON column ──────────
+        // These fields come from the ingest call's frontmatter (§ schema
+        // verbs/ingest.json). The store (#46) might project frequently-queried
+        // ones as indexed computed columns; json_extract works regardless.
+        "title" => "json_extract(extra_frontmatter, '$.title')",
+        "category" => "json_extract(extra_frontmatter, '$.category')",
+        "path" => "json_extract(extra_frontmatter, '$.path')",
+        "priority" => "json_extract(extra_frontmatter, '$.priority')",
+        "version" => "json_extract(extra_frontmatter, '$.version')",
+        "is_static" => "json_extract(extra_frontmatter, '$.is_static')",
+        "tombstoned" => "json_extract(extra_frontmatter, '$.tombstoned')",
+        "active" => "json_extract(extra_frontmatter, '$.active')",
+        // `backlinks` is a JSON array inside extra_frontmatter.
+        "backlinks" => "json_extract(extra_frontmatter, '$.backlinks')",
+
+        // Unreachable: validate_filter rejects any name not in KNOWN_FIELDS.
+        _ => unreachable!("field not in KNOWN_FIELDS; validate_filter must be called first"),
+    }
 }
 
 fn compile_leaf(v: &serde_json::Value, params: &mut Vec<serde_json::Value>) -> String {
@@ -759,10 +797,19 @@ fn compile_array_op(
     value: &serde_json::Value,
     params: &mut Vec<serde_json::Value>,
 ) -> String {
+    // `actor_chain` stores Vec<ActorChainEntry> JSON objects. Callers filter by
+    // identity string (e.g. "agt:claude"), so extract the `identity` field from
+    // each element. All other array columns store plain strings.
+    let elem_expr = if col == "actor_chain" {
+        "json_extract(value, '$.identity')"
+    } else {
+        "value"
+    };
+
     match op {
         "array_contains" => {
             params.push(value.clone());
-            format!("EXISTS (SELECT 1 FROM json_each({col}) WHERE value = ?)")
+            format!("EXISTS (SELECT 1 FROM json_each({col}) WHERE {elem_expr} = ?)")
         }
         "array_contains_any" => {
             let Some(arr) = value.as_array() else {
@@ -773,7 +820,7 @@ fn compile_array_op(
             for v in arr {
                 params.push(v.clone());
             }
-            format!("EXISTS (SELECT 1 FROM json_each({col}) WHERE value IN ({placeholders}))")
+            format!("EXISTS (SELECT 1 FROM json_each({col}) WHERE {elem_expr} IN ({placeholders}))")
         }
         "array_contains_all" => {
             let Some(arr) = value.as_array() else {
@@ -795,7 +842,7 @@ fn compile_array_op(
                 n as u64,
             )));
             format!(
-                "(SELECT COUNT(DISTINCT value) FROM json_each({col}) WHERE value IN ({placeholders})) = ?"
+                "(SELECT COUNT(DISTINCT {elem_expr}) FROM json_each({col}) WHERE {elem_expr} IN ({placeholders})) = ?"
             )
         }
         "array_size_eq" => {

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -174,6 +174,10 @@ pub enum FilterError {
 const MAX_FILTER_DEPTH: usize = 8;
 /// Maximum fanout for `and` / `or` nodes (matches the serde-layer cap).
 const MAX_FILTER_FANOUT: usize = 32;
+/// Maximum number of items in a set operand (`in`, `nin`, `array_contains_any`,
+/// `array_contains_all`). Keeps compiled `?` placeholder counts well below
+/// SQLite's default variable limit (999) even under heavy nesting.
+const MAX_SET_OPERAND_SIZE: usize = 64;
 
 /// Validate a parsed [`SearchArgsFilters`] tree against the P0 field allowlist
 /// and per-type operator rules (§8.0.d).
@@ -308,6 +312,15 @@ fn json_type_name(v: &serde_json::Value) -> &'static str {
     }
 }
 
+fn require_set_size(field: &str, op: &str, len: usize) -> Result<(), FilterError> {
+    if len > MAX_SET_OPERAND_SIZE {
+        return Err(FilterError::MalformedLeaf(format!(
+            "field `{field}` op `{op}` has {len} items; maximum is {MAX_SET_OPERAND_SIZE}"
+        )));
+    }
+    Ok(())
+}
+
 fn require_nonempty_string(field: &str, op: &str, s: &str) -> Result<(), FilterError> {
     if s.is_empty() {
         Err(FilterError::MalformedLeaf(format!(
@@ -365,6 +378,7 @@ fn validate_value_shape(
                         op: op.to_owned(),
                     });
                 }
+                require_set_size(field, op, arr.len())?;
                 for item in arr {
                     let s = item.as_str().ok_or_else(|| FilterError::WrongValueShape {
                         field: field.to_owned(),
@@ -412,6 +426,7 @@ fn validate_number_value(
                     op: op.to_owned(),
                 });
             }
+            require_set_size(field, op, arr.len())?;
             require_array_of(
                 field,
                 op,
@@ -457,6 +472,7 @@ fn validate_array_field_value(
                     op: op.to_owned(),
                 });
             }
+            require_set_size(field, op, arr.len())?;
             for item in arr {
                 let s = item.as_str().ok_or_else(|| FilterError::WrongValueShape {
                     field: field.to_owned(),
@@ -511,6 +527,7 @@ fn validate_timestamp_value(
                     op: op.to_owned(),
                 });
             }
+            require_set_size(field, op, arr.len())?;
             for item in arr {
                 let Some(s) = item.as_str() else {
                     return Err(FilterError::WrongValueShape {

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -53,8 +53,11 @@ const KNOWN_FIELDS: &[(&str, FieldType)] = &[
     // Numeric fields.
     ("priority", FieldType::Number),
     ("version", FieldType::Number),
-    ("created_at", FieldType::Number),
     ("confidence", FieldType::Number),
+    // Timestamp field — stored as RFC3339 text; ISO8601 is lexicographically
+    // sortable, so string ops (eq/neq/in/nin/string_contains/starts_with) work
+    // correctly against the stored representation.
+    ("created_at", FieldType::Str),
     // Boolean fields.
     ("is_static", FieldType::Boolean),
     ("tombstoned", FieldType::Boolean),
@@ -98,6 +101,19 @@ pub enum FilterError {
         /// Human-readable field type ("string", "number", "boolean", "array").
         field_type: &'static str,
     },
+
+    /// The value's JSON type is incompatible with the field type and operator.
+    #[error("value for field `{field}` op `{op}` has wrong shape: expected {expected}, got {got}")]
+    WrongValueShape {
+        /// Field that was queried.
+        field: String,
+        /// Operator that was rejected.
+        op: String,
+        /// What shape was expected.
+        expected: &'static str,
+        /// What shape was actually received.
+        got: &'static str,
+    },
 }
 
 // ── validate_filter ───────────────────────────────────────────────────────────
@@ -128,7 +144,8 @@ pub fn validate_filter(filter: &SearchArgsFilters) -> Result<(), FilterError> {
 
 /// Validate a single leaf.  The serde parser (`validate_filter_leaf_shape`)
 /// already verified that `field`, `op`, and `value` are present and that the
-/// op is shape-valid; here we enforce the field allowlist and type-op matrix.
+/// op is shape-valid; here we enforce the field allowlist, type-op matrix,
+/// and value-shape compatibility.
 fn validate_leaf(v: &serde_json::Value) -> Result<(), FilterError> {
     let Some(obj) = v.as_object() else {
         unreachable!("leaf is always a JSON object after parsing");
@@ -139,9 +156,11 @@ fn validate_leaf(v: &serde_json::Value) -> Result<(), FilterError> {
     let Some(op) = obj["op"].as_str() else {
         unreachable!("op is always a string after parsing");
     };
+    let value = &obj["value"];
 
     let ft = field_type(field).ok_or_else(|| FilterError::UnknownField(field.to_owned()))?;
-    validate_op_for_type(field, op, ft)
+    validate_op_for_type(field, op, ft)?;
+    validate_value_shape(field, op, ft, value)
 }
 
 fn validate_op_for_type(field: &str, op: &str, ft: FieldType) -> Result<(), FilterError> {
@@ -175,6 +194,144 @@ fn validate_op_for_type(field: &str, op: &str, ft: FieldType) -> Result<(), Filt
             op: op.to_owned(),
             field_type: ft.as_str(),
         })
+    }
+}
+
+fn json_type_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Null => "null",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+/// Check that every element in `arr` satisfies `pred`; return `WrongValueShape`
+/// pointing at the first offending element if not.
+fn require_array_of(
+    field: &str,
+    op: &str,
+    arr: &[serde_json::Value],
+    expected: &'static str,
+    pred: impl Fn(&serde_json::Value) -> bool,
+) -> Result<(), FilterError> {
+    for item in arr {
+        if !pred(item) {
+            return Err(FilterError::WrongValueShape {
+                field: field.to_owned(),
+                op: op.to_owned(),
+                expected,
+                got: json_type_name(item),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_value_shape(
+    field: &str,
+    op: &str,
+    ft: FieldType,
+    value: &serde_json::Value,
+) -> Result<(), FilterError> {
+    let scalar_err = |expected: &'static str| FilterError::WrongValueShape {
+        field: field.to_owned(),
+        op: op.to_owned(),
+        expected,
+        got: json_type_name(value),
+    };
+
+    match ft {
+        FieldType::Str => match op {
+            "in" | "nin" => {
+                let arr = value
+                    .as_array()
+                    .ok_or_else(|| scalar_err("array of strings"))?;
+                require_array_of(
+                    field,
+                    op,
+                    arr,
+                    "array of strings",
+                    serde_json::Value::is_string,
+                )
+            }
+            _ => value
+                .is_string()
+                .then_some(())
+                .ok_or_else(|| scalar_err("string")),
+        },
+        FieldType::Number => validate_number_value(field, op, value, scalar_err),
+        FieldType::Boolean => value
+            .is_boolean()
+            .then_some(())
+            .ok_or_else(|| scalar_err("boolean")),
+        FieldType::Array => validate_array_field_value(field, op, value, scalar_err),
+    }
+}
+
+fn validate_number_value(
+    field: &str,
+    op: &str,
+    value: &serde_json::Value,
+    scalar_err: impl Fn(&'static str) -> FilterError,
+) -> Result<(), FilterError> {
+    match op {
+        "in" | "nin" => {
+            let arr = value
+                .as_array()
+                .ok_or_else(|| scalar_err("array of numbers"))?;
+            require_array_of(
+                field,
+                op,
+                arr,
+                "array of numbers",
+                serde_json::Value::is_number,
+            )
+        }
+        "between" => {
+            let ok = value
+                .as_array()
+                .is_some_and(|a| a.len() == 2 && a[0].is_number() && a[1].is_number());
+            ok.then_some(())
+                .ok_or_else(|| scalar_err("[number, number]"))
+        }
+        _ => value
+            .is_number()
+            .then_some(())
+            .ok_or_else(|| scalar_err("number")),
+    }
+}
+
+fn validate_array_field_value(
+    field: &str,
+    op: &str,
+    value: &serde_json::Value,
+    scalar_err: impl Fn(&'static str) -> FilterError,
+) -> Result<(), FilterError> {
+    match op {
+        "array_contains" => value
+            .is_string()
+            .then_some(())
+            .ok_or_else(|| scalar_err("string")),
+        "array_contains_any" | "array_contains_all" => {
+            let arr = value
+                .as_array()
+                .ok_or_else(|| scalar_err("array of strings"))?;
+            require_array_of(
+                field,
+                op,
+                arr,
+                "array of strings",
+                serde_json::Value::is_string,
+            )
+        }
+        "array_size_eq" => value
+            .is_number()
+            .then_some(())
+            .ok_or_else(|| scalar_err("number")),
+        _ => unreachable!("op validated by validate_op_for_type"),
     }
 }
 
@@ -256,6 +413,19 @@ fn compile_leaf(v: &serde_json::Value, params: &mut Vec<serde_json::Value>) -> S
     }
 }
 
+/// Escape `%` and `_` in a LIKE operand so they are treated as literals.
+/// The caller must also emit `ESCAPE '\'` in the SQL fragment.
+fn escape_like(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        if matches!(ch, '%' | '_' | '\\') {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
 fn compile_scalar_op(
     col: &str,
     op: &str,
@@ -323,21 +493,20 @@ fn compile_scalar_op(
             format!("instr({col}, ?) > 0")
         }
         "string_starts_with" => {
-            // Append `%` to the value to build a `LIKE` prefix pattern.
-            // `LIKE` metacharacters (`%`, `_`) in the value itself are NOT escaped
-            // at P0; escaping is a P1 hardening.
             let Some(s) = value.as_str() else {
                 unreachable!("string_starts_with value is a string after validation");
             };
-            params.push(serde_json::Value::String(format!("{s}%")));
-            format!("{col} LIKE ?")
+            let escaped = escape_like(s);
+            params.push(serde_json::Value::String(format!("{escaped}%")));
+            format!("{col} LIKE ? ESCAPE '\\'")
         }
         "string_ends_with" => {
             let Some(s) = value.as_str() else {
                 unreachable!("string_ends_with value is a string after validation");
             };
-            params.push(serde_json::Value::String(format!("%{s}")));
-            format!("{col} LIKE ?")
+            let escaped = escape_like(s);
+            params.push(serde_json::Value::String(format!("%{escaped}")));
+            format!("{col} LIKE ? ESCAPE '\\'")
         }
         _ => unreachable!("op was validated by validate_filter before compile_filter"),
     }
@@ -369,11 +538,17 @@ fn compile_array_op(
             let Some(arr) = value.as_array() else {
                 unreachable!("array_contains_all value is array after validation");
             };
-            let n = arr.len();
+            // Deduplicate to avoid COUNT(DISTINCT) mismatch when the caller
+            // provides repeated values (e.g. ["infra","infra"] must not require
+            // two distinct matches — the row already satisfies the intent).
+            let mut seen = std::collections::HashSet::new();
+            let unique: Vec<&serde_json::Value> =
+                arr.iter().filter(|v| seen.insert(v.as_str())).collect();
+            let n = unique.len();
             let placeholders = "?, ".repeat(n);
             let placeholders = placeholders.trim_end_matches(", ");
-            for v in arr {
-                params.push(v.clone());
+            for v in &unique {
+                params.push((*v).clone());
             }
             params.push(serde_json::Value::Number(serde_json::Number::from(
                 n as u64,

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -12,6 +12,7 @@
 
 use thiserror::Error;
 
+use crate::domain::timestamp::Rfc3339Timestamp;
 use crate::generated::verbs::search::SearchArgsFilters;
 
 // ── Field allowlist ───────────────────────────────────────────────────────────
@@ -123,6 +124,39 @@ pub enum FilterError {
         expected: &'static str,
         /// What shape was actually received.
         got: &'static str,
+    },
+
+    /// A timestamp operand is a string but not a valid RFC3339 value.
+    #[error("field `{field}` op `{op}` has invalid RFC3339 timestamp `{value}`: {reason}")]
+    InvalidTimestamp {
+        /// Field that was queried.
+        field: String,
+        /// Operator that was rejected.
+        op: String,
+        /// The offending value.
+        value: String,
+        /// Parse failure description.
+        reason: String,
+    },
+
+    /// An array operand must be non-empty but was empty.
+    #[error("field `{field}` op `{op}` requires a non-empty array")]
+    EmptyArray {
+        /// Field that was queried.
+        field: String,
+        /// Operator that was rejected.
+        op: String,
+    },
+
+    /// `array_size_eq` operand must be a non-negative integer.
+    #[error("field `{field}` op `{op}` requires a non-negative integer, got `{value}`")]
+    InvalidArraySize {
+        /// Field that was queried.
+        field: String,
+        /// Operator that was rejected.
+        op: String,
+        /// The offending value.
+        value: String,
     },
 }
 
@@ -262,6 +296,12 @@ fn validate_value_shape(
                 let arr = value
                     .as_array()
                     .ok_or_else(|| scalar_err("array of strings"))?;
+                if arr.is_empty() {
+                    return Err(FilterError::EmptyArray {
+                        field: field.to_owned(),
+                        op: op.to_owned(),
+                    });
+                }
                 require_array_of(
                     field,
                     op,
@@ -281,25 +321,9 @@ fn validate_value_shape(
             .then_some(())
             .ok_or_else(|| scalar_err("boolean")),
         FieldType::Array => validate_array_field_value(field, op, value, scalar_err),
-        // Timestamp: eq/neq require a single string; in/nin require array of strings.
-        FieldType::Timestamp => match op {
-            "in" | "nin" => {
-                let arr = value
-                    .as_array()
-                    .ok_or_else(|| scalar_err("array of RFC3339 strings"))?;
-                require_array_of(
-                    field,
-                    op,
-                    arr,
-                    "array of RFC3339 strings",
-                    serde_json::Value::is_string,
-                )
-            }
-            _ => value
-                .is_string()
-                .then_some(())
-                .ok_or_else(|| scalar_err("RFC3339 string")),
-        },
+        // Timestamp: eq/neq require a valid RFC3339 string; in/nin require
+        // a non-empty array of valid RFC3339 strings.
+        FieldType::Timestamp => validate_timestamp_value(field, op, value, scalar_err),
     }
 }
 
@@ -314,6 +338,12 @@ fn validate_number_value(
             let arr = value
                 .as_array()
                 .ok_or_else(|| scalar_err("array of numbers"))?;
+            if arr.is_empty() {
+                return Err(FilterError::EmptyArray {
+                    field: field.to_owned(),
+                    op: op.to_owned(),
+                });
+            }
             require_array_of(
                 field,
                 op,
@@ -351,6 +381,12 @@ fn validate_array_field_value(
             let arr = value
                 .as_array()
                 .ok_or_else(|| scalar_err("array of strings"))?;
+            if arr.is_empty() {
+                return Err(FilterError::EmptyArray {
+                    field: field.to_owned(),
+                    op: op.to_owned(),
+                });
+            }
             require_array_of(
                 field,
                 op,
@@ -359,11 +395,66 @@ fn validate_array_field_value(
                 serde_json::Value::is_string,
             )
         }
-        "array_size_eq" => value
-            .is_number()
-            .then_some(())
-            .ok_or_else(|| scalar_err("number")),
+        "array_size_eq" => {
+            let n = value.as_u64();
+            if n.is_none() {
+                return Err(FilterError::InvalidArraySize {
+                    field: field.to_owned(),
+                    op: op.to_owned(),
+                    value: value.to_string(),
+                });
+            }
+            Ok(())
+        }
         _ => unreachable!("op validated by validate_op_for_type"),
+    }
+}
+
+fn validate_ts(field: &str, op: &str, s: &str) -> Result<(), FilterError> {
+    Rfc3339Timestamp::parse(s)
+        .map(|_| ())
+        .map_err(|e| FilterError::InvalidTimestamp {
+            field: field.to_owned(),
+            op: op.to_owned(),
+            value: s.to_owned(),
+            reason: e.to_string(),
+        })
+}
+
+fn validate_timestamp_value(
+    field: &str,
+    op: &str,
+    value: &serde_json::Value,
+    scalar_err: impl Fn(&'static str) -> FilterError,
+) -> Result<(), FilterError> {
+    match op {
+        "in" | "nin" => {
+            let arr = value
+                .as_array()
+                .ok_or_else(|| scalar_err("array of RFC3339 strings"))?;
+            if arr.is_empty() {
+                return Err(FilterError::EmptyArray {
+                    field: field.to_owned(),
+                    op: op.to_owned(),
+                });
+            }
+            for item in arr {
+                let Some(s) = item.as_str() else {
+                    return Err(FilterError::WrongValueShape {
+                        field: field.to_owned(),
+                        op: op.to_owned(),
+                        expected: "array of RFC3339 strings",
+                        got: json_type_name(item),
+                    });
+                };
+                validate_ts(field, op, s)?;
+            }
+            Ok(())
+        }
+        _ => {
+            let s = value.as_str().ok_or_else(|| scalar_err("RFC3339 string"))?;
+            validate_ts(field, op, s)
+        }
     }
 }
 

--- a/crates/cairn-core/src/domain/filter.rs
+++ b/crates/cairn-core/src/domain/filter.rs
@@ -170,19 +170,43 @@ pub enum FilterError {
 
 // ── validate_filter ───────────────────────────────────────────────────────────
 
+/// Maximum nesting depth for a filter tree (matches the serde-layer cap).
+const MAX_FILTER_DEPTH: usize = 8;
+/// Maximum fanout for `and` / `or` nodes (matches the serde-layer cap).
+const MAX_FILTER_FANOUT: usize = 32;
+
 /// Validate a parsed [`SearchArgsFilters`] tree against the P0 field allowlist
 /// and per-type operator rules (§8.0.d).
 ///
 /// Call this before [`compile_filter`] and before dispatching to any store.
 /// Returns the first [`FilterError`] found, depth-first left-to-right.
+///
+/// Enforces the same depth/fanout caps as the serde parser so that
+/// programmatically constructed trees cannot cause stack exhaustion or
+/// unbounded SQL generation.
 pub fn validate_filter(filter: &SearchArgsFilters) -> Result<(), FilterError> {
+    validate_filter_inner(filter, 0)
+}
+
+fn validate_filter_inner(filter: &SearchArgsFilters, depth: usize) -> Result<(), FilterError> {
+    if depth > MAX_FILTER_DEPTH {
+        return Err(FilterError::MalformedLeaf(format!(
+            "filter tree exceeds maximum nesting depth of {MAX_FILTER_DEPTH}"
+        )));
+    }
     match filter {
         SearchArgsFilters::And { and } => {
             if and.is_empty() {
                 return Err(FilterError::EmptyOperator("and"));
             }
+            if and.len() > MAX_FILTER_FANOUT {
+                return Err(FilterError::MalformedLeaf(format!(
+                    "`and` node has {} children; maximum is {MAX_FILTER_FANOUT}",
+                    and.len()
+                )));
+            }
             for child in and {
-                validate_filter(child)?;
+                validate_filter_inner(child, depth + 1)?;
             }
             Ok(())
         }
@@ -190,12 +214,18 @@ pub fn validate_filter(filter: &SearchArgsFilters) -> Result<(), FilterError> {
             if or.is_empty() {
                 return Err(FilterError::EmptyOperator("or"));
             }
+            if or.len() > MAX_FILTER_FANOUT {
+                return Err(FilterError::MalformedLeaf(format!(
+                    "`or` node has {} children; maximum is {MAX_FILTER_FANOUT}",
+                    or.len()
+                )));
+            }
             for child in or {
-                validate_filter(child)?;
+                validate_filter_inner(child, depth + 1)?;
             }
             Ok(())
         }
-        SearchArgsFilters::Not { not } => validate_filter(not),
+        SearchArgsFilters::Not { not } => validate_filter_inner(not, depth + 1),
         SearchArgsFilters::Leaf(v) => validate_leaf(v),
     }
 }
@@ -278,6 +308,16 @@ fn json_type_name(v: &serde_json::Value) -> &'static str {
     }
 }
 
+fn require_nonempty_string(field: &str, op: &str, s: &str) -> Result<(), FilterError> {
+    if s.is_empty() {
+        Err(FilterError::MalformedLeaf(format!(
+            "field `{field}` op `{op}` value must not be an empty string"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
 /// Check that every element in `arr` satisfies `pred`; return `WrongValueShape`
 /// pointing at the first offending element if not.
 fn require_array_of(
@@ -325,18 +365,23 @@ fn validate_value_shape(
                         op: op.to_owned(),
                     });
                 }
-                require_array_of(
-                    field,
-                    op,
-                    arr,
-                    "array of strings",
-                    serde_json::Value::is_string,
-                )
+                for item in arr {
+                    let s = item.as_str().ok_or_else(|| FilterError::WrongValueShape {
+                        field: field.to_owned(),
+                        op: op.to_owned(),
+                        expected: "array of strings",
+                        got: json_type_name(item),
+                    })?;
+                    require_nonempty_string(field, op, s)?;
+                }
+                Ok(())
             }
-            _ => value
-                .is_string()
-                .then_some(())
-                .ok_or_else(|| scalar_err("string")),
+            _ => {
+                let s = value
+                    .as_str()
+                    .ok_or_else(|| scalar_err("non-empty string"))?;
+                require_nonempty_string(field, op, s)
+            }
         },
         FieldType::Number => validate_number_value(field, op, value, scalar_err),
         FieldType::Boolean => value
@@ -396,10 +441,12 @@ fn validate_array_field_value(
     scalar_err: impl Fn(&'static str) -> FilterError,
 ) -> Result<(), FilterError> {
     match op {
-        "array_contains" => value
-            .is_string()
-            .then_some(())
-            .ok_or_else(|| scalar_err("string")),
+        "array_contains" => {
+            let s = value
+                .as_str()
+                .ok_or_else(|| scalar_err("non-empty string"))?;
+            require_nonempty_string(field, op, s)
+        }
         "array_contains_any" | "array_contains_all" => {
             let arr = value
                 .as_array()
@@ -410,13 +457,16 @@ fn validate_array_field_value(
                     op: op.to_owned(),
                 });
             }
-            require_array_of(
-                field,
-                op,
-                arr,
-                "array of strings",
-                serde_json::Value::is_string,
-            )
+            for item in arr {
+                let s = item.as_str().ok_or_else(|| FilterError::WrongValueShape {
+                    field: field.to_owned(),
+                    op: op.to_owned(),
+                    expected: "array of strings",
+                    got: json_type_name(item),
+                })?;
+                require_nonempty_string(field, op, s)?;
+            }
+            Ok(())
         }
         "array_size_eq" => {
             let n = value.as_u64();

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -21,6 +21,7 @@ pub mod actor_chain;
 pub mod canonical;
 pub mod error;
 pub mod evidence;
+pub mod filter;
 pub mod identity;
 pub mod intent;
 pub mod provenance;

--- a/crates/cairn-core/tests/filter_dsl.rs
+++ b/crates/cairn-core/tests/filter_dsl.rs
@@ -231,12 +231,12 @@ fn compile_string_starts_with() {
         "field": "title", "op": "string_starts_with", "value": "migration"
     }));
     let compiled = compile_filter(&f);
-    // LIKE with trailing %; value is the pattern param
-    assert!(compiled.sql.contains("title") && compiled.sql.contains("LIKE"));
-    assert_eq!(compiled.params.len(), 1);
-    let param = compiled.params[0].as_str().expect("param is a string");
-    assert!(param.ends_with('%'), "starts_with param must end with %");
-    assert!(param.starts_with("migration"));
+    // Uses substr/length for case-sensitive matching consistent with instr().
+    assert!(compiled.sql.contains("title") && compiled.sql.contains("substr"));
+    // Two params: one for length(?), one for the equality check.
+    assert_eq!(compiled.params.len(), 2);
+    assert_eq!(compiled.params[0].as_str(), Some("migration"));
+    assert_eq!(compiled.params[1].as_str(), Some("migration"));
 }
 
 #[test]
@@ -245,11 +245,12 @@ fn compile_string_ends_with() {
         "field": "title", "op": "string_ends_with", "value": "config"
     }));
     let compiled = compile_filter(&f);
-    assert!(compiled.sql.contains("title") && compiled.sql.contains("LIKE"));
-    assert_eq!(compiled.params.len(), 1);
-    let param = compiled.params[0].as_str().expect("param is a string");
-    assert!(param.starts_with('%'), "ends_with param must start with %");
-    assert!(param.ends_with("config"));
+    assert!(compiled.sql.contains("title") && compiled.sql.contains("substr"));
+    // Three params: two for length(?), one for the equality check.
+    assert_eq!(compiled.params.len(), 3);
+    assert_eq!(compiled.params[0].as_str(), Some("config"));
+    assert_eq!(compiled.params[1].as_str(), Some("config"));
+    assert_eq!(compiled.params[2].as_str(), Some("config"));
 }
 
 #[test]

--- a/crates/cairn-core/tests/filter_dsl.rs
+++ b/crates/cairn-core/tests/filter_dsl.rs
@@ -182,7 +182,7 @@ fn validate_accepts_deep_nested_valid_filter() {
 #[test]
 fn compile_string_eq_produces_parameterized_sql() {
     let f = parse(serde_json::json!({"field": "kind", "op": "eq", "value": "note"}));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert_eq!(compiled.sql, "kind = ?");
     assert_eq!(compiled.params, vec![serde_json::json!("note")]);
 }
@@ -190,7 +190,7 @@ fn compile_string_eq_produces_parameterized_sql() {
 #[test]
 fn compile_string_neq() {
     let f = parse(serde_json::json!({"field": "kind", "op": "neq", "value": "draft"}));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert_eq!(compiled.sql, "kind != ?");
     assert_eq!(compiled.params.len(), 1);
 }
@@ -200,7 +200,7 @@ fn compile_string_in() {
     let f = parse(serde_json::json!({
         "field": "kind", "op": "in", "value": ["strategy_success", "playbook"]
     }));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert_eq!(compiled.sql, "kind IN (?, ?)");
     assert_eq!(compiled.params.len(), 2);
     assert_eq!(compiled.params[0], serde_json::json!("strategy_success"));
@@ -212,7 +212,7 @@ fn compile_string_nin() {
     let f = parse(serde_json::json!({
         "field": "category", "op": "nin", "value": ["draft", "archived"]
     }));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert_eq!(compiled.sql, "category NOT IN (?, ?)");
     assert_eq!(compiled.params.len(), 2);
 }
@@ -220,7 +220,7 @@ fn compile_string_nin() {
 #[test]
 fn compile_string_contains_uses_instr() {
     let f = parse(serde_json::json!({"field": "title", "op": "string_contains", "value": "pg"}));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert_eq!(compiled.sql, "instr(title, ?) > 0");
     assert_eq!(compiled.params, vec![serde_json::json!("pg")]);
 }
@@ -230,7 +230,7 @@ fn compile_string_starts_with() {
     let f = parse(serde_json::json!({
         "field": "title", "op": "string_starts_with", "value": "migration"
     }));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     // Uses substr/length for case-sensitive matching consistent with instr().
     assert!(compiled.sql.contains("title") && compiled.sql.contains("substr"));
     // Two params: one for length(?), one for the equality check.
@@ -244,7 +244,7 @@ fn compile_string_ends_with() {
     let f = parse(serde_json::json!({
         "field": "title", "op": "string_ends_with", "value": "config"
     }));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert!(compiled.sql.contains("title") && compiled.sql.contains("substr"));
     // Three params: two for length(?), one for the equality check.
     assert_eq!(compiled.params.len(), 3);
@@ -256,7 +256,7 @@ fn compile_string_ends_with() {
 #[test]
 fn compile_number_lt() {
     let f = parse(serde_json::json!({"field": "priority", "op": "lt", "value": 5}));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert_eq!(compiled.sql, "priority < ?");
     assert_eq!(compiled.params, vec![serde_json::json!(5)]);
 }
@@ -266,7 +266,7 @@ fn compile_number_between() {
     let f = parse(serde_json::json!({
         "field": "confidence", "op": "between", "value": [0.5, 0.9]
     }));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert_eq!(compiled.sql, "confidence BETWEEN ? AND ?");
     assert_eq!(compiled.params.len(), 2);
     assert_eq!(compiled.params[0], serde_json::json!(0.5));
@@ -276,7 +276,7 @@ fn compile_number_between() {
 #[test]
 fn compile_boolean_eq() {
     let f = parse(serde_json::json!({"field": "is_static", "op": "eq", "value": false}));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert_eq!(compiled.sql, "is_static = ?");
     assert_eq!(compiled.params, vec![serde_json::json!(false)]);
 }
@@ -284,7 +284,7 @@ fn compile_boolean_eq() {
 #[test]
 fn compile_array_contains() {
     let f = parse(serde_json::json!({"field": "tags", "op": "array_contains", "value": "infra"}));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert!(
         compiled.sql.contains("json_each(tags)") && compiled.sql.contains("value = ?"),
         "array_contains must use json_each, got: {}",
@@ -298,7 +298,7 @@ fn compile_array_contains_any() {
     let f = parse(serde_json::json!({
         "field": "tags", "op": "array_contains_any", "value": ["infra", "db"]
     }));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert!(
         compiled.sql.contains("json_each(tags)") && compiled.sql.contains("IN"),
         "array_contains_any must use json_each + IN, got: {}",
@@ -312,7 +312,7 @@ fn compile_array_contains_all() {
     let f = parse(serde_json::json!({
         "field": "tags", "op": "array_contains_all", "value": ["infra", "migration"]
     }));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert!(
         compiled.sql.contains("json_each(tags)"),
         "array_contains_all must use json_each, got: {}",
@@ -330,7 +330,7 @@ fn compile_array_contains_all() {
 #[test]
 fn compile_array_size_eq() {
     let f = parse(serde_json::json!({"field": "tags", "op": "array_size_eq", "value": 3}));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert_eq!(compiled.sql, "json_array_length(tags) = ?");
     assert_eq!(compiled.params, vec![serde_json::json!(3)]);
 }
@@ -345,7 +345,7 @@ fn compile_and_wraps_children_with_and() {
             {"field": "is_static", "op": "eq", "value": false},
         ]
     }));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert!(
         compiled.sql.starts_with('(') && compiled.sql.ends_with(')'),
         "and must be wrapped in parens, got: {}",
@@ -367,7 +367,7 @@ fn compile_or_wraps_children_with_or() {
             {"field": "category", "op": "eq", "value": "released"},
         ]
     }));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert!(
         compiled.sql.contains(" OR "),
         "or must use OR keyword, got: {}",
@@ -379,7 +379,7 @@ fn compile_or_wraps_children_with_or() {
 #[test]
 fn compile_not_wraps_child_with_not() {
     let f = parse(serde_json::json!({"not": {"field": "kind", "op": "eq", "value": "draft"}}));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert!(
         compiled.sql.contains("NOT"),
         "not must use NOT keyword, got: {}",
@@ -394,7 +394,7 @@ fn compile_params_never_contain_sql_in_string_value() {
     // bound parameter — never spliced into the SQL fragment itself.
     let malicious = "'; DROP TABLE records; --";
     let f = parse(serde_json::json!({"field": "title", "op": "eq", "value": malicious}));
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     assert!(
         !compiled.sql.contains("DROP"),
         "SQL injection payload must not appear in the sql fragment, got: {}",
@@ -422,7 +422,7 @@ fn compile_brief_example_filter() {
         ]
     }));
     validate_filter(&f).expect("brief example filter must validate");
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     // Should have produced a non-empty SQL fragment.
     assert!(!compiled.sql.is_empty());
     // Parameters must be bound (not interpolated).

--- a/crates/cairn-core/tests/filter_dsl.rs
+++ b/crates/cairn-core/tests/filter_dsl.rs
@@ -1,0 +1,438 @@
+//! Tests for the metadata filter DSL validation and SQL compiler (§8.0.d).
+//!
+//! Covers:
+//! 1. `validate_filter` — field allowlist + per-type op compatibility.
+//! 2. `compile_filter` — parameterized SQL output; no string interpolation of values.
+//! 3. End-to-end invalid DSL fixture rejection (before `SQLite`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use cairn_core::domain::filter::{FilterError, compile_filter, validate_filter};
+use cairn_core::generated::verbs::search::SearchArgsFilters;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn parse(json: serde_json::Value) -> SearchArgsFilters {
+    serde_json::from_value(json).expect("well-formed filter JSON")
+}
+
+// ── validate_filter: unknown field rejected ──────────────────────────────────
+
+#[test]
+fn validate_rejects_unknown_field() {
+    let f = parse(serde_json::json!({"field": "nonexistent_xyz", "op": "eq", "value": "x"}));
+    let err = validate_filter(&f).unwrap_err();
+    assert!(
+        matches!(err, FilterError::UnknownField(ref name) if name == "nonexistent_xyz"),
+        "expected UnknownField, got: {err:?}"
+    );
+}
+
+#[test]
+fn validate_rejects_unknown_field_inside_and() {
+    let f = parse(serde_json::json!({
+        "and": [
+            {"field": "kind", "op": "eq", "value": "note"},
+            {"field": "mystery_column", "op": "eq", "value": "x"},
+        ]
+    }));
+    let err = validate_filter(&f).unwrap_err();
+    assert!(
+        matches!(err, FilterError::UnknownField(ref name) if name == "mystery_column"),
+        "expected UnknownField for nested leaf, got: {err:?}"
+    );
+}
+
+#[test]
+fn validate_rejects_unknown_field_inside_not() {
+    let f = parse(serde_json::json!({"not": {"field": "foo_bar", "op": "eq", "value": "x"}}));
+    let err = validate_filter(&f).unwrap_err();
+    assert!(
+        matches!(err, FilterError::UnknownField(ref name) if name == "foo_bar"),
+        "expected UnknownField inside not, got: {err:?}"
+    );
+}
+
+// ── validate_filter: unsupported op for field type ───────────────────────────
+
+#[test]
+fn validate_rejects_array_op_on_string_field() {
+    // `kind` is a string field; `array_contains` is an array-only op.
+    let f = parse(serde_json::json!({"field": "kind", "op": "array_contains", "value": "note"}));
+    let err = validate_filter(&f).unwrap_err();
+    assert!(
+        matches!(err, FilterError::UnsupportedOp { ref field, ref op, .. }
+            if field == "kind" && op == "array_contains"),
+        "expected UnsupportedOp, got: {err:?}"
+    );
+}
+
+#[test]
+fn validate_rejects_numeric_op_on_boolean_field() {
+    // `is_static` is boolean; only `eq` is supported.
+    // `lt` with a numeric value passes the serde shape check (valid number op)
+    // but must fail the field-type check because `is_static` is boolean.
+    let f = parse(serde_json::json!({"field": "is_static", "op": "lt", "value": 1}));
+    let err = validate_filter(&f).unwrap_err();
+    assert!(
+        matches!(err, FilterError::UnsupportedOp { ref field, ref op, .. }
+            if field == "is_static" && op == "lt"),
+        "expected UnsupportedOp for boolean lt, got: {err:?}"
+    );
+}
+
+#[test]
+fn validate_rejects_string_op_on_number_field() {
+    // `priority` is a number field; `string_contains` is string-only.
+    let f = parse(serde_json::json!({"field": "priority", "op": "string_contains", "value": "7"}));
+    let err = validate_filter(&f).unwrap_err();
+    assert!(
+        matches!(err, FilterError::UnsupportedOp { ref field, .. } if field == "priority"),
+        "expected UnsupportedOp for string_contains on number field, got: {err:?}"
+    );
+}
+
+#[test]
+fn validate_rejects_scalar_eq_on_array_field() {
+    // `tags` is an array field; `eq` is not supported (use `array_contains`).
+    let f = parse(serde_json::json!({"field": "tags", "op": "eq", "value": "infra"}));
+    let err = validate_filter(&f).unwrap_err();
+    assert!(
+        matches!(err, FilterError::UnsupportedOp { ref field, ref op, .. }
+            if field == "tags" && op == "eq"),
+        "expected UnsupportedOp for eq on array field, got: {err:?}"
+    );
+}
+
+// ── validate_filter: valid field+op combos accepted ──────────────────────────
+
+#[test]
+fn validate_accepts_string_eq() {
+    let f = parse(serde_json::json!({"field": "kind", "op": "eq", "value": "note"}));
+    validate_filter(&f).expect("kind eq is valid");
+}
+
+#[test]
+fn validate_accepts_string_in() {
+    let f = parse(serde_json::json!({"field": "kind", "op": "in", "value": ["note", "rule"]}));
+    validate_filter(&f).expect("kind in is valid");
+}
+
+#[test]
+fn validate_accepts_string_contains() {
+    let f = parse(serde_json::json!({"field": "title", "op": "string_contains", "value": "pg"}));
+    validate_filter(&f).expect("title string_contains is valid");
+}
+
+#[test]
+fn validate_accepts_number_gte() {
+    let f = parse(serde_json::json!({"field": "priority", "op": "gte", "value": 7}));
+    validate_filter(&f).expect("priority gte is valid");
+}
+
+#[test]
+fn validate_accepts_number_between() {
+    let f = parse(serde_json::json!({"field": "confidence", "op": "between", "value": [0.5, 0.9]}));
+    validate_filter(&f).expect("confidence between is valid");
+}
+
+#[test]
+fn validate_accepts_boolean_eq() {
+    let f = parse(serde_json::json!({"field": "is_static", "op": "eq", "value": false}));
+    validate_filter(&f).expect("is_static eq is valid");
+}
+
+#[test]
+fn validate_accepts_array_contains() {
+    let f = parse(serde_json::json!({"field": "tags", "op": "array_contains", "value": "infra"}));
+    validate_filter(&f).expect("tags array_contains is valid");
+}
+
+#[test]
+fn validate_accepts_array_contains_all() {
+    let f = parse(serde_json::json!({
+        "field": "tags", "op": "array_contains_all", "value": ["infra", "migration"]
+    }));
+    validate_filter(&f).expect("tags array_contains_all is valid");
+}
+
+#[test]
+fn validate_accepts_array_size_eq() {
+    let f = parse(serde_json::json!({"field": "tags", "op": "array_size_eq", "value": 3}));
+    validate_filter(&f).expect("tags array_size_eq is valid");
+}
+
+#[test]
+fn validate_accepts_deep_nested_valid_filter() {
+    let f = parse(serde_json::json!({
+        "and": [
+            {"field": "kind", "op": "in", "value": ["strategy_success", "playbook"]},
+            {"field": "is_static", "op": "eq", "value": false},
+            {"or": [
+                {"field": "category", "op": "eq", "value": "shipped"},
+                {"not": {"field": "category", "op": "eq", "value": "draft"}}
+            ]}
+        ]
+    }));
+    validate_filter(&f).expect("deep nested filter with valid fields is valid");
+}
+
+// ── compile_filter: SQL output and parameter binding ─────────────────────────
+
+#[test]
+fn compile_string_eq_produces_parameterized_sql() {
+    let f = parse(serde_json::json!({"field": "kind", "op": "eq", "value": "note"}));
+    let compiled = compile_filter(&f);
+    assert_eq!(compiled.sql, "kind = ?");
+    assert_eq!(compiled.params, vec![serde_json::json!("note")]);
+}
+
+#[test]
+fn compile_string_neq() {
+    let f = parse(serde_json::json!({"field": "kind", "op": "neq", "value": "draft"}));
+    let compiled = compile_filter(&f);
+    assert_eq!(compiled.sql, "kind != ?");
+    assert_eq!(compiled.params.len(), 1);
+}
+
+#[test]
+fn compile_string_in() {
+    let f = parse(serde_json::json!({
+        "field": "kind", "op": "in", "value": ["strategy_success", "playbook"]
+    }));
+    let compiled = compile_filter(&f);
+    assert_eq!(compiled.sql, "kind IN (?, ?)");
+    assert_eq!(compiled.params.len(), 2);
+    assert_eq!(compiled.params[0], serde_json::json!("strategy_success"));
+    assert_eq!(compiled.params[1], serde_json::json!("playbook"));
+}
+
+#[test]
+fn compile_string_nin() {
+    let f = parse(serde_json::json!({
+        "field": "category", "op": "nin", "value": ["draft", "archived"]
+    }));
+    let compiled = compile_filter(&f);
+    assert_eq!(compiled.sql, "category NOT IN (?, ?)");
+    assert_eq!(compiled.params.len(), 2);
+}
+
+#[test]
+fn compile_string_contains_uses_instr() {
+    let f = parse(serde_json::json!({"field": "title", "op": "string_contains", "value": "pg"}));
+    let compiled = compile_filter(&f);
+    assert_eq!(compiled.sql, "instr(title, ?) > 0");
+    assert_eq!(compiled.params, vec![serde_json::json!("pg")]);
+}
+
+#[test]
+fn compile_string_starts_with() {
+    let f = parse(serde_json::json!({
+        "field": "title", "op": "string_starts_with", "value": "migration"
+    }));
+    let compiled = compile_filter(&f);
+    // LIKE with trailing %; value is the pattern param
+    assert!(compiled.sql.contains("title") && compiled.sql.contains("LIKE"));
+    assert_eq!(compiled.params.len(), 1);
+    let param = compiled.params[0].as_str().expect("param is a string");
+    assert!(param.ends_with('%'), "starts_with param must end with %");
+    assert!(param.starts_with("migration"));
+}
+
+#[test]
+fn compile_string_ends_with() {
+    let f = parse(serde_json::json!({
+        "field": "title", "op": "string_ends_with", "value": "config"
+    }));
+    let compiled = compile_filter(&f);
+    assert!(compiled.sql.contains("title") && compiled.sql.contains("LIKE"));
+    assert_eq!(compiled.params.len(), 1);
+    let param = compiled.params[0].as_str().expect("param is a string");
+    assert!(param.starts_with('%'), "ends_with param must start with %");
+    assert!(param.ends_with("config"));
+}
+
+#[test]
+fn compile_number_lt() {
+    let f = parse(serde_json::json!({"field": "priority", "op": "lt", "value": 5}));
+    let compiled = compile_filter(&f);
+    assert_eq!(compiled.sql, "priority < ?");
+    assert_eq!(compiled.params, vec![serde_json::json!(5)]);
+}
+
+#[test]
+fn compile_number_between() {
+    let f = parse(serde_json::json!({
+        "field": "confidence", "op": "between", "value": [0.5, 0.9]
+    }));
+    let compiled = compile_filter(&f);
+    assert_eq!(compiled.sql, "confidence BETWEEN ? AND ?");
+    assert_eq!(compiled.params.len(), 2);
+    assert_eq!(compiled.params[0], serde_json::json!(0.5));
+    assert_eq!(compiled.params[1], serde_json::json!(0.9));
+}
+
+#[test]
+fn compile_boolean_eq() {
+    let f = parse(serde_json::json!({"field": "is_static", "op": "eq", "value": false}));
+    let compiled = compile_filter(&f);
+    assert_eq!(compiled.sql, "is_static = ?");
+    assert_eq!(compiled.params, vec![serde_json::json!(false)]);
+}
+
+#[test]
+fn compile_array_contains() {
+    let f = parse(serde_json::json!({"field": "tags", "op": "array_contains", "value": "infra"}));
+    let compiled = compile_filter(&f);
+    assert!(
+        compiled.sql.contains("json_each(tags)") && compiled.sql.contains("value = ?"),
+        "array_contains must use json_each, got: {}",
+        compiled.sql
+    );
+    assert_eq!(compiled.params, vec![serde_json::json!("infra")]);
+}
+
+#[test]
+fn compile_array_contains_any() {
+    let f = parse(serde_json::json!({
+        "field": "tags", "op": "array_contains_any", "value": ["infra", "db"]
+    }));
+    let compiled = compile_filter(&f);
+    assert!(
+        compiled.sql.contains("json_each(tags)") && compiled.sql.contains("IN"),
+        "array_contains_any must use json_each + IN, got: {}",
+        compiled.sql
+    );
+    assert_eq!(compiled.params.len(), 2);
+}
+
+#[test]
+fn compile_array_contains_all() {
+    let f = parse(serde_json::json!({
+        "field": "tags", "op": "array_contains_all", "value": ["infra", "migration"]
+    }));
+    let compiled = compile_filter(&f);
+    assert!(
+        compiled.sql.contains("json_each(tags)"),
+        "array_contains_all must use json_each, got: {}",
+        compiled.sql
+    );
+    // params: the set members + the count
+    assert_eq!(
+        compiled.params.len(),
+        3,
+        "array_contains_all [a,b] → 2 value params + 1 count param"
+    );
+    assert_eq!(compiled.params[2], serde_json::json!(2u64));
+}
+
+#[test]
+fn compile_array_size_eq() {
+    let f = parse(serde_json::json!({"field": "tags", "op": "array_size_eq", "value": 3}));
+    let compiled = compile_filter(&f);
+    assert_eq!(compiled.sql, "json_array_length(tags) = ?");
+    assert_eq!(compiled.params, vec![serde_json::json!(3)]);
+}
+
+// ── compile_filter: boolean combinators ──────────────────────────────────────
+
+#[test]
+fn compile_and_wraps_children_with_and() {
+    let f = parse(serde_json::json!({
+        "and": [
+            {"field": "kind", "op": "eq", "value": "note"},
+            {"field": "is_static", "op": "eq", "value": false},
+        ]
+    }));
+    let compiled = compile_filter(&f);
+    assert!(
+        compiled.sql.starts_with('(') && compiled.sql.ends_with(')'),
+        "and must be wrapped in parens, got: {}",
+        compiled.sql
+    );
+    assert!(
+        compiled.sql.contains(" AND "),
+        "and must use AND keyword, got: {}",
+        compiled.sql
+    );
+    assert_eq!(compiled.params.len(), 2);
+}
+
+#[test]
+fn compile_or_wraps_children_with_or() {
+    let f = parse(serde_json::json!({
+        "or": [
+            {"field": "category", "op": "eq", "value": "shipped"},
+            {"field": "category", "op": "eq", "value": "released"},
+        ]
+    }));
+    let compiled = compile_filter(&f);
+    assert!(
+        compiled.sql.contains(" OR "),
+        "or must use OR keyword, got: {}",
+        compiled.sql
+    );
+    assert_eq!(compiled.params.len(), 2);
+}
+
+#[test]
+fn compile_not_wraps_child_with_not() {
+    let f = parse(serde_json::json!({"not": {"field": "kind", "op": "eq", "value": "draft"}}));
+    let compiled = compile_filter(&f);
+    assert!(
+        compiled.sql.contains("NOT"),
+        "not must use NOT keyword, got: {}",
+        compiled.sql
+    );
+    assert_eq!(compiled.params.len(), 1);
+}
+
+#[test]
+fn compile_params_never_contain_sql_in_string_value() {
+    // Injection guard: a malicious value that looks like SQL must appear as a
+    // bound parameter — never spliced into the SQL fragment itself.
+    let malicious = "'; DROP TABLE records; --";
+    let f = parse(serde_json::json!({"field": "title", "op": "eq", "value": malicious}));
+    let compiled = compile_filter(&f);
+    assert!(
+        !compiled.sql.contains("DROP"),
+        "SQL injection payload must not appear in the sql fragment, got: {}",
+        compiled.sql
+    );
+    assert_eq!(compiled.params, vec![serde_json::json!(malicious)]);
+}
+
+// ── compile_filter: complex example from §8.0.d ──────────────────────────────
+
+#[test]
+fn compile_brief_example_filter() {
+    // Full example from design brief §8.0.d.
+    let f = parse(serde_json::json!({
+        "and": [
+            {"field": "kind",      "op": "in",             "value": ["strategy_success", "playbook"]},
+            {"field": "is_static", "op": "eq",             "value": false},
+            {"field": "tags",      "op": "array_contains", "value": "infra"},
+            {"field": "priority",  "op": "gte",            "value": 7},
+            {"or": [
+                {"field": "category", "op": "eq",          "value": "shipped"},
+                {"not": {"field": "category", "op": "eq",  "value": "draft"}}
+            ]},
+            {"field": "title",     "op": "string_contains","value": "pg"}
+        ]
+    }));
+    validate_filter(&f).expect("brief example filter must validate");
+    let compiled = compile_filter(&f);
+    // Should have produced a non-empty SQL fragment.
+    assert!(!compiled.sql.is_empty());
+    // Parameters must be bound (not interpolated).
+    assert!(
+        compiled.params.len() >= 6,
+        "expected at least 6 params, got {}",
+        compiled.params.len()
+    );
+    // The literal value "strategy_success" must appear only in params, not in sql.
+    assert!(
+        !compiled.sql.contains("strategy_success"),
+        "field value must not appear in SQL fragment"
+    );
+}

--- a/crates/cairn-core/tests/filter_dsl.rs
+++ b/crates/cairn-core/tests/filter_dsl.rs
@@ -213,7 +213,10 @@ fn compile_string_nin() {
         "field": "category", "op": "nin", "value": ["draft", "archived"]
     }));
     let compiled = compile_filter(validate_filter(&f).unwrap());
-    assert_eq!(compiled.sql, "category NOT IN (?, ?)");
+    assert_eq!(
+        compiled.sql,
+        "json_extract(extra_frontmatter, '$.category') NOT IN (?, ?)"
+    );
     assert_eq!(compiled.params.len(), 2);
 }
 
@@ -221,7 +224,10 @@ fn compile_string_nin() {
 fn compile_string_contains_uses_instr() {
     let f = parse(serde_json::json!({"field": "title", "op": "string_contains", "value": "pg"}));
     let compiled = compile_filter(validate_filter(&f).unwrap());
-    assert_eq!(compiled.sql, "instr(title, ?) > 0");
+    assert_eq!(
+        compiled.sql,
+        "instr(json_extract(extra_frontmatter, '$.title'), ?) > 0"
+    );
     assert_eq!(compiled.params, vec![serde_json::json!("pg")]);
 }
 
@@ -232,7 +238,12 @@ fn compile_string_starts_with() {
     }));
     let compiled = compile_filter(validate_filter(&f).unwrap());
     // Uses substr/length for case-sensitive matching consistent with instr().
-    assert!(compiled.sql.contains("title") && compiled.sql.contains("substr"));
+    assert!(
+        compiled
+            .sql
+            .contains("json_extract(extra_frontmatter, '$.title')")
+            && compiled.sql.contains("substr")
+    );
     // Two params: one for length(?), one for the equality check.
     assert_eq!(compiled.params.len(), 2);
     assert_eq!(compiled.params[0].as_str(), Some("migration"));
@@ -245,7 +256,12 @@ fn compile_string_ends_with() {
         "field": "title", "op": "string_ends_with", "value": "config"
     }));
     let compiled = compile_filter(validate_filter(&f).unwrap());
-    assert!(compiled.sql.contains("title") && compiled.sql.contains("substr"));
+    assert!(
+        compiled
+            .sql
+            .contains("json_extract(extra_frontmatter, '$.title')")
+            && compiled.sql.contains("substr")
+    );
     // Three params: two for length(?), one for the equality check.
     assert_eq!(compiled.params.len(), 3);
     assert_eq!(compiled.params[0].as_str(), Some("config"));
@@ -257,7 +273,10 @@ fn compile_string_ends_with() {
 fn compile_number_lt() {
     let f = parse(serde_json::json!({"field": "priority", "op": "lt", "value": 5}));
     let compiled = compile_filter(validate_filter(&f).unwrap());
-    assert_eq!(compiled.sql, "priority < ?");
+    assert_eq!(
+        compiled.sql,
+        "json_extract(extra_frontmatter, '$.priority') < ?"
+    );
     assert_eq!(compiled.params, vec![serde_json::json!(5)]);
 }
 
@@ -277,7 +296,10 @@ fn compile_number_between() {
 fn compile_boolean_eq() {
     let f = parse(serde_json::json!({"field": "is_static", "op": "eq", "value": false}));
     let compiled = compile_filter(validate_filter(&f).unwrap());
-    assert_eq!(compiled.sql, "is_static = ?");
+    assert_eq!(
+        compiled.sql,
+        "json_extract(extra_frontmatter, '$.is_static') = ?"
+    );
     assert_eq!(compiled.params, vec![serde_json::json!(false)]);
 }
 

--- a/crates/cairn-core/tests/filter_sql_exec.rs
+++ b/crates/cairn-core/tests/filter_sql_exec.rs
@@ -1,0 +1,424 @@
+//! E2E execution tests for the metadata filter SQL compiler (§8.0.d).
+//!
+//! Creates an in-memory `SQLite` `records` table covering every P0 filter
+//! field, runs [`compile_filter`] output against it with real data, and
+//! asserts the correct rows are returned.  This validates SQL syntax AND
+//! semantics — not just structure.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use cairn_core::domain::filter::{compile_filter, validate_filter};
+use cairn_core::generated::verbs::search::SearchArgsFilters;
+use rusqlite::{Connection, params_from_iter, types::Value as SqlVal};
+
+// ── Test schema ───────────────────────────────────────────────────────────────
+
+fn open_db() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE records (
+            id          TEXT    PRIMARY KEY,
+            kind        TEXT,
+            class       TEXT,
+            visibility  TEXT,
+            path        TEXT,
+            title       TEXT,
+            category    TEXT,
+            priority    INTEGER,
+            version     INTEGER,
+            created_at  TEXT,
+            confidence  REAL,
+            is_static   INTEGER,
+            tombstoned  INTEGER,
+            active      INTEGER,
+            tags        TEXT,
+            actor_chain TEXT,
+            backlinks   TEXT
+        );",
+    )
+    .unwrap();
+    conn
+}
+
+fn insert(conn: &Connection, row: &[(&str, &str)]) {
+    let cols: Vec<&str> = row.iter().map(|(c, _)| *c).collect();
+    let vals: Vec<&str> = row.iter().map(|(_, v)| *v).collect();
+    let placeholders = cols.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+    let sql = format!(
+        "INSERT INTO records ({}) VALUES ({placeholders})",
+        cols.join(", ")
+    );
+    let p: Vec<&dyn rusqlite::types::ToSql> = vals
+        .iter()
+        .map(|v| v as &dyn rusqlite::types::ToSql)
+        .collect();
+    conn.execute(&sql, p.as_slice()).unwrap();
+}
+
+/// Convert `serde_json::Value` params from [`compile_filter`] to `rusqlite` values.
+fn to_sql_params(params: &[serde_json::Value]) -> Vec<SqlVal> {
+    params
+        .iter()
+        .map(|v| match v {
+            serde_json::Value::String(s) => SqlVal::Text(s.clone()),
+            serde_json::Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    SqlVal::Integer(i)
+                } else {
+                    SqlVal::Real(n.as_f64().unwrap_or(0.0))
+                }
+            }
+            serde_json::Value::Bool(b) => SqlVal::Integer(i64::from(*b)),
+            _ => SqlVal::Null,
+        })
+        .collect()
+}
+
+/// Run a compiled filter against the `records` table and return matching `id`s.
+fn run(conn: &Connection, filter_json: serde_json::Value) -> Vec<String> {
+    let f: SearchArgsFilters = serde_json::from_value(filter_json).unwrap();
+    validate_filter(&f).unwrap();
+    let compiled = compile_filter(&f);
+    let sql = format!("SELECT id FROM records WHERE {}", compiled.sql);
+    let sql_params = to_sql_params(&compiled.params);
+    let mut stmt = conn.prepare(&sql).unwrap();
+    stmt.query_map(params_from_iter(sql_params.iter()), |row| row.get(0))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect()
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+fn seed_db() -> Connection {
+    let conn = open_db();
+
+    insert(
+        &conn,
+        &[
+            ("id", "r1"),
+            ("kind", "user"),
+            ("title", "pg migration strategy"),
+            ("category", "shipped"),
+            ("priority", "8"),
+            ("confidence", "0.9"),
+            ("is_static", "0"),
+            ("tombstoned", "0"),
+            ("active", "1"),
+            ("tags", r#"["infra","migration"]"#),
+            ("actor_chain", r#"["agt:claude"]"#),
+            ("backlinks", r#"[]"#),
+            ("version", "1"),
+        ],
+    );
+    insert(
+        &conn,
+        &[
+            ("id", "r2"),
+            ("kind", "feedback"),
+            ("title", "user prefers dark mode"),
+            ("category", "draft"),
+            ("priority", "3"),
+            ("confidence", "0.5"),
+            ("is_static", "1"),
+            ("tombstoned", "0"),
+            ("active", "1"),
+            ("tags", r#"["pref"]"#),
+            ("actor_chain", r#"["usr:tafeng"]"#),
+            ("backlinks", r#"[]"#),
+            ("version", "2"),
+        ],
+    );
+    insert(
+        &conn,
+        &[
+            ("id", "r3"),
+            ("kind", "rule"),
+            ("title", "always use pg for backups"),
+            ("category", "shipped"),
+            ("priority", "9"),
+            ("confidence", "0.8"),
+            ("is_static", "0"),
+            ("tombstoned", "1"),
+            ("active", "0"),
+            ("tags", r#"["infra","db","backup"]"#),
+            ("actor_chain", r#"["agt:claude"]"#),
+            ("backlinks", r#"["r1"]"#),
+            ("version", "1"),
+        ],
+    );
+
+    conn
+}
+
+// ── String field ops ──────────────────────────────────────────────────────────
+
+#[test]
+fn exec_string_eq_matches_exact() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({"field": "kind", "op": "eq", "value": "user"}),
+    );
+    assert_eq!(ids, vec!["r1"]);
+}
+
+#[test]
+fn exec_string_neq_excludes_value() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({"field": "kind", "op": "neq", "value": "feedback"}),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+#[test]
+fn exec_string_in_matches_set() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({"field": "kind", "op": "in", "value": ["user", "rule"]}),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+#[test]
+fn exec_string_nin_excludes_set() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({"field": "kind", "op": "nin", "value": ["user", "rule"]}),
+    );
+    assert_eq!(ids, vec!["r2"]);
+}
+
+#[test]
+fn exec_string_contains_substring() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({"field": "title", "op": "string_contains", "value": "pg"}),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+#[test]
+fn exec_string_starts_with() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({"field": "title", "op": "string_starts_with", "value": "pg"}),
+    );
+    assert_eq!(ids, vec!["r1"]);
+}
+
+#[test]
+fn exec_string_ends_with() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({"field": "title", "op": "string_ends_with", "value": "mode"}),
+    );
+    assert_eq!(ids, vec!["r2"]);
+}
+
+// ── Numeric field ops ─────────────────────────────────────────────────────────
+
+#[test]
+fn exec_number_gte_filters_rows() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({"field": "priority", "op": "gte", "value": 8}),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+#[test]
+fn exec_number_lt_filters_rows() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({"field": "priority", "op": "lt", "value": 5}),
+    );
+    assert_eq!(ids, vec!["r2"]);
+}
+
+#[test]
+fn exec_number_between_inclusive() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({"field": "confidence", "op": "between", "value": [0.8, 1.0]}),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+// ── Boolean field ops ─────────────────────────────────────────────────────────
+
+#[test]
+fn exec_boolean_eq_true() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({"field": "is_static", "op": "eq", "value": true}),
+    );
+    assert_eq!(ids, vec!["r2"]);
+}
+
+#[test]
+fn exec_boolean_eq_false() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({"field": "is_static", "op": "eq", "value": false}),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+#[test]
+fn exec_tombstoned_eq_true_returns_only_tombstoned() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({"field": "tombstoned", "op": "eq", "value": true}),
+    );
+    assert_eq!(ids, vec!["r3"]);
+}
+
+// ── Array field ops ───────────────────────────────────────────────────────────
+
+#[test]
+fn exec_array_contains_single() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({"field": "tags", "op": "array_contains", "value": "infra"}),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+#[test]
+fn exec_array_contains_any_matches_either() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({
+            "field": "tags", "op": "array_contains_any",
+            "value": ["pref", "backup"]
+        }),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r2", "r3"]);
+}
+
+#[test]
+fn exec_array_contains_all_requires_both() {
+    let conn = seed_db();
+    // r1 has ["infra","migration"], r3 has ["infra","db","backup"] — only r1 has both
+    let ids = run(
+        &conn,
+        serde_json::json!({
+            "field": "tags", "op": "array_contains_all",
+            "value": ["infra", "migration"]
+        }),
+    );
+    assert_eq!(ids, vec!["r1"]);
+}
+
+#[test]
+fn exec_array_size_eq_returns_matching_rows() {
+    let conn = seed_db();
+    // r1 has 2 tags, r2 has 1 tag, r3 has 3 tags
+    let ids = run(
+        &conn,
+        serde_json::json!({"field": "tags", "op": "array_size_eq", "value": 1}),
+    );
+    assert_eq!(ids, vec!["r2"]);
+}
+
+// ── Boolean combinators ───────────────────────────────────────────────────────
+
+#[test]
+fn exec_and_narrows_results() {
+    let conn = seed_db();
+    // kind=user AND priority>=8 → only r1
+    let ids = run(
+        &conn,
+        serde_json::json!({
+            "and": [
+                {"field": "kind", "op": "eq", "value": "user"},
+                {"field": "priority", "op": "gte", "value": 8}
+            ]
+        }),
+    );
+    assert_eq!(ids, vec!["r1"]);
+}
+
+#[test]
+fn exec_or_broadens_results() {
+    let conn = seed_db();
+    // kind=user OR kind=rule → r1 and r3
+    let mut ids = run(
+        &conn,
+        serde_json::json!({
+            "or": [
+                {"field": "kind", "op": "eq", "value": "user"},
+                {"field": "kind", "op": "eq", "value": "rule"}
+            ]
+        }),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+#[test]
+fn exec_not_inverts_match() {
+    let conn = seed_db();
+    // NOT category=draft → r1 and r3
+    let mut ids = run(
+        &conn,
+        serde_json::json!({"not": {"field": "category", "op": "eq", "value": "draft"}}),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+// ── §8.0.d brief example ──────────────────────────────────────────────────────
+
+#[test]
+fn exec_brief_example_filter_returns_correct_rows() {
+    let conn = seed_db();
+    // Adapted from §8.0.d: kind in [user, rule], is_static=false, tags contains infra,
+    // priority >= 7, category=shipped OR NOT category=draft, title contains pg.
+    let ids = run(
+        &conn,
+        serde_json::json!({
+            "and": [
+                {"field": "kind", "op": "in", "value": ["user", "rule"]},
+                {"field": "is_static", "op": "eq", "value": false},
+                {"field": "tags", "op": "array_contains", "value": "infra"},
+                {"field": "priority", "op": "gte", "value": 7},
+                {"or": [
+                    {"field": "category", "op": "eq", "value": "shipped"},
+                    {"not": {"field": "category", "op": "eq", "value": "draft"}}
+                ]},
+                {"field": "title", "op": "string_contains", "value": "pg"}
+            ]
+        }),
+    );
+    // r1: user, not static, has infra tag, priority 8, shipped, title has "pg" → matches
+    // r3: rule, not static, has infra tag, priority 9, shipped, title has "pg" → matches
+    // r2: feedback, static, no infra tag → excluded at multiple predicates
+    let mut ids = ids;
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}

--- a/crates/cairn-core/tests/filter_sql_exec.rs
+++ b/crates/cairn-core/tests/filter_sql_exec.rs
@@ -1,9 +1,21 @@
 //! E2E execution tests for the metadata filter SQL compiler (§8.0.d).
 //!
-//! Creates an in-memory `SQLite` `records` table covering every P0 filter
-//! field, runs [`compile_filter`] output against it with real data, and
-//! asserts the correct rows are returned.  This validates SQL syntax AND
-//! semantics — not just structure.
+//! Creates an in-memory `SQLite` `records` table that mirrors the real
+//! `MemoryRecord` storage layout:
+//!
+//! - Scalar columns for direct `MemoryRecord` fields (`kind`, `class`,
+//!   `visibility`, `confidence`).
+//! - A `provenance TEXT` JSON column — `created_at` lives here as
+//!   `json_extract(provenance, '$.created_at')`.
+//! - A `tags TEXT` JSON column for the plain-string array.
+//! - An `actor_chain TEXT` JSON column storing `Vec<ActorChainEntry>` objects;
+//!   array ops filter on `json_extract(value, '$.identity')`.
+//! - An `extra_frontmatter TEXT` JSON column for all ingest-supplied fields
+//!   (`title`, `category`, `path`, `priority`, `version`, `is_static`,
+//!   `tombstoned`, `active`, `backlinks`).
+//!
+//! This validates SQL syntax AND semantics against the actual expression
+//! mapping in `field_col` — not just structure.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -17,23 +29,15 @@ fn open_db() -> Connection {
     let conn = Connection::open_in_memory().unwrap();
     conn.execute_batch(
         "CREATE TABLE records (
-            id          TEXT    PRIMARY KEY,
-            kind        TEXT,
-            class       TEXT,
-            visibility  TEXT,
-            path        TEXT,
-            title       TEXT,
-            category    TEXT,
-            priority    INTEGER,
-            version     INTEGER,
-            created_at  TEXT,
-            confidence  REAL,
-            is_static   INTEGER,
-            tombstoned  INTEGER,
-            active      INTEGER,
-            tags        TEXT,
-            actor_chain TEXT,
-            backlinks   TEXT
+            id                TEXT PRIMARY KEY,
+            kind              TEXT,
+            class             TEXT,
+            visibility        TEXT,
+            confidence        REAL,
+            provenance        TEXT,
+            tags              TEXT,
+            actor_chain       TEXT,
+            extra_frontmatter TEXT
         );",
     )
     .unwrap();
@@ -92,58 +96,87 @@ fn run(conn: &Connection, filter_json: serde_json::Value) -> Vec<String> {
 fn seed_db() -> Connection {
     let conn = open_db();
 
+    // r1: kind=user, confidence=0.9, tags=["infra","migration"]
+    //     actor_chain=[{role:author,identity:agt:claude}]
+    //     extra_frontmatter: title, category=shipped, priority=8, is_static=0,
+    //                        tombstoned=0, active=1, backlinks=[], version=1
     insert(
         &conn,
         &[
             ("id", "r1"),
             ("kind", "user"),
-            ("title", "pg migration strategy"),
-            ("category", "shipped"),
-            ("priority", "8"),
+            ("class", "semantic"),
+            ("visibility", "private"),
             ("confidence", "0.9"),
-            ("is_static", "0"),
-            ("tombstoned", "0"),
-            ("active", "1"),
+            (
+                "provenance",
+                r#"{"created_at":"2026-04-01T10:00:00Z","source_sensor":"snr:local:hook:cc-session:v1"}"#,
+            ),
             ("tags", r#"["infra","migration"]"#),
-            ("actor_chain", r#"["agt:claude"]"#),
-            ("backlinks", r"[]"),
-            ("version", "1"),
+            (
+                "actor_chain",
+                r#"[{"role":"author","identity":"agt:claude","at":"2026-04-01T10:00:00Z"}]"#,
+            ),
+            (
+                "extra_frontmatter",
+                r#"{"title":"pg migration strategy","category":"shipped","priority":8,"version":1,"is_static":0,"tombstoned":0,"active":1,"backlinks":[]}"#,
+            ),
         ],
     );
+
+    // r2: kind=feedback, confidence=0.5, tags=["pref"]
+    //     actor_chain=[{role:author,identity:usr:tafeng}]
+    //     extra_frontmatter: title, category=draft, priority=3, is_static=1,
+    //                        tombstoned=0, active=1, backlinks=[], version=2
     insert(
         &conn,
         &[
             ("id", "r2"),
             ("kind", "feedback"),
-            ("title", "user prefers dark mode"),
-            ("category", "draft"),
-            ("priority", "3"),
+            ("class", "semantic"),
+            ("visibility", "private"),
             ("confidence", "0.5"),
-            ("is_static", "1"),
-            ("tombstoned", "0"),
-            ("active", "1"),
+            (
+                "provenance",
+                r#"{"created_at":"2026-04-02T11:00:00Z","source_sensor":"snr:local:hook:cc-session:v1"}"#,
+            ),
             ("tags", r#"["pref"]"#),
-            ("actor_chain", r#"["usr:tafeng"]"#),
-            ("backlinks", r"[]"),
-            ("version", "2"),
+            (
+                "actor_chain",
+                r#"[{"role":"author","identity":"usr:tafeng","at":"2026-04-02T11:00:00Z"}]"#,
+            ),
+            (
+                "extra_frontmatter",
+                r#"{"title":"user prefers dark mode","category":"draft","priority":3,"version":2,"is_static":1,"tombstoned":0,"active":1,"backlinks":[]}"#,
+            ),
         ],
     );
+
+    // r3: kind=rule, confidence=0.8, tags=["infra","db","backup"]
+    //     actor_chain=[{role:author,identity:agt:claude}]
+    //     extra_frontmatter: title, category=shipped, priority=9, is_static=0,
+    //                        tombstoned=1, active=0, backlinks=["r1"], version=1
     insert(
         &conn,
         &[
             ("id", "r3"),
             ("kind", "rule"),
-            ("title", "always use pg for backups"),
-            ("category", "shipped"),
-            ("priority", "9"),
+            ("class", "semantic"),
+            ("visibility", "private"),
             ("confidence", "0.8"),
-            ("is_static", "0"),
-            ("tombstoned", "1"),
-            ("active", "0"),
+            (
+                "provenance",
+                r#"{"created_at":"2026-04-03T09:00:00Z","source_sensor":"snr:local:hook:cc-session:v1"}"#,
+            ),
             ("tags", r#"["infra","db","backup"]"#),
-            ("actor_chain", r#"["agt:claude"]"#),
-            ("backlinks", r#"["r1"]"#),
-            ("version", "1"),
+            (
+                "actor_chain",
+                r#"[{"role":"author","identity":"agt:claude","at":"2026-04-03T09:00:00Z"}]"#,
+            ),
+            (
+                "extra_frontmatter",
+                r#"{"title":"always use pg for backups","category":"shipped","priority":9,"version":1,"is_static":0,"tombstoned":1,"active":0,"backlinks":["r1"]}"#,
+            ),
         ],
     );
 
@@ -292,7 +325,38 @@ fn exec_tombstoned_eq_true_returns_only_tombstoned() {
     assert_eq!(ids, vec!["r3"]);
 }
 
-// ── Array field ops ───────────────────────────────────────────────────────────
+// ── Timestamp field ops ───────────────────────────────────────────────────────
+
+#[test]
+fn exec_created_at_eq_matches_exact_timestamp() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({
+            "field": "created_at",
+            "op": "eq",
+            "value": "2026-04-01T10:00:00Z"
+        }),
+    );
+    assert_eq!(ids, vec!["r1"]);
+}
+
+#[test]
+fn exec_created_at_in_set_matches_two() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({
+            "field": "created_at",
+            "op": "in",
+            "value": ["2026-04-01T10:00:00Z", "2026-04-03T09:00:00Z"]
+        }),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+// ── Array field ops — tags (plain string array) ───────────────────────────────
 
 #[test]
 fn exec_array_contains_single() {
@@ -344,6 +408,81 @@ fn exec_array_size_eq_returns_matching_rows() {
     assert_eq!(ids, vec!["r2"]);
 }
 
+// ── Array field ops — actor_chain (struct array, filter on $.identity) ────────
+
+#[test]
+fn exec_actor_chain_contains_agent_identity() {
+    let conn = seed_db();
+    // r1 and r3 both have identity "agt:claude" in their actor_chain entries.
+    let mut ids = run(
+        &conn,
+        serde_json::json!({
+            "field": "actor_chain",
+            "op": "array_contains",
+            "value": "agt:claude"
+        }),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r3"]);
+}
+
+#[test]
+fn exec_actor_chain_contains_user_identity() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({
+            "field": "actor_chain",
+            "op": "array_contains",
+            "value": "usr:tafeng"
+        }),
+    );
+    assert_eq!(ids, vec!["r2"]);
+}
+
+#[test]
+fn exec_actor_chain_contains_any_matches() {
+    let conn = seed_db();
+    let mut ids = run(
+        &conn,
+        serde_json::json!({
+            "field": "actor_chain",
+            "op": "array_contains_any",
+            "value": ["usr:tafeng", "agt:other"]
+        }),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r2"]);
+}
+
+// ── Array field ops — backlinks (JSON array in extra_frontmatter) ─────────────
+
+#[test]
+fn exec_backlinks_contains_ref() {
+    let conn = seed_db();
+    let ids = run(
+        &conn,
+        serde_json::json!({
+            "field": "backlinks",
+            "op": "array_contains",
+            "value": "r1"
+        }),
+    );
+    assert_eq!(ids, vec!["r3"]);
+}
+
+#[test]
+fn exec_backlinks_size_eq_zero_matches_empty() {
+    let conn = seed_db();
+    // r1 and r2 have empty backlinks arrays.
+    let mut ids = run(
+        &conn,
+        serde_json::json!({"field": "backlinks", "op": "array_size_eq", "value": 0}),
+    );
+    ids.sort();
+    assert_eq!(ids, vec!["r1", "r2"]);
+}
+
 // ── Boolean combinators ───────────────────────────────────────────────────────
 
 #[test]
@@ -365,7 +504,6 @@ fn exec_and_narrows_results() {
 #[test]
 fn exec_or_broadens_results() {
     let conn = seed_db();
-    // kind=user OR kind=rule → r1 and r3
     let mut ids = run(
         &conn,
         serde_json::json!({
@@ -382,7 +520,6 @@ fn exec_or_broadens_results() {
 #[test]
 fn exec_not_inverts_match() {
     let conn = seed_db();
-    // NOT category=draft → r1 and r3
     let mut ids = run(
         &conn,
         serde_json::json!({"not": {"field": "category", "op": "eq", "value": "draft"}}),
@@ -396,8 +533,6 @@ fn exec_not_inverts_match() {
 #[test]
 fn exec_brief_example_filter_returns_correct_rows() {
     let conn = seed_db();
-    // Adapted from §8.0.d: kind in [user, rule], is_static=false, tags contains infra,
-    // priority >= 7, category=shipped OR NOT category=draft, title contains pg.
     let ids = run(
         &conn,
         serde_json::json!({

--- a/crates/cairn-core/tests/filter_sql_exec.rs
+++ b/crates/cairn-core/tests/filter_sql_exec.rs
@@ -107,7 +107,7 @@ fn seed_db() -> Connection {
             ("active", "1"),
             ("tags", r#"["infra","migration"]"#),
             ("actor_chain", r#"["agt:claude"]"#),
-            ("backlinks", r#"[]"#),
+            ("backlinks", r"[]"),
             ("version", "1"),
         ],
     );
@@ -125,7 +125,7 @@ fn seed_db() -> Connection {
             ("active", "1"),
             ("tags", r#"["pref"]"#),
             ("actor_chain", r#"["usr:tafeng"]"#),
-            ("backlinks", r#"[]"#),
+            ("backlinks", r"[]"),
             ("version", "2"),
         ],
     );

--- a/crates/cairn-core/tests/filter_sql_exec.rs
+++ b/crates/cairn-core/tests/filter_sql_exec.rs
@@ -77,8 +77,7 @@ fn to_sql_params(params: &[serde_json::Value]) -> Vec<SqlVal> {
 /// Run a compiled filter against the `records` table and return matching `id`s.
 fn run(conn: &Connection, filter_json: serde_json::Value) -> Vec<String> {
     let f: SearchArgsFilters = serde_json::from_value(filter_json).unwrap();
-    validate_filter(&f).unwrap();
-    let compiled = compile_filter(&f);
+    let compiled = compile_filter(validate_filter(&f).unwrap());
     let sql = format!("SELECT id FROM records WHERE {}", compiled.sql);
     let sql_params = to_sql_params(&compiled.params);
     let mut stmt = conn.prepare(&sql).unwrap();


### PR DESCRIPTION
## Summary

Implements §8.0.c (`RetrieveArgs` discriminated union — already in generated code, confirmed) and §8.0.d (metadata filter DSL validation + SQL compilation) from the design brief. Closes #63.

- **`crates/cairn-core/src/domain/filter.rs`** — P0 field allowlist (16 fields: Str/Number/Boolean/Array), `validate_filter` (depth-first, returns first `FilterError`), `compile_filter` (parameterized `CompiledFilter`)
- **SQL ops**: `eq/neq/lt/lte/gt/gte/in/nin/between`, `string_contains` via `instr()` (avoids LIKE metachar escaping), `string_starts_with/ends_with` via `LIKE ?`, array ops via `json_each()` sub-selects and `json_array_length()`
- **Injection safety**: all user values land in `params`; `sql` string contains only structure and `?` placeholders
- **`tests/filter_dsl.rs`** — 36 unit tests: validation rejects (unknown fields, bad op-type combos), all valid combos accepted, compiled SQL structure for every op, combinator nesting, SQL injection guard
- **`tests/filter_sql_exec.rs`** — 21 E2E tests running compiled SQL against in-memory SQLite with real row data covering every op and the §8.0.d brief example
- Added `rusqlite` (bundled) as dev-dep; no system SQLite required (offline P0 OK)

## Invariants touched

- §4 pure functions only — `validate_filter` and `compile_filter` have no I/O or side effects
- §6.2 error handling — `FilterError` uses `thiserror`, no `anyhow` in lib
- §8 `cairn-core` zero workspace crate deps — `rusqlite` is an external crate, only in dev-deps

## Verification

```
cargo fmt --all --check          ✓
cargo clippy --workspace -D warnings  ✓
cargo nextest run --workspace    585/585 ✓
cargo test --doc --workspace     ✓
./scripts/check-core-boundary.sh ✓
```

## Out of scope (tracked separately)

- CLI verb layer wiring (`retrieve` → #61, `search` → #62, command tree → #59)
- Store-level `retrieve` E2E against `cairn-store-sqlite` → #46