### PR TITLE
feat(cli): wire verb dispatch + cairn.mcp.v1 response envelope (#59)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +164,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "cairn-core",
  "cairn-mcp",
  "cairn-sensors-local",
@@ -168,6 +175,7 @@ dependencies = [
  "insta",
  "serde",
  "serde_json",
+ "ulid",
 ]
 
 [[package]]
@@ -1513,6 +1521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "web-time",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1642,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
+ "rand",
  "web-time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tempfile = "3"
 sha2 = { version = "0.10", default-features = false }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
-ulid = { version = "1.1", default-features = false }
+ulid = { version = "1.1", default-features = false, features = ["std"] }
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 
 # Path + version on intra-workspace deps so `cargo publish` can rewrite the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ tempfile = "3"
 sha2 = { version = "0.10", default-features = false }
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
+ulid = { version = "1.1", default-features = false }
+base64 = { version = "0.22", default-features = false, features = ["alloc"] }
 
 # Path + version on intra-workspace deps so `cargo publish` can rewrite the
 # path to a registry version without losing the constraint. The version

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -35,12 +35,10 @@ async-trait = { workspace = true }
 [lints]
 workspace = true
 
-# Forward-declared scaffold deps. anyhow and serde land their first call
-# sites when the verb layer is wired up in a follow-up issue. clap was
-# dropped from this list in Task 17 once main.rs adopted it (Task 13).
-# Drop each remaining entry once its first call site exists.
+# cargo-machete: temporarily suppress deps that are declared now but
+# get their first call site in a later task of this branch.
 [package.metadata.cargo-machete]
-ignored = []
+ignored = ["base64", "ulid"]
 
 [lib]
 name = "cairn_cli"

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -24,6 +24,8 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+ulid = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 cairn-test-fixtures = { workspace = true }
@@ -38,10 +40,7 @@ workspace = true
 # dropped from this list in Task 17 once main.rs adopted it (Task 13).
 # Drop each remaining entry once its first call site exists.
 [package.metadata.cargo-machete]
-ignored = [
-    "anyhow",
-    "serde",
-]
+ignored = []
 
 [lib]
 name = "cairn_cli"

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -38,7 +38,7 @@ workspace = true
 # cargo-machete: temporarily suppress deps that are declared now but
 # get their first call site in a later task of this branch.
 [package.metadata.cargo-machete]
-ignored = ["anyhow", "base64", "serde", "ulid"]
+ignored = ["anyhow", "serde"]
 
 [lib]
 name = "cairn_cli"

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -38,7 +38,7 @@ workspace = true
 # cargo-machete: temporarily suppress deps that are declared now but
 # get their first call site in a later task of this branch.
 [package.metadata.cargo-machete]
-ignored = ["base64", "ulid"]
+ignored = ["anyhow", "base64", "serde", "ulid"]
 
 [lib]
 name = "cairn_cli"

--- a/crates/cairn-cli/src/lib.rs
+++ b/crates/cairn-cli/src/lib.rs
@@ -6,3 +6,4 @@
 //! tolerated here per CLAUDE.md §6.2 (bins/tests).
 
 pub mod plugins;
+pub mod verbs;

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -1,24 +1,38 @@
 //! `cairn` binary entry point.
 //!
-//! Verb subcommands (`ingest`, `search`, …) come from the IDL-generated
-//! clap `Command` tree (`mod generated`); the `plugins` subcommand is
-//! augmented at runtime. Until the verb layer lands (#59 / #9), every
-//! verb exits 2 with a not-implemented message so callers cannot mistake
-//! a scaffold for a real memory operation.
+//! Verb subcommands come from the IDL-generated clap builders (`mod generated`),
+//! each wrapped with a `--json` flag via `cairn_cli::verbs::with_json()`. Actual
+//! verb logic lives in `cairn_cli::verbs::*`; `main.rs` only owns parsing and
+//! dispatch.
 
 use std::io::Write;
 use std::process::ExitCode;
 
-use cairn_cli::plugins;
+use cairn_cli::{plugins, verbs};
 use cairn_core::contract::registry::PluginError;
 use clap::ArgMatches;
 
 mod generated;
 
 fn build_command() -> clap::Command {
-    generated::command()
+    clap::Command::new("cairn")
+        .about("Cairn — agent memory framework (cairn.mcp.v1)")
         .version(env!("CARGO_PKG_VERSION"))
-        .about("Cairn — agent memory framework")
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        // Eight core verbs, each with --json added.
+        .subcommand(verbs::with_json(generated::verbs::ingest_subcommand()))
+        .subcommand(verbs::with_json(generated::verbs::search_subcommand()))
+        .subcommand(verbs::with_json(generated::verbs::retrieve_subcommand()))
+        .subcommand(verbs::with_json(generated::verbs::summarize_subcommand()))
+        .subcommand(verbs::with_json(generated::verbs::assemble_hot_subcommand()))
+        .subcommand(verbs::with_json(generated::verbs::capture_trace_subcommand()))
+        .subcommand(verbs::with_json(generated::verbs::lint_subcommand()))
+        .subcommand(verbs::with_json(generated::verbs::forget_subcommand()))
+        // Protocol preludes.
+        .subcommand(verbs::with_json(generated::prelude::handshake_subcommand()))
+        .subcommand(verbs::with_json(generated::prelude::status_subcommand()))
+        // Management subcommand (plugins already has --json per sub-subcommand).
         .subcommand(plugins_subcommand())
 }
 
@@ -62,28 +76,33 @@ fn main() -> ExitCode {
                 clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
                     ExitCode::SUCCESS
                 }
-                // EX_USAGE — every other clap-detected error is a usage error
-                // (unknown flag, missing required arg, invalid value, unknown
-                // subcommand, …). Spec §5.2 maps these to 64.
+                // EX_USAGE (64) for every clap-detected usage error.
                 _ => ExitCode::from(64),
             };
         }
     };
 
     match matches.subcommand() {
+        Some(("ingest", sub)) => verbs::ingest::run(sub),
+        Some(("search", sub)) => verbs::search::run(sub),
+        Some(("retrieve", sub)) => verbs::retrieve::run(sub),
+        Some(("summarize", sub)) => verbs::summarize::run(sub),
+        Some(("assemble_hot", sub)) => verbs::assemble_hot::run(sub),
+        Some(("capture_trace", sub)) => verbs::capture_trace::run(sub),
+        Some(("lint", sub)) => verbs::lint::run(sub),
+        Some(("forget", sub)) => verbs::forget::run(sub),
+        Some(("status", sub)) => verbs::status::run(sub.get_flag("json")),
+        Some(("handshake", sub)) => verbs::handshake::run(sub.get_flag("json")),
         Some(("plugins", sub)) => run_plugins(sub),
-        Some((verb, _)) => {
-            eprintln!(
-                "cairn {verb}: not yet implemented in this P0 scaffold. \
-                 Verb dispatch lands in #59 / #9; no memory operation was \
-                 performed."
-            );
-            ExitCode::from(2)
-        }
         None => {
             let _ = build_command().print_help();
             println!();
             ExitCode::SUCCESS
+        }
+        Some((verb, _)) => {
+            // Defensive: clap's subcommand_required(true) prevents this in practice.
+            eprintln!("cairn: unknown subcommand '{verb}'");
+            ExitCode::from(64)
         }
     }
 }
@@ -91,13 +110,12 @@ fn main() -> ExitCode {
 fn run_plugins(matches: &ArgMatches) -> ExitCode {
     let registry = match plugins::host::register_all() {
         Ok(r) => r,
-        // EX_CONFIG — bundled plugin.toml failed to parse. Spec §5.2.
+        // EX_CONFIG (78) — bundled plugin.toml failed to parse.
         Err(PluginError::InvalidManifest(msg)) => {
             eprintln!("cairn plugins: bundled plugin manifest invalid — {msg}");
             return ExitCode::from(78);
         }
-        // EX_UNAVAILABLE — registry rejected a plugin (name/contract/version
-        // mismatch, duplicate, identity error). Spec §5.2.
+        // EX_UNAVAILABLE (69) — registry rejected a plugin.
         Err(e) => {
             eprintln!("cairn plugins: startup failed — {e}");
             return ExitCode::from(69);
@@ -113,7 +131,6 @@ fn run_plugins(matches: &ArgMatches) -> ExitCode {
             } else {
                 plugins::list::render_human(&registry)
             };
-            // Newline at end ensures the human table flushes cleanly.
             let _ = writeln!(stdout, "{}", text.trim_end_matches('\n'));
             ExitCode::SUCCESS
         }

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -26,7 +26,9 @@ fn build_command() -> clap::Command {
         .subcommand(verbs::with_json(generated::verbs::retrieve_subcommand()))
         .subcommand(verbs::with_json(generated::verbs::summarize_subcommand()))
         .subcommand(verbs::with_json(generated::verbs::assemble_hot_subcommand()))
-        .subcommand(verbs::with_json(generated::verbs::capture_trace_subcommand()))
+        .subcommand(verbs::with_json(
+            generated::verbs::capture_trace_subcommand(),
+        ))
         .subcommand(verbs::with_json(generated::verbs::lint_subcommand()))
         .subcommand(verbs::with_json(generated::verbs::forget_subcommand()))
         // Protocol preludes.

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -94,11 +94,7 @@ fn main() -> ExitCode {
         Some(("status", sub)) => verbs::status::run(sub.get_flag("json")),
         Some(("handshake", sub)) => verbs::handshake::run(sub.get_flag("json")),
         Some(("plugins", sub)) => run_plugins(sub),
-        None => {
-            let _ = build_command().print_help();
-            println!();
-            ExitCode::SUCCESS
-        }
+        None => unreachable!("subcommand_required(true) ensures a subcommand is always present"),
         Some((verb, _)) => {
             // Defensive: clap's subcommand_required(true) prevents this in practice.
             eprintln!("cairn: unknown subcommand '{verb}'");

--- a/crates/cairn-cli/src/verbs/assemble_hot.rs
+++ b/crates/cairn-cli/src/verbs/assemble_hot.rs
@@ -1,0 +1,1 @@
+//! `cairn assemble_hot` handler.

--- a/crates/cairn-cli/src/verbs/assemble_hot.rs
+++ b/crates/cairn-cli/src/verbs/assemble_hot.rs
@@ -1,1 +1,26 @@
 //! `cairn assemble_hot` handler.
+
+use std::process::ExitCode;
+
+use cairn_core::generated::envelope::ResponseVerb;
+use clap::ArgMatches;
+
+use super::envelope::{emit_json, human_error, unimplemented_response};
+
+/// Run `cairn assemble_hot`.
+#[must_use]
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+    let resp = unimplemented_response(ResponseVerb::AssembleHot);
+    if json {
+        emit_json(&resp);
+    } else {
+        human_error(
+            "assemble_hot",
+            "Internal",
+            "store not wired in this P0 build",
+            &resp.operation_id,
+        );
+    }
+    ExitCode::FAILURE
+}

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -1,0 +1,1 @@
+//! `cairn capture_trace` handler.

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -1,1 +1,26 @@
 //! `cairn capture_trace` handler.
+
+use std::process::ExitCode;
+
+use cairn_core::generated::envelope::ResponseVerb;
+use clap::ArgMatches;
+
+use super::envelope::{emit_json, human_error, unimplemented_response};
+
+/// Run `cairn capture_trace`.
+#[must_use]
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+    let resp = unimplemented_response(ResponseVerb::CaptureTrace);
+    if json {
+        emit_json(&resp);
+    } else {
+        human_error(
+            "capture_trace",
+            "Internal",
+            "store not wired in this P0 build",
+            &resp.operation_id,
+        );
+    }
+    ExitCode::FAILURE
+}

--- a/crates/cairn-cli/src/verbs/envelope.rs
+++ b/crates/cairn-cli/src/verbs/envelope.rs
@@ -53,7 +53,10 @@ pub fn emit_json<T: serde::Serialize>(value: &T) {
 
 /// Print a human-readable one-line error to stderr.
 pub fn human_error(verb: &str, code: &str, message: &str, operation_id: &Ulid) {
-    eprintln!("cairn {verb}: {code} — {message} (operation_id: {})", operation_id.0);
+    eprintln!(
+        "cairn {verb}: {code} — {message} (operation_id: {})",
+        operation_id.0
+    );
 }
 
 #[cfg(test)]

--- a/crates/cairn-cli/src/verbs/envelope.rs
+++ b/crates/cairn-cli/src/verbs/envelope.rs
@@ -1,1 +1,117 @@
 //! Shared helpers for building and emitting response envelopes.
+
+use std::io::Write;
+
+use cairn_core::generated::common::{Nonce16Base64, Ulid};
+use cairn_core::generated::envelope::{
+    Response, ResponsePolicyTrace, ResponseStatus, ResponseVerb,
+};
+
+/// Generate a fresh Crockford base32 ULID suitable for `operation_id`.
+#[must_use]
+pub fn new_operation_id() -> Ulid {
+    Ulid(ulid::Ulid::new().to_string())
+}
+
+/// Generate a fresh 16-byte nonce as standard base64 (24 chars with `==` padding).
+#[must_use]
+pub fn new_nonce() -> Nonce16Base64 {
+    use base64::Engine as _;
+    let raw = ulid::Ulid::new().0.to_be_bytes();
+    Nonce16Base64(base64::engine::general_purpose::STANDARD.encode(raw))
+}
+
+/// Build an `Internal` aborted response for a verb that has no store wired yet.
+#[must_use]
+pub fn unimplemented_response(verb: ResponseVerb) -> Response {
+    Response {
+        contract: "cairn.mcp.v1".to_owned(),
+        data: None,
+        error: Some(serde_json::json!({
+            "code": "Internal",
+            "message": "store not wired in this P0 build — verb dispatch lands in #9",
+        })),
+        operation_id: new_operation_id(),
+        policy_trace: Vec::<ResponsePolicyTrace>::new(),
+        status: ResponseStatus::Aborted,
+        target: None,
+        verb,
+    }
+}
+
+/// Serialize a value as compact JSON + newline to stdout.
+pub fn emit_json<T: serde::Serialize>(value: &T) {
+    let mut out = std::io::stdout().lock();
+    let json = serde_json::to_string(value)
+        .expect("invariant: generated types are always JSON-serializable");
+    let _ = writeln!(out, "{json}");
+}
+
+/// Print a human-readable one-line error to stderr.
+pub fn human_error(verb: &str, code: &str, message: &str, operation_id: &Ulid) {
+    eprintln!("cairn {verb}: {code} — {message} (operation_id: {})", operation_id.0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_operation_id_is_valid_ulid_shape() {
+        let id = new_operation_id();
+        assert_eq!(id.0.len(), 26, "ULID must be 26 chars: {:?}", id.0);
+        assert!(
+            id.0
+                .bytes()
+                .all(|b| matches!(b, b'0'..=b'9' | b'A'..=b'H' | b'J' | b'K' | b'M' | b'N' | b'P'..=b'T' | b'V'..=b'Z')),
+            "ULID must be Crockford base32: {:?}",
+            id.0
+        );
+    }
+
+    #[test]
+    fn new_nonce_is_valid_nonce16_shape() {
+        let n = new_nonce();
+        // Standard base64 for 16 bytes → 24 chars (22 significant + "==")
+        assert_eq!(n.0.len(), 24, "nonce must be 24 chars: {:?}", n.0);
+        assert!(
+            n.0.ends_with("=="),
+            "standard base64 for 16 bytes ends with ==: {:?}",
+            n.0
+        );
+        // 22nd char (index 21) must be in [AQgw] — canonical 16-byte base64 last char
+        let tail = n.0.as_bytes()[21];
+        assert!(
+            matches!(tail, b'A' | b'Q' | b'g' | b'w'),
+            "nonce[21] must be in [AQgw], got: {:?}",
+            tail as char
+        );
+    }
+
+    #[test]
+    fn two_operation_ids_differ() {
+        let a = new_operation_id();
+        let b = new_operation_id();
+        assert_ne!(a.0, b.0, "consecutive operation_ids must differ");
+    }
+
+    #[test]
+    fn two_nonces_differ() {
+        let a = new_nonce();
+        let b = new_nonce();
+        assert_ne!(a.0, b.0, "consecutive nonces must differ");
+    }
+
+    #[test]
+    fn unimplemented_response_fields_are_correct() {
+        let resp = unimplemented_response(ResponseVerb::Ingest);
+        assert_eq!(resp.contract, "cairn.mcp.v1");
+        assert!(matches!(resp.status, ResponseStatus::Aborted));
+        assert!(matches!(resp.verb, ResponseVerb::Ingest));
+        assert!(resp.data.is_none());
+        assert!(resp.target.is_none());
+        let err = resp.error.expect("aborted response must have error");
+        assert_eq!(err["code"], "Internal");
+        assert!(!err["message"].as_str().unwrap_or("").is_empty());
+    }
+}

--- a/crates/cairn-cli/src/verbs/envelope.rs
+++ b/crates/cairn-cli/src/verbs/envelope.rs
@@ -14,6 +14,10 @@ pub fn new_operation_id() -> Ulid {
 }
 
 /// Generate a fresh 16-byte nonce as standard base64 (24 chars with `==` padding).
+///
+/// Uses ULID bytes: 48-bit timestamp + 80-bit random component.
+/// Adequate for P0 challenge correlation; replace with `rand::OsRng` when
+/// the handshake challenge-response is wired to a real signature scheme.
 #[must_use]
 pub fn new_nonce() -> Nonce16Base64 {
     use base64::Engine as _;

--- a/crates/cairn-cli/src/verbs/envelope.rs
+++ b/crates/cairn-cli/src/verbs/envelope.rs
@@ -1,0 +1,1 @@
+//! Shared helpers for building and emitting response envelopes.

--- a/crates/cairn-cli/src/verbs/forget.rs
+++ b/crates/cairn-cli/src/verbs/forget.rs
@@ -1,1 +1,21 @@
 //! `cairn forget` handler.
+
+use std::process::ExitCode;
+
+use cairn_core::generated::envelope::ResponseVerb;
+use clap::ArgMatches;
+
+use super::envelope::{emit_json, human_error, unimplemented_response};
+
+/// Run `cairn forget`.
+#[must_use]
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+    let resp = unimplemented_response(ResponseVerb::Forget);
+    if json {
+        emit_json(&resp);
+    } else {
+        human_error("forget", "Internal", "store not wired in this P0 build", &resp.operation_id);
+    }
+    ExitCode::FAILURE
+}

--- a/crates/cairn-cli/src/verbs/forget.rs
+++ b/crates/cairn-cli/src/verbs/forget.rs
@@ -1,0 +1,1 @@
+//! `cairn forget` handler.

--- a/crates/cairn-cli/src/verbs/forget.rs
+++ b/crates/cairn-cli/src/verbs/forget.rs
@@ -15,7 +15,12 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
     if json {
         emit_json(&resp);
     } else {
-        human_error("forget", "Internal", "store not wired in this P0 build", &resp.operation_id);
+        human_error(
+            "forget",
+            "Internal",
+            "store not wired in this P0 build",
+            &resp.operation_id,
+        );
     }
     ExitCode::FAILURE
 }

--- a/crates/cairn-cli/src/verbs/handshake.rs
+++ b/crates/cairn-cli/src/verbs/handshake.rs
@@ -1,0 +1,1 @@
+//! `cairn handshake` handler.

--- a/crates/cairn-cli/src/verbs/handshake.rs
+++ b/crates/cairn-cli/src/verbs/handshake.rs
@@ -1,32 +1,50 @@
-//! `cairn handshake` handler — P0 stub.
+//! `cairn handshake` handler — fresh challenge mint (§8.0.a).
 //!
-//! Challenge authentication requires persisting the issued nonce into
-//! `outstanding_challenges` so the server can consume it as a single-use
-//! token on the signed intent path. That storage lands in issue #9.
+//! Emits a typed `HandshakeResponse` conforming to the generated handshake
+//! schema. Every call produces a unique nonce (§8.0.a point d).
 //!
-//! Emitting an ephemeral challenge that can never be validated server-side
-//! would mislead callers into believing challenge-auth is available, so this
-//! handler returns `Internal aborted` until the store is wired.
+//! **P0 caveat:** The issued nonce is ephemeral — it is NOT persisted into
+//! `outstanding_challenges` and cannot be consumed server-side. Challenge-mode
+//! signed intents will therefore be rejected until the store is wired in #9.
+//! Callers should not rely on challenge authentication in this build.
 
 use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::envelope::{emit_json, human_error, new_operation_id};
+use cairn_core::generated::handshake::{HandshakeResponse, HandshakeResponseChallenge};
 
-/// Run `cairn handshake`. Exits 1 until challenge storage is wired (issue #9).
+use super::envelope::{emit_json, new_nonce};
+
+const CHALLENGE_TTL_MS: u64 = 60_000;
+
+/// Run `cairn handshake`. Exits 0 with a typed `HandshakeResponse`.
 #[must_use]
 pub fn run(json: bool) -> ExitCode {
-    let op = new_operation_id();
-    let msg = "challenge storage not wired in P0 — handshake authentication lands in #9";
+    let nonce = new_nonce();
+    #[allow(clippy::cast_possible_truncation)]
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("invariant: system clock is after Unix epoch")
+        .as_millis() as u64;
+    let expires_at = now_ms + CHALLENGE_TTL_MS;
+
+    let resp = HandshakeResponse {
+        contract: "cairn.mcp.v1".to_owned(),
+        challenge: HandshakeResponseChallenge {
+            nonce: nonce.clone(),
+            expires_at,
+        },
+    };
+
     if json {
-        emit_json(&serde_json::json!({
-            "contract": "cairn.mcp.v1",
-            "status": "aborted",
-            "error": { "code": "Internal", "message": msg },
-            "operation_id": op.0,
-            "policy_trace": [],
-        }));
+        emit_json(&resp);
     } else {
-        human_error("handshake", "Internal", msg, &op);
+        println!("contract:   {}", resp.contract);
+        println!("nonce:      {}", nonce.0);
+        println!(
+            "expires_at: {} (epoch-ms, TTL 60 s, P0: challenge not persisted)",
+            resp.challenge.expires_at
+        );
     }
-    ExitCode::FAILURE
+    ExitCode::SUCCESS
 }

--- a/crates/cairn-cli/src/verbs/handshake.rs
+++ b/crates/cairn-cli/src/verbs/handshake.rs
@@ -34,9 +34,9 @@ pub fn run(json: bool) -> ExitCode {
     if json {
         emit_json(&resp);
     } else {
-        println!("contract:   cairn.mcp.v1");
+        println!("contract:   {}", resp.contract);
         println!("nonce:      {}", nonce.0);
-        println!("expires_at: {expires_at} (epoch-ms, TTL 60 s)");
+        println!("expires_at: {} (epoch-ms, TTL 60 s)", resp.challenge.expires_at);
     }
     ExitCode::SUCCESS
 }

--- a/crates/cairn-cli/src/verbs/handshake.rs
+++ b/crates/cairn-cli/src/verbs/handshake.rs
@@ -36,7 +36,10 @@ pub fn run(json: bool) -> ExitCode {
     } else {
         println!("contract:   {}", resp.contract);
         println!("nonce:      {}", nonce.0);
-        println!("expires_at: {} (epoch-ms, TTL 60 s)", resp.challenge.expires_at);
+        println!(
+            "expires_at: {} (epoch-ms, TTL 60 s)",
+            resp.challenge.expires_at
+        );
     }
     ExitCode::SUCCESS
 }

--- a/crates/cairn-cli/src/verbs/handshake.rs
+++ b/crates/cairn-cli/src/verbs/handshake.rs
@@ -1,45 +1,32 @@
-//! `cairn handshake` handler — fresh challenge mint (§8.0.a).
+//! `cairn handshake` handler — P0 stub.
 //!
-//! Every call produces a different nonce. The nonce is single-use and would
-//! be stored in `outstanding_challenges` once the store is wired (`issue #9`).
+//! Challenge authentication requires persisting the issued nonce into
+//! `outstanding_challenges` so the server can consume it as a single-use
+//! token on the signed intent path. That storage lands in issue #9.
+//!
+//! Emitting an ephemeral challenge that can never be validated server-side
+//! would mislead callers into believing challenge-auth is available, so this
+//! handler returns `Internal aborted` until the store is wired.
 
 use std::process::ExitCode;
-use std::time::{SystemTime, UNIX_EPOCH};
 
-use cairn_core::generated::handshake::{HandshakeResponse, HandshakeResponseChallenge};
+use super::envelope::{emit_json, human_error, new_operation_id};
 
-use super::envelope::{emit_json, new_nonce};
-
-const CHALLENGE_TTL_MS: u64 = 60_000;
-
-/// Run `cairn handshake`. Exits 0 on success.
+/// Run `cairn handshake`. Exits 1 until challenge storage is wired (issue #9).
 #[must_use]
 pub fn run(json: bool) -> ExitCode {
-    let nonce = new_nonce();
-    #[allow(clippy::cast_possible_truncation)]
-    let now_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("invariant: system clock is after Unix epoch")
-        .as_millis() as u64;
-    let expires_at = now_ms + CHALLENGE_TTL_MS;
-
-    let resp = HandshakeResponse {
-        contract: "cairn.mcp.v1".to_owned(),
-        challenge: HandshakeResponseChallenge {
-            nonce: nonce.clone(),
-            expires_at,
-        },
-    };
-
+    let op = new_operation_id();
+    let msg = "challenge storage not wired in P0 — handshake authentication lands in #9";
     if json {
-        emit_json(&resp);
+        emit_json(&serde_json::json!({
+            "contract": "cairn.mcp.v1",
+            "status": "aborted",
+            "error": { "code": "Internal", "message": msg },
+            "operation_id": op.0,
+            "policy_trace": [],
+        }));
     } else {
-        println!("contract:   {}", resp.contract);
-        println!("nonce:      {}", nonce.0);
-        println!(
-            "expires_at: {} (epoch-ms, TTL 60 s)",
-            resp.challenge.expires_at
-        );
+        human_error("handshake", "Internal", msg, &op);
     }
-    ExitCode::SUCCESS
+    ExitCode::FAILURE
 }

--- a/crates/cairn-cli/src/verbs/handshake.rs
+++ b/crates/cairn-cli/src/verbs/handshake.rs
@@ -1,1 +1,42 @@
-//! `cairn handshake` handler.
+//! `cairn handshake` handler — fresh challenge mint (§8.0.a).
+//!
+//! Every call produces a different nonce. The nonce is single-use and would
+//! be stored in `outstanding_challenges` once the store is wired (`issue #9`).
+
+use std::process::ExitCode;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use cairn_core::generated::handshake::{HandshakeResponse, HandshakeResponseChallenge};
+
+use super::envelope::{emit_json, new_nonce};
+
+const CHALLENGE_TTL_MS: u64 = 60_000;
+
+/// Run `cairn handshake`. Exits 0 on success.
+#[must_use]
+pub fn run(json: bool) -> ExitCode {
+    let nonce = new_nonce();
+    #[allow(clippy::cast_possible_truncation)]
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("invariant: system clock is after Unix epoch")
+        .as_millis() as u64;
+    let expires_at = now_ms + CHALLENGE_TTL_MS;
+
+    let resp = HandshakeResponse {
+        contract: "cairn.mcp.v1".to_owned(),
+        challenge: HandshakeResponseChallenge {
+            nonce: nonce.clone(),
+            expires_at,
+        },
+    };
+
+    if json {
+        emit_json(&resp);
+    } else {
+        println!("contract:   cairn.mcp.v1");
+        println!("nonce:      {}", nonce.0);
+        println!("expires_at: {expires_at} (epoch-ms, TTL 60 s)");
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/cairn-cli/src/verbs/ingest.rs
+++ b/crates/cairn-cli/src/verbs/ingest.rs
@@ -21,7 +21,8 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
     let has_body = sub.get_one::<String>("body").is_some();
     let has_file = sub.get_one::<std::path::PathBuf>("file").is_some();
     let has_url = sub.get_one::<String>("url").is_some();
-    let source_count = u8::from(has_source) + u8::from(has_body) + u8::from(has_file) + u8::from(has_url);
+    let source_count =
+        u8::from(has_source) + u8::from(has_body) + u8::from(has_file) + u8::from(has_url);
     if source_count != 1 {
         eprintln!(
             "cairn ingest: exactly one of [source, --body, --file, --url] is required (got {source_count})"
@@ -34,7 +35,11 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
         if src == "-" {
             let mut buf = String::new();
             // Cap at 4 MiB to avoid unbounded allocation in the stubbed path.
-            if std::io::stdin().take(4 * 1024 * 1024).read_to_string(&mut buf).is_err() {
+            if std::io::stdin()
+                .take(4 * 1024 * 1024)
+                .read_to_string(&mut buf)
+                .is_err()
+            {
                 let r = unimplemented_response(ResponseVerb::Ingest);
                 if json {
                     emit_json(&r);

--- a/crates/cairn-cli/src/verbs/ingest.rs
+++ b/crates/cairn-cli/src/verbs/ingest.rs
@@ -25,7 +25,12 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
                 if json {
                     emit_json(&r);
                 } else {
-                    human_error("ingest", "Internal", "failed to read stdin", &r.operation_id);
+                    human_error(
+                        "ingest",
+                        "Internal",
+                        "failed to read stdin",
+                        &r.operation_id,
+                    );
                 }
                 return ExitCode::FAILURE;
             }
@@ -42,7 +47,12 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
         emit_json(&resp);
     } else {
         let op = resp.operation_id.clone();
-        human_error("ingest", "Internal", "store not wired in this P0 build", &op);
+        human_error(
+            "ingest",
+            "Internal",
+            "store not wired in this P0 build",
+            &op,
+        );
     }
     ExitCode::FAILURE
 }

--- a/crates/cairn-cli/src/verbs/ingest.rs
+++ b/crates/cairn-cli/src/verbs/ingest.rs
@@ -1,1 +1,49 @@
 //! `cairn ingest` handler.
+//!
+//! Parses CLI args. When source is `-`, reads body from stdin (§5.8).
+//! Returns `Internal aborted` until the store is wired (issue #9).
+
+use std::io::Read;
+use std::process::ExitCode;
+
+use cairn_core::generated::envelope::ResponseVerb;
+use clap::ArgMatches;
+
+use super::envelope::{emit_json, human_error, new_operation_id, unimplemented_response};
+
+/// Run `cairn ingest`.
+#[must_use]
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+
+    // Resolve body: positional `source` wins if set; --body/--file/--url otherwise.
+    let _body_resolved: Option<String> = if let Some(src) = sub.get_one::<String>("source") {
+        if src == "-" {
+            let mut buf = String::new();
+            if std::io::stdin().read_to_string(&mut buf).is_err() {
+                let op = new_operation_id();
+                if json {
+                    let r = unimplemented_response(ResponseVerb::Ingest);
+                    emit_json(&r);
+                } else {
+                    human_error("ingest", "Internal", "failed to read stdin", &op);
+                }
+                return ExitCode::FAILURE;
+            }
+            Some(buf)
+        } else {
+            Some(src.clone())
+        }
+    } else {
+        sub.get_one::<String>("body").cloned()
+    };
+
+    let resp = unimplemented_response(ResponseVerb::Ingest);
+    if json {
+        emit_json(&resp);
+    } else {
+        let op = resp.operation_id.clone();
+        human_error("ingest", "Internal", "store not wired in this P0 build", &op);
+    }
+    ExitCode::FAILURE
+}

--- a/crates/cairn-cli/src/verbs/ingest.rs
+++ b/crates/cairn-cli/src/verbs/ingest.rs
@@ -16,6 +16,19 @@ use super::envelope::{emit_json, human_error, unimplemented_response};
 pub fn run(sub: &ArgMatches) -> ExitCode {
     let json = sub.get_flag("json");
 
+    // Enforce IDL exactly-one-of: body/file/url (positional `source` counts as one).
+    let has_source = sub.get_one::<String>("source").is_some();
+    let has_body = sub.get_one::<String>("body").is_some();
+    let has_file = sub.get_one::<std::path::PathBuf>("file").is_some();
+    let has_url = sub.get_one::<String>("url").is_some();
+    let source_count = u8::from(has_source) + u8::from(has_body) + u8::from(has_file) + u8::from(has_url);
+    if source_count != 1 {
+        eprintln!(
+            "cairn ingest: exactly one of [source, --body, --file, --url] is required (got {source_count})"
+        );
+        return ExitCode::from(64);
+    }
+
     // Resolve body: positional `source` wins if set; --body/--file/--url otherwise.
     let _body_resolved: Option<String> = if let Some(src) = sub.get_one::<String>("source") {
         if src == "-" {

--- a/crates/cairn-cli/src/verbs/ingest.rs
+++ b/crates/cairn-cli/src/verbs/ingest.rs
@@ -33,7 +33,8 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
     let _body_resolved: Option<String> = if let Some(src) = sub.get_one::<String>("source") {
         if src == "-" {
             let mut buf = String::new();
-            if std::io::stdin().read_to_string(&mut buf).is_err() {
+            // Cap at 4 MiB to avoid unbounded allocation in the stubbed path.
+            if std::io::stdin().take(4 * 1024 * 1024).read_to_string(&mut buf).is_err() {
                 let r = unimplemented_response(ResponseVerb::Ingest);
                 if json {
                     emit_json(&r);

--- a/crates/cairn-cli/src/verbs/ingest.rs
+++ b/crates/cairn-cli/src/verbs/ingest.rs
@@ -9,7 +9,7 @@ use std::process::ExitCode;
 use cairn_core::generated::envelope::ResponseVerb;
 use clap::ArgMatches;
 
-use super::envelope::{emit_json, human_error, new_operation_id, unimplemented_response};
+use super::envelope::{emit_json, human_error, unimplemented_response};
 
 /// Run `cairn ingest`.
 #[must_use]
@@ -21,12 +21,11 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
         if src == "-" {
             let mut buf = String::new();
             if std::io::stdin().read_to_string(&mut buf).is_err() {
-                let op = new_operation_id();
+                let r = unimplemented_response(ResponseVerb::Ingest);
                 if json {
-                    let r = unimplemented_response(ResponseVerb::Ingest);
                     emit_json(&r);
                 } else {
-                    human_error("ingest", "Internal", "failed to read stdin", &op);
+                    human_error("ingest", "Internal", "failed to read stdin", &r.operation_id);
                 }
                 return ExitCode::FAILURE;
             }

--- a/crates/cairn-cli/src/verbs/ingest.rs
+++ b/crates/cairn-cli/src/verbs/ingest.rs
@@ -1,0 +1,1 @@
+//! `cairn ingest` handler.

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1,0 +1,1 @@
+//! `cairn lint` handler.

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1,1 +1,21 @@
 //! `cairn lint` handler.
+
+use std::process::ExitCode;
+
+use cairn_core::generated::envelope::ResponseVerb;
+use clap::ArgMatches;
+
+use super::envelope::{emit_json, human_error, unimplemented_response};
+
+/// Run `cairn lint`.
+#[must_use]
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+    let resp = unimplemented_response(ResponseVerb::Lint);
+    if json {
+        emit_json(&resp);
+    } else {
+        human_error("lint", "Internal", "store not wired in this P0 build", &resp.operation_id);
+    }
+    ExitCode::FAILURE
+}

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -15,7 +15,12 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
     if json {
         emit_json(&resp);
     } else {
-        human_error("lint", "Internal", "store not wired in this P0 build", &resp.operation_id);
+        human_error(
+            "lint",
+            "Internal",
+            "store not wired in this P0 build",
+            &resp.operation_id,
+        );
     }
     ExitCode::FAILURE
 }

--- a/crates/cairn-cli/src/verbs/mod.rs
+++ b/crates/cairn-cli/src/verbs/mod.rs
@@ -1,0 +1,28 @@
+//! Verb handler dispatch — one submodule per verb.
+
+pub mod assemble_hot;
+pub mod capture_trace;
+pub mod envelope;
+pub mod forget;
+pub mod handshake;
+pub mod ingest;
+pub mod lint;
+pub mod retrieve;
+pub mod search;
+pub mod status;
+pub mod summarize;
+
+/// Exported only for the smoke test; not part of the public API.
+#[doc(hidden)]
+pub fn smoke_fn() {}
+
+/// Add `--json` flag to any generated subcommand without modifying generated files.
+#[must_use]
+pub fn with_json(cmd: clap::Command) -> clap::Command {
+    cmd.arg(
+        clap::Arg::new("json")
+            .long("json")
+            .action(clap::ArgAction::SetTrue)
+            .help("Emit machine-readable JSON response envelope to stdout"),
+    )
+}

--- a/crates/cairn-cli/src/verbs/retrieve.rs
+++ b/crates/cairn-cli/src/verbs/retrieve.rs
@@ -1,1 +1,21 @@
 //! `cairn retrieve` handler.
+
+use std::process::ExitCode;
+
+use cairn_core::generated::envelope::ResponseVerb;
+use clap::ArgMatches;
+
+use super::envelope::{emit_json, human_error, unimplemented_response};
+
+/// Run `cairn retrieve`.
+#[must_use]
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+    let resp = unimplemented_response(ResponseVerb::Retrieve);
+    if json {
+        emit_json(&resp);
+    } else {
+        human_error("retrieve", "Internal", "store not wired in this P0 build", &resp.operation_id);
+    }
+    ExitCode::FAILURE
+}

--- a/crates/cairn-cli/src/verbs/retrieve.rs
+++ b/crates/cairn-cli/src/verbs/retrieve.rs
@@ -15,7 +15,12 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
     if json {
         emit_json(&resp);
     } else {
-        human_error("retrieve", "Internal", "store not wired in this P0 build", &resp.operation_id);
+        human_error(
+            "retrieve",
+            "Internal",
+            "store not wired in this P0 build",
+            &resp.operation_id,
+        );
     }
     ExitCode::FAILURE
 }

--- a/crates/cairn-cli/src/verbs/retrieve.rs
+++ b/crates/cairn-cli/src/verbs/retrieve.rs
@@ -1,0 +1,1 @@
+//! `cairn retrieve` handler.

--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -1,0 +1,1 @@
+//! `cairn search` handler.

--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -15,7 +15,12 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
     if json {
         emit_json(&resp);
     } else {
-        human_error("search", "Internal", "store not wired in this P0 build", &resp.operation_id);
+        human_error(
+            "search",
+            "Internal",
+            "store not wired in this P0 build",
+            &resp.operation_id,
+        );
     }
     ExitCode::FAILURE
 }

--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -1,1 +1,21 @@
 //! `cairn search` handler.
+
+use std::process::ExitCode;
+
+use cairn_core::generated::envelope::ResponseVerb;
+use clap::ArgMatches;
+
+use super::envelope::{emit_json, human_error, unimplemented_response};
+
+/// Run `cairn search`.
+#[must_use]
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+    let resp = unimplemented_response(ResponseVerb::Search);
+    if json {
+        emit_json(&resp);
+    } else {
+        human_error("search", "Internal", "store not wired in this P0 build", &resp.operation_id);
+    }
+    ExitCode::FAILURE
+}

--- a/crates/cairn-cli/src/verbs/status.rs
+++ b/crates/cairn-cli/src/verbs/status.rs
@@ -1,1 +1,161 @@
-//! `cairn status` handler.
+//! `cairn status` handler — deterministic capability discovery (§8.0.a).
+//!
+//! Returns the contract version, advertised capabilities, and server info.
+//! For the P0 scaffold with no store wired, capabilities is empty.
+
+use std::process::ExitCode;
+
+use cairn_core::generated::common::Capabilities;
+use cairn_core::generated::status::{StatusResponse, StatusResponseServerInfo};
+
+use super::envelope::{emit_json, new_operation_id};
+
+/// Run `cairn status`. Exits 0 on success.
+#[must_use]
+pub fn run(json: bool) -> ExitCode {
+    let incarnation = new_operation_id();
+    let started_at = chrono_like_now();
+    let resp = StatusResponse {
+        contract: "cairn.mcp.v1".to_owned(),
+        server_info: StatusResponseServerInfo {
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            build: build_profile(),
+            started_at: started_at.clone(),
+            incarnation: incarnation.clone(),
+        },
+        capabilities: p0_capabilities(),
+        extensions: vec![],
+    };
+
+    if json {
+        emit_json(&resp);
+    } else {
+        println!("contract:    {}", resp.contract);
+        println!("version:     {}", resp.server_info.version);
+        println!("build:       {}", resp.server_info.build);
+        println!("started_at:  {started_at}");
+        println!("incarnation: {}", incarnation.0);
+        if resp.capabilities.is_empty() {
+            println!("capabilities: (none — store not wired in this P0 build)");
+        } else {
+            for cap in &resp.capabilities {
+                println!("  capability: {}", serde_json::to_string(cap).unwrap_or_default());
+            }
+        }
+    }
+    ExitCode::SUCCESS
+}
+
+/// P0 advertises no capabilities — the store adapter is not wired yet.
+/// Update this list when store adapters land (issue #9).
+fn p0_capabilities() -> Vec<Capabilities> {
+    vec![]
+}
+
+/// Return the current UTC time as an RFC-3339 string without sub-second precision.
+fn chrono_like_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("invariant: system clock is after Unix epoch")
+        .as_secs();
+    let (y, mo, d, h, mi, s) = secs_to_ymdhms(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+fn secs_to_ymdhms(mut s: u64) -> (u64, u64, u64, u64, u64, u64) {
+    let sec = s % 60; s /= 60;
+    let min = s % 60; s /= 60;
+    let hour = s % 24; s /= 24;
+    let mut days = s;
+    let mut year = 1970u64;
+    loop {
+        let days_in_year = if is_leap(year) { 366 } else { 365 };
+        if days < days_in_year { break; }
+        days -= days_in_year;
+        year += 1;
+    }
+    let leap = is_leap(year);
+    let months = [31u64, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut month = 1u64;
+    for &m in &months {
+        if days < m { break; }
+        days -= m;
+        month += 1;
+    }
+    (year, month, days + 1, hour, min, sec)
+}
+
+fn is_leap(y: u64) -> bool {
+    (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
+}
+
+fn build_profile() -> String {
+    if cfg!(debug_assertions) {
+        "debug".to_owned()
+    } else {
+        "release".to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chrono_like_now_is_valid_rfc3339() {
+        let now = chrono_like_now();
+        // Format: YYYY-MM-DDTHH:MM:SSZ
+        assert_eq!(now.len(), 20, "RFC-3339 must be 20 chars: {now}");
+        assert!(now.ends_with('Z'), "RFC-3339 must end with Z: {now}");
+        assert!(now.contains('T'), "RFC-3339 must contain T separator: {now}");
+        // Simple validation of structure
+        let parts: Vec<&str> = now.split('T').collect();
+        assert_eq!(parts.len(), 2, "RFC-3339 must have exactly one T: {now}");
+        let date_part = parts[0];
+        assert!(date_part.contains('-'), "date must have dashes: {now}");
+    }
+
+    #[test]
+    fn secs_to_ymdhms_epoch() {
+        let (y, mo, d, h, mi, s) = secs_to_ymdhms(0);
+        assert_eq!(y, 1970);
+        assert_eq!(mo, 1);
+        assert_eq!(d, 1);
+        assert_eq!(h, 0);
+        assert_eq!(mi, 0);
+        assert_eq!(s, 0);
+    }
+
+    #[test]
+    fn secs_to_ymdhms_day_boundary() {
+        let (y, mo, d, h, mi, s) = secs_to_ymdhms(86400); // One day after epoch
+        assert_eq!(y, 1970);
+        assert_eq!(mo, 1);
+        assert_eq!(d, 2);
+        assert_eq!(h, 0);
+        assert_eq!(mi, 0);
+        assert_eq!(s, 0);
+    }
+
+    #[test]
+    fn is_leap_known_values() {
+        assert!(is_leap(2000), "2000 is leap");
+        assert!(!is_leap(1900), "1900 is not leap");
+        assert!(is_leap(2004), "2004 is leap");
+        assert!(!is_leap(2001), "2001 is not leap");
+    }
+
+    #[test]
+    fn build_profile_returns_string() {
+        let profile = build_profile();
+        assert!(!profile.is_empty());
+        assert!(profile == "debug" || profile == "release");
+    }
+
+    #[test]
+    fn p0_capabilities_returns_empty() {
+        let caps = p0_capabilities();
+        assert!(caps.is_empty(), "P0 must advertise no capabilities");
+    }
+}

--- a/crates/cairn-cli/src/verbs/status.rs
+++ b/crates/cairn-cli/src/verbs/status.rs
@@ -1,0 +1,1 @@
+//! `cairn status` handler.

--- a/crates/cairn-cli/src/verbs/status.rs
+++ b/crates/cairn-cli/src/verbs/status.rs
@@ -1,7 +1,9 @@
-//! `cairn status` handler — deterministic capability discovery (§8.0.a).
+//! `cairn status` handler — capability discovery (§8.0.a).
 //!
 //! Returns the contract version, advertised capabilities, and server info.
-//! For the P0 scaffold with no store wired, capabilities is empty.
+//! For P0 (no daemon), a fresh incarnation ULID is minted per invocation.
+//! When the store adapter lands, read the incarnation from the daemon table.
+//! For P0 scaffold with no store wired, capabilities is empty.
 
 use std::process::ExitCode;
 
@@ -136,6 +138,31 @@ mod tests {
         assert_eq!(h, 0);
         assert_eq!(mi, 0);
         assert_eq!(s, 0);
+    }
+
+    #[test]
+    fn secs_to_ymdhms_dec31_non_leap() {
+        // 1999-12-31 23:59:59 UTC — day before Y2K
+        // secs from epoch: 946684799
+        let (y, mo, d, h, mi, s) = secs_to_ymdhms(946_684_799);
+        assert_eq!((y, mo, d, h, mi, s), (1999, 12, 31, 23, 59, 59));
+    }
+
+    #[test]
+    fn secs_to_ymdhms_leap_day_2000() {
+        // 2000-02-29 00:00:00 UTC — century leap year
+        // secs from epoch: 951782400
+        let (y, mo, d, h, mi, s) = secs_to_ymdhms(951_782_400);
+        assert_eq!((y, mo, d), (2000, 2, 29));
+        assert_eq!((h, mi, s), (0, 0, 0));
+    }
+
+    #[test]
+    fn secs_to_ymdhms_year_boundary_y2k() {
+        // 2000-01-01 00:00:00 UTC
+        // secs from epoch: 946684800
+        let (y, mo, d, h, mi, s) = secs_to_ymdhms(946_684_800);
+        assert_eq!((y, mo, d, h, mi, s), (2000, 1, 1, 0, 0, 0));
     }
 
     #[test]

--- a/crates/cairn-cli/src/verbs/status.rs
+++ b/crates/cairn-cli/src/verbs/status.rs
@@ -41,7 +41,10 @@ pub fn run(json: bool) -> ExitCode {
             println!("capabilities: (none — store not wired in this P0 build)");
         } else {
             for cap in &resp.capabilities {
-                println!("  capability: {}", serde_json::to_string(cap).unwrap_or_default());
+                println!(
+                    "  capability: {}",
+                    serde_json::to_string(cap).unwrap_or_default()
+                );
             }
         }
     }
@@ -66,22 +69,42 @@ fn chrono_like_now() -> String {
 }
 
 fn secs_to_ymdhms(mut s: u64) -> (u64, u64, u64, u64, u64, u64) {
-    let sec = s % 60; s /= 60;
-    let min = s % 60; s /= 60;
-    let hour = s % 24; s /= 24;
+    let sec = s % 60;
+    s /= 60;
+    let min = s % 60;
+    s /= 60;
+    let hour = s % 24;
+    s /= 24;
     let mut days = s;
     let mut year = 1970u64;
     loop {
         let days_in_year = if is_leap(year) { 366 } else { 365 };
-        if days < days_in_year { break; }
+        if days < days_in_year {
+            break;
+        }
         days -= days_in_year;
         year += 1;
     }
     let leap = is_leap(year);
-    let months = [31u64, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let months = [
+        31u64,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
     let mut month = 1u64;
     for &m in &months {
-        if days < m { break; }
+        if days < m {
+            break;
+        }
         days -= m;
         month += 1;
     }
@@ -110,7 +133,10 @@ mod tests {
         // Format: YYYY-MM-DDTHH:MM:SSZ
         assert_eq!(now.len(), 20, "RFC-3339 must be 20 chars: {now}");
         assert!(now.ends_with('Z'), "RFC-3339 must end with Z: {now}");
-        assert!(now.contains('T'), "RFC-3339 must contain T separator: {now}");
+        assert!(
+            now.contains('T'),
+            "RFC-3339 must contain T separator: {now}"
+        );
         // Simple validation of structure
         let parts: Vec<&str> = now.split('T').collect();
         assert_eq!(parts.len(), 2, "RFC-3339 must have exactly one T: {now}");

--- a/crates/cairn-cli/src/verbs/summarize.rs
+++ b/crates/cairn-cli/src/verbs/summarize.rs
@@ -1,0 +1,1 @@
+//! `cairn summarize` handler.

--- a/crates/cairn-cli/src/verbs/summarize.rs
+++ b/crates/cairn-cli/src/verbs/summarize.rs
@@ -15,7 +15,12 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
     if json {
         emit_json(&resp);
     } else {
-        human_error("summarize", "Internal", "store not wired in this P0 build", &resp.operation_id);
+        human_error(
+            "summarize",
+            "Internal",
+            "store not wired in this P0 build",
+            &resp.operation_id,
+        );
     }
     ExitCode::FAILURE
 }

--- a/crates/cairn-cli/src/verbs/summarize.rs
+++ b/crates/cairn-cli/src/verbs/summarize.rs
@@ -1,1 +1,21 @@
 //! `cairn summarize` handler.
+
+use std::process::ExitCode;
+
+use cairn_core::generated::envelope::ResponseVerb;
+use clap::ArgMatches;
+
+use super::envelope::{emit_json, human_error, unimplemented_response};
+
+/// Run `cairn summarize`.
+#[must_use]
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+    let resp = unimplemented_response(ResponseVerb::Summarize);
+    if json {
+        emit_json(&resp);
+    } else {
+        human_error("summarize", "Internal", "store not wired in this P0 build", &resp.operation_id);
+    }
+    ExitCode::FAILURE
+}

--- a/crates/cairn-cli/tests/cli.rs
+++ b/crates/cairn-cli/tests/cli.rs
@@ -86,7 +86,11 @@ fn simple_verb_human_mode_exits_one_with_internal() {
             !out.status.success(),
             "verb {verb} exited OK — should fail with Internal"
         );
-        assert_eq!(out.status.code(), Some(1), "verb {verb} wrong exit code (want 1)");
+        assert_eq!(
+            out.status.code(),
+            Some(1),
+            "verb {verb} wrong exit code (want 1)"
+        );
         let stderr = String::from_utf8(out.stderr).expect("utf-8 stderr");
         assert!(
             stderr.contains("Internal"),

--- a/crates/cairn-cli/tests/cli.rs
+++ b/crates/cairn-cli/tests/cli.rs
@@ -75,7 +75,13 @@ fn simple_verb_human_mode_exits_one_with_internal() {
     // and print "Internal" to stderr in human mode.
     // `ingest` is excluded: bare `cairn ingest` has no source → exit 64 (usage error).
     // `retrieve` and `forget` are excluded: required ArgGroup → exit 64 (usage error).
-    for verb in ["search", "summarize", "assemble_hot", "capture_trace", "lint"] {
+    for verb in [
+        "search",
+        "summarize",
+        "assemble_hot",
+        "capture_trace",
+        "lint",
+    ] {
         let out = cli().arg(verb).output().expect("cairn <verb>");
         assert!(
             !out.status.success(),
@@ -113,27 +119,25 @@ fn simple_verb_json_mode_emits_aborted_internal_envelope() {
 fn ingest_with_no_source_exits_64() {
     // Bare `cairn ingest` (no body/file/url/source) must fail with usage error, not Internal.
     let out = cli().arg("ingest").output().expect("cairn ingest");
-    assert_eq!(
-        out.status.code(),
-        Some(64),
-        "exit: {:?}",
-        out.status
-    );
+    assert_eq!(out.status.code(), Some(64), "exit: {:?}", out.status);
 }
 
 #[test]
 fn ingest_with_conflicting_sources_exits_64() {
     // Providing both --body and --file violates the IDL exactly-one-of constraint.
     let out = cli()
-        .args(["ingest", "--kind", "user", "--body", "a", "--file", "/dev/null"])
+        .args([
+            "ingest",
+            "--kind",
+            "user",
+            "--body",
+            "a",
+            "--file",
+            "/dev/null",
+        ])
         .output()
         .expect("cairn ingest --body --file");
-    assert_eq!(
-        out.status.code(),
-        Some(64),
-        "exit: {:?}",
-        out.status
-    );
+    assert_eq!(out.status.code(), Some(64), "exit: {:?}", out.status);
     let stderr = String::from_utf8(out.stderr).expect("utf-8");
     assert!(
         stderr.contains("exactly one"),

--- a/crates/cairn-cli/tests/cli.rs
+++ b/crates/cairn-cli/tests/cli.rs
@@ -1,10 +1,11 @@
 //! End-to-end CLI smoke tests. Invokes the built `cairn` binary and asserts
-//! the P0 stub behaviour: help succeeds, verbs without dispatch fail closed.
+//! the P0 stub behaviour: help succeeds, verbs fail closed with `Internal`.
 //!
-//! The CLI tree itself is generated from the IDL by `cairn-codegen`; verb
-//! dispatch lands in #59 / #9. Exit-code contract (spec §5.2):
-//! - simple verb stubs (`ingest`, `search`, …) reach our dispatch and exit 2
-//!   with a not-implemented marker.
+//! The CLI tree is generated from the IDL by `cairn-codegen`; the store is
+//! not wired yet (lands in #9), so every verb returns an `aborted` envelope
+//! with `code: "Internal"`. Exit-code contract (spec §5.2):
+//! - simple verb stubs (`ingest`, `search`, …) → exit 1, stderr contains
+//!   `Internal`, or `--json` → stdout contains `"status":"aborted"`.
 //! - clap usage errors (unknown flag, unknown subcommand, missing required
 //!   `ArgGroup`, bare invocation with `subcommand_required`) → 64
 //!   (`EX_USAGE`).

--- a/crates/cairn-cli/tests/cli.rs
+++ b/crates/cairn-cli/tests/cli.rs
@@ -73,14 +73,9 @@ fn no_args_prints_help_and_fails_closed() {
 fn simple_verb_human_mode_exits_one_with_internal() {
     // After dispatch wiring: verbs with no store adapter exit 1 (generic failure)
     // and print "Internal" to stderr in human mode.
-    for verb in [
-        "ingest",
-        "search",
-        "summarize",
-        "assemble_hot",
-        "capture_trace",
-        "lint",
-    ] {
+    // `ingest` is excluded: bare `cairn ingest` has no source → exit 64 (usage error).
+    // `retrieve` and `forget` are excluded: required ArgGroup → exit 64 (usage error).
+    for verb in ["search", "summarize", "assemble_hot", "capture_trace", "lint"] {
         let out = cli().arg(verb).output().expect("cairn <verb>");
         assert!(
             !out.status.success(),
@@ -112,6 +107,38 @@ fn simple_verb_json_mode_emits_aborted_internal_envelope() {
     assert_eq!(v["contract"], "cairn.mcp.v1");
     assert_eq!(v["status"], "aborted");
     assert_eq!(v["error"]["code"], "Internal");
+}
+
+#[test]
+fn ingest_with_no_source_exits_64() {
+    // Bare `cairn ingest` (no body/file/url/source) must fail with usage error, not Internal.
+    let out = cli().arg("ingest").output().expect("cairn ingest");
+    assert_eq!(
+        out.status.code(),
+        Some(64),
+        "exit: {:?}",
+        out.status
+    );
+}
+
+#[test]
+fn ingest_with_conflicting_sources_exits_64() {
+    // Providing both --body and --file violates the IDL exactly-one-of constraint.
+    let out = cli()
+        .args(["ingest", "--kind", "user", "--body", "a", "--file", "/dev/null"])
+        .output()
+        .expect("cairn ingest --body --file");
+    assert_eq!(
+        out.status.code(),
+        Some(64),
+        "exit: {:?}",
+        out.status
+    );
+    let stderr = String::from_utf8(out.stderr).expect("utf-8");
+    assert!(
+        stderr.contains("exactly one"),
+        "stderr missing constraint message: {stderr:?}"
+    );
 }
 
 #[test]

--- a/crates/cairn-cli/tests/cli.rs
+++ b/crates/cairn-cli/tests/cli.rs
@@ -69,9 +69,9 @@ fn no_args_prints_help_and_fails_closed() {
 }
 
 #[test]
-fn simple_verb_fails_closed_with_not_implemented_marker() {
-    // Verbs whose Args are not a tagged union accept a bare invocation and
-    // reach the scaffold dispatch in main.rs, which exits 2 with a marker.
+fn simple_verb_human_mode_exits_one_with_internal() {
+    // After dispatch wiring: verbs with no store adapter exit 1 (generic failure)
+    // and print "Internal" to stderr in human mode.
     for verb in [
         "ingest",
         "search",
@@ -83,15 +83,30 @@ fn simple_verb_fails_closed_with_not_implemented_marker() {
         let out = cli().arg(verb).output().expect("cairn <verb>");
         assert!(
             !out.status.success(),
-            "verb {verb} exited OK — should fail closed"
+            "verb {verb} exited OK — should fail with Internal"
         );
-        assert_eq!(out.status.code(), Some(2), "verb {verb} wrong exit code");
+        assert_eq!(out.status.code(), Some(1), "verb {verb} wrong exit code (want 1)");
         let stderr = String::from_utf8(out.stderr).expect("utf-8 stderr");
         assert!(
-            stderr.contains("not yet implemented"),
-            "verb {verb} stderr missing not-implemented marker: {stderr:?}",
+            stderr.contains("Internal"),
+            "verb {verb} stderr missing Internal error code: {stderr:?}",
         );
     }
+}
+
+#[test]
+fn simple_verb_json_mode_emits_aborted_internal_envelope() {
+    let out = cli()
+        .args(["ingest", "--kind", "user", "--body", "hi", "--json"])
+        .output()
+        .expect("cairn ingest --json");
+    assert_eq!(out.status.code(), Some(1), "exit: {:?}", out.status);
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("expected valid JSON on stdout");
+    assert_eq!(v["contract"], "cairn.mcp.v1");
+    assert_eq!(v["status"], "aborted");
+    assert_eq!(v["error"]["code"], "Internal");
 }
 
 #[test]

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -11,7 +11,8 @@ fn assert_aborted_internal(verb_args: &[&str]) {
     let out = {
         let mut cmd = cli();
         cmd.args(verb_args);
-        cmd.output().unwrap_or_else(|e| panic!("failed to run {verb_args:?}: {e}"))
+        cmd.output()
+            .unwrap_or_else(|e| panic!("failed to run {verb_args:?}: {e}"))
     };
     // Aborted → exit 1 (generic failure)
     assert_eq!(
@@ -21,8 +22,9 @@ fn assert_aborted_internal(verb_args: &[&str]) {
         out.status
     );
     let stdout = String::from_utf8(out.stdout).expect("utf-8");
-    let v: serde_json::Value = serde_json::from_str(stdout.trim())
-        .unwrap_or_else(|e| panic!("verb {verb_args:?} JSON parse failed: {e}\nstdout: {stdout:?}"));
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("verb {verb_args:?} JSON parse failed: {e}\nstdout: {stdout:?}")
+    });
     assert_eq!(v["contract"], "cairn.mcp.v1", "verb {verb_args:?}");
     assert_eq!(v["status"], "aborted", "verb {verb_args:?}");
     assert_eq!(v["error"]["code"], "Internal", "verb {verb_args:?}");

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -33,11 +33,6 @@ fn assert_aborted_internal(verb_args: &[&str]) {
 }
 
 #[test]
-fn handshake_returns_aborted_internal() {
-    assert_aborted_internal(&["handshake", "--json"]);
-}
-
-#[test]
 fn ingest_returns_aborted_internal() {
     assert_aborted_internal(&["ingest", "--kind", "user", "--body", "hello", "--json"]);
 }

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -33,6 +33,11 @@ fn assert_aborted_internal(verb_args: &[&str]) {
 }
 
 #[test]
+fn handshake_returns_aborted_internal() {
+    assert_aborted_internal(&["handshake", "--json"]);
+}
+
+#[test]
 fn ingest_returns_aborted_internal() {
     assert_aborted_internal(&["ingest", "--kind", "user", "--body", "hello", "--json"]);
 }

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -1,0 +1,71 @@
+//! Verify that every verb returns a valid cairn.mcp.v1 JSON envelope.
+//! These tests invoke the compiled binary and will pass after Task 7 wires dispatch.
+
+use std::process::Command;
+
+fn cli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_cairn"))
+}
+
+fn assert_aborted_internal(verb_args: &[&str]) {
+    let out = {
+        let mut cmd = cli();
+        cmd.args(verb_args);
+        cmd.output().unwrap_or_else(|e| panic!("failed to run {verb_args:?}: {e}"))
+    };
+    // Aborted → exit 1 (generic failure)
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "verb {verb_args:?} should exit 1 (Internal aborted), got {:?}",
+        out.status
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("verb {verb_args:?} JSON parse failed: {e}\nstdout: {stdout:?}"));
+    assert_eq!(v["contract"], "cairn.mcp.v1", "verb {verb_args:?}");
+    assert_eq!(v["status"], "aborted", "verb {verb_args:?}");
+    assert_eq!(v["error"]["code"], "Internal", "verb {verb_args:?}");
+    assert!(v["operation_id"].is_string(), "verb {verb_args:?}");
+    assert!(v["policy_trace"].is_array(), "verb {verb_args:?}");
+}
+
+#[test]
+fn ingest_returns_aborted_internal() {
+    assert_aborted_internal(&["ingest", "--kind", "user", "--body", "hello", "--json"]);
+}
+
+#[test]
+fn search_returns_aborted_internal() {
+    assert_aborted_internal(&["search", "test query", "--json"]);
+}
+
+#[test]
+fn retrieve_record_returns_aborted_internal() {
+    assert_aborted_internal(&["retrieve", "01JXXXXXXXXXXXXXXXXXXXXXXX", "--json"]);
+}
+
+#[test]
+fn summarize_returns_aborted_internal() {
+    assert_aborted_internal(&["summarize", "01JXXXXXXXXXXXXXXXXXXXXXXX", "--json"]);
+}
+
+#[test]
+fn assemble_hot_returns_aborted_internal() {
+    assert_aborted_internal(&["assemble_hot", "--json"]);
+}
+
+#[test]
+fn capture_trace_returns_aborted_internal() {
+    assert_aborted_internal(&["capture_trace", "--from", "/dev/null", "--json"]);
+}
+
+#[test]
+fn lint_returns_aborted_internal() {
+    assert_aborted_internal(&["lint", "--json"]);
+}
+
+#[test]
+fn forget_record_returns_aborted_internal() {
+    assert_aborted_internal(&["forget", "--record", "01JXXXXXXXXXXXXXXXXXXXXXXX", "--json"]);
+}

--- a/crates/cairn-cli/tests/handshake_tests.rs
+++ b/crates/cairn-cli/tests/handshake_tests.rs
@@ -1,5 +1,8 @@
-//! Integration tests for `cairn handshake` — structural assertions.
-//! These tests invoke the compiled binary and will pass after Task 7 wires dispatch.
+//! Integration tests for `cairn handshake` — P0 stub behaviour.
+//!
+//! Challenge authentication requires persisting the nonce server-side. Until
+//! the store is wired (#9), handshake returns `Internal aborted` rather than
+//! emitting an ephemeral challenge that can never be validated.
 
 use std::process::Command;
 
@@ -8,48 +11,27 @@ fn cli() -> Command {
 }
 
 #[test]
-fn handshake_json_has_challenge_keys() {
+fn handshake_json_returns_internal_aborted() {
     let out = cli()
         .args(["handshake", "--json"])
         .output()
         .expect("cairn handshake --json");
-    assert!(out.status.success(), "exit: {:?}", out.status);
+    assert_eq!(out.status.code(), Some(1), "exit: {:?}", out.status);
     let stdout = String::from_utf8(out.stdout).expect("utf-8");
     let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
     assert_eq!(v["contract"], "cairn.mcp.v1");
-    assert!(v["challenge"]["nonce"].is_string());
-    assert!(v["challenge"]["expires_at"].is_number());
-    let expires: u64 = v["challenge"]["expires_at"].as_u64().expect("u64");
-    assert!(expires > 0, "expires_at must be a positive epoch-ms value");
+    assert_eq!(v["status"], "aborted");
+    assert_eq!(v["error"]["code"], "Internal");
+    assert!(v["operation_id"].is_string());
 }
 
 #[test]
-fn two_handshakes_return_different_nonces() {
-    let out1 = cli()
-        .args(["handshake", "--json"])
-        .output()
-        .expect("handshake 1");
-    let out2 = cli()
-        .args(["handshake", "--json"])
-        .output()
-        .expect("handshake 2");
-    let v1: serde_json::Value =
-        serde_json::from_str(String::from_utf8(out1.stdout).expect("utf-8").trim()).expect("json");
-    let v2: serde_json::Value =
-        serde_json::from_str(String::from_utf8(out2.stdout).expect("utf-8").trim()).expect("json");
-    assert_ne!(
-        v1["challenge"]["nonce"], v2["challenge"]["nonce"],
-        "consecutive handshakes must produce distinct nonces (§8.0.a point d)"
-    );
-}
-
-#[test]
-fn handshake_human_exits_zero() {
+fn handshake_human_exits_one_with_internal() {
     let out = cli().arg("handshake").output().expect("cairn handshake");
-    assert!(out.status.success(), "exit: {:?}", out.status);
-    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    assert_eq!(out.status.code(), Some(1), "exit: {:?}", out.status);
+    let stderr = String::from_utf8(out.stderr).expect("utf-8");
     assert!(
-        stdout.contains("nonce"),
-        "human output missing nonce line: {stdout}"
+        stderr.contains("Internal"),
+        "human output missing Internal error code: {stderr}"
     );
 }

--- a/crates/cairn-cli/tests/handshake_tests.rs
+++ b/crates/cairn-cli/tests/handshake_tests.rs
@@ -1,0 +1,43 @@
+//! Integration tests for `cairn handshake` — structural assertions.
+//! These tests invoke the compiled binary and will pass after Task 7 wires dispatch.
+
+use std::process::Command;
+
+fn cli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_cairn"))
+}
+
+#[test]
+fn handshake_json_has_challenge_keys() {
+    let out = cli().args(["handshake", "--json"]).output().expect("cairn handshake --json");
+    assert!(out.status.success(), "exit: {:?}", out.status);
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(v["contract"], "cairn.mcp.v1");
+    assert!(v["challenge"]["nonce"].is_string());
+    assert!(v["challenge"]["expires_at"].is_number());
+    let expires: u64 = v["challenge"]["expires_at"].as_u64().expect("u64");
+    assert!(expires > 0, "expires_at must be a positive epoch-ms value");
+}
+
+#[test]
+fn two_handshakes_return_different_nonces() {
+    let out1 = cli().args(["handshake", "--json"]).output().expect("handshake 1");
+    let out2 = cli().args(["handshake", "--json"]).output().expect("handshake 2");
+    let v1: serde_json::Value =
+        serde_json::from_str(String::from_utf8(out1.stdout).expect("utf-8").trim()).expect("json");
+    let v2: serde_json::Value =
+        serde_json::from_str(String::from_utf8(out2.stdout).expect("utf-8").trim()).expect("json");
+    assert_ne!(
+        v1["challenge"]["nonce"], v2["challenge"]["nonce"],
+        "consecutive handshakes must produce distinct nonces (§8.0.a point d)"
+    );
+}
+
+#[test]
+fn handshake_human_exits_zero() {
+    let out = cli().arg("handshake").output().expect("cairn handshake");
+    assert!(out.status.success(), "exit: {:?}", out.status);
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    assert!(stdout.contains("nonce"), "human output missing nonce line: {stdout}");
+}

--- a/crates/cairn-cli/tests/handshake_tests.rs
+++ b/crates/cairn-cli/tests/handshake_tests.rs
@@ -1,8 +1,8 @@
-//! Integration tests for `cairn handshake` — P0 stub behaviour.
+//! Integration tests for `cairn handshake` — structural assertions.
 //!
-//! Challenge authentication requires persisting the nonce server-side. Until
-//! the store is wired (#9), handshake returns `Internal aborted` rather than
-//! emitting an ephemeral challenge that can never be validated.
+//! Handshake emits a typed `HandshakeResponse` (schema-conformant). The issued
+//! nonce is ephemeral in P0 (not persisted), so challenge-auth is not usable
+//! until the store lands in #9, but the wire format is correct.
 
 use std::process::Command;
 
@@ -11,27 +11,48 @@ fn cli() -> Command {
 }
 
 #[test]
-fn handshake_json_returns_internal_aborted() {
+fn handshake_json_has_challenge_keys() {
     let out = cli()
         .args(["handshake", "--json"])
         .output()
         .expect("cairn handshake --json");
-    assert_eq!(out.status.code(), Some(1), "exit: {:?}", out.status);
+    assert!(out.status.success(), "exit: {:?}", out.status);
     let stdout = String::from_utf8(out.stdout).expect("utf-8");
     let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
     assert_eq!(v["contract"], "cairn.mcp.v1");
-    assert_eq!(v["status"], "aborted");
-    assert_eq!(v["error"]["code"], "Internal");
-    assert!(v["operation_id"].is_string());
+    assert!(v["challenge"]["nonce"].is_string());
+    assert!(v["challenge"]["expires_at"].is_number());
+    let expires: u64 = v["challenge"]["expires_at"].as_u64().expect("u64");
+    assert!(expires > 0, "expires_at must be a positive epoch-ms value");
 }
 
 #[test]
-fn handshake_human_exits_one_with_internal() {
+fn two_handshakes_return_different_nonces() {
+    let out1 = cli()
+        .args(["handshake", "--json"])
+        .output()
+        .expect("handshake 1");
+    let out2 = cli()
+        .args(["handshake", "--json"])
+        .output()
+        .expect("handshake 2");
+    let v1: serde_json::Value =
+        serde_json::from_str(String::from_utf8(out1.stdout).expect("utf-8").trim()).expect("json");
+    let v2: serde_json::Value =
+        serde_json::from_str(String::from_utf8(out2.stdout).expect("utf-8").trim()).expect("json");
+    assert_ne!(
+        v1["challenge"]["nonce"], v2["challenge"]["nonce"],
+        "consecutive handshakes must produce distinct nonces (§8.0.a point d)"
+    );
+}
+
+#[test]
+fn handshake_human_exits_zero() {
     let out = cli().arg("handshake").output().expect("cairn handshake");
-    assert_eq!(out.status.code(), Some(1), "exit: {:?}", out.status);
-    let stderr = String::from_utf8(out.stderr).expect("utf-8");
+    assert!(out.status.success(), "exit: {:?}", out.status);
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
     assert!(
-        stderr.contains("Internal"),
-        "human output missing Internal error code: {stderr}"
+        stdout.contains("nonce"),
+        "human output missing nonce line: {stdout}"
     );
 }

--- a/crates/cairn-cli/tests/handshake_tests.rs
+++ b/crates/cairn-cli/tests/handshake_tests.rs
@@ -9,7 +9,10 @@ fn cli() -> Command {
 
 #[test]
 fn handshake_json_has_challenge_keys() {
-    let out = cli().args(["handshake", "--json"]).output().expect("cairn handshake --json");
+    let out = cli()
+        .args(["handshake", "--json"])
+        .output()
+        .expect("cairn handshake --json");
     assert!(out.status.success(), "exit: {:?}", out.status);
     let stdout = String::from_utf8(out.stdout).expect("utf-8");
     let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
@@ -22,8 +25,14 @@ fn handshake_json_has_challenge_keys() {
 
 #[test]
 fn two_handshakes_return_different_nonces() {
-    let out1 = cli().args(["handshake", "--json"]).output().expect("handshake 1");
-    let out2 = cli().args(["handshake", "--json"]).output().expect("handshake 2");
+    let out1 = cli()
+        .args(["handshake", "--json"])
+        .output()
+        .expect("handshake 1");
+    let out2 = cli()
+        .args(["handshake", "--json"])
+        .output()
+        .expect("handshake 2");
     let v1: serde_json::Value =
         serde_json::from_str(String::from_utf8(out1.stdout).expect("utf-8").trim()).expect("json");
     let v2: serde_json::Value =
@@ -39,5 +48,8 @@ fn handshake_human_exits_zero() {
     let out = cli().arg("handshake").output().expect("cairn handshake");
     assert!(out.status.success(), "exit: {:?}", out.status);
     let stdout = String::from_utf8(out.stdout).expect("utf-8");
-    assert!(stdout.contains("nonce"), "human output missing nonce line: {stdout}");
+    assert!(
+        stdout.contains("nonce"),
+        "human output missing nonce line: {stdout}"
+    );
 }

--- a/crates/cairn-cli/tests/pipe_tests.rs
+++ b/crates/cairn-cli/tests/pipe_tests.rs
@@ -1,0 +1,40 @@
+//! Tests for §5.8 pipeable CLI modes — stdin pipe for `ingest`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn cli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_cairn"))
+}
+
+#[test]
+fn ingest_reads_body_from_stdin_when_source_is_dash() {
+    let mut child = cli()
+        .args(["ingest", "--kind", "user", "-", "--json"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cairn ingest -");
+
+    child
+        .stdin
+        .take()
+        .expect("stdin pipe")
+        .write_all(b"hello from stdin")
+        .expect("write to stdin");
+
+    let out = child.wait_with_output().expect("wait");
+    // The verb returns Internal (no store wired) but must NOT crash or exit 64
+    // (which would indicate a clap parse failure — stdin was not read).
+    assert_ne!(
+        out.status.code(),
+        Some(64),
+        "exit 64 means clap rejected args before stdin was read"
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    // Even in the error path, the envelope must be valid JSON in --json mode.
+    let v: serde_json::Value = serde_json::from_str(stdout.trim())
+        .expect("expected valid JSON envelope even on Internal error");
+    assert_eq!(v["contract"], "cairn.mcp.v1");
+}

--- a/crates/cairn-cli/tests/status_snapshot.rs
+++ b/crates/cairn-cli/tests/status_snapshot.rs
@@ -1,4 +1,5 @@
-//! Integration tests for `cairn status`.
+//! Integration tests for `cairn status` — structural assertions over
+//! time-varying output (no insta snapshots since `incarnation` differs per call).
 
 use std::process::Command;
 

--- a/crates/cairn-cli/tests/status_snapshot.rs
+++ b/crates/cairn-cli/tests/status_snapshot.rs
@@ -1,0 +1,30 @@
+//! Integration tests for `cairn status`.
+
+use std::process::Command;
+
+fn cli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_cairn"))
+}
+
+#[test]
+fn status_json_has_required_keys() {
+    let out = cli().args(["status", "--json"]).output().expect("cairn status --json");
+    assert!(out.status.success(), "cairn status --json failed: {:?}", out.status);
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    assert_eq!(v["contract"], "cairn.mcp.v1");
+    assert!(v["server_info"]["version"].is_string());
+    assert!(v["server_info"]["incarnation"].is_string());
+    assert!(v["server_info"]["started_at"].is_string());
+    assert!(v["server_info"]["build"].is_string());
+    assert!(v["capabilities"].is_array());
+    assert!(v["extensions"].is_array());
+}
+
+#[test]
+fn status_human_exits_zero() {
+    let out = cli().arg("status").output().expect("cairn status");
+    assert!(out.status.success(), "exit: {:?}", out.status);
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    assert!(stdout.contains("cairn.mcp.v1"), "human output missing contract: {stdout}");
+}

--- a/crates/cairn-cli/tests/status_snapshot.rs
+++ b/crates/cairn-cli/tests/status_snapshot.rs
@@ -9,8 +9,15 @@ fn cli() -> Command {
 
 #[test]
 fn status_json_has_required_keys() {
-    let out = cli().args(["status", "--json"]).output().expect("cairn status --json");
-    assert!(out.status.success(), "cairn status --json failed: {:?}", out.status);
+    let out = cli()
+        .args(["status", "--json"])
+        .output()
+        .expect("cairn status --json");
+    assert!(
+        out.status.success(),
+        "cairn status --json failed: {:?}",
+        out.status
+    );
     let stdout = String::from_utf8(out.stdout).expect("utf-8");
     let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
     assert_eq!(v["contract"], "cairn.mcp.v1");
@@ -27,5 +34,8 @@ fn status_human_exits_zero() {
     let out = cli().arg("status").output().expect("cairn status");
     assert!(out.status.success(), "exit: {:?}", out.status);
     let stdout = String::from_utf8(out.stdout).expect("utf-8");
-    assert!(stdout.contains("cairn.mcp.v1"), "human output missing contract: {stdout}");
+    assert!(
+        stdout.contains("cairn.mcp.v1"),
+        "human output missing contract: {stdout}"
+    );
 }

--- a/crates/cairn-cli/tests/verbs_smoke.rs
+++ b/crates/cairn-cli/tests/verbs_smoke.rs
@@ -1,0 +1,6 @@
+#[test]
+fn verbs_mod_exists() {
+    // Compilation of this file is the test — if cairn_cli::verbs is missing
+    // this file will not compile.
+    let _: fn() = cairn_cli::verbs::smoke_fn;
+}

--- a/crates/cairn-cli/tests/verbs_smoke.rs
+++ b/crates/cairn-cli/tests/verbs_smoke.rs
@@ -1,3 +1,5 @@
+//! Smoke test — verifies that `cairn_cli::verbs` is a reachable public module.
+
 #[test]
 fn verbs_mod_exists() {
     // Compilation of this file is the test — if cairn_cli::verbs is missing


### PR DESCRIPTION
Closes #59

## Summary

- Replaces the "not yet implemented" catch-all in `cairn-cli/src/main.rs` with real verb dispatch for all 8 core verbs plus `status` and `handshake` (brief §8, §13.3)
- Introduces `cairn_cli::verbs` module with one handler per verb, shared envelope helpers (`new_operation_id`, `new_nonce`, `unimplemented_response`, `emit_json`, `human_error`), and a `with_json()` wrapper that adds `--json` to each generated subcommand without touching `@generated` files
- All core verbs return `status=aborted, code=Internal` (honest P0 stub — store wiring lands in #9); `status` and `handshake` return full typed `cairn.mcp.v1` responses

## Implementation notes

- `ulid` and `base64` added as workspace deps for `operation_id` (Crockford base32 ULID) and `Nonce16Base64` generation
- P0 `incarnation` in `status` is a fresh ULID per invocation — noted in doc comment as approximation until persistent daemon state lands (#9)
- `cairn ingest -` reads body from stdin before emitting Internal, satisfying §5.8 pipeable mode
- `cairn ingest` enforces the IDL exactly-one-of constraint (`body`/`file`/`url`/`source`) — exits 64 on violation
- Handshake emits a typed `HandshakeResponse` (schema-conformant); P0 nonces are ephemeral and cannot be validated server-side until `outstanding_challenges` storage lands in #9
- `None` arm in main dispatch is `unreachable!()` — `subcommand_required(true)` makes it structurally impossible

## Brief sections

§5.2 (exit codes), §5.8 (pipeable stdin), §8 (verb table + CLI contract), §13.3 (response envelope)

## Test plan

- [ ] `cargo nextest run --workspace --locked` — 621 tests pass
- [ ] `cargo test --doc --workspace --locked` — doctests pass
- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [ ] `cargo fmt --all --check` — clean
- [ ] `./scripts/check-core-boundary.sh` — `cairn-core boundary OK`
- [ ] `cairn-codegen --check` — no drift
- [ ] `cargo deny check && cargo audit && cargo machete` — all pass
- [ ] `cargo doc --workspace` with `-D warnings` — clean
- [ ] `cairn ingest --kind user --body hello --json` → `{"status":"aborted","error":{"code":"Internal",...}}`
- [ ] `echo hi | cairn ingest --kind user - --json` → valid JSON envelope, exit 1 (not 64)
- [ ] `cairn ingest --kind user --body a --file /dev/null` → exit 64 (XOR violation)
- [ ] `cairn status --json` → valid `StatusResponse` with `cairn.mcp.v1` contract
- [ ] `cairn handshake --json` → valid `HandshakeResponse` with unique nonce