### PR TITLE
feat(bootstrap): full vault initialization, receipt, idempotency (§3.1, #41)

### DIFF
--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { workspace = true }
 ulid = { workspace = true }
 base64 = { workspace = true }
 serde_yaml = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 cairn-test-fixtures = { workspace = true }
@@ -40,10 +41,6 @@ tempfile = { workspace = true }
 
 [lints]
 workspace = true
-
-# anyhow is declared now; its first call site lands when verb logic is wired in #9.
-[package.metadata.cargo-machete]
-ignored = ["anyhow"]
 
 [lib]
 name = "cairn_cli"

--- a/crates/cairn-cli/src/config.rs
+++ b/crates/cairn-cli/src/config.rs
@@ -95,36 +95,6 @@ pub fn load(vault_path: &Path, cli: &CliOverrides) -> Result<CairnConfig> {
     Ok(config)
 }
 
-/// Write the serialized default config to `<vault_path>/.cairn/config.yaml`.
-///
-/// Creates `.cairn/` if it does not exist. Fails if the file already exists
-/// so that re-running bootstrap never silently overwrites user edits.
-///
-/// # Errors
-/// Returns an error if the config file already exists, the directory cannot be
-/// created, YAML serialization fails, or the file cannot be written.
-pub fn write_default(vault_path: &Path) -> Result<()> {
-    let config_dir = vault_path.join(".cairn");
-    let config_path = config_dir.join("config.yaml");
-
-    anyhow::ensure!(
-        !config_path.exists(),
-        "{} already exists; delete it first to re-bootstrap",
-        config_path.display()
-    );
-
-    std::fs::create_dir_all(&config_dir)
-        .with_context(|| format!("creating {}", config_dir.display()))?;
-
-    let yaml = serde_yaml::to_string(&CairnConfig::default())
-        .context("serializing default config to YAML")?;
-
-    std::fs::write(&config_path, yaml)
-        .with_context(|| format!("writing {}", config_path.display()))?;
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cairn-cli/src/lib.rs
+++ b/crates/cairn-cli/src/lib.rs
@@ -7,4 +7,5 @@
 
 pub mod config;
 pub mod plugins;
+pub mod vault;
 pub mod verbs;

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -8,7 +8,6 @@
 use std::io::Write;
 use std::process::ExitCode;
 
-use cairn_cli::config as cli_config;
 use cairn_cli::{plugins, verbs};
 use cairn_core::contract::registry::PluginError;
 use clap::ArgMatches;
@@ -42,13 +41,25 @@ fn build_command() -> clap::Command {
 
 fn bootstrap_subcommand() -> clap::Command {
     clap::Command::new("bootstrap")
-        .about("Write a default .cairn/config.yaml to a vault directory")
+        .about("Initialize a vault directory tree with the §3 layout")
         .arg(
             clap::Arg::new("vault-path")
                 .long("vault-path")
                 .default_value(".")
                 .value_name("PATH")
                 .help("Vault root directory (default: current directory)"),
+        )
+        .arg(
+            clap::Arg::new("json")
+                .long("json")
+                .action(clap::ArgAction::SetTrue)
+                .help("Emit JSON receipt instead of human-readable output"),
+        )
+        .arg(
+            clap::Arg::new("force")
+                .long("force")
+                .action(clap::ArgAction::SetTrue)
+                .help("Overwrite existing placeholder files"),
         )
 }
 
@@ -124,21 +135,29 @@ fn run_bootstrap(matches: &ArgMatches) -> ExitCode {
     let vault_path = std::path::PathBuf::from(
         matches
             .get_one::<String>("vault-path")
-            .expect("vault-path has a default value"),
+            .expect("invariant: vault-path has a default value"),
     );
+    let json = matches.get_flag("json");
+    let force = matches.get_flag("force");
 
-    match cli_config::write_default(&vault_path) {
-        Ok(()) => {
-            println!(
-                "cairn bootstrap: wrote default config to {}",
-                vault_path.join(".cairn/config.yaml").display()
-            );
+    let opts = cairn_cli::vault::BootstrapOpts { vault_path, force };
+
+    match cairn_cli::vault::bootstrap(&opts) {
+        Ok(receipt) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&receipt)
+                        .expect("invariant: BootstrapReceipt is always serializable")
+                );
+            } else {
+                println!("{}", cairn_cli::vault::render_human(&receipt));
+            }
             ExitCode::SUCCESS
         }
         Err(e) => {
-            // EX_CONFIG (78) — bad config or file already exists
             eprintln!("cairn bootstrap: {e:#}");
-            ExitCode::from(78)
+            ExitCode::from(74) // EX_IOERR
         }
     }
 }

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use cairn_core::config::CairnConfig;
 
 /// Options for [`bootstrap`].
+#[derive(Debug, Clone)]
 pub struct BootstrapOpts {
     /// The root directory for the vault.
     pub vault_path: PathBuf,
@@ -92,15 +93,19 @@ pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
         } else {
             receipt.dirs_created.push(dir.clone());
         }
-        std::fs::create_dir_all(&dir)
-            .with_context(|| format!("creating {}", dir.display()))?;
+        std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
     }
 
     // --- placeholder files ---
     let config_yaml = serde_yaml::to_string(&CairnConfig::default())
         .context("serializing default config to YAML")?;
     write_once(&config_path, &config_yaml, opts.force, &mut receipt)?;
-    write_once(&vault.join("purpose.md"), PURPOSE_MD, opts.force, &mut receipt)?;
+    write_once(
+        &vault.join("purpose.md"),
+        PURPOSE_MD,
+        opts.force,
+        &mut receipt,
+    )?;
     write_once(&vault.join("index.md"), "", opts.force, &mut receipt)?;
     write_once(&vault.join("log.md"), "", opts.force, &mut receipt)?;
 
@@ -147,8 +152,7 @@ fn write_once(
         receipt.files_skipped.push(path.to_owned());
         return Ok(());
     }
-    std::fs::write(path, content)
-        .with_context(|| format!("writing {}", path.display()))?;
+    std::fs::write(path, content).with_context(|| format!("writing {}", path.display()))?;
     receipt.files_created.push(path.to_owned());
     Ok(())
 }

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -1,0 +1,154 @@
+//! Vault initialization for `cairn bootstrap` (brief §3, §3.1).
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use cairn_core::config::CairnConfig;
+
+/// Options for [`bootstrap`].
+pub struct BootstrapOpts {
+    /// The root directory for the vault.
+    pub vault_path: PathBuf,
+    /// If `true`, overwrite existing placeholder files.
+    pub force: bool,
+}
+
+/// Result of a bootstrap run, emitted as JSON with `--json` or formatted by
+/// [`render_human`].
+#[derive(Debug, Serialize)]
+pub struct BootstrapReceipt {
+    /// The root vault directory.
+    pub vault_path: PathBuf,
+    /// Path to the generated config file.
+    pub config_path: PathBuf,
+    /// Path where the `SQLite` database will be created on first ingest.
+    pub db_path: PathBuf,
+    /// Directories that were newly created.
+    pub dirs_created: Vec<PathBuf>,
+    /// Directories that already existed.
+    pub dirs_existing: Vec<PathBuf>,
+    /// Placeholder files that were newly written.
+    pub files_created: Vec<PathBuf>,
+    /// Placeholder files that were skipped because they already existed.
+    pub files_skipped: Vec<PathBuf>,
+}
+
+/// All directories the vault layout requires (brief §3.1). Listed in creation
+/// order so parents always precede children.
+const VAULT_DIRS: &[&str] = &[
+    "sources",
+    "sources/articles",
+    "sources/papers",
+    "sources/transcripts",
+    "sources/documents",
+    "sources/chat",
+    "sources/assets",
+    "raw",
+    "wiki",
+    "wiki/entities",
+    "wiki/concepts",
+    "wiki/summaries",
+    "wiki/synthesis",
+    "wiki/prompts",
+    "skills",
+    ".cairn",
+    ".cairn/evolution",
+    ".cairn/cache",
+    ".cairn/models",
+];
+
+const PURPOSE_MD: &str = "# Purpose\n\n<!-- Why does this vault exist? -->\n";
+
+/// Initialize the vault directory tree and placeholder files at `opts.vault_path`.
+///
+/// Idempotent: existing directories are left unchanged; existing files are
+/// added to [`BootstrapReceipt::files_skipped`] unless `opts.force` is set.
+///
+/// # Errors
+/// Returns an error if any directory cannot be created or any file cannot be
+/// written.
+pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
+    let vault = &opts.vault_path;
+    let config_path = vault.join(".cairn/config.yaml");
+    let db_path = vault.join(".cairn/cairn.db");
+
+    let mut receipt = BootstrapReceipt {
+        vault_path: vault.clone(),
+        config_path: config_path.clone(),
+        db_path,
+        dirs_created: Vec::new(),
+        dirs_existing: Vec::new(),
+        files_created: Vec::new(),
+        files_skipped: Vec::new(),
+    };
+
+    // --- directory tree ---
+    for rel in VAULT_DIRS {
+        let dir = vault.join(rel);
+        if dir.exists() {
+            receipt.dirs_existing.push(dir.clone());
+        } else {
+            receipt.dirs_created.push(dir.clone());
+        }
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating {}", dir.display()))?;
+    }
+
+    // --- placeholder files ---
+    let config_yaml = serde_yaml::to_string(&CairnConfig::default())
+        .context("serializing default config to YAML")?;
+    write_once(&config_path, &config_yaml, opts.force, &mut receipt)?;
+    write_once(&vault.join("purpose.md"), PURPOSE_MD, opts.force, &mut receipt)?;
+    write_once(&vault.join("index.md"), "", opts.force, &mut receipt)?;
+    write_once(&vault.join("log.md"), "", opts.force, &mut receipt)?;
+
+    Ok(receipt)
+}
+
+/// Render a human-readable summary of a bootstrap receipt.
+#[must_use]
+pub fn render_human(receipt: &BootstrapReceipt) -> String {
+    let header = if receipt.dirs_created.is_empty() && receipt.files_created.is_empty() {
+        format!(
+            "cairn bootstrap: vault already initialized at {}",
+            receipt.vault_path.display()
+        )
+    } else {
+        format!(
+            "cairn bootstrap: vault initialized at {}",
+            receipt.vault_path.display()
+        )
+    };
+    let config_status = if receipt.files_skipped.contains(&receipt.config_path) {
+        "existing"
+    } else {
+        "created"
+    };
+    format!(
+        "{header}\n  config    {}  [{config_status}]\n  db        {}  (created on first ingest)\n  dirs      {} created, {} existing\n  files     {} created, {} skipped",
+        receipt.config_path.display(),
+        receipt.db_path.display(),
+        receipt.dirs_created.len(),
+        receipt.dirs_existing.len(),
+        receipt.files_created.len(),
+        receipt.files_skipped.len(),
+    )
+}
+
+fn write_once(
+    path: &std::path::Path,
+    content: &str,
+    force: bool,
+    receipt: &mut BootstrapReceipt,
+) -> Result<()> {
+    if path.exists() && !force {
+        receipt.files_skipped.push(path.to_owned());
+        return Ok(());
+    }
+    std::fs::write(path, content)
+        .with_context(|| format!("writing {}", path.display()))?;
+    receipt.files_created.push(path.to_owned());
+    Ok(())
+}

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -80,13 +80,13 @@ pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
     // we must operate on the clean form.
     let vault = vault.components().collect::<PathBuf>();
     let vault = &vault;
-    if let Ok(meta) = std::fs::symlink_metadata(vault) {
-        if meta.file_type().is_symlink() {
-            anyhow::bail!(
-                "{} is a symlink — pass the real vault path to bootstrap",
-                vault.display()
-            );
-        }
+    if let Ok(meta) = std::fs::symlink_metadata(vault)
+        && meta.file_type().is_symlink()
+    {
+        anyhow::bail!(
+            "{} is a symlink — pass the real vault path to bootstrap",
+            vault.display()
+        );
     }
 
     let config_path = vault.join(".cairn/config.yaml");
@@ -188,13 +188,13 @@ fn write_once(
     // would redirect every subsequent operation, so we reject it on every
     // code path, not just the write path.
     let dir = path.parent().unwrap_or(std::path::Path::new("."));
-    if let Ok(meta) = std::fs::symlink_metadata(dir) {
-        if meta.file_type().is_symlink() {
-            anyhow::bail!(
-                "parent directory {} is a symlink — bootstrap will not write through it",
-                dir.display()
-            );
-        }
+    if let Ok(meta) = std::fs::symlink_metadata(dir)
+        && meta.file_type().is_symlink()
+    {
+        anyhow::bail!(
+            "parent directory {} is a symlink — bootstrap will not write through it",
+            dir.display()
+        );
     }
 
     // Inspect the final target without following symlinks.

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -183,6 +183,20 @@ fn write_once(
 ) -> Result<()> {
     use std::io::Write as _;
 
+    // Validate the parent directory first, before any path — including the
+    // early-return skip path.  A symlink-swapped parent (e.g. `.cairn`)
+    // would redirect every subsequent operation, so we reject it on every
+    // code path, not just the write path.
+    let dir = path.parent().unwrap_or(std::path::Path::new("."));
+    if let Ok(meta) = std::fs::symlink_metadata(dir) {
+        if meta.file_type().is_symlink() {
+            anyhow::bail!(
+                "parent directory {} is a symlink — bootstrap will not write through it",
+                dir.display()
+            );
+        }
+    }
+
     // Inspect the final target without following symlinks.
     if let Ok(meta) = std::fs::symlink_metadata(path) {
         let ft = meta.file_type();
@@ -211,19 +225,6 @@ fn write_once(
     // A random name eliminates the predictable-temp-path symlink attack.
     // Both the force and non-force paths use this temp file; only the final
     // publish step differs.
-    //
-    // Re-validate the parent directory immediately before opening the temp
-    // file: a symlink swap of the parent after the directory-tree pass
-    // would otherwise let the write escape to the symlink target.
-    let dir = path.parent().unwrap_or(std::path::Path::new("."));
-    if let Ok(meta) = std::fs::symlink_metadata(dir) {
-        if meta.file_type().is_symlink() {
-            anyhow::bail!(
-                "parent directory {} is a symlink — bootstrap will not write through it",
-                dir.display()
-            );
-        }
-    }
     let mut tmp = tempfile::Builder::new()
         .prefix(".bootstrap")
         .tempfile_in(dir)

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -116,6 +116,17 @@ pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
             Err(_) => receipt.dirs_created.push(dir.clone()),
         }
         std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        // Post-creation check: a symlink swap between the lstat above and
+        // create_dir_all would make the created path land in the link target.
+        // Re-lstat immediately after creation to catch persistent symlinks.
+        let post = std::fs::symlink_metadata(&dir)
+            .with_context(|| format!("verifying {} after creation", dir.display()))?;
+        if post.file_type().is_symlink() {
+            anyhow::bail!(
+                "{} became a symlink during creation — possible race attack",
+                dir.display()
+            );
+        }
     }
 
     // --- placeholder files ---

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -148,11 +148,70 @@ fn write_once(
     force: bool,
     receipt: &mut BootstrapReceipt,
 ) -> Result<()> {
-    if path.exists() && !force {
-        receipt.files_skipped.push(path.to_owned());
-        return Ok(());
+    use std::io::Write as _;
+
+    // Reject symlinks regardless of force — writing through a symlink can
+    // affect paths outside the vault, which is never intended by bootstrap.
+    if let Ok(meta) = std::fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            anyhow::bail!(
+                "{} is a symlink — bootstrap will not write through it",
+                path.display()
+            );
+        }
+        if !force {
+            receipt.files_skipped.push(path.to_owned());
+            return Ok(());
+        }
+        // force=true, file exists, not a symlink — fall through to atomic overwrite
     }
-    std::fs::write(path, content).with_context(|| format!("writing {}", path.display()))?;
+
+    if force {
+        // Atomic overwrite: write to a sibling temp file, sync, then rename.
+        // rename(2) is atomic on the same filesystem — the target sees either
+        // the old content or the new content, never a partial write.
+        let dir = path.parent().unwrap_or(std::path::Path::new("."));
+        let tmp_name = format!(
+            ".{}.bootstrap.tmp",
+            path.file_name().and_then(|n| n.to_str()).unwrap_or("file")
+        );
+        let tmp = dir.join(tmp_name);
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp)
+                .with_context(|| format!("creating temp file {}", tmp.display()))?;
+            f.write_all(content.as_bytes())
+                .with_context(|| format!("writing {}", tmp.display()))?;
+            f.sync_all()
+                .with_context(|| format!("syncing {}", tmp.display()))?;
+        }
+        std::fs::rename(&tmp, path)
+            .with_context(|| format!("renaming {} to {}", tmp.display(), path.display()))?;
+    } else {
+        // Non-force: exclusive create eliminates the TOCTOU race between the
+        // existence check and the write for concurrent bootstrap invocations.
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+        {
+            Ok(mut f) => {
+                f.write_all(content.as_bytes())
+                    .with_context(|| format!("writing {}", path.display()))?;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                receipt.files_skipped.push(path.to_owned());
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(e).with_context(|| format!("creating {}", path.display()));
+            }
+        }
+    }
+
     receipt.files_created.push(path.to_owned());
     Ok(())
 }

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -75,6 +75,11 @@ pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
 
     // Reject a symlinked vault root — all subsequent paths are derived from it,
     // so a symlink here can route every write outside the intended directory.
+    // Canonicalize the component count to strip trailing separators and `.`
+    // segments; `symlink_metadata("link/")` follows the link on POSIX, so
+    // we must operate on the clean form.
+    let vault = vault.components().collect::<PathBuf>();
+    let vault = &vault;
     if let Ok(meta) = std::fs::symlink_metadata(vault) {
         if meta.file_type().is_symlink() {
             anyhow::bail!(
@@ -219,8 +224,22 @@ fn write_once(
         match tmp.persist_noclobber(path) {
             Ok(_) => {}
             Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => {
-                receipt.files_skipped.push(path.to_owned());
-                return Ok(());
+                // Re-check: a race may have placed a symlink or non-regular
+                // file at the path between our initial check and now.
+                match std::fs::symlink_metadata(path) {
+                    Ok(m) if m.file_type().is_symlink() => anyhow::bail!(
+                        "{} is a symlink — bootstrap will not write through it",
+                        path.display()
+                    ),
+                    Ok(m) if !m.file_type().is_file() => anyhow::bail!(
+                        "{} exists but is not a regular file — bootstrap cannot overwrite it",
+                        path.display()
+                    ),
+                    _ => {
+                        receipt.files_skipped.push(path.to_owned());
+                        return Ok(());
+                    }
+                }
             }
             Err(e) => {
                 return Err(anyhow::Error::from(e.error))

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -72,6 +72,18 @@ const PURPOSE_MD: &str = "# Purpose\n\n<!-- Why does this vault exist? -->\n";
 /// written.
 pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
     let vault = &opts.vault_path;
+
+    // Reject a symlinked vault root — all subsequent paths are derived from it,
+    // so a symlink here can route every write outside the intended directory.
+    if let Ok(meta) = std::fs::symlink_metadata(vault) {
+        if meta.file_type().is_symlink() {
+            anyhow::bail!(
+                "{} is a symlink — pass the real vault path to bootstrap",
+                vault.display()
+            );
+        }
+    }
+
     let config_path = vault.join(".cairn/config.yaml");
     let db_path = vault.join(".cairn/cairn.db");
 
@@ -155,12 +167,20 @@ fn write_once(
 ) -> Result<()> {
     use std::io::Write as _;
 
-    // Reject symlinks at the final target — writing through one can affect
-    // paths outside the vault. symlink_metadata does not follow symlinks.
+    // Inspect the final target without following symlinks.
     if let Ok(meta) = std::fs::symlink_metadata(path) {
-        if meta.file_type().is_symlink() {
+        let ft = meta.file_type();
+        if ft.is_symlink() {
             anyhow::bail!(
                 "{} is a symlink — bootstrap will not write through it",
+                path.display()
+            );
+        }
+        if !ft.is_file() {
+            // A directory or special file at a placeholder path means the
+            // vault is in an inconsistent state; bootstrap cannot repair it.
+            anyhow::bail!(
+                "{} exists but is not a regular file — bootstrap cannot overwrite it",
                 path.display()
             );
         }
@@ -168,7 +188,7 @@ fn write_once(
             receipt.files_skipped.push(path.to_owned());
             return Ok(());
         }
-        // force=true, real file — fall through to atomic overwrite
+        // force=true, regular file — fall through to atomic overwrite
     }
 
     // Write to a randomly-named temp file in the same directory.

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -200,7 +200,19 @@ fn write_once(
     // A random name eliminates the predictable-temp-path symlink attack.
     // Both the force and non-force paths use this temp file; only the final
     // publish step differs.
+    //
+    // Re-validate the parent directory immediately before opening the temp
+    // file: a symlink swap of the parent after the directory-tree pass
+    // would otherwise let the write escape to the symlink target.
     let dir = path.parent().unwrap_or(std::path::Path::new("."));
+    if let Ok(meta) = std::fs::symlink_metadata(dir) {
+        if meta.file_type().is_symlink() {
+            anyhow::bail!(
+                "parent directory {} is a symlink — bootstrap will not write through it",
+                dir.display()
+            );
+        }
+    }
     let mut tmp = tempfile::Builder::new()
         .prefix(".bootstrap")
         .tempfile_in(dir)
@@ -226,6 +238,8 @@ fn write_once(
             Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => {
                 // Re-check: a race may have placed a symlink or non-regular
                 // file at the path between our initial check and now.
+                // Only skip if symlink_metadata confirms a regular file;
+                // propagate all other outcomes (errors, NotFound, non-regular).
                 match std::fs::symlink_metadata(path) {
                     Ok(m) if m.file_type().is_symlink() => anyhow::bail!(
                         "{} is a symlink — bootstrap will not write through it",
@@ -235,9 +249,15 @@ fn write_once(
                         "{} exists but is not a regular file — bootstrap cannot overwrite it",
                         path.display()
                     ),
-                    _ => {
+                    Ok(_) => {
+                        // is_file() is the only remaining case after the arms above.
                         receipt.files_skipped.push(path.to_owned());
                         return Ok(());
+                    }
+                    Err(re) => {
+                        return Err(anyhow::Error::from(re)).with_context(|| {
+                            format!("revalidating {} after AlreadyExists race", path.display())
+                        });
                     }
                 }
             }

--- a/crates/cairn-cli/src/vault.rs
+++ b/crates/cairn-cli/src/vault.rs
@@ -88,10 +88,15 @@ pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
     // --- directory tree ---
     for rel in VAULT_DIRS {
         let dir = vault.join(rel);
-        if dir.exists() {
-            receipt.dirs_existing.push(dir.clone());
-        } else {
-            receipt.dirs_created.push(dir.clone());
+        match std::fs::symlink_metadata(&dir) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                anyhow::bail!(
+                    "{} is a symlink — bootstrap will not traverse it",
+                    dir.display()
+                );
+            }
+            Ok(_) => receipt.dirs_existing.push(dir.clone()),
+            Err(_) => receipt.dirs_created.push(dir.clone()),
         }
         std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
     }
@@ -150,8 +155,8 @@ fn write_once(
 ) -> Result<()> {
     use std::io::Write as _;
 
-    // Reject symlinks regardless of force — writing through a symlink can
-    // affect paths outside the vault, which is never intended by bootstrap.
+    // Reject symlinks at the final target — writing through one can affect
+    // paths outside the vault. symlink_metadata does not follow symlinks.
     if let Ok(meta) = std::fs::symlink_metadata(path) {
         if meta.file_type().is_symlink() {
             anyhow::bail!(
@@ -163,51 +168,43 @@ fn write_once(
             receipt.files_skipped.push(path.to_owned());
             return Ok(());
         }
-        // force=true, file exists, not a symlink — fall through to atomic overwrite
+        // force=true, real file — fall through to atomic overwrite
     }
 
+    // Write to a randomly-named temp file in the same directory.
+    // A random name eliminates the predictable-temp-path symlink attack.
+    // Both the force and non-force paths use this temp file; only the final
+    // publish step differs.
+    let dir = path.parent().unwrap_or(std::path::Path::new("."));
+    let mut tmp = tempfile::Builder::new()
+        .prefix(".bootstrap")
+        .tempfile_in(dir)
+        .with_context(|| format!("creating temp file in {}", dir.display()))?;
+    tmp.write_all(content.as_bytes())
+        .with_context(|| format!("writing temp file for {}", path.display()))?;
+    tmp.as_file()
+        .sync_all()
+        .with_context(|| format!("syncing temp file for {}", path.display()))?;
+
     if force {
-        // Atomic overwrite: write to a sibling temp file, sync, then rename.
-        // rename(2) is atomic on the same filesystem — the target sees either
-        // the old content or the new content, never a partial write.
-        let dir = path.parent().unwrap_or(std::path::Path::new("."));
-        let tmp_name = format!(
-            ".{}.bootstrap.tmp",
-            path.file_name().and_then(|n| n.to_str()).unwrap_or("file")
-        );
-        let tmp = dir.join(tmp_name);
-        {
-            let mut f = std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(&tmp)
-                .with_context(|| format!("creating temp file {}", tmp.display()))?;
-            f.write_all(content.as_bytes())
-                .with_context(|| format!("writing {}", tmp.display()))?;
-            f.sync_all()
-                .with_context(|| format!("syncing {}", tmp.display()))?;
-        }
-        std::fs::rename(&tmp, path)
-            .with_context(|| format!("renaming {} to {}", tmp.display(), path.display()))?;
+        // Atomic overwrite: persist renames the temp file over the target.
+        // rename(2) is atomic on the same filesystem — no partial-write window.
+        tmp.persist(path)
+            .map_err(|e| e.error)
+            .with_context(|| format!("persisting to {}", path.display()))?;
     } else {
-        // Non-force: exclusive create eliminates the TOCTOU race between the
-        // existence check and the write for concurrent bootstrap invocations.
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(path)
-        {
-            Ok(mut f) => {
-                f.write_all(content.as_bytes())
-                    .with_context(|| format!("writing {}", path.display()))?;
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+        // Atomic exclusive create: persist_noclobber fails if the target
+        // appeared between the symlink_metadata check above and now, so a
+        // partial write can never be left at the final path.
+        match tmp.persist_noclobber(path) {
+            Ok(_) => {}
+            Err(e) if e.error.kind() == std::io::ErrorKind::AlreadyExists => {
                 receipt.files_skipped.push(path.to_owned());
                 return Ok(());
             }
             Err(e) => {
-                return Err(e).with_context(|| format!("creating {}", path.display()));
+                return Err(anyhow::Error::from(e.error))
+                    .with_context(|| format!("persisting to {}", path.display()));
             }
         }
     }

--- a/crates/cairn-cli/tests/bootstrap.rs
+++ b/crates/cairn-cli/tests/bootstrap.rs
@@ -5,12 +5,18 @@ use std::path::Path;
 use cairn_cli::vault::{BootstrapOpts, bootstrap};
 
 fn opts(dir: &Path) -> BootstrapOpts {
-    BootstrapOpts { vault_path: dir.to_path_buf(), force: false }
+    BootstrapOpts {
+        vault_path: dir.to_path_buf(),
+        force: false,
+    }
 }
 
 #[allow(dead_code)]
 fn forced(dir: &Path) -> BootstrapOpts {
-    BootstrapOpts { vault_path: dir.to_path_buf(), force: true }
+    BootstrapOpts {
+        vault_path: dir.to_path_buf(),
+        force: true,
+    }
 }
 
 #[test]
@@ -40,10 +46,7 @@ fn bootstrap_creates_full_tree() {
         ".cairn/models",
     ];
     for rel in &expected_dirs {
-        assert!(
-            dir.path().join(rel).is_dir(),
-            "expected dir missing: {rel}"
-        );
+        assert!(dir.path().join(rel).is_dir(), "expected dir missing: {rel}");
     }
 }
 
@@ -51,6 +54,10 @@ fn bootstrap_creates_full_tree() {
 fn bootstrap_receipt_counts_dirs() {
     let dir = tempfile::tempdir().unwrap();
     let receipt = bootstrap(&opts(dir.path())).unwrap();
-    assert_eq!(receipt.dirs_created.len(), 19, "first run: all 19 dirs should be created");
+    assert_eq!(
+        receipt.dirs_created.len(),
+        19,
+        "first run: all 19 dirs should be created"
+    );
     assert_eq!(receipt.dirs_existing.len(), 0);
 }

--- a/crates/cairn-cli/tests/bootstrap.rs
+++ b/crates/cairn-cli/tests/bootstrap.rs
@@ -11,7 +11,6 @@ fn opts(dir: &Path) -> BootstrapOpts {
     }
 }
 
-#[allow(dead_code)]
 fn forced(dir: &Path) -> BootstrapOpts {
     BootstrapOpts {
         vault_path: dir.to_path_buf(),
@@ -60,4 +59,91 @@ fn bootstrap_receipt_counts_dirs() {
         "first run: all 19 dirs should be created"
     );
     assert_eq!(receipt.dirs_existing.len(), 0);
+}
+
+#[test]
+fn bootstrap_creates_placeholder_files() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    assert!(
+        dir.path().join(".cairn/config.yaml").is_file(),
+        "config.yaml missing"
+    );
+    assert!(
+        dir.path().join("purpose.md").is_file(),
+        "purpose.md missing"
+    );
+    assert!(dir.path().join("index.md").is_file(), "index.md missing");
+    assert!(dir.path().join("log.md").is_file(), "log.md missing");
+}
+
+#[test]
+fn bootstrap_receipt_counts_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+    assert_eq!(receipt.files_created.len(), 4);
+    assert_eq!(receipt.files_skipped.len(), 0);
+}
+
+#[test]
+fn bootstrap_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    // second run
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+
+    // dirs: all existing, none created
+    assert_eq!(receipt.dirs_created.len(), 0);
+    assert_eq!(receipt.dirs_existing.len(), 19);
+
+    // files: all skipped, none created
+    assert_eq!(receipt.files_created.len(), 0);
+    assert_eq!(receipt.files_skipped.len(), 4);
+
+    // vault is still intact
+    assert!(dir.path().join(".cairn/config.yaml").is_file());
+    assert!(dir.path().join("purpose.md").is_file());
+}
+
+#[test]
+fn bootstrap_skips_user_edited_purpose() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    // user edits purpose.md
+    let purpose = dir.path().join("purpose.md");
+    std::fs::write(&purpose, "# My vault\n\nPersonal knowledge base.\n").unwrap();
+
+    // second run without --force
+    bootstrap(&opts(dir.path())).unwrap();
+
+    // user's content must survive
+    let content = std::fs::read_to_string(&purpose).unwrap();
+    assert_eq!(content, "# My vault\n\nPersonal knowledge base.\n");
+}
+
+#[test]
+fn bootstrap_force_overwrites_files() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    // user edits purpose.md
+    let purpose = dir.path().join("purpose.md");
+    std::fs::write(&purpose, "# My vault\n\nPersonal knowledge base.\n").unwrap();
+
+    // --force run
+    let receipt = bootstrap(&forced(dir.path())).unwrap();
+
+    // purpose.md is overwritten with the template
+    let content = std::fs::read_to_string(&purpose).unwrap();
+    assert_eq!(
+        content,
+        "# Purpose\n\n<!-- Why does this vault exist? -->\n"
+    );
+
+    // receipt shows all 4 files created
+    assert_eq!(receipt.files_created.len(), 4);
+    assert_eq!(receipt.files_skipped.len(), 0);
 }

--- a/crates/cairn-cli/tests/bootstrap.rs
+++ b/crates/cairn-cli/tests/bootstrap.rs
@@ -1,5 +1,8 @@
 //! Integration tests for vault bootstrap (brief §3.1, issue #41).
 
+// 19 = VAULT_DIRS.len() in vault.rs (brief §3.1 directory tree)
+// 4  = placeholder files: .cairn/config.yaml, purpose.md, index.md, log.md
+
 use std::path::Path;
 
 use cairn_cli::vault::{BootstrapOpts, bootstrap};
@@ -82,8 +85,16 @@ fn bootstrap_creates_placeholder_files() {
 fn bootstrap_receipt_counts_files() {
     let dir = tempfile::tempdir().unwrap();
     let receipt = bootstrap(&opts(dir.path())).unwrap();
-    assert_eq!(receipt.files_created.len(), 4);
-    assert_eq!(receipt.files_skipped.len(), 0);
+    assert_eq!(
+        receipt.files_created.len(),
+        4,
+        "first run: all 4 placeholder files should be created"
+    );
+    assert_eq!(
+        receipt.files_skipped.len(),
+        0,
+        "first run: no files should be skipped"
+    );
 }
 
 #[test]
@@ -95,12 +106,28 @@ fn bootstrap_idempotent() {
     let receipt = bootstrap(&opts(dir.path())).unwrap();
 
     // dirs: all existing, none created
-    assert_eq!(receipt.dirs_created.len(), 0);
-    assert_eq!(receipt.dirs_existing.len(), 19);
+    assert_eq!(
+        receipt.dirs_created.len(),
+        0,
+        "second run: no new dirs should be created"
+    );
+    assert_eq!(
+        receipt.dirs_existing.len(),
+        19,
+        "second run: all 19 dirs should already exist"
+    );
 
     // files: all skipped, none created
-    assert_eq!(receipt.files_created.len(), 0);
-    assert_eq!(receipt.files_skipped.len(), 4);
+    assert_eq!(
+        receipt.files_created.len(),
+        0,
+        "second run: no files should be created"
+    );
+    assert_eq!(
+        receipt.files_skipped.len(),
+        4,
+        "second run: all 4 files should be skipped"
+    );
 
     // vault is still intact
     assert!(dir.path().join(".cairn/config.yaml").is_file());
@@ -117,11 +144,18 @@ fn bootstrap_skips_user_edited_purpose() {
     std::fs::write(&purpose, "# My vault\n\nPersonal knowledge base.\n").unwrap();
 
     // second run without --force
-    bootstrap(&opts(dir.path())).unwrap();
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
 
     // user's content must survive
     let content = std::fs::read_to_string(&purpose).unwrap();
     assert_eq!(content, "# My vault\n\nPersonal knowledge base.\n");
+
+    // receipt must report all 4 files skipped
+    assert_eq!(
+        receipt.files_skipped.len(),
+        4,
+        "second run: all 4 files should be skipped"
+    );
 }
 
 #[test]
@@ -138,12 +172,21 @@ fn bootstrap_force_overwrites_files() {
 
     // purpose.md is overwritten with the template
     let content = std::fs::read_to_string(&purpose).unwrap();
+    // must match PURPOSE_MD in vault.rs
     assert_eq!(
         content,
         "# Purpose\n\n<!-- Why does this vault exist? -->\n"
     );
 
     // receipt shows all 4 files created
-    assert_eq!(receipt.files_created.len(), 4);
-    assert_eq!(receipt.files_skipped.len(), 0);
+    assert_eq!(
+        receipt.files_created.len(),
+        4,
+        "force: all 4 files should be overwritten"
+    );
+    assert_eq!(
+        receipt.files_skipped.len(),
+        0,
+        "force: no files should be skipped"
+    );
 }

--- a/crates/cairn-cli/tests/bootstrap.rs
+++ b/crates/cairn-cli/tests/bootstrap.rs
@@ -214,3 +214,23 @@ fn bootstrap_receipt_serializes_to_json() {
     assert!(parsed.get("files_created").is_some());
     assert!(parsed.get("files_skipped").is_some());
 }
+
+#[test]
+fn bootstrap_human_output_first_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = cairn_cli::vault::bootstrap(&opts(dir.path())).unwrap();
+    let output = cairn_cli::vault::render_human(&receipt);
+    // normalize absolute path so the snapshot is stable across machines
+    let normalized = output.replace(dir.path().to_str().unwrap(), "<vault>");
+    insta::assert_snapshot!(normalized);
+}
+
+#[test]
+fn bootstrap_human_output_second_run() {
+    let dir = tempfile::tempdir().unwrap();
+    cairn_cli::vault::bootstrap(&opts(dir.path())).unwrap();
+    let receipt = cairn_cli::vault::bootstrap(&opts(dir.path())).unwrap();
+    let output = cairn_cli::vault::render_human(&receipt);
+    let normalized = output.replace(dir.path().to_str().unwrap(), "<vault>");
+    insta::assert_snapshot!(normalized);
+}

--- a/crates/cairn-cli/tests/bootstrap.rs
+++ b/crates/cairn-cli/tests/bootstrap.rs
@@ -1,0 +1,56 @@
+//! Integration tests for vault bootstrap (brief §3.1, issue #41).
+
+use std::path::Path;
+
+use cairn_cli::vault::{BootstrapOpts, bootstrap};
+
+fn opts(dir: &Path) -> BootstrapOpts {
+    BootstrapOpts { vault_path: dir.to_path_buf(), force: false }
+}
+
+#[allow(dead_code)]
+fn forced(dir: &Path) -> BootstrapOpts {
+    BootstrapOpts { vault_path: dir.to_path_buf(), force: true }
+}
+
+#[test]
+fn bootstrap_creates_full_tree() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    let expected_dirs = [
+        "sources",
+        "sources/articles",
+        "sources/papers",
+        "sources/transcripts",
+        "sources/documents",
+        "sources/chat",
+        "sources/assets",
+        "raw",
+        "wiki",
+        "wiki/entities",
+        "wiki/concepts",
+        "wiki/summaries",
+        "wiki/synthesis",
+        "wiki/prompts",
+        "skills",
+        ".cairn",
+        ".cairn/evolution",
+        ".cairn/cache",
+        ".cairn/models",
+    ];
+    for rel in &expected_dirs {
+        assert!(
+            dir.path().join(rel).is_dir(),
+            "expected dir missing: {rel}"
+        );
+    }
+}
+
+#[test]
+fn bootstrap_receipt_counts_dirs() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+    assert_eq!(receipt.dirs_created.len(), 19, "first run: all 19 dirs should be created");
+    assert_eq!(receipt.dirs_existing.len(), 0);
+}

--- a/crates/cairn-cli/tests/bootstrap.rs
+++ b/crates/cairn-cli/tests/bootstrap.rs
@@ -190,3 +190,27 @@ fn bootstrap_force_overwrites_files() {
         "force: no files should be skipped"
     );
 }
+
+#[test]
+fn bootstrap_reports_db_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+    assert_eq!(receipt.db_path, dir.path().join(".cairn/cairn.db"));
+    // db is NOT created by bootstrap — only its path is reported
+    assert!(!dir.path().join(".cairn/cairn.db").exists());
+}
+
+#[test]
+fn bootstrap_receipt_serializes_to_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+    let json = serde_json::to_string(&receipt).expect("receipt must serialize");
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(parsed.get("vault_path").is_some());
+    assert!(parsed.get("config_path").is_some());
+    assert!(parsed.get("db_path").is_some());
+    assert!(parsed.get("dirs_created").is_some());
+    assert!(parsed.get("dirs_existing").is_some());
+    assert!(parsed.get("files_created").is_some());
+    assert!(parsed.get("files_skipped").is_some());
+}

--- a/crates/cairn-cli/tests/cli.rs
+++ b/crates/cairn-cli/tests/cli.rs
@@ -177,3 +177,73 @@ fn unknown_argument_fails_closed() {
         "stderr missing clap usage marker: {stderr:?}",
     );
 }
+
+#[test]
+fn bootstrap_emits_json_with_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = cli()
+        .args([
+            "bootstrap",
+            "--vault-path",
+            dir.path().to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("cairn bootstrap --json");
+    assert!(
+        out.status.success(),
+        "exit: {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--json must emit valid JSON");
+    assert!(
+        parsed.get("vault_path").is_some(),
+        "JSON missing vault_path"
+    );
+    assert!(
+        parsed.get("dirs_created").is_some(),
+        "JSON missing dirs_created"
+    );
+}
+
+#[test]
+fn bootstrap_force_flag_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    // first run
+    cli()
+        .args(["bootstrap", "--vault-path", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    // second run with --force must succeed
+    let out = cli()
+        .args([
+            "bootstrap",
+            "--vault-path",
+            dir.path().to_str().unwrap(),
+            "--force",
+        ])
+        .output()
+        .expect("cairn bootstrap --force");
+    assert!(out.status.success(), "exit: {:?}", out.status);
+}
+
+#[test]
+fn bootstrap_io_error_exits_74() {
+    // Point at a path we cannot write to — use a file as the vault path so
+    // create_dir_all fails.
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let out = cli()
+        .args(["bootstrap", "--vault-path", file.path().to_str().unwrap()])
+        .output()
+        .expect("cairn bootstrap <file-as-vault>");
+    assert_eq!(
+        out.status.code(),
+        Some(74),
+        "expected EX_IOERR(74), got: {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/crates/cairn-cli/tests/config.rs
+++ b/crates/cairn-cli/tests/config.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the cairn-cli config loader (brief §3.1, §6.5).
 
-use cairn_cli::config::{CliOverrides, load, write_default};
+use cairn_cli::config::{CliOverrides, load};
 use cairn_core::config::{CairnConfig, StoreKind};
 
 fn write_yaml(vault: &std::path::Path, content: &str) {
@@ -88,27 +88,14 @@ fn invalid_config_returns_error() {
 // ── Bootstrap ─────────────────────────────────────────────────────────────
 
 #[test]
-fn bootstrap_writes_config_file() {
+fn bootstrap_config_round_trips() {
+    use cairn_cli::vault::{BootstrapOpts, bootstrap};
     let dir = tempfile::tempdir().unwrap();
-    write_default(dir.path()).unwrap();
-    assert!(dir.path().join(".cairn/config.yaml").exists());
-}
-
-#[test]
-fn bootstrap_round_trips_to_default() {
-    let dir = tempfile::tempdir().unwrap();
-    write_default(dir.path()).unwrap();
+    bootstrap(&BootstrapOpts {
+        vault_path: dir.path().to_path_buf(),
+        force: false,
+    })
+    .unwrap();
     let config = load(dir.path(), &CliOverrides::default()).unwrap();
-    assert_eq!(config, CairnConfig::default());
-}
-
-#[test]
-fn bootstrap_fails_if_file_already_exists() {
-    let dir = tempfile::tempdir().unwrap();
-    write_yaml(dir.path(), "vault:\n  name: existing\n");
-    let err = write_default(dir.path()).unwrap_err();
-    assert!(
-        format!("{err}").contains("already exists"),
-        "should describe the conflict: {err}"
-    );
+    assert_eq!(config, cairn_core::config::CairnConfig::default());
 }

--- a/crates/cairn-cli/tests/snapshots/bootstrap__bootstrap_human_output_first_run.snap
+++ b/crates/cairn-cli/tests/snapshots/bootstrap__bootstrap_human_output_first_run.snap
@@ -1,0 +1,9 @@
+---
+source: crates/cairn-cli/tests/bootstrap.rs
+expression: normalized
+---
+cairn bootstrap: vault initialized at <vault>
+  config    <vault>/.cairn/config.yaml  [created]
+  db        <vault>/.cairn/cairn.db  (created on first ingest)
+  dirs      19 created, 0 existing
+  files     4 created, 0 skipped

--- a/crates/cairn-cli/tests/snapshots/bootstrap__bootstrap_human_output_second_run.snap
+++ b/crates/cairn-cli/tests/snapshots/bootstrap__bootstrap_human_output_second_run.snap
@@ -1,0 +1,9 @@
+---
+source: crates/cairn-cli/tests/bootstrap.rs
+expression: normalized
+---
+cairn bootstrap: vault already initialized at <vault>
+  config    <vault>/.cairn/config.yaml  [existing]
+  db        <vault>/.cairn/cairn.db  (created on first ingest)
+  dirs      0 created, 19 existing
+  files     0 created, 4 skipped

--- a/docs/superpowers/plans/2026-04-26-bootstrap-vault-init.md
+++ b/docs/superpowers/plans/2026-04-26-bootstrap-vault-init.md
@@ -1,0 +1,792 @@
+# Bootstrap Vault Initialization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `cairn bootstrap` so it creates the full §3 vault directory tree, writes placeholder files idempotently, and emits a machine-readable `BootstrapReceipt`.
+
+**Architecture:** New `cairn_cli::vault` module holds `BootstrapOpts`, `BootstrapReceipt`, `bootstrap()`, and `render_human()`. The existing `config::write_default` is removed; its callers and tests migrate to the new module. `main.rs` gains `--json` and `--force` flags on the `bootstrap` subcommand.
+
+**Tech Stack:** Rust 1.95, `anyhow` (errors), `serde` + `serde_json` + `serde_yaml` (serialization), `insta` (snapshots), `tempfile` (test dirs), `cairn_core::config::CairnConfig` (default config).
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `crates/cairn-cli/src/vault.rs` | **Create** | `BootstrapOpts`, `BootstrapReceipt`, `bootstrap()`, `render_human()` |
+| `crates/cairn-cli/src/lib.rs` | **Modify** | add `pub mod vault;` |
+| `crates/cairn-cli/src/config.rs` | **Modify** | remove `write_default`; keep `load` + `interpolate_env` |
+| `crates/cairn-cli/src/main.rs` | **Modify** | add `--json` + `--force` to `bootstrap_subcommand`; update `run_bootstrap` |
+| `crates/cairn-cli/tests/bootstrap.rs` | **Create** | all bootstrap integration tests |
+| `crates/cairn-cli/tests/config.rs` | **Modify** | remove `write_default`-dependent tests (they move to `bootstrap.rs`) |
+| `crates/cairn-cli/tests/snapshots/bootstrap_human_output.snap` | **Created by insta** | snapshot of human-readable receipt |
+
+---
+
+## Task 1: Create `vault.rs` with types and stub `bootstrap()`
+
+**Files:**
+- Create: `crates/cairn-cli/src/vault.rs`
+- Modify: `crates/cairn-cli/src/lib.rs`
+
+- [ ] **Step 1: Add `pub mod vault;` to `lib.rs`**
+
+Open `crates/cairn-cli/src/lib.rs` and add the module declaration:
+
+```rust
+pub mod config;
+pub mod plugins;
+pub mod vault;
+```
+
+- [ ] **Step 2: Create `vault.rs` with types + stub**
+
+Create `crates/cairn-cli/src/vault.rs`:
+
+```rust
+//! Vault initialization for `cairn bootstrap` (brief §3, §3.1).
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use cairn_core::config::CairnConfig;
+
+/// Options for [`bootstrap`].
+pub struct BootstrapOpts {
+    pub vault_path: PathBuf,
+    pub force: bool,
+}
+
+/// Result of a bootstrap run, emitted as JSON with `--json` or formatted by
+/// [`render_human`].
+#[derive(Debug, Serialize)]
+pub struct BootstrapReceipt {
+    pub vault_path: PathBuf,
+    pub config_path: PathBuf,
+    pub db_path: PathBuf,
+    pub dirs_created: Vec<PathBuf>,
+    pub dirs_existing: Vec<PathBuf>,
+    pub files_created: Vec<PathBuf>,
+    pub files_skipped: Vec<PathBuf>,
+}
+
+/// All directories the vault layout requires (brief §3.1). Listed in creation
+/// order so parents always precede children.
+const VAULT_DIRS: &[&str] = &[
+    "sources",
+    "sources/articles",
+    "sources/papers",
+    "sources/transcripts",
+    "sources/documents",
+    "sources/chat",
+    "sources/assets",
+    "raw",
+    "wiki",
+    "wiki/entities",
+    "wiki/concepts",
+    "wiki/summaries",
+    "wiki/synthesis",
+    "wiki/prompts",
+    "skills",
+    ".cairn",
+    ".cairn/evolution",
+    ".cairn/cache",
+    ".cairn/models",
+];
+
+const PURPOSE_MD: &str = "# Purpose\n\n<!-- Why does this vault exist? -->\n";
+
+/// Initialize the vault directory tree and placeholder files at `opts.vault_path`.
+///
+/// Idempotent: existing directories are left unchanged; existing files are
+/// added to [`BootstrapReceipt::files_skipped`] unless `opts.force` is set.
+///
+/// # Errors
+/// Returns an error if any directory cannot be created or any file cannot be
+/// written.
+pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
+    let vault = &opts.vault_path;
+    let config_path = vault.join(".cairn/config.yaml");
+    let db_path = vault.join(".cairn/cairn.db");
+
+    let mut receipt = BootstrapReceipt {
+        vault_path: vault.clone(),
+        config_path: config_path.clone(),
+        db_path,
+        dirs_created: Vec::new(),
+        dirs_existing: Vec::new(),
+        files_created: Vec::new(),
+        files_skipped: Vec::new(),
+    };
+
+    // --- directory tree ---
+    for rel in VAULT_DIRS {
+        let dir = vault.join(rel);
+        if dir.exists() {
+            receipt.dirs_existing.push(dir.clone());
+        } else {
+            receipt.dirs_created.push(dir.clone());
+        }
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating {}", dir.display()))?;
+    }
+
+    // --- placeholder files ---
+    let config_yaml = serde_yaml::to_string(&CairnConfig::default())
+        .context("serializing default config to YAML")?;
+    write_once(&config_path, &config_yaml, opts.force, &mut receipt)?;
+    write_once(&vault.join("purpose.md"), PURPOSE_MD, opts.force, &mut receipt)?;
+    write_once(&vault.join("index.md"), "", opts.force, &mut receipt)?;
+    write_once(&vault.join("log.md"), "", opts.force, &mut receipt)?;
+
+    Ok(receipt)
+}
+
+/// Render a human-readable summary of a bootstrap receipt.
+pub fn render_human(receipt: &BootstrapReceipt) -> String {
+    let header = if receipt.dirs_created.is_empty() && receipt.files_created.is_empty() {
+        format!(
+            "cairn bootstrap: vault already initialized at {}",
+            receipt.vault_path.display()
+        )
+    } else {
+        format!(
+            "cairn bootstrap: vault initialized at {}",
+            receipt.vault_path.display()
+        )
+    };
+    let config_status = if receipt.files_skipped.contains(&receipt.config_path) {
+        "existing"
+    } else {
+        "created"
+    };
+    format!(
+        "{header}\n  config    {}  [{config_status}]\n  db        {}  (created on first ingest)\n  dirs      {} created, {} existing\n  files     {} created, {} skipped",
+        receipt.config_path.display(),
+        receipt.db_path.display(),
+        receipt.dirs_created.len(),
+        receipt.dirs_existing.len(),
+        receipt.files_created.len(),
+        receipt.files_skipped.len(),
+    )
+}
+
+fn write_once(
+    path: &std::path::Path,
+    content: &str,
+    force: bool,
+    receipt: &mut BootstrapReceipt,
+) -> Result<()> {
+    if path.exists() && !force {
+        receipt.files_skipped.push(path.to_owned());
+        return Ok(());
+    }
+    std::fs::write(path, content)
+        .with_context(|| format!("writing {}", path.display()))?;
+    receipt.files_created.push(path.to_owned());
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cargo check -p cairn-cli --locked
+```
+
+Expected: no errors. If `serde_yaml` is missing from deps, it is already in `cairn-cli/Cargo.toml` — verify with `grep serde_yaml crates/cairn-cli/Cargo.toml`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-cli/src/vault.rs crates/cairn-cli/src/lib.rs
+git commit -m "feat(bootstrap): add vault module with BootstrapOpts/Receipt types and bootstrap() (§3.1)"
+```
+
+---
+
+## Task 2: TDD — directory creation
+
+**Files:**
+- Create: `crates/cairn-cli/tests/bootstrap.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/cairn-cli/tests/bootstrap.rs`:
+
+```rust
+//! Integration tests for vault bootstrap (brief §3.1, issue #41).
+
+use std::path::Path;
+
+use cairn_cli::vault::{BootstrapOpts, bootstrap};
+
+fn opts(dir: &Path) -> BootstrapOpts {
+    BootstrapOpts { vault_path: dir.to_path_buf(), force: false }
+}
+
+fn forced(dir: &Path) -> BootstrapOpts {
+    BootstrapOpts { vault_path: dir.to_path_buf(), force: true }
+}
+
+#[test]
+fn bootstrap_creates_full_tree() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    let expected_dirs = [
+        "sources",
+        "sources/articles",
+        "sources/papers",
+        "sources/transcripts",
+        "sources/documents",
+        "sources/chat",
+        "sources/assets",
+        "raw",
+        "wiki",
+        "wiki/entities",
+        "wiki/concepts",
+        "wiki/summaries",
+        "wiki/synthesis",
+        "wiki/prompts",
+        "skills",
+        ".cairn",
+        ".cairn/evolution",
+        ".cairn/cache",
+        ".cairn/models",
+    ];
+    for rel in &expected_dirs {
+        assert!(
+            dir.path().join(rel).is_dir(),
+            "expected dir missing: {rel}"
+        );
+    }
+}
+
+#[test]
+fn bootstrap_receipt_counts_dirs() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+    assert_eq!(receipt.dirs_created.len(), 19, "first run: all 19 dirs should be created");
+    assert_eq!(receipt.dirs_existing.len(), 0);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cargo nextest run -p cairn-cli --test bootstrap --locked 2>&1 | head -30
+```
+
+Expected: compilation error — `tests/bootstrap.rs` doesn't exist yet (this step creates it) or type errors.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo nextest run -p cairn-cli --test bootstrap --locked
+```
+
+Expected: both tests PASS (the implementation was written in Task 1).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-cli/tests/bootstrap.rs
+git commit -m "test(bootstrap): directory creation + receipt dir counts"
+```
+
+---
+
+## Task 3: TDD — placeholder files, idempotency, force
+
+**Files:**
+- Modify: `crates/cairn-cli/tests/bootstrap.rs`
+
+- [ ] **Step 1: Add tests**
+
+Append to `crates/cairn-cli/tests/bootstrap.rs`:
+
+```rust
+#[test]
+fn bootstrap_creates_placeholder_files() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    assert!(dir.path().join(".cairn/config.yaml").is_file(), "config.yaml missing");
+    assert!(dir.path().join("purpose.md").is_file(), "purpose.md missing");
+    assert!(dir.path().join("index.md").is_file(), "index.md missing");
+    assert!(dir.path().join("log.md").is_file(), "log.md missing");
+}
+
+#[test]
+fn bootstrap_receipt_counts_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+    assert_eq!(receipt.files_created.len(), 4);
+    assert_eq!(receipt.files_skipped.len(), 0);
+}
+
+#[test]
+fn bootstrap_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    // second run
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+
+    // dirs: all existing, none created
+    assert_eq!(receipt.dirs_created.len(), 0);
+    assert_eq!(receipt.dirs_existing.len(), 19);
+
+    // files: all skipped, none created
+    assert_eq!(receipt.files_created.len(), 0);
+    assert_eq!(receipt.files_skipped.len(), 4);
+
+    // vault is still intact
+    assert!(dir.path().join(".cairn/config.yaml").is_file());
+    assert!(dir.path().join("purpose.md").is_file());
+}
+
+#[test]
+fn bootstrap_skips_user_edited_purpose() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    // user edits purpose.md
+    let purpose = dir.path().join("purpose.md");
+    std::fs::write(&purpose, "# My vault\n\nPersonal knowledge base.\n").unwrap();
+
+    // second run without --force
+    bootstrap(&opts(dir.path())).unwrap();
+
+    // user's content must survive
+    let content = std::fs::read_to_string(&purpose).unwrap();
+    assert_eq!(content, "# My vault\n\nPersonal knowledge base.\n");
+}
+
+#[test]
+fn bootstrap_force_overwrites_files() {
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&opts(dir.path())).unwrap();
+
+    // user edits purpose.md
+    let purpose = dir.path().join("purpose.md");
+    std::fs::write(&purpose, "# My vault\n\nPersonal knowledge base.\n").unwrap();
+
+    // --force run
+    let receipt = bootstrap(&forced(dir.path())).unwrap();
+
+    // purpose.md is overwritten with the template
+    let content = std::fs::read_to_string(&purpose).unwrap();
+    assert_eq!(content, "# Purpose\n\n<!-- Why does this vault exist? -->\n");
+
+    // receipt shows all 4 files created
+    assert_eq!(receipt.files_created.len(), 4);
+    assert_eq!(receipt.files_skipped.len(), 0);
+}
+```
+
+- [ ] **Step 2: Run to verify they pass**
+
+```bash
+cargo nextest run -p cairn-cli --test bootstrap --locked
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-cli/tests/bootstrap.rs
+git commit -m "test(bootstrap): placeholder files, idempotency, --force behavior"
+```
+
+---
+
+## Task 4: TDD — receipt fields + JSON output
+
+**Files:**
+- Modify: `crates/cairn-cli/tests/bootstrap.rs`
+
+- [ ] **Step 1: Add tests**
+
+Append to `crates/cairn-cli/tests/bootstrap.rs`:
+
+```rust
+#[test]
+fn bootstrap_reports_db_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+    assert_eq!(receipt.db_path, dir.path().join(".cairn/cairn.db"));
+    // db is NOT created by bootstrap — only its path is reported
+    assert!(!dir.path().join(".cairn/cairn.db").exists());
+}
+
+#[test]
+fn bootstrap_receipt_serializes_to_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = bootstrap(&opts(dir.path())).unwrap();
+    let json = serde_json::to_string(&receipt).expect("receipt must serialize");
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(parsed.get("vault_path").is_some());
+    assert!(parsed.get("config_path").is_some());
+    assert!(parsed.get("db_path").is_some());
+    assert!(parsed.get("dirs_created").is_some());
+    assert!(parsed.get("dirs_existing").is_some());
+    assert!(parsed.get("files_created").is_some());
+    assert!(parsed.get("files_skipped").is_some());
+}
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo nextest run -p cairn-cli --test bootstrap --locked
+```
+
+Expected: PASS. If `serde_json` isn't in test scope, add it to `[dev-dependencies]` in `crates/cairn-cli/Cargo.toml` — it is already present there.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-cli/tests/bootstrap.rs
+git commit -m "test(bootstrap): db_path field + JSON serialization of receipt"
+```
+
+---
+
+## Task 5: TDD — `render_human` snapshot
+
+**Files:**
+- Modify: `crates/cairn-cli/tests/bootstrap.rs`
+
+- [ ] **Step 1: Add snapshot test**
+
+Append to `crates/cairn-cli/tests/bootstrap.rs`:
+
+```rust
+#[test]
+fn bootstrap_human_output_first_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let receipt = cairn_cli::vault::bootstrap(&opts(dir.path())).unwrap();
+    let output = cairn_cli::vault::render_human(&receipt);
+    // normalize absolute path so the snapshot is stable across machines
+    let normalized = output.replace(dir.path().to_str().unwrap(), "<vault>");
+    insta::assert_snapshot!(normalized);
+}
+
+#[test]
+fn bootstrap_human_output_second_run() {
+    let dir = tempfile::tempdir().unwrap();
+    cairn_cli::vault::bootstrap(&opts(dir.path())).unwrap();
+    let receipt = cairn_cli::vault::bootstrap(&opts(dir.path())).unwrap();
+    let output = cairn_cli::vault::render_human(&receipt);
+    let normalized = output.replace(dir.path().to_str().unwrap(), "<vault>");
+    insta::assert_snapshot!(normalized);
+}
+```
+
+Also add `insta` to the imports at the top of the test file (it is already a dev-dep in `Cargo.toml`).
+
+- [ ] **Step 2: Run to generate snapshots**
+
+```bash
+cargo nextest run -p cairn-cli --test bootstrap --locked 2>&1 | tail -20
+```
+
+Expected: tests fail with "snapshot not found" — that is correct for a first insta run.
+
+- [ ] **Step 3: Review and accept snapshots**
+
+```bash
+cargo insta review
+```
+
+Review the two snapshots. First-run snapshot should look like:
+
+```
+cairn bootstrap: vault initialized at <vault>
+  config    <vault>/.cairn/config.yaml  [created]
+  db        <vault>/.cairn/cairn.db  (created on first ingest)
+  dirs      19 created, 0 existing
+  files     4 created, 0 skipped
+```
+
+Second-run snapshot should look like:
+
+```
+cairn bootstrap: vault already initialized at <vault>
+  config    <vault>/.cairn/config.yaml  [existing]
+  db        <vault>/.cairn/cairn.db  (created on first ingest)
+  dirs      0 created, 19 existing
+  files     0 created, 4 skipped
+```
+
+Accept both with `a`.
+
+- [ ] **Step 4: Run again to confirm snapshots pass**
+
+```bash
+cargo nextest run -p cairn-cli --test bootstrap --locked
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-cli/tests/bootstrap.rs crates/cairn-cli/tests/snapshots/
+git commit -m "test(bootstrap): snapshot tests for render_human first + second run"
+```
+
+---
+
+## Task 6: Update `main.rs` — `--json` + `--force` flags
+
+**Files:**
+- Modify: `crates/cairn-cli/src/main.rs`
+
+- [ ] **Step 1: Write E2E test in `tests/cli.rs`**
+
+Open `crates/cairn-cli/tests/cli.rs` and append:
+
+```rust
+#[test]
+fn bootstrap_emits_json_with_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = cli()
+        .args(["bootstrap", "--vault-path", dir.path().to_str().unwrap(), "--json"])
+        .output()
+        .expect("cairn bootstrap --json");
+    assert!(out.status.success(), "exit: {:?}\nstderr: {}", out.status, String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8(out.stdout).expect("utf-8");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .expect("--json must emit valid JSON");
+    assert!(parsed.get("vault_path").is_some(), "JSON missing vault_path");
+    assert!(parsed.get("dirs_created").is_some(), "JSON missing dirs_created");
+}
+
+#[test]
+fn bootstrap_force_flag_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    // first run
+    cli()
+        .args(["bootstrap", "--vault-path", dir.path().to_str().unwrap()])
+        .output().unwrap();
+    // second run with --force must succeed
+    let out = cli()
+        .args(["bootstrap", "--vault-path", dir.path().to_str().unwrap(), "--force"])
+        .output()
+        .expect("cairn bootstrap --force");
+    assert!(out.status.success(), "exit: {:?}", out.status);
+}
+
+#[test]
+fn bootstrap_io_error_exits_74() {
+    // Point at a path we cannot write to — use a file as the vault path so
+    // create_dir_all fails.
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let out = cli()
+        .args(["bootstrap", "--vault-path", file.path().to_str().unwrap()])
+        .output()
+        .expect("cairn bootstrap <file-as-vault>");
+    assert_eq!(out.status.code(), Some(74), "expected EX_IOERR(74)");
+}
+```
+
+Also add `use tempfile;` / ensure `tempfile` is in scope (it is a dev-dep in `Cargo.toml`).
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```bash
+cargo nextest run -p cairn-cli --test cli bootstrap --locked 2>&1 | tail -20
+```
+
+Expected: tests fail — `--json` and `--force` flags are unknown (clap rejects them).
+
+- [ ] **Step 3: Update `bootstrap_subcommand` in `main.rs`**
+
+Replace the existing `bootstrap_subcommand` function:
+
+```rust
+fn bootstrap_subcommand() -> clap::Command {
+    clap::Command::new("bootstrap")
+        .about("Initialize a vault directory tree with the §3 layout")
+        .arg(
+            clap::Arg::new("vault-path")
+                .long("vault-path")
+                .default_value(".")
+                .value_name("PATH")
+                .help("Vault root directory (default: current directory)"),
+        )
+        .arg(
+            clap::Arg::new("json")
+                .long("json")
+                .action(clap::ArgAction::SetTrue)
+                .help("Emit JSON receipt instead of human-readable output"),
+        )
+        .arg(
+            clap::Arg::new("force")
+                .long("force")
+                .action(clap::ArgAction::SetTrue)
+                .help("Overwrite existing placeholder files"),
+        )
+}
+```
+
+- [ ] **Step 4: Update `run_bootstrap` in `main.rs`**
+
+Replace the existing `run_bootstrap` function:
+
+```rust
+fn run_bootstrap(matches: &ArgMatches) -> ExitCode {
+    let vault_path = std::path::PathBuf::from(
+        matches
+            .get_one::<String>("vault-path")
+            .expect("invariant: vault-path has a default value"),
+    );
+    let json = matches.get_flag("json");
+    let force = matches.get_flag("force");
+
+    let opts = cairn_cli::vault::BootstrapOpts { vault_path, force };
+
+    match cairn_cli::vault::bootstrap(&opts) {
+        Ok(receipt) => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&receipt)
+                        .expect("invariant: BootstrapReceipt is always serializable")
+                );
+            } else {
+                println!("{}", cairn_cli::vault::render_human(&receipt));
+            }
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("cairn bootstrap: {e:#}");
+            ExitCode::from(74) // EX_IOERR
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run to confirm tests pass**
+
+```bash
+cargo nextest run -p cairn-cli --test cli --locked
+```
+
+Expected: all CLI tests PASS including the three new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-cli/src/main.rs crates/cairn-cli/tests/cli.rs
+git commit -m "feat(bootstrap): --json + --force flags; EX_IOERR(74) on I/O failure"
+```
+
+---
+
+## Task 7: Remove `write_default`, migrate stale tests
+
+**Files:**
+- Modify: `crates/cairn-cli/src/config.rs`
+- Modify: `crates/cairn-cli/tests/config.rs`
+
+- [ ] **Step 1: Remove `write_default` from `config.rs`**
+
+Delete the `write_default` function (lines 98–126 in the current file) and its doc comment. Keep `load`, `interpolate_env`, `CliOverrides`, and all their tests.
+
+- [ ] **Step 2: Remove bootstrap tests from `tests/config.rs`**
+
+Delete the three tests under `// ── Bootstrap ───`:
+- `bootstrap_writes_config_file`
+- `bootstrap_round_trips_to_default`
+- `bootstrap_fails_if_file_already_exists`
+
+These behaviors are now covered by `tests/bootstrap.rs`.
+
+Add one replacement test in `tests/config.rs` that verifies `load()` round-trips the config written by `vault::bootstrap`:
+
+```rust
+#[test]
+fn bootstrap_config_round_trips() {
+    use cairn_cli::vault::{BootstrapOpts, bootstrap};
+    let dir = tempfile::tempdir().unwrap();
+    bootstrap(&BootstrapOpts { vault_path: dir.path().to_path_buf(), force: false }).unwrap();
+    let config = load(dir.path(), &CliOverrides::default()).unwrap();
+    assert_eq!(config, cairn_core::config::CairnConfig::default());
+}
+```
+
+- [ ] **Step 3: Remove `write_default` from the machete ignore list if present**
+
+Check `crates/cairn-cli/Cargo.toml` — it currently ignores `"anyhow"` via `cargo-machete`. If `write_default` was the last user of `anyhow` in `config.rs`, verify `anyhow` is still used elsewhere in `lib.rs`/`vault.rs` (it is — `vault.rs` uses `anyhow::Context`). No change needed.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+cargo nextest run -p cairn-cli --locked
+cargo test --doc -p cairn-cli --locked
+```
+
+Expected: all tests PASS; no reference to `write_default` remains.
+
+- [ ] **Step 5: Run verification checklist**
+
+```bash
+cargo fmt --all --check
+cargo clippy -p cairn-cli --all-targets --locked -- -D warnings
+./scripts/check-core-boundary.sh
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-cli/src/config.rs crates/cairn-cli/tests/config.rs
+git commit -m "refactor(config): remove write_default; bootstrap tests live in bootstrap.rs"
+```
+
+---
+
+## Task 8: Full workspace verification
+
+- [ ] **Step 1: Run the full CI checklist**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo check --workspace --all-targets --locked
+cargo nextest run --workspace --locked --no-fail-fast
+cargo test --doc --workspace --locked
+./scripts/check-core-boundary.sh
+cargo run -p cairn-idl --bin cairn-codegen --locked -- --check
+```
+
+Expected: all pass with no warnings promoted to errors.
+
+- [ ] **Step 2: Smoke-test the binary manually**
+
+```bash
+cd /tmp && mkdir test-vault && cargo run -p cairn-cli -- bootstrap --vault-path test-vault
+cargo run -p cairn-cli -- bootstrap --vault-path test-vault          # second run — must succeed
+cargo run -p cairn-cli -- bootstrap --vault-path test-vault --json   # JSON output
+cargo run -p cairn-cli -- bootstrap --vault-path test-vault --force  # force overwrite
+find test-vault -type d | sort
+```
+
+Expected: 19 dirs visible; second run prints "vault already initialized"; JSON is valid.
+
+- [ ] **Step 3: Commit if anything needed fixing**
+
+If any clippy or fmt fix was needed:
+```bash
+git add -p
+git commit -m "fix(bootstrap): clippy/fmt cleanup"
+```

--- a/docs/superpowers/specs/2026-04-26-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-04-26-bootstrap-design.md
@@ -1,0 +1,162 @@
+# Design: `cairn bootstrap` vault initialization
+
+**Date:** 2026-04-26  
+**Issue:** [#41](https://github.com/windoliver/cairn/issues/41)  
+**Brief sections:** §3 Vault Layout, §3.1 Layout template, §19.a v0.1 subset  
+**Status:** Approved
+
+---
+
+## Problem
+
+`cairn bootstrap` currently only writes `.cairn/config.yaml`. It does not create the vault directory tree, does not emit a machine-readable receipt, and fails on a second invocation. Issue #41 requires full vault initialization: complete directory scaffold, idempotent behavior, and a structured receipt for SDK/MCP callers.
+
+---
+
+## Approach
+
+New `cairn_cli::vault` module in `cairn-cli`. `BootstrapReceipt` lives in `cairn-cli` (management command, not a core verb; MCP wrapping of bootstrap is P1+). `config::write_default` is removed and replaced by `vault::bootstrap`.
+
+---
+
+## Module structure
+
+```
+cairn-cli/src/
+├── config.rs          unchanged except write_default removed
+├── vault.rs           NEW — bootstrap logic + receipt type
+├── lib.rs             adds `pub mod vault;`
+└── main.rs            bootstrap_subcommand gains --json + --force; run_bootstrap calls vault::bootstrap
+```
+
+---
+
+## Types
+
+```rust
+// cairn-cli/src/vault.rs
+
+pub struct BootstrapOpts {
+    pub vault_path: PathBuf,
+    pub force: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BootstrapReceipt {
+    pub vault_path: PathBuf,
+    pub config_path: PathBuf,
+    pub db_path: PathBuf,
+    pub dirs_created: Vec<PathBuf>,
+    pub dirs_existing: Vec<PathBuf>,
+    pub files_created: Vec<PathBuf>,
+    pub files_skipped: Vec<PathBuf>,
+}
+
+pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt>
+```
+
+---
+
+## Directory tree
+
+All dirs created via `create_dir_all` (idempotent; no `--force` needed for dirs):
+
+```
+sources/articles/
+sources/papers/
+sources/transcripts/
+sources/documents/
+sources/chat/
+sources/assets/
+raw/
+wiki/entities/
+wiki/concepts/
+wiki/summaries/
+wiki/synthesis/
+wiki/prompts/
+skills/
+.cairn/evolution/
+.cairn/cache/
+.cairn/models/
+```
+
+---
+
+## Placeholder files
+
+Created on first run; skipped on subsequent runs unless `--force`:
+
+| File | Content | Owned by |
+|---|---|---|
+| `.cairn/config.yaml` | `CairnConfig::default()` serialized as YAML | human (config) |
+| `purpose.md` | `# Purpose\n\n<!-- Why does this vault exist? -->\n` | human |
+| `index.md` | empty | LLM |
+| `log.md` | empty | LLM |
+
+`.cairn/cairn.db` is **not** created by bootstrap (out of scope per issue; the store adapter owns DB initialization). The receipt reports its expected path regardless.
+
+---
+
+## Idempotency and exit behavior
+
+| Scenario | Behavior | Exit code |
+|---|---|---|
+| First run, clean dir | Create all dirs + files; receipt shows full `dirs_created` / `files_created` | 0 |
+| Second run, no `--force` | Dirs silently ensured; existing files go to `files_skipped`; receipt emitted | 0 |
+| Second run, `--force` | Overwrites all placeholder files; dirs unchanged | 0 |
+| Any I/O error | `eprintln!` error message | 74 (`EX_IOERR`) |
+
+---
+
+## CLI surface
+
+```
+cairn bootstrap [--vault-path PATH] [--json] [--force]
+```
+
+Human output (no `--json`):
+
+```
+cairn bootstrap: vault initialized at /path/to/vault
+  config    /path/to/vault/.cairn/config.yaml  [created]
+  db        /path/to/vault/.cairn/cairn.db  (created on first ingest)
+  dirs      14 created, 0 existing
+  files     4 created, 0 skipped
+```
+
+Second run (no `--force`):
+
+```
+cairn bootstrap: vault already initialized at /path/to/vault
+  config    /path/to/vault/.cairn/config.yaml  [existing]
+  db        /path/to/vault/.cairn/cairn.db  (created on first ingest)
+  dirs      0 created, 14 existing
+  files     0 created, 4 skipped
+```
+
+`--json` emits `BootstrapReceipt` as JSON to stdout.
+
+---
+
+## Tests
+
+New integration test file: `crates/cairn-cli/tests/bootstrap.rs`
+
+| Test | Asserts |
+|---|---|
+| `bootstrap_creates_full_tree` | All 14 dirs + 4 files exist after first run |
+| `bootstrap_idempotent` | Second run exits 0; `files_skipped == 4`; no dirs/files destroyed |
+| `bootstrap_force_overwrites_files` | `--force` re-creates placeholder files even when they exist |
+| `bootstrap_skips_user_edited_purpose` | User edits `purpose.md`; second run without `--force` leaves content intact |
+| `bootstrap_receipt_json` | `--json` emits valid JSON matching `BootstrapReceipt` shape |
+| `bootstrap_reports_db_path` | Receipt `db_path` == `.cairn/cairn.db` regardless of whether file exists |
+
+Existing `config.rs` tests updated: `bootstrap_fails_if_file_already_exists` changes to verify idempotent behavior (files skipped, not error). Snapshot test for human-readable stdout via `insta`.
+
+---
+
+## Invariants touched
+
+- Invariant 3 (CLI is ground truth): `bootstrap` is a management command, not a core verb; logic lives in `cairn-cli`
+- Invariant 4 (seven contracts, pure functions otherwise): no new contract added; `vault::bootstrap` is a plain function with `Result` return
+- No WAL involvement (bootstrap is not a memory mutation)

--- a/docs/superpowers/specs/2026-04-26-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-04-26-bootstrap-design.md
@@ -120,7 +120,7 @@ Human output (no `--json`):
 cairn bootstrap: vault initialized at /path/to/vault
   config    /path/to/vault/.cairn/config.yaml  [created]
   db        /path/to/vault/.cairn/cairn.db  (created on first ingest)
-  dirs      14 created, 0 existing
+  dirs      19 created, 0 existing
   files     4 created, 0 skipped
 ```
 
@@ -130,7 +130,7 @@ Second run (no `--force`):
 cairn bootstrap: vault already initialized at /path/to/vault
   config    /path/to/vault/.cairn/config.yaml  [existing]
   db        /path/to/vault/.cairn/cairn.db  (created on first ingest)
-  dirs      0 created, 14 existing
+  dirs      0 created, 19 existing
   files     0 created, 4 skipped
 ```
 


### PR DESCRIPTION
## Summary

- Adds `cairn_cli::vault` module with `bootstrap()`, `BootstrapReceipt`, `render_human()`, and `write_once()` — implements the full vault directory tree (19 dirs per §3.1) and 4 placeholder files (`config.yaml`, `purpose.md`, `index.md`, `log.md`)
- Idempotent: existing dirs are left unchanged, existing files go to `files_skipped` unless `--force`; exits 74 (`EX_IOERR`) on I/O error
- `cairn bootstrap` gains `--json` (machine-readable `BootstrapReceipt`) and `--force` flags; `config::write_default` removed (superseded)
- Extensive symlink hardening via 8-round adversarial review: vault root trailing-separator normalization, dir pre+post-creation lstat checks, parent dir validated on all `write_once` paths (including early-return skip), `AlreadyExists` race revalidation, atomic temp+rename writes

## Brief sections

§3 Vault Layout · §3.1 Layout template · §19.a v0.1 subset

## Invariants touched

- Invariant 3 (CLI is ground truth): bootstrap is a management command — logic stays in `cairn-cli`, not `cairn-core`
- Invariant 4 (seven contracts, pure functions): no new contract; `vault::bootstrap` is a plain `Result`-returning function

## Test plan

- [x] `cargo nextest run --workspace --locked` — 601/601 tests pass
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --all --check` — formatted
- [ ] Second `cairn bootstrap` run produces `files_skipped == 4`, exit 0
- [ ] `cairn bootstrap --json` emits valid `BootstrapReceipt` JSON
- [ ] `cairn bootstrap --force` overwrites placeholder files

## Known limitation

Intermediate-ancestor TOCTOU (e.g. `sources/` swapped to a symlink between two child iterations) cannot be fully closed without `openat`/`mkdirat` fd-relative APIs, which require `unsafe` code or `libc`/`nix` deps — both prohibited by project invariants. The attack surface requires an adversary with rename rights on vault parent directories (machine already compromised). Documented in code comments.