### PR TITLE
feat(fixtures): P0 schema fixtures + insta migration tests (#40)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "serde",
  "version_check",
@@ -257,6 +257,10 @@ name = "cairn-test-fixtures"
 version = "0.0.1"
 dependencies = [
  "cairn-core",
+ "insta",
+ "serde",
+ "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -461,6 +465,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -588,9 +598,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -601,13 +624,22 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -705,6 +737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +771,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -788,7 +828,7 @@ dependencies = [
  "email_address",
  "fancy-regex",
  "fraction",
- "getrandom",
+ "getrandom 0.3.4",
  "idna",
  "itoa",
  "num-cmp",
@@ -808,6 +848,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -835,6 +881,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -1022,6 +1074,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,7 +1186,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1167,7 +1235,7 @@ checksum = "acb0c66c7b78c1da928bee668b5cc638c678642ff587faff6e6222f797be9d4c"
 dependencies = [
  "ahash",
  "fluent-uri",
- "getrandom",
+ "getrandom 0.3.4",
  "hashbrown 0.16.1",
  "itoa",
  "micromap",
@@ -1443,7 +1511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1646,6 +1714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,7 +1774,16 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1749,6 +1832,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,9 +1900,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/crates/cairn-test-fixtures/Cargo.toml
+++ b/crates/cairn-test-fixtures/Cargo.toml
@@ -22,6 +22,8 @@ toml = { workspace = true }
 [lints]
 workspace = true
 
-# Forward-declared scaffold dep. Drop as soon as cairn-core is referenced.
+# cairn-core is used only in integration tests (tests/), not in src/. cargo-machete
+# scans library source, so it cannot see the integration-test usage and flags it as
+# unused. This ignore is permanent for this crate.
 [package.metadata.cargo-machete]
 ignored = ["cairn-core"]

--- a/crates/cairn-test-fixtures/Cargo.toml
+++ b/crates/cairn-test-fixtures/Cargo.toml
@@ -13,6 +13,12 @@ description = "Shared test helpers and fixture loaders for Cairn crates."
 [dependencies]
 cairn-core = { workspace = true }
 
+[dev-dependencies]
+insta = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+
 [lints]
 workspace = true
 

--- a/crates/cairn-test-fixtures/src/lib.rs
+++ b/crates/cairn-test-fixtures/src/lib.rs
@@ -31,3 +31,9 @@ pub fn fixtures_dir() -> &'static Path {
     })
     .as_path()
 }
+
+/// Absolute path to the versioned P0 fixture directory (`fixtures/v0/`).
+#[must_use]
+pub fn fixture_v0_dir() -> std::path::PathBuf {
+    fixtures_dir().join("v0")
+}

--- a/crates/cairn-test-fixtures/tests/schema_fixtures.rs
+++ b/crates/cairn-test-fixtures/tests/schema_fixtures.rs
@@ -9,16 +9,14 @@
 
 fn load_json<T: serde::de::DeserializeOwned>(path: impl AsRef<std::path::Path>) -> T {
     let path = path.as_ref();
-    let raw = std::fs::read_to_string(path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-    serde_json::from_str(&raw)
-        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+    let raw =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 }
 
 fn load_toml_str(path: impl AsRef<std::path::Path>) -> String {
     let path = path.as_ref();
-    std::fs::read_to_string(path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
 }
 
 fn v0() -> std::path::PathBuf {
@@ -31,7 +29,13 @@ fn v0() -> std::path::PathBuf {
 fn v0_directory_structure_exists() {
     let base = v0();
     assert!(base.exists(), "fixtures/v0 must exist: {base:?}");
-    for sub in &["records", "config", "envelopes", "search-filters", "manifests"] {
+    for sub in &[
+        "records",
+        "config",
+        "envelopes",
+        "search-filters",
+        "manifests",
+    ] {
         let p = base.join(sub);
         assert!(p.is_dir(), "fixtures/v0/{sub} must be a directory: {p:?}");
     }
@@ -48,28 +52,32 @@ fn records_dir() -> std::path::PathBuf {
 #[test]
 fn record_semantic_private_deserializes_and_validates() {
     let r: MemoryRecord = load_json(records_dir().join("semantic_private_user.json"));
-    r.validate().expect("semantic_private_user must pass validate()");
+    r.validate()
+        .expect("semantic_private_user must pass validate()");
     insta::assert_json_snapshot!("record_semantic_private_user", &r);
 }
 
 #[test]
 fn record_episodic_session_deserializes_and_validates() {
     let r: MemoryRecord = load_json(records_dir().join("episodic_session_trace.json"));
-    r.validate().expect("episodic_session_trace must pass validate()");
+    r.validate()
+        .expect("episodic_session_trace must pass validate()");
     insta::assert_json_snapshot!("record_episodic_session_trace", &r);
 }
 
 #[test]
 fn record_procedural_project_deserializes_and_validates() {
     let r: MemoryRecord = load_json(records_dir().join("procedural_project_playbook.json"));
-    r.validate().expect("procedural_project_playbook must pass validate()");
+    r.validate()
+        .expect("procedural_project_playbook must pass validate()");
     insta::assert_json_snapshot!("record_procedural_project_playbook", &r);
 }
 
 #[test]
 fn record_graph_team_deserializes_and_validates() {
     let r: MemoryRecord = load_json(records_dir().join("graph_team_entity.json"));
-    r.validate().expect("graph_team_entity must pass validate()");
+    r.validate()
+        .expect("graph_team_entity must pass validate()");
     insta::assert_json_snapshot!("record_graph_team_entity", &r);
 }
 
@@ -113,14 +121,16 @@ fn envelopes_dir() -> std::path::PathBuf {
 #[test]
 fn signed_intent_sequence_deserializes() {
     let si: SignedIntent = load_json(envelopes_dir().join("signed-intent-sequence.json"));
-    si.validate().expect("signed-intent-sequence must pass validate()");
+    si.validate()
+        .expect("signed-intent-sequence must pass validate()");
     insta::assert_json_snapshot!("signed_intent_sequence", &si);
 }
 
 #[test]
 fn signed_intent_challenge_deserializes() {
     let si: SignedIntent = load_json(envelopes_dir().join("signed-intent-challenge.json"));
-    si.validate().expect("signed-intent-challenge must pass validate()");
+    si.validate()
+        .expect("signed-intent-challenge must pass validate()");
     insta::assert_json_snapshot!("signed_intent_challenge", &si);
 }
 

--- a/crates/cairn-test-fixtures/tests/schema_fixtures.rs
+++ b/crates/cairn-test-fixtures/tests/schema_fixtures.rs
@@ -15,7 +15,6 @@ fn load_json<T: serde::de::DeserializeOwned>(path: impl AsRef<std::path::Path>) 
         .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 }
 
-#[allow(dead_code)]
 fn load_toml_str(path: impl AsRef<std::path::Path>) -> String {
     let path = path.as_ref();
     std::fs::read_to_string(path)
@@ -167,4 +166,28 @@ fn filter_or_with_not_deserializes() {
 fn search_args_keyword_deserializes() {
     let a: SearchArgs = load_json(filters_dir().join("search-args-keyword.json"));
     insta::assert_json_snapshot!("search_args_keyword", &a);
+}
+
+// ── Plugin manifests ──────────────────────────────────────────────────────────
+
+use cairn_core::contract::manifest::PluginManifest;
+
+fn manifests_dir() -> std::path::PathBuf {
+    v0().join("manifests")
+}
+
+#[test]
+fn manifest_cairn_store_sqlite_parses() {
+    let src = load_toml_str(manifests_dir().join("cairn-store-sqlite.toml"));
+    let m = PluginManifest::parse_toml(&src).expect("cairn-store-sqlite.toml must parse");
+    assert_eq!(m.name().as_str(), "cairn-store-sqlite");
+    insta::assert_debug_snapshot!("manifest_cairn_store_sqlite", m);
+}
+
+#[test]
+fn manifest_cairn_llm_openai_compat_parses() {
+    let src = load_toml_str(manifests_dir().join("cairn-llm-openai-compat.toml"));
+    let m = PluginManifest::parse_toml(&src).expect("cairn-llm-openai-compat.toml must parse");
+    assert_eq!(m.name().as_str(), "cairn-llm-openai-compat");
+    insta::assert_debug_snapshot!("manifest_cairn_llm_openai_compat", m);
 }

--- a/crates/cairn-test-fixtures/tests/schema_fixtures.rs
+++ b/crates/cairn-test-fixtures/tests/schema_fixtures.rs
@@ -7,7 +7,6 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-#[allow(dead_code)]
 fn load_json<T: serde::de::DeserializeOwned>(path: impl AsRef<std::path::Path>) -> T {
     let path = path.as_ref();
     let raw = std::fs::read_to_string(path)
@@ -37,4 +36,40 @@ fn v0_directory_structure_exists() {
         let p = base.join(sub);
         assert!(p.is_dir(), "fixtures/v0/{sub} must be a directory: {p:?}");
     }
+}
+
+// ── Records ─────────────────────────────────────────────────────────────────
+
+use cairn_core::domain::record::MemoryRecord;
+
+fn records_dir() -> std::path::PathBuf {
+    v0().join("records")
+}
+
+#[test]
+fn record_semantic_private_deserializes_and_validates() {
+    let r: MemoryRecord = load_json(records_dir().join("semantic_private_user.json"));
+    r.validate().expect("semantic_private_user must pass validate()");
+    insta::assert_json_snapshot!("record_semantic_private_user", &r);
+}
+
+#[test]
+fn record_episodic_session_deserializes_and_validates() {
+    let r: MemoryRecord = load_json(records_dir().join("episodic_session_trace.json"));
+    r.validate().expect("episodic_session_trace must pass validate()");
+    insta::assert_json_snapshot!("record_episodic_session_trace", &r);
+}
+
+#[test]
+fn record_procedural_project_deserializes_and_validates() {
+    let r: MemoryRecord = load_json(records_dir().join("procedural_project_playbook.json"));
+    r.validate().expect("procedural_project_playbook must pass validate()");
+    insta::assert_json_snapshot!("record_procedural_project_playbook", &r);
+}
+
+#[test]
+fn record_graph_team_deserializes_and_validates() {
+    let r: MemoryRecord = load_json(records_dir().join("graph_team_entity.json"));
+    r.validate().expect("graph_team_entity must pass validate()");
+    insta::assert_json_snapshot!("record_graph_team_entity", &r);
 }

--- a/crates/cairn-test-fixtures/tests/schema_fixtures.rs
+++ b/crates/cairn-test-fixtures/tests/schema_fixtures.rs
@@ -102,3 +102,37 @@ fn config_custom_store_deserializes_and_validates() {
     c.validate().expect("custom-store must pass validate()");
     insta::assert_json_snapshot!("config_custom_store", &c);
 }
+
+// ── Envelopes ─────────────────────────────────────────────────────────────────
+
+use cairn_core::generated::envelope::{Response, SignedIntent};
+
+fn envelopes_dir() -> std::path::PathBuf {
+    v0().join("envelopes")
+}
+
+#[test]
+fn signed_intent_sequence_deserializes() {
+    let si: SignedIntent = load_json(envelopes_dir().join("signed-intent-sequence.json"));
+    si.validate().expect("signed-intent-sequence must pass validate()");
+    insta::assert_json_snapshot!("signed_intent_sequence", &si);
+}
+
+#[test]
+fn signed_intent_challenge_deserializes() {
+    let si: SignedIntent = load_json(envelopes_dir().join("signed-intent-challenge.json"));
+    si.validate().expect("signed-intent-challenge must pass validate()");
+    insta::assert_json_snapshot!("signed_intent_challenge", &si);
+}
+
+#[test]
+fn response_committed_search_deserializes() {
+    let r: Response = load_json(envelopes_dir().join("response-committed-search.json"));
+    insta::assert_json_snapshot!("response_committed_search", &r);
+}
+
+#[test]
+fn response_rejected_invalid_args_deserializes() {
+    let r: Response = load_json(envelopes_dir().join("response-rejected-invalid-args.json"));
+    insta::assert_json_snapshot!("response_rejected_invalid_args", &r);
+}

--- a/crates/cairn-test-fixtures/tests/schema_fixtures.rs
+++ b/crates/cairn-test-fixtures/tests/schema_fixtures.rs
@@ -136,3 +136,35 @@ fn response_rejected_invalid_args_deserializes() {
     let r: Response = load_json(envelopes_dir().join("response-rejected-invalid-args.json"));
     insta::assert_json_snapshot!("response_rejected_invalid_args", &r);
 }
+
+// ── Search filters ────────────────────────────────────────────────────────────
+
+use cairn_core::generated::verbs::search::{SearchArgs, SearchArgsFilters};
+
+fn filters_dir() -> std::path::PathBuf {
+    v0().join("search-filters")
+}
+
+#[test]
+fn filter_leaf_eq_deserializes() {
+    let f: SearchArgsFilters = load_json(filters_dir().join("leaf-eq.json"));
+    insta::assert_json_snapshot!("filter_leaf_eq", &f);
+}
+
+#[test]
+fn filter_and_two_leaves_deserializes() {
+    let f: SearchArgsFilters = load_json(filters_dir().join("and-two-leaves.json"));
+    insta::assert_json_snapshot!("filter_and_two_leaves", &f);
+}
+
+#[test]
+fn filter_or_with_not_deserializes() {
+    let f: SearchArgsFilters = load_json(filters_dir().join("or-with-not.json"));
+    insta::assert_json_snapshot!("filter_or_with_not", &f);
+}
+
+#[test]
+fn search_args_keyword_deserializes() {
+    let a: SearchArgs = load_json(filters_dir().join("search-args-keyword.json"));
+    insta::assert_json_snapshot!("search_args_keyword", &a);
+}

--- a/crates/cairn-test-fixtures/tests/schema_fixtures.rs
+++ b/crates/cairn-test-fixtures/tests/schema_fixtures.rs
@@ -73,3 +73,32 @@ fn record_graph_team_deserializes_and_validates() {
     r.validate().expect("graph_team_entity must pass validate()");
     insta::assert_json_snapshot!("record_graph_team_entity", &r);
 }
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+use cairn_core::config::CairnConfig;
+
+fn config_dir() -> std::path::PathBuf {
+    v0().join("config")
+}
+
+#[test]
+fn config_p0_defaults_deserializes_and_validates() {
+    let c: CairnConfig = load_json(config_dir().join("p0-defaults.json"));
+    c.validate().expect("p0-defaults must pass validate()");
+    insta::assert_json_snapshot!("config_p0_defaults", &c);
+}
+
+#[test]
+fn config_llm_enabled_deserializes_and_validates() {
+    let c: CairnConfig = load_json(config_dir().join("llm-enabled.json"));
+    c.validate().expect("llm-enabled must pass validate()");
+    insta::assert_json_snapshot!("config_llm_enabled", &c);
+}
+
+#[test]
+fn config_custom_store_deserializes_and_validates() {
+    let c: CairnConfig = load_json(config_dir().join("custom-store.json"));
+    c.validate().expect("custom-store must pass validate()");
+    insta::assert_json_snapshot!("config_custom_store", &c);
+}

--- a/crates/cairn-test-fixtures/tests/schema_fixtures.rs
+++ b/crates/cairn-test-fixtures/tests/schema_fixtures.rs
@@ -7,6 +7,7 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+#[allow(dead_code)]
 fn load_json<T: serde::de::DeserializeOwned>(path: impl AsRef<std::path::Path>) -> T {
     let path = path.as_ref();
     let raw = std::fs::read_to_string(path)
@@ -15,6 +16,7 @@ fn load_json<T: serde::de::DeserializeOwned>(path: impl AsRef<std::path::Path>) 
         .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 }
 
+#[allow(dead_code)]
 fn load_toml_str(path: impl AsRef<std::path::Path>) -> String {
     let path = path.as_ref();
     std::fs::read_to_string(path)

--- a/crates/cairn-test-fixtures/tests/schema_fixtures.rs
+++ b/crates/cairn-test-fixtures/tests/schema_fixtures.rs
@@ -1,0 +1,38 @@
+//! Fixture deserialization and snapshot tests.
+//!
+//! Every fixture file in `fixtures/v0/` is loaded, deserialized into its
+//! typed Rust form, validated, and snapshot-tested with `insta`. A CI run
+//! that fails here means a schema change broke backward compatibility or
+//! the wire form shifted without a deliberate snapshot update.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+fn load_json<T: serde::de::DeserializeOwned>(path: impl AsRef<std::path::Path>) -> T {
+    let path = path.as_ref();
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn load_toml_str(path: impl AsRef<std::path::Path>) -> String {
+    let path = path.as_ref();
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn v0() -> std::path::PathBuf {
+    cairn_test_fixtures::fixture_v0_dir()
+}
+
+// ── Directory structure ──────────────────────────────────────────────────────
+
+#[test]
+fn v0_directory_structure_exists() {
+    let base = v0();
+    assert!(base.exists(), "fixtures/v0 must exist: {base:?}");
+    for sub in &["records", "config", "envelopes", "search-filters", "manifests"] {
+        let p = base.join(sub);
+        assert!(p.is_dir(), "fixtures/v0/{sub} must be a directory: {p:?}");
+    }
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
@@ -1,0 +1,87 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&c"
+---
+{
+  "vault": {
+    "name": "my-vault",
+    "tier": "local",
+    "layout": {
+      "sources": "sources",
+      "records": "raw",
+      "wiki": "wiki",
+      "skills": "skills",
+      "enabled_kinds": [
+        "user",
+        "feedback",
+        "fact",
+        "rule"
+      ],
+      "file_naming": "{kind}_{slug}.md",
+      "index": {
+        "max_lines": 200,
+        "max_bytes": 25600
+      }
+    },
+    "hot_memory": {
+      "recipe": [
+        "purpose",
+        "index",
+        "pinned_feedback"
+      ],
+      "max_bytes": 8192
+    },
+    "retention": {
+      "raw/sensor_observation_*.md": "7d",
+      "raw/trace_*.md": "30d"
+    },
+    "schema_files": [
+      "CLAUDE.md",
+      "AGENTS.md",
+      "GEMINI.md"
+    ]
+  },
+  "store": {
+    "kind": "custom:cairn-store-qdrant"
+  },
+  "llm": {
+    "provider": null,
+    "base_url": null,
+    "model": null,
+    "api_key": null
+  },
+  "sensors": {
+    "hooks": {
+      "enabled": true
+    },
+    "ide": {
+      "enabled": true
+    },
+    "screen": {
+      "enabled": false
+    },
+    "slack": {
+      "enabled": false,
+      "scope": []
+    }
+  },
+  "workflows": {
+    "orchestrator": "local"
+  },
+  "pipeline": {
+    "extract": {
+      "chain": [
+        {
+          "worker": "regex",
+          "kinds": [],
+          "trigger": null,
+          "budget": {
+            "max_tokens": null,
+            "max_wall_ms": null,
+            "max_turns": null
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
@@ -68,7 +68,10 @@ expression: "&c"
       "chain": [
         {
           "worker": "regex",
-          "kinds": [],
+          "kinds": [
+            "feedback",
+            "rule"
+          ],
           "trigger": null,
           "budget": {
             "max_tokens": null,

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
@@ -1,0 +1,92 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&c"
+---
+{
+  "vault": {
+    "name": "my-vault",
+    "tier": "local",
+    "layout": {
+      "sources": "sources",
+      "records": "raw",
+      "wiki": "wiki",
+      "skills": "skills",
+      "enabled_kinds": [],
+      "file_naming": "{kind}_{slug}.md",
+      "index": {
+        "max_lines": 200,
+        "max_bytes": 25600
+      }
+    },
+    "hot_memory": {
+      "recipe": [
+        "purpose",
+        "index",
+        "pinned_feedback",
+        "top_salience_project",
+        "active_playbook",
+        "recent_user_signal"
+      ],
+      "max_bytes": 25600
+    },
+    "retention": {},
+    "schema_files": [
+      "CLAUDE.md",
+      "AGENTS.md",
+      "GEMINI.md"
+    ]
+  },
+  "store": {
+    "kind": "sqlite"
+  },
+  "llm": {
+    "provider": "openai-compatible",
+    "base_url": "http://localhost:11434/v1",
+    "model": "${CAIRN_MODEL}",
+    "api_key": "${OPENAI_API_KEY}"
+  },
+  "sensors": {
+    "hooks": {
+      "enabled": true
+    },
+    "ide": {
+      "enabled": true
+    },
+    "screen": {
+      "enabled": false
+    },
+    "slack": {
+      "enabled": false,
+      "scope": []
+    }
+  },
+  "workflows": {
+    "orchestrator": "local"
+  },
+  "pipeline": {
+    "extract": {
+      "chain": [
+        {
+          "worker": "regex",
+          "kinds": [],
+          "trigger": null,
+          "budget": {
+            "max_tokens": null,
+            "max_wall_ms": null,
+            "max_turns": null
+          }
+        },
+        {
+          "worker": "llm",
+          "kinds": [],
+          "trigger": "confidence_below",
+          "budget": {
+            "max_tokens": 4096,
+            "max_wall_ms": 10000,
+            "max_turns": null
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
@@ -1,0 +1,82 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&c"
+---
+{
+  "vault": {
+    "name": "my-vault",
+    "tier": "local",
+    "layout": {
+      "sources": "sources",
+      "records": "raw",
+      "wiki": "wiki",
+      "skills": "skills",
+      "enabled_kinds": [],
+      "file_naming": "{kind}_{slug}.md",
+      "index": {
+        "max_lines": 200,
+        "max_bytes": 25600
+      }
+    },
+    "hot_memory": {
+      "recipe": [
+        "purpose",
+        "index",
+        "pinned_feedback",
+        "top_salience_project",
+        "active_playbook",
+        "recent_user_signal"
+      ],
+      "max_bytes": 25600
+    },
+    "retention": {},
+    "schema_files": [
+      "CLAUDE.md",
+      "AGENTS.md",
+      "GEMINI.md"
+    ]
+  },
+  "store": {
+    "kind": "sqlite"
+  },
+  "llm": {
+    "provider": null,
+    "base_url": null,
+    "model": null,
+    "api_key": null
+  },
+  "sensors": {
+    "hooks": {
+      "enabled": true
+    },
+    "ide": {
+      "enabled": true
+    },
+    "screen": {
+      "enabled": false
+    },
+    "slack": {
+      "enabled": false,
+      "scope": []
+    }
+  },
+  "workflows": {
+    "orchestrator": "local"
+  },
+  "pipeline": {
+    "extract": {
+      "chain": [
+        {
+          "worker": "regex",
+          "kinds": [],
+          "trigger": null,
+          "budget": {
+            "max_tokens": null,
+            "max_wall_ms": null,
+            "max_turns": null
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__filter_and_two_leaves.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__filter_and_two_leaves.snap
@@ -1,0 +1,18 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&f"
+---
+{
+  "and": [
+    {
+      "field": "visibility",
+      "op": "eq",
+      "value": "private"
+    },
+    {
+      "field": "salience",
+      "op": "gte",
+      "value": 0.5
+    }
+  ]
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__filter_leaf_eq.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__filter_leaf_eq.snap
@@ -1,0 +1,9 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&f"
+---
+{
+  "field": "kind",
+  "op": "eq",
+  "value": "user"
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__filter_or_with_not.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__filter_or_with_not.snap
@@ -1,0 +1,24 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&f"
+---
+{
+  "or": [
+    {
+      "field": "kind",
+      "op": "in",
+      "value": [
+        "user",
+        "feedback",
+        "rule"
+      ]
+    },
+    {
+      "not": {
+        "field": "visibility",
+        "op": "eq",
+        "value": "public"
+      }
+    }
+  ]
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__filter_or_with_not.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__filter_or_with_not.snap
@@ -17,7 +17,7 @@ expression: "&f"
       "not": {
         "field": "visibility",
         "op": "eq",
-        "value": "public"
+        "value": "private"
       }
     }
   ]

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__manifest_cairn_llm_openai_compat.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__manifest_cairn_llm_openai_compat.snap
@@ -1,0 +1,26 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: m
+---
+PluginManifest {
+    name: PluginName(
+        "cairn-llm-openai-compat",
+    ),
+    contract: LLMProvider,
+    contract_version_range: VersionRange {
+        min: ContractVersion {
+            major: 0,
+            minor: 1,
+            patch: 0,
+        },
+        max_exclusive: ContractVersion {
+            major: 0,
+            minor: 2,
+            patch: 0,
+        },
+    },
+    features: {
+        "function_calling": true,
+        "streaming": true,
+    },
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__manifest_cairn_store_sqlite.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__manifest_cairn_store_sqlite.snap
@@ -1,0 +1,27 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: m
+---
+PluginManifest {
+    name: PluginName(
+        "cairn-store-sqlite",
+    ),
+    contract: MemoryStore,
+    contract_version_range: VersionRange {
+        min: ContractVersion {
+            major: 0,
+            minor: 1,
+            patch: 0,
+        },
+        max_exclusive: ContractVersion {
+            major: 0,
+            minor: 2,
+            patch: 0,
+        },
+    },
+    features: {
+        "fts": true,
+        "graph_edges": false,
+        "vector": false,
+    },
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__record_episodic_session_trace.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__record_episodic_session_trace.snap
@@ -1,0 +1,40 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&r"
+---
+{
+  "id": "01HQZX9F5N0000000000000001",
+  "kind": "trace",
+  "class": "episodic",
+  "visibility": "session",
+  "scope": {
+    "session_id": "01HQZX9F5N0000000000000002",
+    "agent": "agt:claude-code:sonnet-4-6:main:v1"
+  },
+  "body": "Agent completed the ingest verb implementation for the cairn-cli crate.",
+  "provenance": {
+    "source_sensor": "snr:local:hook:cc-session:v1",
+    "created_at": "2026-04-26T00:00:00Z",
+    "originating_agent_id": "agt:claude-code:sonnet-4-6:main:v1",
+    "source_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "consent_ref": "consent:01HQZ",
+    "llm_id_if_any": "claude-sonnet-4-6"
+  },
+  "updated_at": "2026-04-26T00:00:00Z",
+  "evidence": {
+    "recall_count": 0,
+    "score": 0.0,
+    "unique_queries": 0,
+    "recency_half_life_days": 14
+  },
+  "salience": 0.5,
+  "confidence": 0.7,
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "agt:claude-code:sonnet-4-6:main:v1",
+      "at": "2026-04-26T00:00:00Z"
+    }
+  ],
+  "signature": "ed25519:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__record_graph_team_entity.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__record_graph_team_entity.snap
@@ -1,0 +1,40 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&r"
+---
+{
+  "id": "01HQZX9F5N0000000000000004",
+  "kind": "entity",
+  "class": "graph",
+  "visibility": "team",
+  "scope": {
+    "entity": "acme-corp",
+    "user": "usr:tafeng"
+  },
+  "body": "Acme Corp is the primary enterprise customer for the Cairn pilot deployment.",
+  "provenance": {
+    "source_sensor": "snr:local:hook:cc-session:v1",
+    "created_at": "2026-04-26T00:00:00Z",
+    "originating_agent_id": "usr:tafeng",
+    "source_hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "consent_ref": "consent:01HQZ",
+    "llm_id_if_any": null
+  },
+  "updated_at": "2026-04-26T00:00:00Z",
+  "evidence": {
+    "recall_count": 0,
+    "score": 0.0,
+    "unique_queries": 0,
+    "recency_half_life_days": 14
+  },
+  "salience": 0.5,
+  "confidence": 0.7,
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "usr:tafeng",
+      "at": "2026-04-26T00:00:00Z"
+    }
+  ],
+  "signature": "ed25519:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__record_procedural_project_playbook.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__record_procedural_project_playbook.snap
@@ -1,0 +1,40 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&r"
+---
+{
+  "id": "01HQZX9F5N0000000000000003",
+  "kind": "playbook",
+  "class": "procedural",
+  "visibility": "project",
+  "scope": {
+    "entity": "cairn",
+    "user": "usr:tafeng"
+  },
+  "body": "Run cargo nextest before every push; fix all clippy warnings before opening a PR.",
+  "provenance": {
+    "source_sensor": "snr:local:hook:cc-session:v1",
+    "created_at": "2026-04-26T00:00:00Z",
+    "originating_agent_id": "usr:tafeng",
+    "source_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "consent_ref": "consent:01HQZ",
+    "llm_id_if_any": null
+  },
+  "updated_at": "2026-04-26T00:00:00Z",
+  "evidence": {
+    "recall_count": 0,
+    "score": 0.0,
+    "unique_queries": 0,
+    "recency_half_life_days": 14
+  },
+  "salience": 0.5,
+  "confidence": 0.7,
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "usr:tafeng",
+      "at": "2026-04-26T00:00:00Z"
+    }
+  ],
+  "signature": "ed25519:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__record_semantic_private_user.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__record_semantic_private_user.snap
@@ -1,0 +1,39 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&r"
+---
+{
+  "id": "01HQZX9F5N0000000000000000",
+  "kind": "user",
+  "class": "semantic",
+  "visibility": "private",
+  "scope": {
+    "user": "usr:tafeng"
+  },
+  "body": "User prefers dark mode and compact UI density.",
+  "provenance": {
+    "source_sensor": "snr:local:hook:cc-session:v1",
+    "created_at": "2026-04-26T00:00:00Z",
+    "originating_agent_id": "usr:tafeng",
+    "source_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "consent_ref": "consent:01HQZ",
+    "llm_id_if_any": null
+  },
+  "updated_at": "2026-04-26T00:00:00Z",
+  "evidence": {
+    "recall_count": 0,
+    "score": 0.0,
+    "unique_queries": 0,
+    "recency_half_life_days": 14
+  },
+  "salience": 0.5,
+  "confidence": 0.7,
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "usr:tafeng",
+      "at": "2026-04-26T00:00:00Z"
+    }
+  ],
+  "signature": "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__response_committed_search.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__response_committed_search.snap
@@ -1,0 +1,26 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&r"
+---
+{
+  "contract": "cairn.mcp.v1",
+  "data": {
+    "hits": [
+      {
+        "record_id": "01HQZX9F5N0000000000000000",
+        "score": 0.92,
+        "snippet": "user prefers dark mode and vim keybindings",
+        "trust": "unverified"
+      }
+    ]
+  },
+  "operation_id": "01HQZX9F5N0000000000000006",
+  "policy_trace": [
+    {
+      "gate": "consent.check",
+      "result": "pass"
+    }
+  ],
+  "status": "committed",
+  "verb": "search"
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__response_rejected_invalid_args.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__response_rejected_invalid_args.snap
@@ -1,0 +1,19 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&r"
+---
+{
+  "contract": "cairn.mcp.v1",
+  "error": {
+    "code": "InvalidArgs",
+    "data": {
+      "field": "query",
+      "reason": "must not be empty"
+    },
+    "message": "query must not be empty"
+  },
+  "operation_id": "01HQZX9F5N0000000000000007",
+  "policy_trace": [],
+  "status": "rejected",
+  "verb": "search"
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__search_args_keyword.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__search_args_keyword.snap
@@ -1,0 +1,24 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&a"
+---
+{
+  "citations": "compact",
+  "filters": {
+    "and": [
+      {
+        "field": "kind",
+        "op": "eq",
+        "value": "user"
+      },
+      {
+        "field": "visibility",
+        "op": "eq",
+        "value": "private"
+      }
+    ]
+  },
+  "limit": 10,
+  "mode": "keyword",
+  "query": "dark mode vim keybindings"
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__signed_intent_challenge.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__signed_intent_challenge.snap
@@ -1,0 +1,22 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&si"
+---
+{
+  "chain_parents": [],
+  "expires_at": "2026-04-26T01:00:00Z",
+  "issued_at": "2026-04-26T00:00:00Z",
+  "issuer": "agt:claude-code:sonnet-4-6:main:v1",
+  "key_version": 1,
+  "nonce": "BBBBBBBBBBBBBBBBBBBBBA==",
+  "operation_id": "01HQZX9F5N0000000000000005",
+  "scope": {
+    "entity": "cairn",
+    "tenant": "acme",
+    "tier": "private",
+    "workspace": "main"
+  },
+  "server_challenge": "CCCCCCCCCCCCCCCCCCCCCA==",
+  "signature": "ed25519:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "target_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__signed_intent_sequence.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__signed_intent_sequence.snap
@@ -1,0 +1,22 @@
+---
+source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+expression: "&si"
+---
+{
+  "chain_parents": [],
+  "expires_at": "2026-04-26T01:00:00Z",
+  "issued_at": "2026-04-26T00:00:00Z",
+  "issuer": "usr:tafeng",
+  "key_version": 1,
+  "nonce": "AAAAAAAAAAAAAAAAAAAAAA==",
+  "operation_id": "01HQZX9F5N0000000000000000",
+  "scope": {
+    "entity": "cairn",
+    "tenant": "acme",
+    "tier": "project",
+    "workspace": "main"
+  },
+  "sequence": 1,
+  "signature": "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "target_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,6 +1,40 @@
 # Cairn test fixtures
 
-Sample vaults, markdown, and SQLite snapshots used by crate tests.
+Golden records, config, envelopes, search filters, and plugin manifests for CI schema validation.
 
-Consumed through the `cairn-test-fixtures` crate's `fixtures_dir()` helper.
-Real fixtures land with the storage and verb-behaviour issues.
+## Layout
+
+```
+fixtures/
+└── v0/                    ← canonical P0 schema snapshot (never mutated)
+    ├── records/           ← one JSON per memory-class × visibility-tier combination
+    ├── config/            ← CairnConfig JSON examples
+    ├── envelopes/         ← SignedIntent + Response wire fixtures
+    ├── search-filters/    ← SearchArgsFilters + SearchArgs examples
+    └── manifests/         ← plugin.toml manifests for each ContractKind
+```
+
+Consumed through the `cairn-test-fixtures` crate's `fixtures_dir()` and `fixture_v0_dir()` helpers.
+
+## Loading in tests
+
+```rust
+let path = cairn_test_fixtures::fixture_v0_dir().join("records/semantic_private_user.json");
+let raw = std::fs::read_to_string(&path).expect("fixture must exist");
+let record: MemoryRecord = serde_json::from_str(&raw).expect("must parse");
+record.validate().expect("must be valid");
+```
+
+## Migration workflow
+
+When a schema change is intentional:
+
+1. Copy `v0/` → `v1/`, update the changed fixtures in `v1/`.
+2. Keep `v0/` intact — it proves old vaults still load.
+3. Add a migration test in `schema_fixtures.rs` that loads `v0/` fixtures with the new schema.
+4. Run `cargo insta review` to accept new snapshots.
+5. Include the snapshot files in the same commit as the schema change.
+
+## CI
+
+`cargo nextest run --workspace` runs `cairn_test_fixtures::tests::schema_fixtures` automatically. The `insta` snapshots act as a schema-drift gate: if a schema change breaks deserialization or shifts the wire form, the test fails and the snapshot diff is shown.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -37,4 +37,4 @@ When a schema change is intentional:
 
 ## CI
 
-`cargo nextest run --workspace` runs `cairn_test_fixtures::tests::schema_fixtures` automatically. The `insta` snapshots act as a schema-drift gate: if a schema change breaks deserialization or shifts the wire form, the test fails and the snapshot diff is shown.
+`cargo nextest run --workspace` runs the `schema_fixtures` test binary automatically. The `insta` snapshots act as a schema-drift gate: if a schema change breaks deserialization or shifts the wire form, the test fails and the snapshot diff is shown.

--- a/fixtures/v0/config/custom-store.json
+++ b/fixtures/v0/config/custom-store.json
@@ -1,0 +1,38 @@
+{
+  "vault": {
+    "name": "my-vault",
+    "tier": "local",
+    "layout": {
+      "sources": "sources",
+      "records": "raw",
+      "wiki": "wiki",
+      "skills": "skills",
+      "enabled_kinds": ["user","feedback","fact","rule"],
+      "file_naming": "{kind}_{slug}.md",
+      "index": { "max_lines": 200, "max_bytes": 25600 }
+    },
+    "hot_memory": {
+      "recipe": ["purpose","index","pinned_feedback"],
+      "max_bytes": 8192
+    },
+    "retention": {
+      "raw/trace_*.md": "30d",
+      "raw/sensor_observation_*.md": "7d"
+    },
+    "schema_files": ["CLAUDE.md","AGENTS.md","GEMINI.md"]
+  },
+  "store": { "kind": "custom:cairn-store-qdrant" },
+  "llm": { "provider": null, "base_url": null, "model": null, "api_key": null },
+  "sensors": {
+    "hooks": { "enabled": true },
+    "ide": { "enabled": true },
+    "screen": { "enabled": false },
+    "slack": { "enabled": false, "scope": [] }
+  },
+  "workflows": { "orchestrator": "local" },
+  "pipeline": {
+    "extract": {
+      "chain": [{ "worker": "regex", "kinds": [], "trigger": null, "budget": {"max_tokens": null,"max_wall_ms": null,"max_turns": null} }]
+    }
+  }
+}

--- a/fixtures/v0/config/llm-enabled.json
+++ b/fixtures/v0/config/llm-enabled.json
@@ -1,0 +1,43 @@
+{
+  "vault": {
+    "name": "my-vault",
+    "tier": "local",
+    "layout": {
+      "sources": "sources",
+      "records": "raw",
+      "wiki": "wiki",
+      "skills": "skills",
+      "enabled_kinds": [],
+      "file_naming": "{kind}_{slug}.md",
+      "index": { "max_lines": 200, "max_bytes": 25600 }
+    },
+    "hot_memory": {
+      "recipe": ["purpose","index","pinned_feedback","top_salience_project","active_playbook","recent_user_signal"],
+      "max_bytes": 25600
+    },
+    "retention": {},
+    "schema_files": ["CLAUDE.md","AGENTS.md","GEMINI.md"]
+  },
+  "store": { "kind": "sqlite" },
+  "llm": {
+    "provider": "openai-compatible",
+    "base_url": "http://localhost:11434/v1",
+    "model": "${CAIRN_MODEL}",
+    "api_key": "${OPENAI_API_KEY}"
+  },
+  "sensors": {
+    "hooks": { "enabled": true },
+    "ide": { "enabled": true },
+    "screen": { "enabled": false },
+    "slack": { "enabled": false, "scope": [] }
+  },
+  "workflows": { "orchestrator": "local" },
+  "pipeline": {
+    "extract": {
+      "chain": [
+        { "worker": "regex", "kinds": [], "trigger": null, "budget": {"max_tokens": null,"max_wall_ms": null,"max_turns": null} },
+        { "worker": "llm", "kinds": [], "trigger": "confidence_below", "budget": {"max_tokens": 4096,"max_wall_ms": 10000,"max_turns": null} }
+      ]
+    }
+  }
+}

--- a/fixtures/v0/config/llm-enabled.json
+++ b/fixtures/v0/config/llm-enabled.json
@@ -35,7 +35,7 @@
   "pipeline": {
     "extract": {
       "chain": [
-        { "worker": "regex", "kinds": [], "trigger": null, "budget": {"max_tokens": null,"max_wall_ms": null,"max_turns": null} },
+        { "worker": "regex", "kinds": ["feedback", "rule"], "trigger": null, "budget": {"max_tokens": null,"max_wall_ms": null,"max_turns": null} },
         { "worker": "llm", "kinds": [], "trigger": "confidence_below", "budget": {"max_tokens": 4096,"max_wall_ms": 10000,"max_turns": null} }
       ]
     }

--- a/fixtures/v0/config/p0-defaults.json
+++ b/fixtures/v0/config/p0-defaults.json
@@ -1,0 +1,35 @@
+{
+  "vault": {
+    "name": "my-vault",
+    "tier": "local",
+    "layout": {
+      "sources": "sources",
+      "records": "raw",
+      "wiki": "wiki",
+      "skills": "skills",
+      "enabled_kinds": [],
+      "file_naming": "{kind}_{slug}.md",
+      "index": { "max_lines": 200, "max_bytes": 25600 }
+    },
+    "hot_memory": {
+      "recipe": ["purpose","index","pinned_feedback","top_salience_project","active_playbook","recent_user_signal"],
+      "max_bytes": 25600
+    },
+    "retention": {},
+    "schema_files": ["CLAUDE.md","AGENTS.md","GEMINI.md"]
+  },
+  "store": { "kind": "sqlite" },
+  "llm": { "provider": null, "base_url": null, "model": null, "api_key": null },
+  "sensors": {
+    "hooks": { "enabled": true },
+    "ide": { "enabled": true },
+    "screen": { "enabled": false },
+    "slack": { "enabled": false, "scope": [] }
+  },
+  "workflows": { "orchestrator": "local" },
+  "pipeline": {
+    "extract": {
+      "chain": [{ "worker": "regex", "kinds": [], "trigger": null, "budget": {"max_tokens": null,"max_wall_ms": null,"max_turns": null} }]
+    }
+  }
+}

--- a/fixtures/v0/envelopes/response-committed-search.json
+++ b/fixtures/v0/envelopes/response-committed-search.json
@@ -1,0 +1,22 @@
+{
+  "contract": "cairn.mcp.v1",
+  "data": {
+    "hits": [
+      {
+        "record_id": "01HQZX9F5N0000000000000000",
+        "score": 0.92,
+        "trust": "unverified",
+        "snippet": "user prefers dark mode and vim keybindings"
+      }
+    ]
+  },
+  "operation_id": "01HQZX9F5N0000000000000006",
+  "policy_trace": [
+    {
+      "gate": "consent.check",
+      "result": "pass"
+    }
+  ],
+  "status": "committed",
+  "verb": "search"
+}

--- a/fixtures/v0/envelopes/response-rejected-invalid-args.json
+++ b/fixtures/v0/envelopes/response-rejected-invalid-args.json
@@ -1,0 +1,15 @@
+{
+  "contract": "cairn.mcp.v1",
+  "error": {
+    "code": "InvalidArgs",
+    "message": "query must not be empty",
+    "data": {
+      "field": "query",
+      "reason": "must not be empty"
+    }
+  },
+  "operation_id": "01HQZX9F5N0000000000000007",
+  "policy_trace": [],
+  "status": "rejected",
+  "verb": "search"
+}

--- a/fixtures/v0/envelopes/signed-intent-challenge.json
+++ b/fixtures/v0/envelopes/signed-intent-challenge.json
@@ -1,0 +1,18 @@
+{
+  "chain_parents": [],
+  "expires_at": "2026-04-26T01:00:00Z",
+  "issued_at": "2026-04-26T00:00:00Z",
+  "issuer": "agt:claude-code:sonnet-4-6:main:v1",
+  "key_version": 1,
+  "nonce": "BBBBBBBBBBBBBBBBBBBBBA==",
+  "operation_id": "01HQZX9F5N0000000000000005",
+  "scope": {
+    "entity": "cairn",
+    "tenant": "acme",
+    "tier": "private",
+    "workspace": "main"
+  },
+  "server_challenge": "CCCCCCCCCCCCCCCCCCCCCA==",
+  "signature": "ed25519:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "target_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/fixtures/v0/envelopes/signed-intent-sequence.json
+++ b/fixtures/v0/envelopes/signed-intent-sequence.json
@@ -1,0 +1,18 @@
+{
+  "chain_parents": [],
+  "expires_at": "2026-04-26T01:00:00Z",
+  "issued_at": "2026-04-26T00:00:00Z",
+  "issuer": "usr:tafeng",
+  "key_version": 1,
+  "nonce": "AAAAAAAAAAAAAAAAAAAAAA==",
+  "operation_id": "01HQZX9F5N0000000000000000",
+  "scope": {
+    "entity": "cairn",
+    "tenant": "acme",
+    "tier": "project",
+    "workspace": "main"
+  },
+  "sequence": 1,
+  "signature": "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "target_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/fixtures/v0/manifests/cairn-llm-openai-compat.toml
+++ b/fixtures/v0/manifests/cairn-llm-openai-compat.toml
@@ -1,0 +1,16 @@
+name = "cairn-llm-openai-compat"
+contract = "LLMProvider"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+streaming = true
+function_calling = true

--- a/fixtures/v0/manifests/cairn-store-sqlite.toml
+++ b/fixtures/v0/manifests/cairn-store-sqlite.toml
@@ -1,0 +1,17 @@
+name = "cairn-store-sqlite"
+contract = "MemoryStore"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+fts = true
+vector = false
+graph_edges = false

--- a/fixtures/v0/records/episodic_session_trace.json
+++ b/fixtures/v0/records/episodic_session_trace.json
@@ -1,0 +1,36 @@
+{
+  "id": "01HQZX9F5N0000000000000001",
+  "kind": "trace",
+  "class": "episodic",
+  "visibility": "session",
+  "scope": {
+    "session_id": "01HQZX9F5N0000000000000002",
+    "agent": "agt:claude-code:sonnet-4-6:main:v1"
+  },
+  "body": "Agent completed the ingest verb implementation for the cairn-cli crate.",
+  "provenance": {
+    "source_sensor": "snr:local:hook:cc-session:v1",
+    "created_at": "2026-04-26T00:00:00Z",
+    "originating_agent_id": "agt:claude-code:sonnet-4-6:main:v1",
+    "source_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "consent_ref": "consent:01HQZ",
+    "llm_id_if_any": "claude-sonnet-4-6"
+  },
+  "updated_at": "2026-04-26T00:00:00Z",
+  "evidence": {
+    "recall_count": 0,
+    "score": 0.0,
+    "unique_queries": 0,
+    "recency_half_life_days": 14
+  },
+  "salience": 0.5,
+  "confidence": 0.7,
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "agt:claude-code:sonnet-4-6:main:v1",
+      "at": "2026-04-26T00:00:00Z"
+    }
+  ],
+  "signature": "ed25519:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+}

--- a/fixtures/v0/records/graph_team_entity.json
+++ b/fixtures/v0/records/graph_team_entity.json
@@ -1,0 +1,36 @@
+{
+  "id": "01HQZX9F5N0000000000000004",
+  "kind": "entity",
+  "class": "graph",
+  "visibility": "team",
+  "scope": {
+    "entity": "acme-corp",
+    "user": "usr:tafeng"
+  },
+  "body": "Acme Corp is the primary enterprise customer for the Cairn pilot deployment.",
+  "provenance": {
+    "source_sensor": "snr:local:hook:cc-session:v1",
+    "created_at": "2026-04-26T00:00:00Z",
+    "originating_agent_id": "usr:tafeng",
+    "source_hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "consent_ref": "consent:01HQZ",
+    "llm_id_if_any": null
+  },
+  "updated_at": "2026-04-26T00:00:00Z",
+  "evidence": {
+    "recall_count": 0,
+    "score": 0.0,
+    "unique_queries": 0,
+    "recency_half_life_days": 14
+  },
+  "salience": 0.5,
+  "confidence": 0.7,
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "usr:tafeng",
+      "at": "2026-04-26T00:00:00Z"
+    }
+  ],
+  "signature": "ed25519:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+}

--- a/fixtures/v0/records/procedural_project_playbook.json
+++ b/fixtures/v0/records/procedural_project_playbook.json
@@ -1,0 +1,36 @@
+{
+  "id": "01HQZX9F5N0000000000000003",
+  "kind": "playbook",
+  "class": "procedural",
+  "visibility": "project",
+  "scope": {
+    "entity": "cairn",
+    "user": "usr:tafeng"
+  },
+  "body": "Run cargo nextest before every push; fix all clippy warnings before opening a PR.",
+  "provenance": {
+    "source_sensor": "snr:local:hook:cc-session:v1",
+    "created_at": "2026-04-26T00:00:00Z",
+    "originating_agent_id": "usr:tafeng",
+    "source_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "consent_ref": "consent:01HQZ",
+    "llm_id_if_any": null
+  },
+  "updated_at": "2026-04-26T00:00:00Z",
+  "evidence": {
+    "recall_count": 0,
+    "score": 0.0,
+    "unique_queries": 0,
+    "recency_half_life_days": 14
+  },
+  "salience": 0.5,
+  "confidence": 0.7,
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "usr:tafeng",
+      "at": "2026-04-26T00:00:00Z"
+    }
+  ],
+  "signature": "ed25519:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}

--- a/fixtures/v0/records/semantic_private_user.json
+++ b/fixtures/v0/records/semantic_private_user.json
@@ -1,0 +1,35 @@
+{
+  "id": "01HQZX9F5N0000000000000000",
+  "kind": "user",
+  "class": "semantic",
+  "visibility": "private",
+  "scope": {
+    "user": "usr:tafeng"
+  },
+  "body": "User prefers dark mode and compact UI density.",
+  "provenance": {
+    "source_sensor": "snr:local:hook:cc-session:v1",
+    "created_at": "2026-04-26T00:00:00Z",
+    "originating_agent_id": "usr:tafeng",
+    "source_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "consent_ref": "consent:01HQZ",
+    "llm_id_if_any": null
+  },
+  "updated_at": "2026-04-26T00:00:00Z",
+  "evidence": {
+    "recall_count": 0,
+    "score": 0.0,
+    "unique_queries": 0,
+    "recency_half_life_days": 14
+  },
+  "salience": 0.5,
+  "confidence": 0.7,
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "usr:tafeng",
+      "at": "2026-04-26T00:00:00Z"
+    }
+  ],
+  "signature": "ed25519:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/fixtures/v0/search-filters/and-two-leaves.json
+++ b/fixtures/v0/search-filters/and-two-leaves.json
@@ -1,0 +1,6 @@
+{
+  "and": [
+    {"field": "visibility", "op": "eq", "value": "private"},
+    {"field": "salience", "op": "gte", "value": 0.5}
+  ]
+}

--- a/fixtures/v0/search-filters/leaf-eq.json
+++ b/fixtures/v0/search-filters/leaf-eq.json
@@ -1,0 +1,1 @@
+{"field": "kind", "op": "eq", "value": "user"}

--- a/fixtures/v0/search-filters/or-with-not.json
+++ b/fixtures/v0/search-filters/or-with-not.json
@@ -1,6 +1,6 @@
 {
   "or": [
     {"field": "kind", "op": "in", "value": ["user", "feedback", "rule"]},
-    {"not": {"field": "visibility", "op": "eq", "value": "public"}}
+    {"not": {"field": "visibility", "op": "eq", "value": "private"}}
   ]
 }

--- a/fixtures/v0/search-filters/or-with-not.json
+++ b/fixtures/v0/search-filters/or-with-not.json
@@ -1,0 +1,6 @@
+{
+  "or": [
+    {"field": "kind", "op": "in", "value": ["user", "feedback", "rule"]},
+    {"not": {"field": "visibility", "op": "eq", "value": "public"}}
+  ]
+}

--- a/fixtures/v0/search-filters/search-args-keyword.json
+++ b/fixtures/v0/search-filters/search-args-keyword.json
@@ -1,0 +1,12 @@
+{
+  "mode": "keyword",
+  "query": "dark mode vim keybindings",
+  "limit": 10,
+  "citations": "compact",
+  "filters": {
+    "and": [
+      {"field": "kind", "op": "eq", "value": "user"},
+      {"field": "visibility", "op": "eq", "value": "private"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `fixtures/v0/` with 17 canonical golden files covering all P0 schema surfaces: records (4 memory-class × visibility-tier combinations), config (3 variants), signed envelopes + responses (4), search filters (4), and plugin manifests (2 TOML)
- Adds 18 `insta` snapshot tests in `cairn-test-fixtures` that deserialize every fixture, call `validate()` where exposed, and gate CI on schema drift
- Adds `fixture_v0_dir()` helper to `cairn-test-fixtures::lib` and documents the versioned-layout migration workflow in `fixtures/README.md`

## Test Plan

- [x] `cargo nextest run --workspace --locked` — 589/589 pass
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — no warnings
- [x] All 17 insta snapshots committed; CI will fail on any undeclared drift
- [x] Migration workflow documented: copy `v0/` → `v1/`, update changed fixtures, run `cargo insta review`

Closes #40