### PR TITLE
feat(domain): CaptureEvent schema + capture-mode attribution (#71)

### DIFF
--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -362,10 +362,18 @@ impl std::fmt::Display for SourceFamily {
 /// Modality-specific payload metadata for a [`CaptureEvent`].
 ///
 /// The variant **must agree** with the event's [`SourceFamily`] —
-/// validation enforces this. Bodies are deliberately metadata-only: raw
-/// content (utterances, frames, clipboard text) lives behind `payload_ref`
-/// and is hashed by `payload_hash` so the envelope can be logged at
-/// `info` without leaking source bytes (CLAUDE.md §6.6, brief §14).
+/// validation enforces this. Raw content (utterances, frames, clipboard
+/// text) stays behind `payload_ref` + `payload_hash` rather than inline.
+///
+/// **Treat the envelope as sensitive, not log-safe.** Several variants
+/// carry high-signal user metadata that must not be emitted to
+/// structured logs at `info` or above (CLAUDE.md §6.6, brief §14):
+/// `Terminal.command`, `Screen.window_title`, `Screen.url`,
+/// `Ide.file_path`, `Voice.speaker_id`, `Proactive.rationale`. A
+/// downstream observer needs a redacted projection of the envelope —
+/// not a structured-log dump of the raw struct — before any of these
+/// fields leave `trace`. A separate sanitized log type is out of scope
+/// for this issue and tracked as a follow-up.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "source_family", rename_all = "snake_case", deny_unknown_fields)]
 #[non_exhaustive]
@@ -809,6 +817,15 @@ fn validate_vault_relative_path(field: &'static str, raw: &str) -> Result<(), Do
     if raw.contains('\0') {
         return Err(DomainError::MalformedCapture {
             message: format!("{field}: NUL byte not permitted"),
+        });
+    }
+    // Reject backslashes regardless of host platform — vault paths are
+    // forward-slash canonical. This blocks `sources/..\\..\\Win\\x` from
+    // smuggling a parent-dir hop through a single segment on consumers
+    // that normalize backslashes.
+    if raw.contains('\\') {
+        return Err(DomainError::MalformedCapture {
+            message: format!("{field} `{raw}`: backslash not permitted"),
         });
     }
     if raw.contains("://") {

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -1,0 +1,757 @@
+//! `CaptureEvent` schema — the unified envelope every sensor emits into the
+//! ingestion pipeline (brief §5.0.a, §9).
+//!
+//! Every source — hooks, IDE, terminal, clipboard, voice, screen, batch
+//! recordings, the explicit `cairn ingest` CLI, and proactive agent
+//! emissions — produces the same `CaptureEvent` shape. The `source_family`
+//! discriminator selects which `CapturePayload` variant carries the
+//! modality-specific extraction hint; the rest of the envelope is uniform
+//! so the pipeline (Capture → Tool-squash → Extract → Filter → Classify →
+//! Scope → Store) can route, deduplicate, and attribute every event with
+//! the same machinery.
+//!
+//! ## Scope of this module
+//!
+//! - **Schema only.** Extractor implementations (regex/llm/agent) live
+//!   downstream of this module. We define the wire and in-memory shape, the
+//!   newtypes that enforce per-field invariants, and the
+//!   [`CaptureEvent::validate`] entry point that rejects malformed events
+//!   before they enter the pipeline.
+//! - **Sensor manifest validation** lives in
+//!   [`super::capture_manifest`]; **mode → author attribution** lives in
+//!   [`super::capture_attribution`]. Both are re-exported from the crate
+//!   root for convenience.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{ActorChainEntry, DomainError, Identity, IdentityKind, Rfc3339Timestamp};
+
+/// ULID identifier for a single `CaptureEvent` (Crockford base32, 26 chars).
+///
+/// Matches the `Ulid` schema in `crates/cairn-idl/schema/common/primitives.json`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct CaptureEventId(String);
+
+impl CaptureEventId {
+    /// Parse a ULID. Returns [`DomainError::MalformedCapture`] if the input
+    /// is not exactly 26 Crockford base32 characters
+    /// (`0-9`, `A-H`, `J`, `K`, `M`, `N`, `P-T`, `V-Z`).
+    pub fn parse(raw: impl Into<String>) -> Result<Self, DomainError> {
+        let raw = raw.into();
+        if raw.len() != 26 {
+            return Err(DomainError::MalformedCapture {
+                message: format!("event_id `{raw}`: ULID must be exactly 26 chars"),
+            });
+        }
+        if !raw.bytes().all(is_crockford_base32) {
+            return Err(DomainError::MalformedCapture {
+                message: format!("event_id `{raw}`: non-Crockford-base32 character"),
+            });
+        }
+        Ok(Self(raw))
+    }
+
+    /// ULID string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+const fn is_crockford_base32(b: u8) -> bool {
+    matches!(b,
+        b'0'..=b'9'
+        | b'A'..=b'H'
+        | b'J' | b'K' | b'M' | b'N'
+        | b'P'..=b'T'
+        | b'V'..=b'Z'
+    )
+}
+
+impl std::fmt::Display for CaptureEventId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for CaptureEventId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// The body portion of a [`crate::domain::Identity`] of kind
+/// [`IdentityKind::Sensor`] — i.e. `<body>` in `snr:<body>`. Used as the
+/// key for manifest lookup (see [`super::capture_manifest`]).
+///
+/// Construction validates the shape (`[A-Za-z0-9._:-]+`, non-empty)
+/// without re-validating the `snr:` prefix; convert from a full
+/// [`Identity`] via [`SensorLabel::from_identity`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct SensorLabel(String);
+
+impl SensorLabel {
+    /// Parse a bare label body (no `snr:` prefix). Returns
+    /// [`DomainError::MalformedCapture`] if empty or containing
+    /// out-of-class characters.
+    pub fn parse(raw: impl Into<String>) -> Result<Self, DomainError> {
+        let raw = raw.into();
+        if raw.is_empty() {
+            return Err(DomainError::MalformedCapture {
+                message: "sensor_label: empty".to_owned(),
+            });
+        }
+        if !raw.bytes().all(|b| {
+            matches!(b,
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b':' | b'-')
+        }) {
+            return Err(DomainError::MalformedCapture {
+                message: format!("sensor_label `{raw}`: chars must be in [A-Za-z0-9._:-]"),
+            });
+        }
+        Ok(Self(raw))
+    }
+
+    /// Extract the label body from a sensor [`Identity`].
+    pub fn from_identity(id: &Identity) -> Result<Self, DomainError> {
+        if id.kind() != IdentityKind::Sensor {
+            return Err(DomainError::MalformedCapture {
+                message: format!(
+                    "sensor_label: identity `{}` is not a sensor (`snr:`)",
+                    id.as_str()
+                ),
+            });
+        }
+        let body =
+            id.as_str()
+                .strip_prefix("snr:")
+                .ok_or_else(|| DomainError::MalformedCapture {
+                    message: format!(
+                        "sensor_label: identity `{}` missing `snr:` prefix",
+                        id.as_str()
+                    ),
+                })?;
+        Self::parse(body.to_owned())
+    }
+
+    /// Label body string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for SensorLabel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for SensorLabel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// SHA-256 hash of the raw payload bytes for a [`CaptureEvent`], formatted
+/// as `sha256:<64 lowercase hex>`. Same shape as
+/// [`crate::domain::CanonicalRecordHash`] and the `target_hash` of a
+/// signed intent — keeps every hash slot in the pipeline using a single
+/// canonical encoding.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct PayloadHash(String);
+
+impl PayloadHash {
+    /// Parse a `sha256:<64 lowercase hex>` string.
+    pub fn parse(raw: impl Into<String>) -> Result<Self, DomainError> {
+        let raw = raw.into();
+        let hex = raw
+            .strip_prefix("sha256:")
+            .ok_or_else(|| DomainError::InvalidPayloadHash {
+                message: format!("`{raw}`: missing `sha256:` prefix"),
+            })?;
+        if hex.len() != 64 {
+            return Err(DomainError::InvalidPayloadHash {
+                message: format!("`{raw}`: hex must be exactly 64 chars"),
+            });
+        }
+        if !hex.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')) {
+            return Err(DomainError::InvalidPayloadHash {
+                message: format!("`{raw}`: hex must be lowercase [0-9a-f]"),
+            });
+        }
+        Ok(Self(raw))
+    }
+
+    /// Wire-form `sha256:<hex>` slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PayloadHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for PayloadHash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// One of the three concurrent capture modes (brief §5.0.a).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CaptureMode {
+    /// Mode A — sensor-driven hook fired automatically; agent uninvolved.
+    /// Author of the resulting record is the sensor's [`Identity`].
+    Auto,
+    /// Mode B — user explicitly invoked the skill / `cairn ingest` (e.g.
+    /// "remember that …"). Author is the human; the agent (if any) is the
+    /// delegator.
+    Explicit,
+    /// Mode C — agent decided to record (novel entity, correction, success
+    /// strategy). Author is the agent identity.
+    Proactive,
+}
+
+impl std::fmt::Display for CaptureMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl CaptureMode {
+    /// Stable wire-form slice (`auto` / `explicit` / `proactive`).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Explicit => "explicit",
+            Self::Proactive => "proactive",
+        }
+    }
+
+    /// Parse from the wire form. Returns
+    /// [`DomainError::UnsupportedCaptureMode`] on miss.
+    pub fn parse(raw: &str) -> Result<Self, DomainError> {
+        match raw {
+            "auto" => Ok(Self::Auto),
+            "explicit" => Ok(Self::Explicit),
+            "proactive" => Ok(Self::Proactive),
+            other => Err(DomainError::UnsupportedCaptureMode {
+                value: other.to_owned(),
+            }),
+        }
+    }
+}
+
+/// Source-family discriminator for [`CapturePayload`]. Each variant maps
+/// 1:1 to a sensor or input channel listed in brief §9.1 (local) and
+/// §9.1.a (recording batch). The CLI / MCP / proactive-agent variants
+/// model the three §5.0.a entry points that aren't strictly "sensors" but
+/// share the same envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SourceFamily {
+    /// Hook sensor — `SessionStart`, `UserPromptSubmit`, `PostToolUse`,
+    /// `PreCompact`, `Stop` events from a cooperating harness.
+    Hook,
+    /// IDE sensor — file edits, diagnostics, tests, LSP events.
+    Ide,
+    /// Terminal sensor — captured commands and outputs.
+    Terminal,
+    /// Clipboard sensor — clipboard snapshots.
+    Clipboard,
+    /// Voice sensor — VAD-gated utterances, ASR transcript, speaker
+    /// embeddings.
+    Voice,
+    /// Screen sensor — frame OCR + active-window + URL events.
+    Screen,
+    /// Recording-batch — `cairn ingest --recording <file>` audio + video
+    /// after-the-fact extraction (brief §9.1.a).
+    RecordingBatch,
+    /// Explicit `cairn ingest` invocation (CLI or skill-triggered, Mode B).
+    Cli,
+    /// Explicit `cairn ingest` invocation through the MCP adapter (Mode B).
+    Mcp,
+    /// Proactive agent emission (Mode C) — no external sensor channel.
+    Proactive,
+}
+
+impl SourceFamily {
+    /// Stable wire-form slice.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Hook => "hook",
+            Self::Ide => "ide",
+            Self::Terminal => "terminal",
+            Self::Clipboard => "clipboard",
+            Self::Voice => "voice",
+            Self::Screen => "screen",
+            Self::RecordingBatch => "recording_batch",
+            Self::Cli => "cli",
+            Self::Mcp => "mcp",
+            Self::Proactive => "proactive",
+        }
+    }
+
+    /// Parse from wire form. Returns
+    /// [`DomainError::UnsupportedSourceFamily`] on miss.
+    pub fn parse(raw: &str) -> Result<Self, DomainError> {
+        match raw {
+            "hook" => Ok(Self::Hook),
+            "ide" => Ok(Self::Ide),
+            "terminal" => Ok(Self::Terminal),
+            "clipboard" => Ok(Self::Clipboard),
+            "voice" => Ok(Self::Voice),
+            "screen" => Ok(Self::Screen),
+            "recording_batch" => Ok(Self::RecordingBatch),
+            "cli" => Ok(Self::Cli),
+            "mcp" => Ok(Self::Mcp),
+            "proactive" => Ok(Self::Proactive),
+            other => Err(DomainError::UnsupportedSourceFamily {
+                value: other.to_owned(),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for SourceFamily {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Modality-specific payload metadata for a [`CaptureEvent`].
+///
+/// The variant **must agree** with the event's [`SourceFamily`] —
+/// validation enforces this. Bodies are deliberately metadata-only: raw
+/// content (utterances, frames, clipboard text) lives behind `payload_ref`
+/// and is hashed by `payload_hash` so the envelope can be logged at
+/// `info` without leaking source bytes (CLAUDE.md §6.6, brief §14).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "source_family", rename_all = "snake_case", deny_unknown_fields)]
+#[non_exhaustive]
+pub enum CapturePayload {
+    /// Hook event — names the harness hook plus session/turn/tool refs.
+    Hook {
+        /// Harness hook name (e.g., `SessionStart`, `PostToolUse`).
+        hook_name: String,
+        /// Optional tool name, present on `PreToolUse` / `PostToolUse`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_name: Option<String>,
+    },
+    /// IDE event — file path, event kind (edit/diagnostic/test/lsp).
+    Ide {
+        /// Workspace-relative path of the affected file.
+        file_path: String,
+        /// Event subtype (`edit`, `diagnostic`, `test`, `lsp`).
+        event_kind: String,
+    },
+    /// Terminal command + output.
+    Terminal {
+        /// Argv-style command line.
+        command: String,
+        /// Process exit code, if the command had completed at capture
+        /// time.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exit_code: Option<i32>,
+    },
+    /// Clipboard snapshot.
+    Clipboard {
+        /// Clipboard MIME type (`text/plain`, `image/png`, …).
+        mime_type: String,
+        /// Length of the clipboard payload in bytes.
+        byte_len: u64,
+    },
+    /// Voice utterance (post-VAD, post-ASR).
+    Voice {
+        /// Speaker label assigned by diarization
+        /// (e.g., `unknown_speaker_<ulid>` until enrolled).
+        speaker_id: String,
+        /// Number of milliseconds the utterance spans.
+        duration_ms: u64,
+        /// ASR confidence in `[0.0, 1.0]`.
+        confidence: f32,
+    },
+    /// Screen frame.
+    Screen {
+        /// Active application bundle / process name.
+        app: String,
+        /// Active window title (may be redacted at the sensor boundary).
+        window_title: String,
+        /// URL extracted from the active tab, if a browser was active.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        url: Option<String>,
+    },
+    /// Aligned segment from a batch recording (brief §9.1.a).
+    RecordingBatch {
+        /// Path of the source recording file (under `sources/`).
+        recording_path: String,
+        /// Segment start offset within the recording, in milliseconds.
+        segment_start_ms: u64,
+        /// Segment duration in milliseconds.
+        segment_duration_ms: u64,
+    },
+    /// `cairn ingest` invocation from the CLI (Mode B).
+    Cli {
+        /// Memory taxonomy kind hint declared by the user (§5.0.a Mode B).
+        kind_hint: String,
+    },
+    /// `cairn ingest` invocation through the MCP adapter (Mode B).
+    Mcp {
+        /// Memory taxonomy kind hint declared by the user.
+        kind_hint: String,
+    },
+    /// Proactive agent emission (Mode C).
+    Proactive {
+        /// Memory taxonomy kind the agent decided to emit (e.g.,
+        /// `entity`, `feedback`, `strategy_success`, `knowledge_gap`).
+        kind: String,
+        /// Short rationale string the agent attached to the emission.
+        rationale: String,
+    },
+}
+
+impl CapturePayload {
+    /// The [`SourceFamily`] this payload belongs to.
+    #[must_use]
+    pub const fn source_family(&self) -> SourceFamily {
+        match self {
+            Self::Hook { .. } => SourceFamily::Hook,
+            Self::Ide { .. } => SourceFamily::Ide,
+            Self::Terminal { .. } => SourceFamily::Terminal,
+            Self::Clipboard { .. } => SourceFamily::Clipboard,
+            Self::Voice { .. } => SourceFamily::Voice,
+            Self::Screen { .. } => SourceFamily::Screen,
+            Self::RecordingBatch { .. } => SourceFamily::RecordingBatch,
+            Self::Cli { .. } => SourceFamily::Cli,
+            Self::Mcp { .. } => SourceFamily::Mcp,
+            Self::Proactive { .. } => SourceFamily::Proactive,
+        }
+    }
+}
+
+/// Optional turn / tool / session references that pin a capture event into
+/// the per-session timeline. Absent when the source is a one-off batch
+/// (clipboard, recording) with no live session context.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CaptureRefs {
+    /// Harness session id, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Per-session turn id, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    /// Per-turn tool-call id, if the event was emitted under one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_id: Option<String>,
+}
+
+/// The unified capture envelope.
+///
+/// Every sensor (or the explicit Mode B / Mode C entry points) emits this
+/// shape into the ingestion pipeline. The envelope is signable as a unit:
+/// the `event_id` is the natural primary key, the `payload_hash` binds it
+/// to the raw bytes stored under `sources/`, and the `actor_chain` carries
+/// the §4.2 attribution that downstream pipeline stages check against
+/// [`super::capture_attribution::attribute`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CaptureEvent {
+    /// ULID identifying this event.
+    pub event_id: CaptureEventId,
+    /// Sensor identity that produced the event. For Mode B / Mode C
+    /// entries (CLI, MCP, proactive) the originating surface still has a
+    /// sensor identity (`snr:local:cli:*`, `snr:local:mcp:*`,
+    /// `snr:local:proactive:<agent>:v1`) so attribution stays uniform.
+    pub sensor_id: Identity,
+    /// One of the §5.0.a capture modes.
+    pub capture_mode: CaptureMode,
+    /// Author + delegator + sensor entries; validated against
+    /// [`super::validate_chain`] and [`super::attribute`].
+    pub actor_chain: Vec<ActorChainEntry>,
+    /// Optional session / turn / tool references.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refs: Option<CaptureRefs>,
+    /// SHA-256 of the raw payload bytes referenced by `payload_ref`.
+    pub payload_hash: PayloadHash,
+    /// URI pointing into the `sources/` vault layer (brief §3) where the
+    /// raw bytes live. P0 stores everything as a `file://` URI.
+    pub payload_ref: String,
+    /// Wall-clock instant the sensor observed the event.
+    pub captured_at: Rfc3339Timestamp,
+    /// Modality-specific payload metadata. Its tag must equal
+    /// `source_family` below.
+    pub payload: CapturePayload,
+    /// Source-family discriminator. Stored alongside `payload` so a
+    /// reader that only inspects the envelope (without parsing the
+    /// payload) can still route the event.
+    pub source_family: SourceFamily,
+}
+
+impl CaptureEvent {
+    /// Run every invariant on the event:
+    ///
+    /// 1. `payload_ref` non-empty.
+    /// 2. `sensor_id` is a `snr:` identity (Mode B / C still flow through
+    ///    a sensor surface).
+    /// 3. `payload.source_family() == self.source_family`.
+    /// 4. `actor_chain` validates per §4.2
+    ///    ([`super::actor_chain::validate_chain`]).
+    /// 5. `actor_chain` author matches `capture_mode` per §5.0.a
+    ///    ([`super::capture_attribution::attribute`]).
+    /// 6. Sensor label is in the declared P0 manifest
+    ///    ([`super::capture_manifest::validate_label`]).
+    pub fn validate(&self) -> Result<(), DomainError> {
+        if self.payload_ref.is_empty() {
+            return Err(DomainError::EmptyField {
+                field: "payload_ref",
+            });
+        }
+        if self.sensor_id.kind() != IdentityKind::Sensor {
+            return Err(DomainError::MalformedCapture {
+                message: format!(
+                    "sensor_id `{}` is not a sensor identity (`snr:` prefix)",
+                    self.sensor_id.as_str()
+                ),
+            });
+        }
+        if self.payload.source_family() != self.source_family {
+            return Err(DomainError::MalformedCapture {
+                message: format!(
+                    "payload variant `{}` disagrees with source_family `{}`",
+                    self.payload.source_family().as_str(),
+                    self.source_family.as_str()
+                ),
+            });
+        }
+
+        super::actor_chain::validate_chain(&self.actor_chain)?;
+        super::capture_attribution::attribute(self.capture_mode, &self.actor_chain)?;
+
+        let label = SensorLabel::from_identity(&self.sensor_id)?;
+        super::capture_manifest::validate_label(&label)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::ChainRole;
+
+    fn ts() -> Rfc3339Timestamp {
+        Rfc3339Timestamp::parse("2026-04-22T14:02:11Z").expect("valid")
+    }
+
+    fn ulid_a() -> CaptureEventId {
+        // Crockford-base32, lexically valid ULID.
+        CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid ULID")
+    }
+
+    fn sensor() -> Identity {
+        Identity::parse("snr:local:hook:cc-session:v1").expect("valid")
+    }
+
+    fn entry(role: ChainRole, id: &str) -> ActorChainEntry {
+        ActorChainEntry {
+            role,
+            identity: Identity::parse(id).expect("valid"),
+            at: ts(),
+        }
+    }
+
+    fn auto_event() -> CaptureEvent {
+        CaptureEvent {
+            event_id: ulid_a(),
+            sensor_id: sensor(),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![entry(ChainRole::Author, "snr:local:hook:cc-session:v1")],
+            refs: Some(CaptureRefs {
+                session_id: Some("sess-42".into()),
+                turn_id: Some("turn-7".into()),
+                tool_id: None,
+            }),
+            payload_hash: PayloadHash::parse(format!("sha256:{}", "ab".repeat(32))).expect("valid"),
+            payload_ref: "file:///vault/sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json".into(),
+            captured_at: ts(),
+            payload: CapturePayload::Hook {
+                hook_name: "PostToolUse".into(),
+                tool_name: Some("Read".into()),
+            },
+            source_family: SourceFamily::Hook,
+        }
+    }
+
+    #[test]
+    fn captureeventid_parses_ulid() {
+        CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    }
+
+    #[test]
+    fn captureeventid_rejects_bad_length() {
+        let err = CaptureEventId::parse("SHORT").unwrap_err();
+        assert!(matches!(err, DomainError::MalformedCapture { .. }));
+    }
+
+    #[test]
+    fn captureeventid_rejects_bad_chars() {
+        // 'I' is excluded from Crockford base32.
+        let err = CaptureEventId::parse("0IARZ3NDEKTSV4RRFFQ69G5FAV").unwrap_err();
+        assert!(matches!(err, DomainError::MalformedCapture { .. }));
+    }
+
+    #[test]
+    fn payload_hash_parses() {
+        PayloadHash::parse(format!("sha256:{}", "0".repeat(64))).expect("valid");
+    }
+
+    #[test]
+    fn payload_hash_rejects_uppercase() {
+        let err = PayloadHash::parse(format!("sha256:{}", "A".repeat(64))).unwrap_err();
+        assert!(matches!(err, DomainError::InvalidPayloadHash { .. }));
+    }
+
+    #[test]
+    fn payload_hash_rejects_short() {
+        let err = PayloadHash::parse(format!("sha256:{}", "a".repeat(63))).unwrap_err();
+        assert!(matches!(err, DomainError::InvalidPayloadHash { .. }));
+    }
+
+    #[test]
+    fn payload_hash_rejects_missing_prefix() {
+        let err = PayloadHash::parse("a".repeat(64)).unwrap_err();
+        assert!(matches!(err, DomainError::InvalidPayloadHash { .. }));
+    }
+
+    #[test]
+    fn capture_mode_round_trip() {
+        for mode in [
+            CaptureMode::Auto,
+            CaptureMode::Explicit,
+            CaptureMode::Proactive,
+        ] {
+            let s = serde_json::to_string(&mode).expect("ser");
+            let back: CaptureMode = serde_json::from_str(&s).expect("de");
+            assert_eq!(back, mode);
+        }
+    }
+
+    #[test]
+    fn capture_mode_rejects_unknown() {
+        let err = CaptureMode::parse("bogus").unwrap_err();
+        assert!(matches!(err, DomainError::UnsupportedCaptureMode { .. }));
+    }
+
+    #[test]
+    fn source_family_round_trip() {
+        for fam in [
+            SourceFamily::Hook,
+            SourceFamily::Ide,
+            SourceFamily::Terminal,
+            SourceFamily::Clipboard,
+            SourceFamily::Voice,
+            SourceFamily::Screen,
+            SourceFamily::RecordingBatch,
+            SourceFamily::Cli,
+            SourceFamily::Mcp,
+            SourceFamily::Proactive,
+        ] {
+            assert_eq!(SourceFamily::parse(fam.as_str()).expect("round-trip"), fam);
+        }
+    }
+
+    #[test]
+    fn source_family_rejects_unknown() {
+        let err = SourceFamily::parse("smell").unwrap_err();
+        assert!(matches!(err, DomainError::UnsupportedSourceFamily { .. }));
+    }
+
+    #[test]
+    fn sensor_label_from_identity_strips_prefix() {
+        let lbl = SensorLabel::from_identity(&sensor()).expect("valid");
+        assert_eq!(lbl.as_str(), "local:hook:cc-session:v1");
+    }
+
+    #[test]
+    fn sensor_label_rejects_non_sensor_identity() {
+        let usr = Identity::parse("usr:tafeng").expect("valid");
+        let err = SensorLabel::from_identity(&usr).unwrap_err();
+        assert!(matches!(err, DomainError::MalformedCapture { .. }));
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_auto_event() {
+        auto_event().validate().expect("valid");
+    }
+
+    #[test]
+    fn validate_rejects_payload_family_mismatch() {
+        let mut ev = auto_event();
+        ev.source_family = SourceFamily::Voice;
+        let err = ev.validate().unwrap_err();
+        assert!(matches!(err, DomainError::MalformedCapture { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_non_sensor_sensor_id() {
+        let mut ev = auto_event();
+        ev.sensor_id = Identity::parse("agt:claude-code:opus-4-7:main:v1").expect("valid");
+        // Author also needs to match for fairness; but the sensor_id check
+        // fails first.
+        let err = ev.validate().unwrap_err();
+        assert!(matches!(err, DomainError::MalformedCapture { .. }));
+    }
+
+    #[test]
+    fn validate_rejects_empty_payload_ref() {
+        let mut ev = auto_event();
+        ev.payload_ref.clear();
+        let err = ev.validate().unwrap_err();
+        assert!(matches!(err, DomainError::EmptyField { .. }));
+    }
+
+    #[test]
+    fn json_round_trip() {
+        let ev = auto_event();
+        let s = serde_json::to_string(&ev).expect("ser");
+        let back: CaptureEvent = serde_json::from_str(&s).expect("de");
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn deny_unknown_fields_at_envelope_level() {
+        let ev = auto_event();
+        let mut v = serde_json::to_value(&ev).expect("to_value");
+        v.as_object_mut()
+            .expect("obj")
+            .insert("rogue".into(), serde_json::json!("nope"));
+        let s = serde_json::to_string(&v).expect("ser");
+        let res: Result<CaptureEvent, _> = serde_json::from_str(&s);
+        assert!(res.is_err(), "unknown fields must be rejected");
+    }
+}

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -429,10 +429,13 @@ pub enum CapturePayload {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         url: Option<String>,
     },
-    /// Aligned segment from a batch recording (brief §9.1.a).
+    /// Aligned segment from a batch recording (brief §9.1.a). The
+    /// source recording file is referenced by the envelope-level
+    /// `payload_ref` (and bound to `payload_hash`); this variant only
+    /// carries the segment offsets within that file. Keeping a single
+    /// canonical source reference prevents drift between the hashed
+    /// bytes and the bytes a downstream batch extractor reopens.
     RecordingBatch {
-        /// Path of the source recording file (under `sources/`).
-        recording_path: String,
         /// Segment start offset within the recording, in milliseconds.
         segment_start_ms: u64,
         /// Segment duration in milliseconds.
@@ -501,12 +504,11 @@ impl std::fmt::Debug for CapturePayload {
             Self::RecordingBatch {
                 segment_start_ms,
                 segment_duration_ms,
-                ..
             } => f
                 .debug_struct("CapturePayload::RecordingBatch")
                 .field("segment_start_ms", segment_start_ms)
                 .field("segment_duration_ms", segment_duration_ms)
-                .finish_non_exhaustive(),
+                .finish(),
             Self::Cli { .. } => f
                 .debug_struct("CapturePayload::Cli")
                 .finish_non_exhaustive(),
@@ -583,14 +585,9 @@ impl CapturePayload {
                 require_non_empty("app", app)?;
             }
             Self::RecordingBatch {
-                recording_path,
                 segment_duration_ms,
                 ..
             } => {
-                // Same trust boundary as `payload_ref` — a downstream
-                // batch extractor reopens this file, so it must be a
-                // vault-relative `sources/...` path.
-                validate_vault_relative_path("recording_path", recording_path)?;
                 if *segment_duration_ms == 0 {
                     return Err(DomainError::OutOfRange {
                         field: "segment_duration_ms",
@@ -719,6 +716,12 @@ fn identity_agent_slug(identity: &str) -> Option<&str> {
 /// Optional turn / tool / session references that pin a capture event into
 /// the per-session timeline. Absent when the source is a one-off batch
 /// (clipboard, recording) with no live session context.
+///
+/// Each ref, when present, must be a non-empty, non-whitespace string —
+/// downstream ordering, dedup, and replay tooling keys off these
+/// values, so admitting `Some("")` or `Some("   ")` would create
+/// orphaned timeline entries indistinguishable from valid ones at the
+/// type level. Use `None` for absence.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CaptureRefs {
@@ -731,6 +734,25 @@ pub struct CaptureRefs {
     /// Per-turn tool-call id, if the event was emitted under one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_id: Option<String>,
+}
+
+impl CaptureRefs {
+    /// Reject empty or whitespace-only ref values. Absent refs use
+    /// `None`; `Some("")` is malformed.
+    pub fn validate(&self) -> Result<(), DomainError> {
+        require_non_blank_opt("refs.session_id", self.session_id.as_deref())?;
+        require_non_blank_opt("refs.turn_id", self.turn_id.as_deref())?;
+        require_non_blank_opt("refs.tool_id", self.tool_id.as_deref())?;
+        Ok(())
+    }
+}
+
+fn require_non_blank_opt(field: &'static str, value: Option<&str>) -> Result<(), DomainError> {
+    match value {
+        None => Ok(()),
+        Some(s) if !s.trim().is_empty() => Ok(()),
+        Some(_) => Err(DomainError::EmptyField { field }),
+    }
 }
 
 /// The unified capture envelope.
@@ -850,6 +872,44 @@ impl std::fmt::Debug for CaptureEvent {
 }
 
 impl CaptureEvent {
+    /// Build a [`CaptureEvent`] from typed parts, running every
+    /// invariant via [`Self::validate`] before yielding the value.
+    /// In-process callers that want construction-time enforcement (the
+    /// same guarantee `serde(try_from = "CaptureEventRaw")` gives the
+    /// wire-deserialization path) should prefer this over field
+    /// literals. Direct field construction is allowed — this matches
+    /// the [`crate::domain::MemoryRecord`] convention — but it is the
+    /// caller's responsibility to call [`Self::validate`] before
+    /// trusting the value at any boundary.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_new(
+        event_id: CaptureEventId,
+        sensor_id: Identity,
+        capture_mode: CaptureMode,
+        actor_chain: Vec<ActorChainEntry>,
+        refs: Option<CaptureRefs>,
+        payload_hash: PayloadHash,
+        payload_ref: String,
+        captured_at: Rfc3339Timestamp,
+        payload: CapturePayload,
+        source_family: SourceFamily,
+    ) -> Result<Self, DomainError> {
+        let event = Self {
+            event_id,
+            sensor_id,
+            capture_mode,
+            actor_chain,
+            refs,
+            payload_hash,
+            payload_ref,
+            captured_at,
+            payload,
+            source_family,
+        };
+        event.validate()?;
+        Ok(event)
+    }
+
     /// Run every invariant on the event:
     ///
     /// 1. `payload_ref` is a non-empty vault-relative path beginning
@@ -898,6 +958,9 @@ impl CaptureEvent {
             });
         }
         self.payload.validate()?;
+        if let Some(refs) = &self.refs {
+            refs.validate()?;
+        }
         if !mode_allows_family(self.capture_mode, self.source_family) {
             return Err(DomainError::MalformedCapture {
                 message: format!(

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -555,6 +555,104 @@ fn require_non_empty(field: &'static str, value: &str) -> Result<(), DomainError
     }
 }
 
+/// Mode A: the chain `Author` identity must equal `sensor_id` — the
+/// sensor authors its own raw events.
+fn bind_auto_author(chain: &[ActorChainEntry], sensor_id: &Identity) -> Result<(), DomainError> {
+    let author = chain
+        .iter()
+        .find(|e| e.role == ChainRole::Author)
+        .ok_or_else(|| DomainError::MissingSignature {
+            message: "actor_chain has no `author` entry".to_owned(),
+        })?;
+    if &author.identity != sensor_id {
+        return Err(DomainError::AttributionMismatch {
+            message: format!(
+                "mode `auto` requires author identity `{}` to equal sensor_id `{}`",
+                author.identity.as_str(),
+                sensor_id.as_str()
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Mode C: the proactive sensor label carries the agent slug
+/// (`local:proactive:<agent>:v<N>`); the chain author must be an
+/// `agt:<agent>:...` whose slug matches. Blocks cross-agent spoofing.
+fn bind_proactive_author(
+    chain: &[ActorChainEntry],
+    sensor_id: &Identity,
+    label: &str,
+) -> Result<(), DomainError> {
+    let author = chain
+        .iter()
+        .find(|e| e.role == ChainRole::Author)
+        .ok_or_else(|| DomainError::MissingSignature {
+            message: "actor_chain has no `author` entry".to_owned(),
+        })?;
+    let sensor_agent =
+        sensor_label_proactive_agent(label).ok_or_else(|| DomainError::MalformedCapture {
+            message: format!(
+                "proactive sensor_id `{}` does not encode an agent slug",
+                sensor_id.as_str()
+            ),
+        })?;
+    let author_agent = identity_agent_slug(author.identity.as_str()).ok_or_else(|| {
+        DomainError::AttributionMismatch {
+            message: format!(
+                "proactive author `{}` is not an `agt:<slug>:...` identity",
+                author.identity.as_str()
+            ),
+        }
+    })?;
+    if sensor_agent != author_agent {
+        return Err(DomainError::AttributionMismatch {
+            message: format!(
+                "proactive sensor agent `{sensor_agent}` does not match author agent \
+                 `{author_agent}`"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Any `Sensor`-role entry in the chain must equal `sensor_id`.
+fn bind_chain_sensor_entries(
+    chain: &[ActorChainEntry],
+    sensor_id: &Identity,
+) -> Result<(), DomainError> {
+    for entry in chain {
+        if entry.role == ChainRole::Sensor && &entry.identity != sensor_id {
+            return Err(DomainError::AttributionMismatch {
+                message: format!(
+                    "actor_chain `sensor` entry `{}` does not match sensor_id `{}`",
+                    entry.identity.as_str(),
+                    sensor_id.as_str()
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Extract the `<agent>` slug from a `local:proactive:<agent>:v<N>`
+/// sensor label. Returns `None` for non-proactive labels.
+fn sensor_label_proactive_agent(label: &str) -> Option<&str> {
+    let rest = label.strip_prefix("local:proactive:")?;
+    let (agent, _) = rest.split_once(':')?;
+    if agent.is_empty() { None } else { Some(agent) }
+}
+
+/// Extract the `<slug>` from an `agt:<slug>:...` identity. Returns
+/// `None` if the identity is not an agent identity. The slug is the
+/// vendor / product key that pairs with proactive sensor labels — for
+/// `agt:claude-code:opus-4-7:main:v1` the slug is `claude-code`.
+fn identity_agent_slug(identity: &str) -> Option<&str> {
+    let rest = identity.strip_prefix("agt:")?;
+    let slug = rest.split(':').next()?;
+    if slug.is_empty() { None } else { Some(slug) }
+}
+
 /// Optional turn / tool / session references that pin a capture event into
 /// the per-session timeline. Absent when the source is a one-off batch
 /// (clipboard, recording) with no live session context.
@@ -697,35 +795,16 @@ impl CaptureEvent {
         super::actor_chain::validate_chain(&self.actor_chain)?;
         super::capture_attribution::attribute(self.capture_mode, &self.actor_chain)?;
 
-        if self.capture_mode == CaptureMode::Auto {
-            let author = self
-                .actor_chain
-                .iter()
-                .find(|e| e.role == ChainRole::Author)
-                .ok_or_else(|| DomainError::MissingSignature {
-                    message: "actor_chain has no `author` entry".to_owned(),
-                })?;
-            if author.identity != self.sensor_id {
-                return Err(DomainError::AttributionMismatch {
-                    message: format!(
-                        "mode `auto` requires author identity `{}` to equal sensor_id `{}`",
-                        author.identity.as_str(),
-                        self.sensor_id.as_str()
-                    ),
-                });
+        match self.capture_mode {
+            CaptureMode::Auto => {
+                bind_auto_author(&self.actor_chain, &self.sensor_id)?;
             }
-        }
-        for entry in &self.actor_chain {
-            if entry.role == ChainRole::Sensor && entry.identity != self.sensor_id {
-                return Err(DomainError::AttributionMismatch {
-                    message: format!(
-                        "actor_chain `sensor` entry `{}` does not match sensor_id `{}`",
-                        entry.identity.as_str(),
-                        self.sensor_id.as_str()
-                    ),
-                });
+            CaptureMode::Proactive => {
+                bind_proactive_author(&self.actor_chain, &self.sensor_id, label.as_str())?;
             }
+            CaptureMode::Explicit => {}
         }
+        bind_chain_sensor_entries(&self.actor_chain, &self.sensor_id)?;
 
         Ok(())
     }

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -853,10 +853,12 @@ pub struct CaptureEvent {
 impl std::fmt::Debug for CaptureEvent {
     /// Redacted `Debug`: prints structural metadata
     /// (`event_id`, `sensor_id`, `capture_mode`, `source_family`,
-    /// `captured_at`, `payload_hash`, `payload_ref`) plus the redacted
-    /// payload from [`CapturePayload`'s `Debug`]. Keeps `tracing`/panic
-    /// dumps free of user content. Use serde-JSON when a full dump is
-    /// intentionally needed at `trace`.
+    /// `captured_at`, `payload_hash`) plus the redacted payload from
+    /// [`CapturePayload`'s `Debug`]. `payload_ref` is replaced with
+    /// `<redacted>` because vault-relative paths can embed
+    /// producer-chosen filenames that may carry user-derived content.
+    /// Keeps `tracing`/panic dumps free of user content. Use serde-JSON
+    /// when a full dump is intentionally needed at `trace`.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CaptureEvent")
             .field("event_id", &self.event_id)
@@ -865,7 +867,7 @@ impl std::fmt::Debug for CaptureEvent {
             .field("source_family", &self.source_family)
             .field("captured_at", &self.captured_at)
             .field("payload_hash", &self.payload_hash)
-            .field("payload_ref", &self.payload_ref)
+            .field("payload_ref", &"<redacted>")
             .field("payload", &self.payload)
             .finish_non_exhaustive()
     }

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -974,17 +974,17 @@ impl CaptureEvent {
         }
 
         let label = SensorLabel::from_identity(&self.sensor_id)?;
-        // Schema-level admission enforces both the structural rule and
-        // membership in the default canonical registry. Pre-#50 there is
-        // no runtime sensor provisioning to extend the registry, so
-        // accepting an unregistered-but-shape-valid label like
-        // `snr:local:hook:evil-host:v1` would let an attacker mint
-        // trusted events. When #50 ships, the call site switches to the
-        // runtime registry.
-        super::capture_manifest::validate_label_in_registry(
-            &label,
-            super::capture_manifest::P0_CANONICAL_LABELS,
-        )?;
+        // Schema-level admission is the structural rule only
+        // (`local:<family>:<instance>(:<sub>)*:v<digits>`). Closed-list
+        // / instance-version authorization is *not* enforced here:
+        // host-specific sensor instances and producer-side version
+        // bumps must roll out independently of a `cairn-core` release.
+        // Real sensor-instance trust comes from keychain-backed signing
+        // landing with #50; deployments that need closed-list
+        // enforcement before then can pair this with
+        // [`super::capture_manifest::validate_label_in_registry`] at
+        // their ingress boundary.
+        super::capture_manifest::validate_label(&label)?;
 
         let expected_family =
             family_for_label(&label).ok_or_else(|| DomainError::UndeclaredSensor {

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -454,6 +454,80 @@ impl CapturePayload {
             Self::Proactive { .. } => SourceFamily::Proactive,
         }
     }
+
+    /// Per-variant invariants beyond `serde` shape: required identifier
+    /// strings are non-empty, scalars are in their documented range.
+    /// Returns the first failure as
+    /// [`DomainError::MalformedCapture`] / [`DomainError::OutOfRange`] /
+    /// [`DomainError::EmptyField`].
+    pub fn validate(&self) -> Result<(), DomainError> {
+        match self {
+            Self::Hook { hook_name, .. } => {
+                require_non_empty("hook_name", hook_name)?;
+            }
+            Self::Ide {
+                file_path,
+                event_kind,
+            } => {
+                require_non_empty("file_path", file_path)?;
+                require_non_empty("event_kind", event_kind)?;
+            }
+            Self::Terminal { command, .. } => {
+                require_non_empty("command", command)?;
+            }
+            Self::Clipboard { mime_type, .. } => {
+                require_non_empty("mime_type", mime_type)?;
+            }
+            Self::Voice {
+                speaker_id,
+                confidence,
+                ..
+            } => {
+                require_non_empty("speaker_id", speaker_id)?;
+                if !confidence.is_finite() || !(0.0..=1.0).contains(confidence) {
+                    return Err(DomainError::OutOfRange {
+                        field: "confidence",
+                        message: format!("expected `[0.0, 1.0]`, got `{confidence}`"),
+                    });
+                }
+            }
+            Self::Screen {
+                app, window_title, ..
+            } => {
+                require_non_empty("app", app)?;
+                require_non_empty("window_title", window_title)?;
+            }
+            Self::RecordingBatch {
+                recording_path,
+                segment_duration_ms,
+                ..
+            } => {
+                require_non_empty("recording_path", recording_path)?;
+                if *segment_duration_ms == 0 {
+                    return Err(DomainError::OutOfRange {
+                        field: "segment_duration_ms",
+                        message: "must be > 0".to_owned(),
+                    });
+                }
+            }
+            Self::Cli { kind_hint } | Self::Mcp { kind_hint } => {
+                require_non_empty("kind_hint", kind_hint)?;
+            }
+            Self::Proactive { kind, rationale } => {
+                require_non_empty("kind", kind)?;
+                require_non_empty("rationale", rationale)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn require_non_empty(field: &'static str, value: &str) -> Result<(), DomainError> {
+    if value.is_empty() {
+        Err(DomainError::EmptyField { field })
+    } else {
+        Ok(())
+    }
 }
 
 /// Optional turn / tool / session references that pin a capture event into
@@ -501,8 +575,11 @@ pub struct CaptureEvent {
     pub refs: Option<CaptureRefs>,
     /// SHA-256 of the raw payload bytes referenced by `payload_ref`.
     pub payload_hash: PayloadHash,
-    /// URI pointing into the `sources/` vault layer (brief §3) where the
-    /// raw bytes live. P0 stores everything as a `file://` URI.
+    /// Vault-relative path of the raw bytes, beginning with `sources/`
+    /// (brief §3). Storing a relative path — rather than an absolute
+    /// `file://` URI — keeps the trust boundary tight: a downstream
+    /// resolver joins this against the configured vault root, so the
+    /// envelope alone cannot point outside the managed vault.
     pub payload_ref: String,
     /// Wall-clock instant the sensor observed the event.
     pub captured_at: Rfc3339Timestamp,
@@ -518,29 +595,31 @@ pub struct CaptureEvent {
 impl CaptureEvent {
     /// Run every invariant on the event:
     ///
-    /// 1. `payload_ref` is a non-empty `file://` URI rooted under
-    ///    `/sources/` and free of `..` segments. P0 vault layout (§3)
-    ///    keeps raw bytes under that subtree; rejecting other shapes
-    ///    closes off SSRF / off-vault dereferences in any downstream
-    ///    stage that resolves the URI.
+    /// 1. `payload_ref` is a non-empty vault-relative path beginning
+    ///    with `sources/`, with no `..` segments, no leading `/`, no
+    ///    NUL bytes, and no scheme/authority — the resolver joins it
+    ///    against the configured vault root.
     /// 2. `sensor_id` is a `snr:` identity (Mode B / C still flow through
     ///    a sensor surface).
     /// 3. `payload.source_family() == self.source_family`.
-    /// 4. `capture_mode` and `source_family` are a declared §5.0.a pair
+    /// 4. Per-payload invariants
+    ///    ([`CapturePayload::validate`]) — required identifiers
+    ///    non-empty, `confidence` in `[0.0, 1.0]`, etc.
+    /// 5. `capture_mode` and `source_family` are a declared §5.0.a pair
     ///    (Auto = sensor families, Explicit = `cli` / `mcp`,
     ///    Proactive = `proactive`).
-    /// 5. `source_family` matches the family expected from the sensor
+    /// 6. `source_family` matches the family expected from the sensor
     ///    label — a `local:cli:` sensor cannot emit a `screen` payload.
-    /// 6. `actor_chain` validates per §4.2
+    /// 7. `actor_chain` validates per §4.2
     ///    ([`super::actor_chain::validate_chain`]).
-    /// 7. `actor_chain` author matches `capture_mode` per §5.0.a
+    /// 8. `actor_chain` author matches `capture_mode` per §5.0.a
     ///    ([`super::capture_attribution::attribute`]).
-    /// 8. For Mode A captures, the `Author` entry's identity equals
+    /// 9. For Mode A captures, the `Author` entry's identity equals
     ///    `sensor_id` (the sensor authors its own raw events). For any
     ///    mode, if a `Sensor` role entry is present in the chain, it
     ///    must equal `sensor_id`.
-    /// 9. Sensor label is in the declared P0 manifest
-    ///    ([`super::capture_manifest::validate_label`]).
+    /// 10. Sensor label is in the declared P0 manifest
+    ///     ([`super::capture_manifest::validate_label`]).
     pub fn validate(&self) -> Result<(), DomainError> {
         validate_payload_ref(&self.payload_ref)?;
 
@@ -561,6 +640,7 @@ impl CaptureEvent {
                 ),
             });
         }
+        self.payload.validate()?;
         if !mode_allows_family(self.capture_mode, self.source_family) {
             return Err(DomainError::MalformedCapture {
                 message: format!(
@@ -691,43 +771,50 @@ fn family_for_label(label: &SensorLabel) -> Option<SourceFamily> {
 /// Reject `payload_ref` strings that would let a downstream stage
 /// dereference bytes outside the managed `sources/` vault layer (§3).
 ///
-/// Accepted shape: `file:///<abs-path>/sources/<rest>` — strictly empty
-/// authority (three slashes after `file:`), no query, no fragment, no
-/// `..` traversal. The path is percent-decoded before the traversal
-/// check so encoded escapes (`%2e%2e`) cannot bypass the rule. Pure
-/// syntactic check — no filesystem access at this layer.
+/// Accepted shape: a non-empty vault-relative path that begins with the
+/// literal prefix `sources/`, contains no `..` segment, no empty `//`
+/// segment, no leading `/`, no NUL byte, no scheme/authority marker
+/// (`://`), and no query or fragment. A downstream resolver joins this
+/// against the configured vault root, so the envelope alone cannot
+/// reference paths outside the vault. Pure syntactic check — no
+/// filesystem access at this layer.
 fn validate_payload_ref(raw: &str) -> Result<(), DomainError> {
     if raw.is_empty() {
         return Err(DomainError::EmptyField {
             field: "payload_ref",
         });
     }
-    // `file:///` rather than `file://`: require an empty authority so
-    // `file://attacker-host/sources/x` is rejected. The third `/` is the
-    // start of the absolute path.
-    let path = raw
-        .strip_prefix("file:///")
-        .ok_or_else(|| DomainError::MalformedCapture {
-            message: format!("payload_ref `{raw}`: must be a `file:///` URI with empty authority"),
-        })?;
-    if path.contains('?') || path.contains('#') {
+    if raw.contains('\0') {
+        return Err(DomainError::MalformedCapture {
+            message: "payload_ref: NUL byte not permitted".to_owned(),
+        });
+    }
+    if raw.contains("://") {
+        return Err(DomainError::MalformedCapture {
+            message: format!("payload_ref `{raw}`: scheme not permitted, use vault-relative path"),
+        });
+    }
+    if raw.starts_with('/') {
+        return Err(DomainError::MalformedCapture {
+            message: format!("payload_ref `{raw}`: must not be absolute"),
+        });
+    }
+    if !raw.starts_with("sources/") {
+        return Err(DomainError::MalformedCapture {
+            message: format!("payload_ref `{raw}`: must begin with `sources/`"),
+        });
+    }
+    if raw.contains('?') || raw.contains('#') {
         return Err(DomainError::MalformedCapture {
             message: format!("payload_ref `{raw}`: query/fragment not permitted"),
         });
     }
-    let decoded = percent_decode(path).ok_or_else(|| DomainError::MalformedCapture {
-        message: format!("payload_ref `{raw}`: malformed percent-encoding"),
-    })?;
-    // The decoded path must contain a `/sources/` segment so off-vault
-    // paths like `/etc/passwd` are rejected, and must have no `..`
-    // segments after decoding so percent-encoded traversals
-    // (`%2e%2e`) cannot escape the vault root.
-    if !decoded.contains("/sources/") && !decoded.starts_with("sources/") {
-        return Err(DomainError::MalformedCapture {
-            message: format!("payload_ref `{raw}`: path must contain `/sources/`"),
-        });
-    }
-    for segment in decoded.split('/') {
+    for segment in raw.split('/') {
+        if segment.is_empty() {
+            return Err(DomainError::MalformedCapture {
+                message: format!("payload_ref `{raw}`: empty path segment"),
+            });
+        }
         if segment == ".." {
             return Err(DomainError::MalformedCapture {
                 message: format!("payload_ref `{raw}`: `..` traversal not permitted"),
@@ -735,30 +822,6 @@ fn validate_payload_ref(raw: &str) -> Result<(), DomainError> {
         }
     }
     Ok(())
-}
-
-/// Decode `%XX` escapes in a URI path. Returns `None` if a `%` is not
-/// followed by two hex digits. Stays in `cairn-core` to avoid pulling
-/// `percent-encoding` for one decoder.
-fn percent_decode(s: &str) -> Option<String> {
-    let bytes = s.as_bytes();
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' {
-            if i + 2 >= bytes.len() {
-                return None;
-            }
-            let hi = u8::try_from((bytes[i + 1] as char).to_digit(16)?).ok()?;
-            let lo = u8::try_from((bytes[i + 2] as char).to_digit(16)?).ok()?;
-            out.push(hi * 16 + lo);
-            i += 3;
-        } else {
-            out.push(bytes[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8(out).ok()
 }
 
 #[cfg(test)]
@@ -799,7 +862,7 @@ mod tests {
                 tool_id: None,
             }),
             payload_hash: PayloadHash::parse(format!("sha256:{}", "ab".repeat(32))).expect("valid"),
-            payload_ref: "file:///vault/sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json".into(),
+            payload_ref: "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json".into(),
             captured_at: ts(),
             payload: CapturePayload::Hook {
                 hook_name: "PostToolUse".into(),

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -36,9 +36,14 @@ use crate::domain::{
 pub struct CaptureEventId(String);
 
 impl CaptureEventId {
-    /// Parse a ULID. Returns [`DomainError::MalformedCapture`] if the input
-    /// is not exactly 26 Crockford base32 characters
-    /// (`0-9`, `A-H`, `J`, `K`, `M`, `N`, `P-T`, `V-Z`).
+    /// Parse a wire-form ULID.
+    ///
+    /// Length is 26, alphabet is Crockford base32 (uppercase, no
+    /// `I L O U`), and the first character is bounded to `[0..=7]`
+    /// because a ULID encodes a 128-bit integer and the high 5 bits of
+    /// the leading Crockford symbol must be zero — otherwise the value
+    /// overflows 128 bits and downstream ULID decoders will misorder or
+    /// reject it. Mirrors [`crate::domain::record::RecordId::parse`].
     pub fn parse(raw: impl Into<String>) -> Result<Self, DomainError> {
         let raw = raw.into();
         if raw.len() != 26 {
@@ -46,7 +51,15 @@ impl CaptureEventId {
                 message: format!("event_id `{raw}`: ULID must be exactly 26 chars"),
             });
         }
-        if !raw.bytes().all(is_crockford_base32) {
+        let bytes = raw.as_bytes();
+        if !matches!(bytes[0], b'0'..=b'7') {
+            return Err(DomainError::MalformedCapture {
+                message: format!(
+                    "event_id `{raw}`: first char must be `0`-`7` (128-bit ULID range)"
+                ),
+            });
+        }
+        if !bytes[1..].iter().copied().all(is_crockford_base32) {
             return Err(DomainError::MalformedCapture {
                 message: format!("event_id `{raw}`: non-Crockford-base32 character"),
             });
@@ -491,18 +504,22 @@ impl CapturePayload {
                     });
                 }
             }
-            Self::Screen {
-                app, window_title, ..
-            } => {
+            Self::Screen { app, .. } => {
+                // `window_title` is intentionally allowed to be empty —
+                // privacy-redacted captures and titleless OS surfaces
+                // (notifications, lock screens) submit `""` rather than
+                // forcing the sensor to invent a placeholder.
                 require_non_empty("app", app)?;
-                require_non_empty("window_title", window_title)?;
             }
             Self::RecordingBatch {
                 recording_path,
                 segment_duration_ms,
                 ..
             } => {
-                require_non_empty("recording_path", recording_path)?;
+                // Same trust boundary as `payload_ref` — a downstream
+                // batch extractor reopens this file, so it must be a
+                // vault-relative `sources/...` path.
+                validate_vault_relative_path("recording_path", recording_path)?;
                 if *segment_duration_ms == 0 {
                     return Err(DomainError::OutOfRange {
                         field: "segment_duration_ms",
@@ -779,45 +796,50 @@ fn family_for_label(label: &SensorLabel) -> Option<SourceFamily> {
 /// reference paths outside the vault. Pure syntactic check — no
 /// filesystem access at this layer.
 fn validate_payload_ref(raw: &str) -> Result<(), DomainError> {
+    validate_vault_relative_path("payload_ref", raw)
+}
+
+/// Shared vault-relative path validator used by both `payload_ref` and
+/// per-payload path fields like `RecordingBatch.recording_path`. See the
+/// [`validate_payload_ref`] doc-comment for the accepted shape.
+fn validate_vault_relative_path(field: &'static str, raw: &str) -> Result<(), DomainError> {
     if raw.is_empty() {
-        return Err(DomainError::EmptyField {
-            field: "payload_ref",
-        });
+        return Err(DomainError::EmptyField { field });
     }
     if raw.contains('\0') {
         return Err(DomainError::MalformedCapture {
-            message: "payload_ref: NUL byte not permitted".to_owned(),
+            message: format!("{field}: NUL byte not permitted"),
         });
     }
     if raw.contains("://") {
         return Err(DomainError::MalformedCapture {
-            message: format!("payload_ref `{raw}`: scheme not permitted, use vault-relative path"),
+            message: format!("{field} `{raw}`: scheme not permitted, use vault-relative path"),
         });
     }
     if raw.starts_with('/') {
         return Err(DomainError::MalformedCapture {
-            message: format!("payload_ref `{raw}`: must not be absolute"),
+            message: format!("{field} `{raw}`: must not be absolute"),
         });
     }
     if !raw.starts_with("sources/") {
         return Err(DomainError::MalformedCapture {
-            message: format!("payload_ref `{raw}`: must begin with `sources/`"),
+            message: format!("{field} `{raw}`: must begin with `sources/`"),
         });
     }
     if raw.contains('?') || raw.contains('#') {
         return Err(DomainError::MalformedCapture {
-            message: format!("payload_ref `{raw}`: query/fragment not permitted"),
+            message: format!("{field} `{raw}`: query/fragment not permitted"),
         });
     }
     for segment in raw.split('/') {
         if segment.is_empty() {
             return Err(DomainError::MalformedCapture {
-                message: format!("payload_ref `{raw}`: empty path segment"),
+                message: format!("{field} `{raw}`: empty path segment"),
             });
         }
         if segment == ".." {
             return Err(DomainError::MalformedCapture {
-                message: format!("payload_ref `{raw}`: `..` traversal not permitted"),
+                message: format!("{field} `{raw}`: `..` traversal not permitted"),
             });
         }
     }

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -909,7 +909,17 @@ impl CaptureEvent {
         }
 
         let label = SensorLabel::from_identity(&self.sensor_id)?;
-        super::capture_manifest::validate_label(&label)?;
+        // Schema-level admission enforces both the structural rule and
+        // membership in the default canonical registry. Pre-#50 there is
+        // no runtime sensor provisioning to extend the registry, so
+        // accepting an unregistered-but-shape-valid label like
+        // `snr:local:hook:evil-host:v1` would let an attacker mint
+        // trusted events. When #50 ships, the call site switches to the
+        // runtime registry.
+        super::capture_manifest::validate_label_in_registry(
+            &label,
+            super::capture_manifest::P0_CANONICAL_LABELS,
+        )?;
 
         let expected_family =
             family_for_label(&label).ok_or_else(|| DomainError::UndeclaredSensor {

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -574,14 +574,16 @@ impl CaptureEvent {
         let label = SensorLabel::from_identity(&self.sensor_id)?;
         super::capture_manifest::validate_label(&label)?;
 
-        if let Some(expected) = family_for_label(&label)
-            && expected != self.source_family
-        {
+        let expected_family =
+            family_for_label(&label).ok_or_else(|| DomainError::UndeclaredSensor {
+                label: label.as_str().to_owned(),
+            })?;
+        if expected_family != self.source_family {
             return Err(DomainError::MalformedCapture {
                 message: format!(
                     "sensor `{}` declares family `{}` but event source_family is `{}`",
                     self.sensor_id.as_str(),
-                    expected.as_str(),
+                    expected_family.as_str(),
                     self.source_family.as_str()
                 ),
             });
@@ -644,14 +646,24 @@ const fn mode_allows_family(mode: CaptureMode, family: SourceFamily) -> bool {
 }
 
 /// Map a declared [`SensorLabel`] prefix to the [`SourceFamily`] its
-/// sensor produces. Returns `None` when the label has no canonical family
-/// pinned (e.g., `local:neuroskill:` produces structured tool-call traces
-/// shaped like Hook events but is not exclusively a hook channel — we
-/// don't pin its family yet so that future neuroskill payload variants
-/// don't require a manifest change).
+/// sensor is allowed to emit. Every prefix in
+/// [`super::capture_manifest::P0_SENSOR_LABEL_PREFIXES`] has a fixed
+/// family — a sensor cannot impersonate another capture surface.
+///
+/// `local:neuroskill:` is pinned to [`SourceFamily::Hook`] because brief
+/// §9.1 describes it as "structured agent tool-call traces emitted by
+/// the harness itself" — semantically the same channel as harness
+/// `PostToolUse`/`PreToolUse` hooks, just emitted directly by the
+/// harness's neuroskill protocol. If a future payload variant needs a
+/// different family, add it to [`SourceFamily`] and pin the prefix
+/// here in the same PR.
+///
+/// Returns `None` only for labels not in the manifest — callers should
+/// run [`super::capture_manifest::validate_label`] before this so an
+/// unpinned label is impossible at the call site.
 fn family_for_label(label: &SensorLabel) -> Option<SourceFamily> {
     let s = label.as_str();
-    if s.starts_with("local:hook:") {
+    if s.starts_with("local:hook:") || s.starts_with("local:neuroskill:") {
         Some(SourceFamily::Hook)
     } else if s.starts_with("local:ide:") {
         Some(SourceFamily::Ide)
@@ -679,35 +691,43 @@ fn family_for_label(label: &SensorLabel) -> Option<SourceFamily> {
 /// Reject `payload_ref` strings that would let a downstream stage
 /// dereference bytes outside the managed `sources/` vault layer (§3).
 ///
-/// The accepted shape is `file://<host>/<path>/sources/<rest>` with no
-/// `..` traversal segments, no query, and no fragment. Pure syntactic
-/// check — there is no filesystem access at this layer.
+/// Accepted shape: `file:///<abs-path>/sources/<rest>` — strictly empty
+/// authority (three slashes after `file:`), no query, no fragment, no
+/// `..` traversal. The path is percent-decoded before the traversal
+/// check so encoded escapes (`%2e%2e`) cannot bypass the rule. Pure
+/// syntactic check — no filesystem access at this layer.
 fn validate_payload_ref(raw: &str) -> Result<(), DomainError> {
     if raw.is_empty() {
         return Err(DomainError::EmptyField {
             field: "payload_ref",
         });
     }
-    let rest = raw
-        .strip_prefix("file://")
+    // `file:///` rather than `file://`: require an empty authority so
+    // `file://attacker-host/sources/x` is rejected. The third `/` is the
+    // start of the absolute path.
+    let path = raw
+        .strip_prefix("file:///")
         .ok_or_else(|| DomainError::MalformedCapture {
-            message: format!("payload_ref `{raw}`: must use `file://` scheme"),
+            message: format!("payload_ref `{raw}`: must be a `file:///` URI with empty authority"),
         })?;
-    if rest.contains('?') || rest.contains('#') {
+    if path.contains('?') || path.contains('#') {
         return Err(DomainError::MalformedCapture {
             message: format!("payload_ref `{raw}`: query/fragment not permitted"),
         });
     }
-    // After the `file://` prefix, the path must contain a `/sources/`
-    // segment so off-vault paths like `/etc/passwd` are rejected.
-    if !rest.contains("/sources/") {
+    let decoded = percent_decode(path).ok_or_else(|| DomainError::MalformedCapture {
+        message: format!("payload_ref `{raw}`: malformed percent-encoding"),
+    })?;
+    // The decoded path must contain a `/sources/` segment so off-vault
+    // paths like `/etc/passwd` are rejected, and must have no `..`
+    // segments after decoding so percent-encoded traversals
+    // (`%2e%2e`) cannot escape the vault root.
+    if !decoded.contains("/sources/") && !decoded.starts_with("sources/") {
         return Err(DomainError::MalformedCapture {
             message: format!("payload_ref `{raw}`: path must contain `/sources/`"),
         });
     }
-    // Reject `..` traversal segments. Match on segment boundaries so
-    // legitimate filenames like `foo..bar.json` aren't rejected.
-    for segment in rest.split('/') {
+    for segment in decoded.split('/') {
         if segment == ".." {
             return Err(DomainError::MalformedCapture {
                 message: format!("payload_ref `{raw}`: `..` traversal not permitted"),
@@ -715,6 +735,30 @@ fn validate_payload_ref(raw: &str) -> Result<(), DomainError> {
         }
     }
     Ok(())
+}
+
+/// Decode `%XX` escapes in a URI path. Returns `None` if a `%` is not
+/// followed by two hex digits. Stays in `cairn-core` to avoid pulling
+/// `percent-encoding` for one decoder.
+fn percent_decode(s: &str) -> Option<String> {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return None;
+            }
+            let hi = u8::try_from((bytes[i + 1] as char).to_digit(16)?).ok()?;
+            let lo = u8::try_from((bytes[i + 2] as char).to_digit(16)?).ok()?;
+            out.push(hi * 16 + lo);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).ok()
 }
 
 #[cfg(test)]

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -374,7 +374,7 @@ impl std::fmt::Display for SourceFamily {
 /// not a structured-log dump of the raw struct — before any of these
 /// fields leave `trace`. A separate sanitized log type is out of scope
 /// for this issue and tracked as a follow-up.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "source_family", rename_all = "snake_case", deny_unknown_fields)]
 #[non_exhaustive]
 pub enum CapturePayload {
@@ -456,6 +456,69 @@ pub enum CapturePayload {
         /// Short rationale string the agent attached to the emission.
         rationale: String,
     },
+}
+
+impl std::fmt::Debug for CapturePayload {
+    /// Redacted `Debug`: prints the variant name plus only the
+    /// non-sensitive scalar fields. Identifier strings, command lines,
+    /// titles, URLs, and rationale text are replaced with `<redacted>`
+    /// so accidental `tracing`/panic dumps cannot leak user metadata
+    /// (CLAUDE.md §6.6, brief §14). Use `serde_json::to_string` (which
+    /// preserves all fields) when a full dump is intentionally needed
+    /// at `trace`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Hook { .. } => f
+                .debug_struct("CapturePayload::Hook")
+                .finish_non_exhaustive(),
+            Self::Ide { .. } => f
+                .debug_struct("CapturePayload::Ide")
+                .finish_non_exhaustive(),
+            Self::Terminal { exit_code, .. } => f
+                .debug_struct("CapturePayload::Terminal")
+                .field("exit_code", exit_code)
+                .finish_non_exhaustive(),
+            Self::Clipboard {
+                mime_type,
+                byte_len,
+            } => f
+                .debug_struct("CapturePayload::Clipboard")
+                .field("mime_type", mime_type)
+                .field("byte_len", byte_len)
+                .finish(),
+            Self::Voice {
+                duration_ms,
+                confidence,
+                ..
+            } => f
+                .debug_struct("CapturePayload::Voice")
+                .field("duration_ms", duration_ms)
+                .field("confidence", confidence)
+                .finish_non_exhaustive(),
+            Self::Screen { .. } => f
+                .debug_struct("CapturePayload::Screen")
+                .finish_non_exhaustive(),
+            Self::RecordingBatch {
+                segment_start_ms,
+                segment_duration_ms,
+                ..
+            } => f
+                .debug_struct("CapturePayload::RecordingBatch")
+                .field("segment_start_ms", segment_start_ms)
+                .field("segment_duration_ms", segment_duration_ms)
+                .finish_non_exhaustive(),
+            Self::Cli { .. } => f
+                .debug_struct("CapturePayload::Cli")
+                .finish_non_exhaustive(),
+            Self::Mcp { .. } => f
+                .debug_struct("CapturePayload::Mcp")
+                .finish_non_exhaustive(),
+            Self::Proactive { kind, .. } => f
+                .debug_struct("CapturePayload::Proactive")
+                .field("kind", kind)
+                .finish_non_exhaustive(),
+        }
+    }
 }
 
 impl CapturePayload {
@@ -678,8 +741,58 @@ pub struct CaptureRefs {
 /// to the raw bytes stored under `sources/`, and the `actor_chain` carries
 /// the §4.2 attribution that downstream pipeline stages check against
 /// [`super::capture_attribution::attribute`].
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Wire-form mirror of [`CaptureEvent`] used as the deserialization
+/// target. `serde(try_from = "CaptureEventRaw")` on `CaptureEvent`
+/// routes every JSON payload through this struct first, then runs
+/// [`CaptureEvent::validate`] before yielding the typed envelope. That
+/// makes invalid states unconstructable at the trust boundary —
+/// callers cannot accidentally skip validation by going through
+/// `serde_json::from_str` (or any other format that uses serde).
+#[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
+struct CaptureEventRaw {
+    event_id: CaptureEventId,
+    sensor_id: Identity,
+    capture_mode: CaptureMode,
+    actor_chain: Vec<ActorChainEntry>,
+    #[serde(default)]
+    refs: Option<CaptureRefs>,
+    payload_hash: PayloadHash,
+    payload_ref: String,
+    captured_at: Rfc3339Timestamp,
+    payload: CapturePayload,
+    source_family: SourceFamily,
+}
+
+impl TryFrom<CaptureEventRaw> for CaptureEvent {
+    type Error = DomainError;
+
+    fn try_from(raw: CaptureEventRaw) -> Result<Self, Self::Error> {
+        let event = Self {
+            event_id: raw.event_id,
+            sensor_id: raw.sensor_id,
+            capture_mode: raw.capture_mode,
+            actor_chain: raw.actor_chain,
+            refs: raw.refs,
+            payload_hash: raw.payload_hash,
+            payload_ref: raw.payload_ref,
+            captured_at: raw.captured_at,
+            payload: raw.payload,
+            source_family: raw.source_family,
+        };
+        event.validate()?;
+        Ok(event)
+    }
+}
+
+/// The unified capture envelope (brief §5.0.a, §9). See module-level
+/// docs for the full validation contract — including the §5.0.a
+/// attribution rule, the closed source-family list, and the trust
+/// boundary on `payload_ref`. JSON deserialization runs
+/// [`CaptureEvent::validate`] via `serde(try_from = "CaptureEventRaw")`,
+/// so malformed events cannot enter the type at the wire boundary.
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, try_from = "CaptureEventRaw")]
 pub struct CaptureEvent {
     /// ULID identifying this event.
     pub event_id: CaptureEventId,
@@ -713,6 +826,27 @@ pub struct CaptureEvent {
     /// reader that only inspects the envelope (without parsing the
     /// payload) can still route the event.
     pub source_family: SourceFamily,
+}
+
+impl std::fmt::Debug for CaptureEvent {
+    /// Redacted `Debug`: prints structural metadata
+    /// (`event_id`, `sensor_id`, `capture_mode`, `source_family`,
+    /// `captured_at`, `payload_hash`, `payload_ref`) plus the redacted
+    /// payload from [`CapturePayload`'s `Debug`]. Keeps `tracing`/panic
+    /// dumps free of user content. Use serde-JSON when a full dump is
+    /// intentionally needed at `trace`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CaptureEvent")
+            .field("event_id", &self.event_id)
+            .field("sensor_id", &self.sensor_id)
+            .field("capture_mode", &self.capture_mode)
+            .field("source_family", &self.source_family)
+            .field("captured_at", &self.captured_at)
+            .field("payload_hash", &self.payload_hash)
+            .field("payload_ref", &self.payload_ref)
+            .field("payload", &self.payload)
+            .finish_non_exhaustive()
+    }
 }
 
 impl CaptureEvent {

--- a/crates/cairn-core/src/domain/capture.rs
+++ b/crates/cairn-core/src/domain/capture.rs
@@ -24,7 +24,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::domain::{ActorChainEntry, DomainError, Identity, IdentityKind, Rfc3339Timestamp};
+use crate::domain::{
+    ActorChainEntry, ChainRole, DomainError, Identity, IdentityKind, Rfc3339Timestamp,
+};
 
 /// ULID identifier for a single `CaptureEvent` (Crockford base32, 26 chars).
 ///
@@ -516,22 +518,32 @@ pub struct CaptureEvent {
 impl CaptureEvent {
     /// Run every invariant on the event:
     ///
-    /// 1. `payload_ref` non-empty.
+    /// 1. `payload_ref` is a non-empty `file://` URI rooted under
+    ///    `/sources/` and free of `..` segments. P0 vault layout (§3)
+    ///    keeps raw bytes under that subtree; rejecting other shapes
+    ///    closes off SSRF / off-vault dereferences in any downstream
+    ///    stage that resolves the URI.
     /// 2. `sensor_id` is a `snr:` identity (Mode B / C still flow through
     ///    a sensor surface).
     /// 3. `payload.source_family() == self.source_family`.
-    /// 4. `actor_chain` validates per §4.2
+    /// 4. `capture_mode` and `source_family` are a declared §5.0.a pair
+    ///    (Auto = sensor families, Explicit = `cli` / `mcp`,
+    ///    Proactive = `proactive`).
+    /// 5. `source_family` matches the family expected from the sensor
+    ///    label — a `local:cli:` sensor cannot emit a `screen` payload.
+    /// 6. `actor_chain` validates per §4.2
     ///    ([`super::actor_chain::validate_chain`]).
-    /// 5. `actor_chain` author matches `capture_mode` per §5.0.a
+    /// 7. `actor_chain` author matches `capture_mode` per §5.0.a
     ///    ([`super::capture_attribution::attribute`]).
-    /// 6. Sensor label is in the declared P0 manifest
+    /// 8. For Mode A captures, the `Author` entry's identity equals
+    ///    `sensor_id` (the sensor authors its own raw events). For any
+    ///    mode, if a `Sensor` role entry is present in the chain, it
+    ///    must equal `sensor_id`.
+    /// 9. Sensor label is in the declared P0 manifest
     ///    ([`super::capture_manifest::validate_label`]).
     pub fn validate(&self) -> Result<(), DomainError> {
-        if self.payload_ref.is_empty() {
-            return Err(DomainError::EmptyField {
-                field: "payload_ref",
-            });
-        }
+        validate_payload_ref(&self.payload_ref)?;
+
         if self.sensor_id.kind() != IdentityKind::Sensor {
             return Err(DomainError::MalformedCapture {
                 message: format!(
@@ -549,14 +561,160 @@ impl CaptureEvent {
                 ),
             });
         }
+        if !mode_allows_family(self.capture_mode, self.source_family) {
+            return Err(DomainError::MalformedCapture {
+                message: format!(
+                    "capture_mode `{}` is incompatible with source_family `{}`",
+                    self.capture_mode.as_str(),
+                    self.source_family.as_str()
+                ),
+            });
+        }
+
+        let label = SensorLabel::from_identity(&self.sensor_id)?;
+        super::capture_manifest::validate_label(&label)?;
+
+        if let Some(expected) = family_for_label(&label)
+            && expected != self.source_family
+        {
+            return Err(DomainError::MalformedCapture {
+                message: format!(
+                    "sensor `{}` declares family `{}` but event source_family is `{}`",
+                    self.sensor_id.as_str(),
+                    expected.as_str(),
+                    self.source_family.as_str()
+                ),
+            });
+        }
 
         super::actor_chain::validate_chain(&self.actor_chain)?;
         super::capture_attribution::attribute(self.capture_mode, &self.actor_chain)?;
 
-        let label = SensorLabel::from_identity(&self.sensor_id)?;
-        super::capture_manifest::validate_label(&label)?;
+        if self.capture_mode == CaptureMode::Auto {
+            let author = self
+                .actor_chain
+                .iter()
+                .find(|e| e.role == ChainRole::Author)
+                .ok_or_else(|| DomainError::MissingSignature {
+                    message: "actor_chain has no `author` entry".to_owned(),
+                })?;
+            if author.identity != self.sensor_id {
+                return Err(DomainError::AttributionMismatch {
+                    message: format!(
+                        "mode `auto` requires author identity `{}` to equal sensor_id `{}`",
+                        author.identity.as_str(),
+                        self.sensor_id.as_str()
+                    ),
+                });
+            }
+        }
+        for entry in &self.actor_chain {
+            if entry.role == ChainRole::Sensor && entry.identity != self.sensor_id {
+                return Err(DomainError::AttributionMismatch {
+                    message: format!(
+                        "actor_chain `sensor` entry `{}` does not match sensor_id `{}`",
+                        entry.identity.as_str(),
+                        self.sensor_id.as_str()
+                    ),
+                });
+            }
+        }
+
         Ok(())
     }
+}
+
+/// True iff a [`CaptureMode`] is permitted to carry events of a given
+/// [`SourceFamily`] per brief §5.0.a.
+const fn mode_allows_family(mode: CaptureMode, family: SourceFamily) -> bool {
+    matches!(
+        (mode, family),
+        (
+            CaptureMode::Auto,
+            SourceFamily::Hook
+                | SourceFamily::Ide
+                | SourceFamily::Terminal
+                | SourceFamily::Clipboard
+                | SourceFamily::Voice
+                | SourceFamily::Screen
+                | SourceFamily::RecordingBatch,
+        ) | (CaptureMode::Explicit, SourceFamily::Cli | SourceFamily::Mcp)
+            | (CaptureMode::Proactive, SourceFamily::Proactive)
+    )
+}
+
+/// Map a declared [`SensorLabel`] prefix to the [`SourceFamily`] its
+/// sensor produces. Returns `None` when the label has no canonical family
+/// pinned (e.g., `local:neuroskill:` produces structured tool-call traces
+/// shaped like Hook events but is not exclusively a hook channel — we
+/// don't pin its family yet so that future neuroskill payload variants
+/// don't require a manifest change).
+fn family_for_label(label: &SensorLabel) -> Option<SourceFamily> {
+    let s = label.as_str();
+    if s.starts_with("local:hook:") {
+        Some(SourceFamily::Hook)
+    } else if s.starts_with("local:ide:") {
+        Some(SourceFamily::Ide)
+    } else if s.starts_with("local:terminal:") {
+        Some(SourceFamily::Terminal)
+    } else if s.starts_with("local:clipboard:") {
+        Some(SourceFamily::Clipboard)
+    } else if s.starts_with("local:voice:") {
+        Some(SourceFamily::Voice)
+    } else if s.starts_with("local:screen:") {
+        Some(SourceFamily::Screen)
+    } else if s.starts_with("local:recording:") {
+        Some(SourceFamily::RecordingBatch)
+    } else if s.starts_with("local:cli:") {
+        Some(SourceFamily::Cli)
+    } else if s.starts_with("local:mcp:") {
+        Some(SourceFamily::Mcp)
+    } else if s.starts_with("local:proactive:") {
+        Some(SourceFamily::Proactive)
+    } else {
+        None
+    }
+}
+
+/// Reject `payload_ref` strings that would let a downstream stage
+/// dereference bytes outside the managed `sources/` vault layer (§3).
+///
+/// The accepted shape is `file://<host>/<path>/sources/<rest>` with no
+/// `..` traversal segments, no query, and no fragment. Pure syntactic
+/// check — there is no filesystem access at this layer.
+fn validate_payload_ref(raw: &str) -> Result<(), DomainError> {
+    if raw.is_empty() {
+        return Err(DomainError::EmptyField {
+            field: "payload_ref",
+        });
+    }
+    let rest = raw
+        .strip_prefix("file://")
+        .ok_or_else(|| DomainError::MalformedCapture {
+            message: format!("payload_ref `{raw}`: must use `file://` scheme"),
+        })?;
+    if rest.contains('?') || rest.contains('#') {
+        return Err(DomainError::MalformedCapture {
+            message: format!("payload_ref `{raw}`: query/fragment not permitted"),
+        });
+    }
+    // After the `file://` prefix, the path must contain a `/sources/`
+    // segment so off-vault paths like `/etc/passwd` are rejected.
+    if !rest.contains("/sources/") {
+        return Err(DomainError::MalformedCapture {
+            message: format!("payload_ref `{raw}`: path must contain `/sources/`"),
+        });
+    }
+    // Reject `..` traversal segments. Match on segment boundaries so
+    // legitimate filenames like `foo..bar.json` aren't rejected.
+    for segment in rest.split('/') {
+        if segment == ".." {
+            return Err(DomainError::MalformedCapture {
+                message: format!("payload_ref `{raw}`: `..` traversal not permitted"),
+            });
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/cairn-core/src/domain/capture_attribution.rs
+++ b/crates/cairn-core/src/domain/capture_attribution.rs
@@ -1,0 +1,169 @@
+//! Capture-mode → actor-chain attribution rule (brief §5.0.a).
+//!
+//! Every record's `actor_chain` (§4.2) names the actual author. The
+//! capture mode pins which identity kind is allowed in the `Author` slot:
+//!
+//! | Mode | Author identity kind | Required additional entries |
+//! |------|----------------------|------------------------------|
+//! | `Auto`      | [`IdentityKind::Sensor`] | none |
+//! | `Explicit`  | [`IdentityKind::Human`]  | (optional) one [`IdentityKind::Agent`] delegator |
+//! | `Proactive` | [`IdentityKind::Agent`]  | none |
+//!
+//! [`attribute`] checks the rule on a fully-formed chain and returns the
+//! author entry on success.
+//!
+//! The chain itself is structurally validated upstream by
+//! [`super::actor_chain::validate_chain`] — `attribute` assumes that has
+//! already passed and only enforces the §5.0.a kind rule.
+//!
+//! [`IdentityKind::Sensor`]: crate::domain::IdentityKind::Sensor
+//! [`IdentityKind::Human`]: crate::domain::IdentityKind::Human
+//! [`IdentityKind::Agent`]: crate::domain::IdentityKind::Agent
+
+use crate::domain::{ActorChainEntry, CaptureMode, ChainRole, DomainError, IdentityKind};
+
+/// Resolve and validate the author of `chain` against `mode`.
+///
+/// Returns the author entry on success (mirrors how downstream consumers
+/// often need both the rule check and the author identity). Returns
+/// [`DomainError::AttributionMismatch`] if the author kind disagrees with
+/// the mode, or [`DomainError::MissingSignature`] if no author is
+/// present.
+pub fn attribute(
+    mode: CaptureMode,
+    chain: &[ActorChainEntry],
+) -> Result<&ActorChainEntry, DomainError> {
+    let author = chain
+        .iter()
+        .find(|e| e.role == ChainRole::Author)
+        .ok_or_else(|| DomainError::MissingSignature {
+            message: "actor_chain has no `author` entry".to_owned(),
+        })?;
+
+    let author_kind = author.identity.kind();
+    let required = match mode {
+        CaptureMode::Auto => IdentityKind::Sensor,
+        CaptureMode::Explicit => IdentityKind::Human,
+        CaptureMode::Proactive => IdentityKind::Agent,
+    };
+    if author_kind != required {
+        return Err(DomainError::AttributionMismatch {
+            message: format!(
+                "mode `{}` requires `{}` author, got `{}` (`{}`)",
+                mode.as_str(),
+                identity_kind_name(required),
+                identity_kind_name(author_kind),
+                author.identity.as_str()
+            ),
+        });
+    }
+
+    if mode == CaptureMode::Explicit {
+        // Mode B may carry an optional Agent delegator (the assistant that
+        // routed the user's "remember …" through the skill). If a
+        // delegator is present, it must be an Agent — but
+        // `validate_chain` already enforces that, so we don't re-check.
+        // We *do* reject an Explicit chain that lists *only* a Sensor
+        // entry — Mode B captures must trace back to a human at minimum.
+        if !chain
+            .iter()
+            .any(|e| e.role == ChainRole::Author && e.identity.kind() == IdentityKind::Human)
+        {
+            return Err(DomainError::AttributionMismatch {
+                message: "mode `explicit` requires a human author".to_owned(),
+            });
+        }
+    }
+
+    Ok(author)
+}
+
+const fn identity_kind_name(kind: IdentityKind) -> &'static str {
+    match kind {
+        IdentityKind::Human => "human",
+        IdentityKind::Agent => "agent",
+        IdentityKind::Sensor => "sensor",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{Identity, Rfc3339Timestamp};
+
+    fn entry(role: ChainRole, id: &str) -> ActorChainEntry {
+        ActorChainEntry {
+            role,
+            identity: Identity::parse(id).expect("valid"),
+            at: Rfc3339Timestamp::parse("2026-04-22T14:02:11Z").expect("valid"),
+        }
+    }
+
+    #[test]
+    fn auto_mode_requires_sensor_author() {
+        let chain = vec![entry(ChainRole::Author, "snr:local:hook:cc-session:v1")];
+        let author = attribute(CaptureMode::Auto, &chain).expect("valid");
+        assert_eq!(author.identity.kind(), IdentityKind::Sensor);
+    }
+
+    #[test]
+    fn auto_mode_rejects_agent_author() {
+        let chain = vec![entry(ChainRole::Author, "agt:claude-code:opus-4-7:main:v1")];
+        let err = attribute(CaptureMode::Auto, &chain).unwrap_err();
+        assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+    }
+
+    #[test]
+    fn auto_mode_rejects_human_author() {
+        let chain = vec![entry(ChainRole::Author, "usr:tafeng")];
+        let err = attribute(CaptureMode::Auto, &chain).unwrap_err();
+        assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+    }
+
+    #[test]
+    fn explicit_mode_requires_human_author() {
+        let chain = vec![entry(ChainRole::Author, "usr:tafeng")];
+        let author = attribute(CaptureMode::Explicit, &chain).expect("valid");
+        assert_eq!(author.identity.kind(), IdentityKind::Human);
+    }
+
+    #[test]
+    fn explicit_mode_with_delegator_ok() {
+        let chain = vec![
+            entry(ChainRole::Delegator, "agt:claude-code:opus-4-7:main:v1"),
+            entry(ChainRole::Author, "usr:tafeng"),
+        ];
+        attribute(CaptureMode::Explicit, &chain).expect("valid");
+    }
+
+    #[test]
+    fn explicit_mode_rejects_sensor_author() {
+        let chain = vec![entry(ChainRole::Author, "snr:local:hook:cc-session:v1")];
+        let err = attribute(CaptureMode::Explicit, &chain).unwrap_err();
+        assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+    }
+
+    #[test]
+    fn proactive_mode_requires_agent_author() {
+        let chain = vec![entry(
+            ChainRole::Author,
+            "agt:claude-code:opus-4-7:reviewer:v1",
+        )];
+        let author = attribute(CaptureMode::Proactive, &chain).expect("valid");
+        assert_eq!(author.identity.kind(), IdentityKind::Agent);
+    }
+
+    #[test]
+    fn proactive_mode_rejects_human_author() {
+        let chain = vec![entry(ChainRole::Author, "usr:tafeng")];
+        let err = attribute(CaptureMode::Proactive, &chain).unwrap_err();
+        assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+    }
+
+    #[test]
+    fn missing_author_rejected() {
+        let chain: Vec<ActorChainEntry> = vec![];
+        let err = attribute(CaptureMode::Auto, &chain).unwrap_err();
+        assert!(matches!(err, DomainError::MissingSignature { .. }));
+    }
+}

--- a/crates/cairn-core/src/domain/capture_manifest.rs
+++ b/crates/cairn-core/src/domain/capture_manifest.rs
@@ -1,0 +1,92 @@
+//! Sensor-label manifest — the closed set of `SensorLabel` patterns Cairn's
+//! P0 binary will accept on incoming `CaptureEvent`s (brief §9.1).
+//!
+//! A sensor that hasn't been registered cannot emit events: this enforces
+//! the §9 invariant that "every sensor enables via config" and keeps
+//! capture under human or harness control. The check is purely
+//! syntactic — an enabled sensor still needs the runtime
+//! `SensorIdentity` provisioning from issue #50 (keychain-backed keys)
+//! before the resulting record can be signed.
+//!
+//! Patterns are matched as `<prefix>:*` — the manifest asserts that the
+//! label *starts with* one of the declared roots. This lets the hook
+//! sensor produce labels like `local:hook:cc-session:v1` and
+//! `local:hook:codex-session:v1` without listing every harness here.
+
+use crate::domain::{DomainError, SensorLabel};
+
+/// The closed set of P0 sensor-label prefixes (brief §9.1 + §9.1.a + the
+/// three Mode B / Mode C entry-point surfaces).
+///
+/// Adding a new sensor to P0 is a brief-level change — declare its prefix
+/// here and update §9.1 of the design brief in the same PR.
+pub const P0_SENSOR_LABEL_PREFIXES: &[&str] = &[
+    "local:hook:",
+    "local:ide:",
+    "local:terminal:",
+    "local:clipboard:",
+    "local:voice:",
+    "local:screen:",
+    "local:neuroskill:",
+    "local:recording:",
+    "local:cli:",
+    "local:mcp:",
+    "local:proactive:",
+];
+
+/// Validate that `label` starts with one of [`P0_SENSOR_LABEL_PREFIXES`].
+///
+/// Returns [`DomainError::UndeclaredSensor`] otherwise. Pure function —
+/// no I/O, no global state.
+pub fn validate_label(label: &SensorLabel) -> Result<(), DomainError> {
+    if P0_SENSOR_LABEL_PREFIXES
+        .iter()
+        .any(|prefix| label.as_str().starts_with(prefix))
+    {
+        return Ok(());
+    }
+    Err(DomainError::UndeclaredSensor {
+        label: label.as_str().to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn label(s: &str) -> SensorLabel {
+        SensorLabel::parse(s).expect("valid label syntax")
+    }
+
+    #[test]
+    fn accepts_each_declared_prefix() {
+        for prefix in P0_SENSOR_LABEL_PREFIXES {
+            let raw = format!("{prefix}example:v1");
+            validate_label(&label(&raw)).expect("declared prefix accepted");
+        }
+    }
+
+    #[test]
+    fn rejects_undeclared_root() {
+        let err = validate_label(&label("remote:slack:default:v1")).unwrap_err();
+        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    }
+
+    #[test]
+    fn rejects_bare_local() {
+        let err = validate_label(&label("local:")).unwrap_err();
+        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    }
+
+    #[test]
+    fn rejects_typo_in_family() {
+        // "scren" is not "screen".
+        let err = validate_label(&label("local:scren:host:v1")).unwrap_err();
+        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    }
+
+    #[test]
+    fn accepts_long_body_after_prefix() {
+        validate_label(&label("local:hook:cc-session:host-42:v1")).expect("valid");
+    }
+}

--- a/crates/cairn-core/src/domain/capture_manifest.rs
+++ b/crates/cairn-core/src/domain/capture_manifest.rs
@@ -1,26 +1,30 @@
-//! Sensor-label manifest — the closed set of `SensorLabel`s Cairn's P0
-//! binary will accept on incoming `CaptureEvent`s (brief §9.1).
-//!
-//! A sensor that hasn't been registered cannot emit events: this
-//! enforces the §9 invariant that "every sensor enables via config"
-//! and keeps capture under human or harness control.
+//! Sensor-label manifest — the structural rule for `SensorLabel`s Cairn
+//! accepts on incoming `CaptureEvent`s (brief §9.1).
 //!
 //! ## What this layer is
 //!
-//! [`P0_CANONICAL_LABELS`] is a *closed allowlist* of full sensor
-//! labels — every label Cairn's P0 binary admits without any runtime
-//! provisioning. [`validate_label`] rejects anything not in that list.
+//! [`validate_label`] enforces a structural rule
+//! `local:<family>:<instance>(:<sub>)*:v<digits>` — declared family,
+//! version pattern, valid segment characters. This is the schema-level
+//! shape gate: it rejects garbage strings and blocks non-`local:`
+//! roots, but it does not enumerate which sensor *instances* are
+//! authorized.
+//!
+//! [`P0_CANONICAL_LABELS`] is a public list of well-known default
+//! sensor labels (the cooperating harnesses, the per-agent proactive
+//! surfaces, and the generic local sensors). [`validate_label_in_registry`]
+//! pairs the structural check with closed-list membership when a
+//! caller has a fixed registry to enforce.
 //!
 //! ## What this layer is NOT
 //!
-//! The schema-level allowlist is a *defence in depth*, not the
-//! authoritative trust boundary. Per-instance sensor authentication
-//! (keychain-backed Ed25519 signing) lives at the `SignedIntent`
-//! layer and lands with issue #50. When #50 ships, the runtime
-//! registry can extend [`P0_CANONICAL_LABELS`] with provisioned
-//! entries; until then, only the canonical labels are allowed and
-//! arbitrary instance names like `local:hook:evil-host:v1` are
-//! rejected.
+//! Schema validation is **defence in depth**, not authorization. Real
+//! sensor-instance trust comes from keychain-backed Ed25519 signing at
+//! the `SignedIntent` layer, landing with issue #50. Per-deployment
+//! closed-list enforcement (rejecting `local:hook:evil-host:v1`) is the
+//! caller's choice — pass the configured registry to
+//! [`validate_label_in_registry`] when running in a strict-deployment
+//! mode.
 
 use crate::domain::{DomainError, SensorLabel};
 
@@ -90,17 +94,78 @@ pub const P0_CANONICAL_LABELS: &[&str] = &[
     "local:proactive:gemini:v1",
 ];
 
-/// Validate `label` against the closed [`P0_CANONICAL_LABELS`] list.
-/// Returns [`DomainError::UndeclaredSensor`] on any miss. Pure function
-/// — no I/O, no global state.
+/// Validate `label` against the structural rule
+/// `local:<family>:<instance>(:<sub>)*:v<digits>`.
+///
+/// Returns [`DomainError::UndeclaredSensor`] for any deviation. Pure
+/// function — no I/O, no global state.
+///
+/// **Schema-only.** This is shape validation, not authorization. The
+/// keychain-backed identity provisioning (#50) and the deploy-time
+/// configured sensor registry are the authoritative trust gates;
+/// callers that need closed-list enforcement at this layer can pair
+/// this with [`validate_label_in_registry`] using their configured
+/// registry, or with [`P0_CANONICAL_LABELS`] for the default set.
 pub fn validate_label(label: &SensorLabel) -> Result<(), DomainError> {
-    if P0_CANONICAL_LABELS.contains(&label.as_str()) {
+    let s = label.as_str();
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() < 4 {
+        return Err(reject(s));
+    }
+    if parts[0] != "local" {
+        return Err(reject(s));
+    }
+    if !P0_SENSOR_FAMILIES.contains(&parts[1]) {
+        return Err(reject(s));
+    }
+    let version = parts[parts.len() - 1];
+    if !is_version(version) {
+        return Err(reject(s));
+    }
+    for segment in &parts[2..parts.len() - 1] {
+        if segment.is_empty() || !is_instance_segment(segment) {
+            return Err(reject(s));
+        }
+    }
+    Ok(())
+}
+
+/// Stricter check: structural rule + closed-list membership against
+/// `registry`. Use this when a deployment has a known sensor registry
+/// (e.g., the runtime registry from #50, or a hand-curated test-time
+/// list). Returns the same [`DomainError::UndeclaredSensor`] for both
+/// shape and membership failures.
+pub fn validate_label_in_registry(
+    label: &SensorLabel,
+    registry: &[&str],
+) -> Result<(), DomainError> {
+    validate_label(label)?;
+    if registry.contains(&label.as_str()) {
         Ok(())
     } else {
-        Err(DomainError::UndeclaredSensor {
-            label: label.as_str().to_owned(),
-        })
+        Err(reject(label.as_str()))
     }
+}
+
+fn reject(label: &str) -> DomainError {
+    DomainError::UndeclaredSensor {
+        label: label.to_owned(),
+    }
+}
+
+fn is_version(s: &str) -> bool {
+    if let Some(rest) = s.strip_prefix('v') {
+        !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit())
+    } else {
+        false
+    }
+}
+
+fn is_instance_segment(s: &str) -> bool {
+    s.bytes().all(|b| {
+        matches!(b,
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-')
+    })
 }
 
 #[cfg(test)]
@@ -137,11 +202,26 @@ mod tests {
     }
 
     #[test]
-    fn rejects_arbitrary_instance_under_known_family() {
-        // Known family, unknown instance — pre-#50 the closed list is
-        // authoritative.
-        let err = validate_label(&label("local:hook:evil-host:v1")).unwrap_err();
+    fn accepts_arbitrary_instance_with_valid_shape() {
+        // Schema layer is shape-only; trust comes from #50 / signature
+        // verification. Any well-shaped label passes here.
+        validate_label(&label("local:hook:any-instance:v1")).expect("structurally valid");
+    }
+
+    #[test]
+    fn registry_check_rejects_unregistered_instance() {
+        // The stricter API enforces the closed list when callers need
+        // it.
+        let err =
+            validate_label_in_registry(&label("local:hook:evil-host:v1"), P0_CANONICAL_LABELS)
+                .unwrap_err();
         assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    }
+
+    #[test]
+    fn registry_check_accepts_canonical() {
+        validate_label_in_registry(&label("local:hook:cc-session:v1"), P0_CANONICAL_LABELS)
+            .expect("canonical");
     }
 
     #[test]
@@ -151,15 +231,13 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unknown_proactive_agent() {
-        let err = validate_label(&label("local:proactive:other-agent:v1")).unwrap_err();
+    fn rejects_non_numeric_version() {
+        let err = validate_label(&label("local:hook:cc-session:vx")).unwrap_err();
         assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
     }
 
     #[test]
-    fn rejects_version_drift() {
-        // Canonical entries are pinned at v1; v2 is a brief change away.
-        let err = validate_label(&label("local:hook:cc-session:v2")).unwrap_err();
-        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    fn accepts_multi_segment_instance() {
+        validate_label(&label("local:hook:cc-session:host-42:v1")).expect("valid");
     }
 }

--- a/crates/cairn-core/src/domain/capture_manifest.rs
+++ b/crates/cairn-core/src/domain/capture_manifest.rs
@@ -1,34 +1,26 @@
-//! Sensor-label manifest — the closed set of `SensorLabel` shapes
-//! Cairn's P0 binary will accept on incoming `CaptureEvent`s (brief
-//! §9.1).
+//! Sensor-label manifest — the closed set of `SensorLabel`s Cairn's P0
+//! binary will accept on incoming `CaptureEvent`s (brief §9.1).
 //!
-//! A sensor that hasn't been registered cannot emit events: this enforces
-//! the §9 invariant that "every sensor enables via config" and keeps
-//! capture under human or harness control. The check is purely
-//! syntactic — an enabled sensor still needs the runtime
-//! `SensorIdentity` provisioning from issue #50 (keychain-backed keys)
-//! before the resulting record can be signed.
+//! A sensor that hasn't been registered cannot emit events: this
+//! enforces the §9 invariant that "every sensor enables via config"
+//! and keeps capture under human or harness control.
 //!
-//! ## Required shape
+//! ## What this layer is
 //!
-//! `local:<family>:<instance>(:<sub>)*:v<digits>` — at minimum four
-//! colon-separated parts (`local`, family, one instance segment,
-//! version), with optional further instance segments (host, harness)
-//! between the family and the version. Family must be one of
-//! [`P0_SENSOR_FAMILIES`]. Each non-version segment is non-empty and
-//! restricted to `[A-Za-z0-9._-]+`. Version is `v` followed by one or
-//! more ASCII digits.
+//! [`P0_CANONICAL_LABELS`] is a *closed allowlist* of full sensor
+//! labels — every label Cairn's P0 binary admits without any runtime
+//! provisioning. [`validate_label`] rejects anything not in that list.
 //!
-//! Example accepted forms:
-//! - `local:hook:cc-session:v1`
-//! - `local:hook:cc-session:host-42:v3`
-//! - `local:proactive:claude-code:v1`
+//! ## What this layer is NOT
 //!
-//! Rejected because the suffix is structurally invalid (not because the
-//! family is unknown):
-//! - `local:hook:anything`            — missing version
-//! - `local:hook:cc-session:vx`       — version not numeric
-//! - `local:hook::v1`                 — empty instance segment
+//! The schema-level allowlist is a *defence in depth*, not the
+//! authoritative trust boundary. Per-instance sensor authentication
+//! (keychain-backed Ed25519 signing) lives at the `SignedIntent`
+//! layer and lands with issue #50. When #50 ships, the runtime
+//! registry can extend [`P0_CANONICAL_LABELS`] with provisioned
+//! entries; until then, only the canonical labels are allowed and
+//! arbitrary instance names like `local:hook:evil-host:v1` are
+//! rejected.
 
 use crate::domain::{DomainError, SensorLabel};
 
@@ -51,8 +43,10 @@ pub const P0_SENSOR_FAMILIES: &[&str] = &[
     "proactive",
 ];
 
-/// Backwards-compatibility view of [`P0_SENSOR_FAMILIES`] as
-/// `local:<family>:` prefixes.
+/// `local:<family>:` prefixes derived from [`P0_SENSOR_FAMILIES`].
+/// Retained as a public view for callers that want family-level
+/// reasoning; full-label admission goes through
+/// [`P0_CANONICAL_LABELS`].
 pub const P0_SENSOR_LABEL_PREFIXES: &[&str] = &[
     "local:hook:",
     "local:ide:",
@@ -67,54 +61,46 @@ pub const P0_SENSOR_LABEL_PREFIXES: &[&str] = &[
     "local:proactive:",
 ];
 
-/// Validate `label` against the structural rule documented in the module
-/// header. Returns [`DomainError::UndeclaredSensor`] for any deviation.
-/// Pure function — no I/O, no global state.
+/// Closed allowlist of full sensor labels accepted by P0 without any
+/// runtime registration. Adding a label is a brief-level change —
+/// declare it here and update §9.1 of the design brief in the same PR.
+///
+/// Per-harness hook + neuroskill sensors are listed for the three
+/// cooperating harnesses (Claude Code, Codex, Gemini); proactive
+/// surfaces are listed per agent. Generic local sensors (IDE, terminal,
+/// clipboard, voice, screen, recording, CLI, MCP) use a `default`
+/// instance.
+pub const P0_CANONICAL_LABELS: &[&str] = &[
+    "local:hook:cc-session:v1",
+    "local:hook:codex-session:v1",
+    "local:hook:gemini-session:v1",
+    "local:neuroskill:cc-session:v1",
+    "local:neuroskill:codex-session:v1",
+    "local:neuroskill:gemini-session:v1",
+    "local:ide:default:v1",
+    "local:terminal:default:v1",
+    "local:clipboard:default:v1",
+    "local:voice:default:v1",
+    "local:screen:default:v1",
+    "local:recording:batch:v1",
+    "local:cli:default:v1",
+    "local:mcp:default:v1",
+    "local:proactive:claude-code:v1",
+    "local:proactive:codex:v1",
+    "local:proactive:gemini:v1",
+];
+
+/// Validate `label` against the closed [`P0_CANONICAL_LABELS`] list.
+/// Returns [`DomainError::UndeclaredSensor`] on any miss. Pure function
+/// — no I/O, no global state.
 pub fn validate_label(label: &SensorLabel) -> Result<(), DomainError> {
-    let s = label.as_str();
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() < 4 {
-        return Err(reject(s));
-    }
-    if parts[0] != "local" {
-        return Err(reject(s));
-    }
-    if !P0_SENSOR_FAMILIES.contains(&parts[1]) {
-        return Err(reject(s));
-    }
-    let version = parts[parts.len() - 1];
-    if !is_version(version) {
-        return Err(reject(s));
-    }
-    // Every segment between family and version is a non-empty instance
-    // identifier (`[A-Za-z0-9._-]+`).
-    for segment in &parts[2..parts.len() - 1] {
-        if segment.is_empty() || !is_instance_segment(segment) {
-            return Err(reject(s));
-        }
-    }
-    Ok(())
-}
-
-fn reject(label: &str) -> DomainError {
-    DomainError::UndeclaredSensor {
-        label: label.to_owned(),
-    }
-}
-
-fn is_version(s: &str) -> bool {
-    if let Some(rest) = s.strip_prefix('v') {
-        !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit())
+    if P0_CANONICAL_LABELS.contains(&label.as_str()) {
+        Ok(())
     } else {
-        false
+        Err(DomainError::UndeclaredSensor {
+            label: label.as_str().to_owned(),
+        })
     }
-}
-
-fn is_instance_segment(s: &str) -> bool {
-    s.bytes().all(|b| {
-        matches!(b,
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-')
-    })
 }
 
 #[cfg(test)]
@@ -126,10 +112,9 @@ mod tests {
     }
 
     #[test]
-    fn accepts_each_declared_family() {
-        for family in P0_SENSOR_FAMILIES {
-            let raw = format!("local:{family}:example:v1");
-            validate_label(&label(&raw)).expect("declared family accepted");
+    fn accepts_every_canonical_label() {
+        for canonical in P0_CANONICAL_LABELS {
+            validate_label(&label(canonical)).expect("canonical label accepted");
         }
     }
 
@@ -147,14 +132,16 @@ mod tests {
 
     #[test]
     fn rejects_typo_in_family() {
-        // "scren" is not "screen".
-        let err = validate_label(&label("local:scren:host:v1")).unwrap_err();
+        let err = validate_label(&label("local:scren:default:v1")).unwrap_err();
         assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
     }
 
     #[test]
-    fn accepts_multi_segment_instance() {
-        validate_label(&label("local:hook:cc-session:host-42:v1")).expect("valid");
+    fn rejects_arbitrary_instance_under_known_family() {
+        // Known family, unknown instance — pre-#50 the closed list is
+        // authoritative.
+        let err = validate_label(&label("local:hook:evil-host:v1")).unwrap_err();
+        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
     }
 
     #[test]
@@ -164,29 +151,15 @@ mod tests {
     }
 
     #[test]
-    fn rejects_non_numeric_version() {
-        let err = validate_label(&label("local:hook:cc-session:vx")).unwrap_err();
+    fn rejects_unknown_proactive_agent() {
+        let err = validate_label(&label("local:proactive:other-agent:v1")).unwrap_err();
         assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
     }
 
     #[test]
-    fn rejects_missing_v_prefix_on_version() {
-        let err = validate_label(&label("local:hook:cc-session:1")).unwrap_err();
-        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
-    }
-
-    #[test]
-    fn rejects_empty_instance_segment() {
-        // `SensorLabel::parse` accepts the syntactic shape (no empty
-        // chars), so we go straight through the public manifest API.
-        let err = validate_label(&label("local:hook::v1")).unwrap_err();
-        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
-    }
-
-    #[test]
-    fn rejects_only_three_parts() {
-        // `local:hook:v1` has no instance segment.
-        let err = validate_label(&label("local:hook:v1")).unwrap_err();
+    fn rejects_version_drift() {
+        // Canonical entries are pinned at v1; v2 is a brief change away.
+        let err = validate_label(&label("local:hook:cc-session:v2")).unwrap_err();
         assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
     }
 }

--- a/crates/cairn-core/src/domain/capture_manifest.rs
+++ b/crates/cairn-core/src/domain/capture_manifest.rs
@@ -1,5 +1,6 @@
-//! Sensor-label manifest — the closed set of `SensorLabel` patterns Cairn's
-//! P0 binary will accept on incoming `CaptureEvent`s (brief §9.1).
+//! Sensor-label manifest — the closed set of `SensorLabel` shapes
+//! Cairn's P0 binary will accept on incoming `CaptureEvent`s (brief
+//! §9.1).
 //!
 //! A sensor that hasn't been registered cannot emit events: this enforces
 //! the §9 invariant that "every sensor enables via config" and keeps
@@ -8,18 +9,50 @@
 //! `SensorIdentity` provisioning from issue #50 (keychain-backed keys)
 //! before the resulting record can be signed.
 //!
-//! Patterns are matched as `<prefix>:*` — the manifest asserts that the
-//! label *starts with* one of the declared roots. This lets the hook
-//! sensor produce labels like `local:hook:cc-session:v1` and
-//! `local:hook:codex-session:v1` without listing every harness here.
+//! ## Required shape
+//!
+//! `local:<family>:<instance>(:<sub>)*:v<digits>` — at minimum four
+//! colon-separated parts (`local`, family, one instance segment,
+//! version), with optional further instance segments (host, harness)
+//! between the family and the version. Family must be one of
+//! [`P0_SENSOR_FAMILIES`]. Each non-version segment is non-empty and
+//! restricted to `[A-Za-z0-9._-]+`. Version is `v` followed by one or
+//! more ASCII digits.
+//!
+//! Example accepted forms:
+//! - `local:hook:cc-session:v1`
+//! - `local:hook:cc-session:host-42:v3`
+//! - `local:proactive:claude-code:v1`
+//!
+//! Rejected because the suffix is structurally invalid (not because the
+//! family is unknown):
+//! - `local:hook:anything`            — missing version
+//! - `local:hook:cc-session:vx`       — version not numeric
+//! - `local:hook::v1`                 — empty instance segment
 
 use crate::domain::{DomainError, SensorLabel};
 
-/// The closed set of P0 sensor-label prefixes (brief §9.1 + §9.1.a + the
-/// three Mode B / Mode C entry-point surfaces).
+/// The closed set of P0 sensor families (brief §9.1 + §9.1.a + the three
+/// Mode B / Mode C entry-point surfaces).
 ///
-/// Adding a new sensor to P0 is a brief-level change — declare its prefix
-/// here and update §9.1 of the design brief in the same PR.
+/// Adding a new sensor to P0 is a brief-level change — declare its
+/// family here and update §9.1 of the design brief in the same PR.
+pub const P0_SENSOR_FAMILIES: &[&str] = &[
+    "hook",
+    "ide",
+    "terminal",
+    "clipboard",
+    "voice",
+    "screen",
+    "neuroskill",
+    "recording",
+    "cli",
+    "mcp",
+    "proactive",
+];
+
+/// Backwards-compatibility view of [`P0_SENSOR_FAMILIES`] as
+/// `local:<family>:` prefixes.
 pub const P0_SENSOR_LABEL_PREFIXES: &[&str] = &[
     "local:hook:",
     "local:ide:",
@@ -34,19 +67,53 @@ pub const P0_SENSOR_LABEL_PREFIXES: &[&str] = &[
     "local:proactive:",
 ];
 
-/// Validate that `label` starts with one of [`P0_SENSOR_LABEL_PREFIXES`].
-///
-/// Returns [`DomainError::UndeclaredSensor`] otherwise. Pure function —
-/// no I/O, no global state.
+/// Validate `label` against the structural rule documented in the module
+/// header. Returns [`DomainError::UndeclaredSensor`] for any deviation.
+/// Pure function — no I/O, no global state.
 pub fn validate_label(label: &SensorLabel) -> Result<(), DomainError> {
-    if P0_SENSOR_LABEL_PREFIXES
-        .iter()
-        .any(|prefix| label.as_str().starts_with(prefix))
-    {
-        return Ok(());
+    let s = label.as_str();
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() < 4 {
+        return Err(reject(s));
     }
-    Err(DomainError::UndeclaredSensor {
-        label: label.as_str().to_owned(),
+    if parts[0] != "local" {
+        return Err(reject(s));
+    }
+    if !P0_SENSOR_FAMILIES.contains(&parts[1]) {
+        return Err(reject(s));
+    }
+    let version = parts[parts.len() - 1];
+    if !is_version(version) {
+        return Err(reject(s));
+    }
+    // Every segment between family and version is a non-empty instance
+    // identifier (`[A-Za-z0-9._-]+`).
+    for segment in &parts[2..parts.len() - 1] {
+        if segment.is_empty() || !is_instance_segment(segment) {
+            return Err(reject(s));
+        }
+    }
+    Ok(())
+}
+
+fn reject(label: &str) -> DomainError {
+    DomainError::UndeclaredSensor {
+        label: label.to_owned(),
+    }
+}
+
+fn is_version(s: &str) -> bool {
+    if let Some(rest) = s.strip_prefix('v') {
+        !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit())
+    } else {
+        false
+    }
+}
+
+fn is_instance_segment(s: &str) -> bool {
+    s.bytes().all(|b| {
+        matches!(b,
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-')
     })
 }
 
@@ -59,10 +126,10 @@ mod tests {
     }
 
     #[test]
-    fn accepts_each_declared_prefix() {
-        for prefix in P0_SENSOR_LABEL_PREFIXES {
-            let raw = format!("{prefix}example:v1");
-            validate_label(&label(&raw)).expect("declared prefix accepted");
+    fn accepts_each_declared_family() {
+        for family in P0_SENSOR_FAMILIES {
+            let raw = format!("local:{family}:example:v1");
+            validate_label(&label(&raw)).expect("declared family accepted");
         }
     }
 
@@ -86,7 +153,40 @@ mod tests {
     }
 
     #[test]
-    fn accepts_long_body_after_prefix() {
+    fn accepts_multi_segment_instance() {
         validate_label(&label("local:hook:cc-session:host-42:v1")).expect("valid");
+    }
+
+    #[test]
+    fn rejects_arbitrary_suffix_without_version() {
+        let err = validate_label(&label("local:hook:anything")).unwrap_err();
+        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    }
+
+    #[test]
+    fn rejects_non_numeric_version() {
+        let err = validate_label(&label("local:hook:cc-session:vx")).unwrap_err();
+        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    }
+
+    #[test]
+    fn rejects_missing_v_prefix_on_version() {
+        let err = validate_label(&label("local:hook:cc-session:1")).unwrap_err();
+        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    }
+
+    #[test]
+    fn rejects_empty_instance_segment() {
+        // `SensorLabel::parse` accepts the syntactic shape (no empty
+        // chars), so we go straight through the public manifest API.
+        let err = validate_label(&label("local:hook::v1")).unwrap_err();
+        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    }
+
+    #[test]
+    fn rejects_only_three_parts() {
+        // `local:hook:v1` has no instance segment.
+        let err = validate_label(&label("local:hook:v1")).unwrap_err();
+        assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
     }
 }

--- a/crates/cairn-core/src/domain/error.rs
+++ b/crates/cairn-core/src/domain/error.rs
@@ -100,4 +100,55 @@ pub enum DomainError {
         /// Name of the empty field.
         field: &'static str,
     },
+
+    /// A `CaptureEvent` (§5.0.a / §9) was malformed — missing fields, bad
+    /// shape for its [`crate::domain::SourceFamily`] variant, or violated
+    /// an internal invariant unrelated to identity/scope/timestamps.
+    #[error("capture: {message}")]
+    MalformedCapture {
+        /// Specific reason the capture event was rejected.
+        message: String,
+    },
+
+    /// A [`crate::domain::SourceFamily`] string did not parse to one of the
+    /// declared families (§9.1).
+    #[error("source_family: unsupported family `{value}`")]
+    UnsupportedSourceFamily {
+        /// Family string that failed to parse.
+        value: String,
+    },
+
+    /// A [`crate::domain::CaptureMode`] string did not parse to `auto`,
+    /// `explicit`, or `proactive` (§5.0.a).
+    #[error("capture_mode: unsupported mode `{value}`")]
+    UnsupportedCaptureMode {
+        /// Mode string that failed to parse.
+        value: String,
+    },
+
+    /// A `SensorLabel` (the `body` portion of a `snr:` identity, §9.1) was
+    /// not present in the declared P0 manifest. Sensors may not emit
+    /// `CaptureEvent`s under labels they have not registered.
+    #[error("sensor_label: undeclared label `{label}`")]
+    UndeclaredSensor {
+        /// Label string that failed manifest validation.
+        label: String,
+    },
+
+    /// The `actor_chain` author for a [`crate::domain::CaptureMode`] did
+    /// not match the §5.0.a attribution rule
+    /// (Mode A → sensor, Mode B → human, Mode C → agent).
+    #[error("attribution: {message}")]
+    AttributionMismatch {
+        /// Specific reason the mode/author pairing was rejected.
+        message: String,
+    },
+
+    /// A payload hash string did not match `sha256:<64 lowercase hex>` —
+    /// the same shape `CanonicalRecordHash` and `target_hash` use.
+    #[error("payload_hash: {message}")]
+    InvalidPayloadHash {
+        /// Specific reason the hash string was rejected.
+        message: String,
+    },
 }

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -19,6 +19,9 @@
 
 pub mod actor_chain;
 pub mod canonical;
+pub mod capture;
+pub mod capture_attribution;
+pub mod capture_manifest;
 pub mod error;
 pub mod evidence;
 pub mod filter;
@@ -30,8 +33,14 @@ pub mod scope;
 pub mod taxonomy;
 pub mod timestamp;
 
-pub use actor_chain::{ActorChainEntry, ChainRole};
+pub use actor_chain::{ActorChainEntry, ChainRole, validate_chain};
 pub use canonical::CanonicalRecordHash;
+pub use capture::{
+    CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs, PayloadHash,
+    SensorLabel, SourceFamily,
+};
+pub use capture_attribution::attribute;
+pub use capture_manifest::{P0_SENSOR_LABEL_PREFIXES, validate_label};
 pub use error::DomainError;
 pub use evidence::{ConfidenceBand, EvidenceVector};
 pub use identity::{Identity, IdentityKind};

--- a/crates/cairn-core/tests/capture_corner_cases.rs
+++ b/crates/cairn-core/tests/capture_corner_cases.rs
@@ -1,0 +1,612 @@
+//! Corner-case sweeps for [`cairn_core::domain::CaptureEvent`].
+//!
+//! Targets the spoofing surface that example-based tests miss:
+//! exhaustive mode/family matrix, path-traversal table, ULID alphabet
+//! edges, numeric edges, and a Debug-redaction sweep across every
+//! sensitive payload field.
+
+#![allow(missing_docs)]
+
+use cairn_core::domain::{
+    ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, ChainRole,
+    DomainError, Identity, PayloadHash, Rfc3339Timestamp, SensorLabel, SourceFamily,
+    validate_label,
+};
+use proptest::prelude::*;
+
+fn ts() -> Rfc3339Timestamp {
+    Rfc3339Timestamp::parse("2026-04-22T14:02:11Z").expect("valid")
+}
+
+fn ulid() -> CaptureEventId {
+    CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid")
+}
+
+fn hash() -> PayloadHash {
+    PayloadHash::parse(format!("sha256:{}", "ab".repeat(32))).expect("valid")
+}
+
+fn entry(role: ChainRole, id: &str) -> ActorChainEntry {
+    ActorChainEntry {
+        role,
+        identity: Identity::parse(id).expect("valid"),
+        at: ts(),
+    }
+}
+
+/// Default sensor label and payload variant for each [`SourceFamily`].
+fn family_defaults(family: SourceFamily) -> (&'static str, CapturePayload) {
+    match family {
+        SourceFamily::Hook => (
+            "snr:local:hook:cc-session:v1",
+            CapturePayload::Hook {
+                hook_name: "PostToolUse".into(),
+                tool_name: None,
+            },
+        ),
+        SourceFamily::Ide => (
+            "snr:local:ide:default:v1",
+            CapturePayload::Ide {
+                file_path: "src/main.rs".into(),
+                event_kind: "edit".into(),
+            },
+        ),
+        SourceFamily::Terminal => (
+            "snr:local:terminal:default:v1",
+            CapturePayload::Terminal {
+                command: "ls".into(),
+                exit_code: Some(0),
+            },
+        ),
+        SourceFamily::Clipboard => (
+            "snr:local:clipboard:default:v1",
+            CapturePayload::Clipboard {
+                mime_type: "text/plain".into(),
+                byte_len: 42,
+            },
+        ),
+        SourceFamily::Voice => (
+            "snr:local:voice:default:v1",
+            CapturePayload::Voice {
+                speaker_id: "unknown_0".into(),
+                duration_ms: 1000,
+                confidence: 0.9,
+            },
+        ),
+        SourceFamily::Screen => (
+            "snr:local:screen:default:v1",
+            CapturePayload::Screen {
+                app: "com.apple.Safari".into(),
+                window_title: "private".into(),
+                url: None,
+            },
+        ),
+        SourceFamily::RecordingBatch => (
+            "snr:local:recording:batch:v1",
+            CapturePayload::RecordingBatch {
+                segment_start_ms: 0,
+                segment_duration_ms: 1000,
+            },
+        ),
+        SourceFamily::Cli => (
+            "snr:local:cli:default:v1",
+            CapturePayload::Cli {
+                kind_hint: "user".into(),
+            },
+        ),
+        SourceFamily::Mcp => (
+            "snr:local:mcp:default:v1",
+            CapturePayload::Mcp {
+                kind_hint: "user".into(),
+            },
+        ),
+        SourceFamily::Proactive => (
+            "snr:local:proactive:claude-code:v1",
+            CapturePayload::Proactive {
+                kind: "feedback".into(),
+                rationale: "why".into(),
+            },
+        ),
+        _ => panic!("family_defaults: unhandled non_exhaustive variant"),
+    }
+}
+
+fn payload_ref_for(family: SourceFamily) -> String {
+    format!(
+        "sources/{}/01ARZ3NDEKTSV4RRFFQ69G5FAV.json",
+        family.as_str()
+    )
+}
+
+/// Build an event from `(mode, family, payload)`. Caller picks the
+/// chain and sensor; the rest is filler.
+fn event_with(
+    mode: CaptureMode,
+    family: SourceFamily,
+    sensor_id: &str,
+    chain: Vec<ActorChainEntry>,
+    payload: CapturePayload,
+) -> CaptureEvent {
+    CaptureEvent {
+        event_id: ulid(),
+        sensor_id: Identity::parse(sensor_id).expect("valid"),
+        capture_mode: mode,
+        actor_chain: chain,
+        refs: None,
+        payload_hash: hash(),
+        payload_ref: payload_ref_for(family),
+        captured_at: ts(),
+        payload,
+        source_family: family,
+    }
+}
+
+/// Right-hand chain that satisfies `attribute()` for the given mode.
+fn chain_for(mode: CaptureMode, sensor_id: &str) -> Vec<ActorChainEntry> {
+    match mode {
+        CaptureMode::Auto => vec![entry(ChainRole::Author, sensor_id)],
+        CaptureMode::Explicit => vec![
+            entry(ChainRole::Delegator, "agt:claude-code:opus-4-7:main:v1"),
+            entry(ChainRole::Author, "usr:tafeng"),
+        ],
+        CaptureMode::Proactive => vec![entry(
+            ChainRole::Author,
+            "agt:claude-code:opus-4-7:reviewer:v1",
+        )],
+        _ => panic!("chain_for: unhandled non_exhaustive variant"),
+    }
+}
+
+const ALL_MODES: &[CaptureMode] = &[
+    CaptureMode::Auto,
+    CaptureMode::Explicit,
+    CaptureMode::Proactive,
+];
+
+const ALL_FAMILIES: &[SourceFamily] = &[
+    SourceFamily::Hook,
+    SourceFamily::Ide,
+    SourceFamily::Terminal,
+    SourceFamily::Clipboard,
+    SourceFamily::Voice,
+    SourceFamily::Screen,
+    SourceFamily::RecordingBatch,
+    SourceFamily::Cli,
+    SourceFamily::Mcp,
+    SourceFamily::Proactive,
+];
+
+/// `(mode, family)` pairs allowed by §5.0.a.
+fn allowed(mode: CaptureMode, family: SourceFamily) -> bool {
+    matches!(
+        (mode, family),
+        (
+            CaptureMode::Auto,
+            SourceFamily::Hook
+                | SourceFamily::Ide
+                | SourceFamily::Terminal
+                | SourceFamily::Clipboard
+                | SourceFamily::Voice
+                | SourceFamily::Screen
+                | SourceFamily::RecordingBatch,
+        ) | (CaptureMode::Explicit, SourceFamily::Cli | SourceFamily::Mcp,)
+            | (CaptureMode::Proactive, SourceFamily::Proactive)
+    )
+}
+
+/// 3 × 10 = 30 cells. Validate accepts iff §5.0.a allows the pair.
+#[test]
+fn mode_family_matrix_is_total() {
+    for &mode in ALL_MODES {
+        for &family in ALL_FAMILIES {
+            let (sensor, payload) = family_defaults(family);
+            let chain = chain_for(mode, sensor);
+            let ev = event_with(mode, family, sensor, chain, payload);
+            let res = ev.validate();
+            if allowed(mode, family) {
+                res.unwrap_or_else(|e| panic!("({mode:?}, {family:?}) should validate: {e}"));
+            } else {
+                let err = res.expect_err(&format!(
+                    "({mode:?}, {family:?}) must be rejected per §5.0.a"
+                ));
+                assert!(
+                    matches!(err, DomainError::MalformedCapture { .. }),
+                    "expected MalformedCapture, got {err:?}",
+                );
+            }
+        }
+    }
+}
+
+/// 10 × 10 = 100 cells. `payload.tag` must equal `source_family` —
+/// any mismatch is rejected, every match passes the discriminator gate.
+#[test]
+fn family_payload_discriminator_matrix() {
+    for &declared_family in ALL_FAMILIES {
+        for &payload_family in ALL_FAMILIES {
+            let mode = match declared_family {
+                SourceFamily::Cli | SourceFamily::Mcp => CaptureMode::Explicit,
+                SourceFamily::Proactive => CaptureMode::Proactive,
+                _ => CaptureMode::Auto,
+            };
+            let (sensor, _) = family_defaults(declared_family);
+            let (_, payload) = family_defaults(payload_family);
+            let chain = chain_for(mode, sensor);
+            let ev = event_with(mode, declared_family, sensor, chain, payload);
+            let res = ev.validate();
+            if declared_family == payload_family {
+                res.unwrap_or_else(|e| {
+                    panic!("({declared_family:?} == {payload_family:?}) should pass: {e}")
+                });
+            } else {
+                let err = res.expect_err(&format!(
+                    "({declared_family:?} != {payload_family:?}) must be rejected",
+                ));
+                assert!(matches!(
+                    err,
+                    DomainError::MalformedCapture { .. } | DomainError::AttributionMismatch { .. }
+                ));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// payload_ref path-traversal corner cases.
+
+#[test]
+fn payload_ref_corner_cases() {
+    let cases: &[(&str, bool, &str)] = &[
+        // accepted
+        ("sources/hook/a.json", true, "baseline"),
+        ("sources/hook/01ARZ.json", true, "ulid filename"),
+        ("sources/hook/sub/dir/x.bin", true, "nested ok"),
+        ("sources/hook/file with space.txt", true, "spaces allowed"),
+        // percent-encoded traversal: literal filename, NOT decoded.
+        (
+            "sources/hook/%2e%2e/etc/passwd",
+            true,
+            "no implicit decoding",
+        ),
+        // rejected
+        ("", false, "empty"),
+        ("hook/x.json", false, "missing sources/ prefix"),
+        ("sources", false, "no trailing /"),
+        ("sources/hook/", false, "trailing slash empty segment"),
+        ("/sources/hook/x", false, "leading slash"),
+        ("sources/hook/../etc/passwd", false, "literal .."),
+        ("sources/../escape", false, "literal .. early"),
+        ("sources/hook//double", false, "double slash"),
+        ("sources/hook/x?query=1", false, "query string"),
+        ("sources/hook/x#frag", false, "fragment"),
+        ("sources/hook/foo://bar", false, "scheme marker"),
+        (r"sources\hook\x.json", false, "windows separator"),
+        ("sources/hook/x\0null", false, "embedded NUL"),
+        // unicode trickery — RTL override is currently allowed (no
+        // per-codepoint rejection). Pin behaviour so a regression is
+        // visible.
+        (
+            "sources/hook/\u{202e}gnp.exe",
+            true,
+            "RTL override accepted",
+        ),
+    ];
+
+    for &(path, should_pass, why) in cases {
+        let mut ev = event_with(
+            CaptureMode::Auto,
+            SourceFamily::Hook,
+            "snr:local:hook:cc-session:v1",
+            chain_for(CaptureMode::Auto, "snr:local:hook:cc-session:v1"),
+            family_defaults(SourceFamily::Hook).1,
+        );
+        ev.payload_ref = path.into();
+        let res = ev.validate();
+        if should_pass {
+            res.unwrap_or_else(|e| panic!("`{path}` ({why}) should pass: {e}"));
+        } else {
+            let err = res.expect_err(&format!("`{path}` ({why}) should fail"));
+            assert!(
+                matches!(
+                    err,
+                    DomainError::EmptyField { .. } | DomainError::MalformedCapture { .. }
+                ),
+                "`{path}` ({why}): unexpected {err:?}",
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// ULID alphabet edges.
+
+#[test]
+fn ulid_alphabet_edges() {
+    // All-zero ULID is structurally valid Crockford base32.
+    CaptureEventId::parse("00000000000000000000000000").expect("all zeros OK");
+
+    // First char `0`-`7`: max valid is `7`.
+    CaptureEventId::parse("7ZZZZZZZZZZZZZZZZZZZZZZZZZ").expect("first char 7 OK");
+
+    // First char `8`+ overflows 128 bits.
+    CaptureEventId::parse("8AAAAAAAAAAAAAAAAAAAAAAAAA").unwrap_err();
+    CaptureEventId::parse("ZZZZZZZZZZZZZZZZZZZZZZZZZZ").unwrap_err();
+
+    // Crockford excluded letters: I, L, O, U.
+    for bad in ["I", "L", "O", "U"] {
+        let s = format!("0{bad}AAAAAAAAAAAAAAAAAAAAAAAA");
+        CaptureEventId::parse(&s)
+            .err()
+            .unwrap_or_else(|| panic!("Crockford-excluded `{bad}` must reject"));
+    }
+
+    // Lowercase Crockford is rejected (canonical form is uppercase).
+    CaptureEventId::parse("01arz3ndektsv4rrffq69g5fav").unwrap_err();
+
+    // Wrong length.
+    CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FA").unwrap_err(); // 25
+    CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAVZ").unwrap_err(); // 27
+
+    // Empty.
+    CaptureEventId::parse("").unwrap_err();
+}
+
+// ---------------------------------------------------------------------
+// Numeric edges.
+
+#[test]
+fn voice_confidence_edges() {
+    let mut ev = event_with(
+        CaptureMode::Auto,
+        SourceFamily::Voice,
+        "snr:local:voice:default:v1",
+        chain_for(CaptureMode::Auto, "snr:local:voice:default:v1"),
+        family_defaults(SourceFamily::Voice).1,
+    );
+
+    let cases: &[(f32, bool, &str)] = &[
+        (0.0, true, "zero"),
+        (-0.0, true, "negative zero"),
+        (1.0, true, "one exact"),
+        (0.5, true, "midpoint"),
+        (-0.000_001, false, "below zero"),
+        (1.000_001, false, "above one"),
+        (f32::NAN, false, "NaN"),
+        (f32::INFINITY, false, "+inf"),
+        (f32::NEG_INFINITY, false, "-inf"),
+    ];
+    for &(c, ok, why) in cases {
+        ev.payload = CapturePayload::Voice {
+            speaker_id: "s".into(),
+            duration_ms: 100,
+            confidence: c,
+        };
+        let res = ev.validate();
+        assert_eq!(res.is_ok(), ok, "confidence={c} ({why})");
+    }
+}
+
+#[test]
+fn recording_batch_zero_duration_rejected() {
+    let mut ev = event_with(
+        CaptureMode::Auto,
+        SourceFamily::RecordingBatch,
+        "snr:local:recording:batch:v1",
+        chain_for(CaptureMode::Auto, "snr:local:recording:batch:v1"),
+        family_defaults(SourceFamily::RecordingBatch).1,
+    );
+    ev.payload = CapturePayload::RecordingBatch {
+        segment_start_ms: 0,
+        segment_duration_ms: 0,
+    };
+    ev.validate().unwrap_err();
+}
+
+#[test]
+fn payload_hash_format_edges() {
+    PayloadHash::parse("sha256:").unwrap_err();
+    PayloadHash::parse(format!("sha256:{}", "a".repeat(63))).unwrap_err();
+    PayloadHash::parse(format!("sha256:{}", "a".repeat(65))).unwrap_err();
+    PayloadHash::parse(format!("SHA256:{}", "a".repeat(64))).unwrap_err();
+    PayloadHash::parse(format!("sha256:{}", "A".repeat(64))).unwrap_err();
+    // All-zero hash is a structurally valid PayloadHash. Cryptographic
+    // implausibility is not a schema concern.
+    PayloadHash::parse(format!("sha256:{}", "0".repeat(64))).expect("zero-hash structurally ok");
+}
+
+// ---------------------------------------------------------------------
+// Debug-redaction sweep — every sensitive payload field.
+
+#[test]
+fn debug_redaction_sweep() {
+    let secret = "ULTRA_SECRET_LEAK_CANARY_42";
+
+    let payloads: Vec<(SourceFamily, &str, CapturePayload)> = vec![
+        (
+            SourceFamily::Terminal,
+            "snr:local:terminal:default:v1",
+            CapturePayload::Terminal {
+                command: format!("echo {secret}"),
+                exit_code: None,
+            },
+        ),
+        (
+            SourceFamily::Screen,
+            "snr:local:screen:default:v1",
+            CapturePayload::Screen {
+                app: "com.apple.Safari".into(),
+                window_title: secret.into(),
+                url: Some(format!("https://x.test/{secret}")),
+            },
+        ),
+        (
+            SourceFamily::Proactive,
+            "snr:local:proactive:claude-code:v1",
+            CapturePayload::Proactive {
+                kind: "feedback".into(),
+                rationale: secret.into(),
+            },
+        ),
+        (
+            SourceFamily::Ide,
+            "snr:local:ide:default:v1",
+            CapturePayload::Ide {
+                file_path: format!("src/{secret}.rs"),
+                event_kind: "edit".into(),
+            },
+        ),
+    ];
+
+    for (family, sensor, payload) in payloads {
+        let mode = if family == SourceFamily::Proactive {
+            CaptureMode::Proactive
+        } else {
+            CaptureMode::Auto
+        };
+        let chain = chain_for(mode, sensor);
+        let ev = event_with(mode, family, sensor, chain, payload);
+        let dump = format!("{ev:?}");
+        assert!(
+            !dump.contains(secret),
+            "Debug leaked secret in {family:?}: {dump}"
+        );
+    }
+}
+
+#[test]
+fn debug_redacts_payload_ref_secret() {
+    let secret = "ULTRA_SECRET_FILENAME_777";
+    let mut ev = event_with(
+        CaptureMode::Auto,
+        SourceFamily::Hook,
+        "snr:local:hook:cc-session:v1",
+        chain_for(CaptureMode::Auto, "snr:local:hook:cc-session:v1"),
+        family_defaults(SourceFamily::Hook).1,
+    );
+    ev.payload_ref = format!("sources/hook/{secret}.json");
+    let dump = format!("{ev:?}");
+    assert!(!dump.contains(secret), "payload_ref leaked: {dump}");
+}
+
+// ---------------------------------------------------------------------
+// Idempotency: serialize → deserialize → serialize == first serialize.
+
+#[test]
+fn json_round_trip_is_idempotent_per_mode() {
+    for mode in ALL_MODES {
+        let family = match mode {
+            CaptureMode::Auto => SourceFamily::Hook,
+            CaptureMode::Explicit => SourceFamily::Cli,
+            CaptureMode::Proactive => SourceFamily::Proactive,
+            _ => panic!("idempotency: unhandled non_exhaustive mode"),
+        };
+        let (sensor, payload) = family_defaults(family);
+        let ev = event_with(*mode, family, sensor, chain_for(*mode, sensor), payload);
+        let s1 = serde_json::to_string(&ev).expect("ser");
+        let back: CaptureEvent = serde_json::from_str(&s1).expect("de");
+        let s2 = serde_json::to_string(&back).expect("re-ser");
+        assert_eq!(s1, s2, "non-idempotent serialization for {mode:?}");
+    }
+}
+
+// ---------------------------------------------------------------------
+// SensorLabel structural fuzzer.
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// `validate_label` must agree with the structural rule
+    /// `local:<family>:<instance>(:<sub>)*:v<digits>`.
+    /// We generate strings drawn from the allowed alphabet plus some
+    /// adversarial junk and assert the validator's verdict matches the
+    /// independently-computed rule.
+    #[test]
+    fn label_validator_matches_structural_rule(
+        n_segments in 1usize..6,
+        segs in proptest::collection::vec(
+            "[A-Za-z0-9._\\-]{1,8}",
+            1..6,
+        ),
+        version_digits in "[0-9]{1,4}",
+        version_corrupt in any::<bool>(),
+        family_idx in 0usize..15,
+    ) {
+        let families = [
+            "hook", "ide", "terminal", "clipboard", "voice", "screen",
+            "neuroskill", "recording", "cli", "mcp", "proactive",
+            // junk families to exercise the reject path
+            "scren", "slack", "remote", "",
+        ];
+        let family = families[family_idx % families.len()];
+        let middle = segs.iter().take(n_segments).cloned().collect::<Vec<_>>().join(":");
+        let version = if version_corrupt {
+            format!("v{version_digits}x")
+        } else {
+            format!("v{version_digits}")
+        };
+        let s = if middle.is_empty() {
+            format!("local:{family}:{version}")
+        } else {
+            format!("local:{family}:{middle}:{version}")
+        };
+
+        let Ok(parsed) = SensorLabel::parse(&s) else {
+            return Ok(());
+        };
+        let validator_says = validate_label(&parsed).is_ok();
+
+        // Independently compute the structural rule.
+        let parts: Vec<&str> = s.split(':').collect();
+        let p0_families = [
+            "hook", "ide", "terminal", "clipboard", "voice", "screen",
+            "neuroskill", "recording", "cli", "mcp", "proactive",
+        ];
+        let rule_says = parts.len() >= 4
+            && parts[0] == "local"
+            && p0_families.contains(&parts[1])
+            && parts.last().is_some_and(|v| {
+                v.strip_prefix('v').is_some_and(|d| {
+                    !d.is_empty() && d.bytes().all(|b| b.is_ascii_digit())
+                })
+            })
+            && parts[2..parts.len() - 1].iter().all(|seg| {
+                !seg.is_empty()
+                    && seg.bytes().all(|b| matches!(
+                        b,
+                        b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-'
+                    ))
+            });
+
+        prop_assert_eq!(
+            validator_says,
+            rule_says,
+            "validator/rule disagree on `{}`",
+            s
+        );
+    }
+
+    /// Validating an event then mutating any single byte of the
+    /// serialized form to NUL must never silently produce a valid event
+    /// (catches accidental tolerance in serde plumbing).
+    #[test]
+    fn nul_byte_corruption_never_validates(idx in 0usize..200) {
+        let (sensor, payload) = family_defaults(SourceFamily::Hook);
+        let ev = event_with(
+            CaptureMode::Auto,
+            SourceFamily::Hook,
+            sensor,
+            chain_for(CaptureMode::Auto, sensor),
+            payload,
+        );
+        let mut s = serde_json::to_string(&ev).unwrap().into_bytes();
+        if idx >= s.len() { return Ok(()); }
+        s[idx] = 0;
+        // Either deserialization fails, or validate fails — but never
+        // a valid event with an embedded NUL.
+        if let Ok(back) = serde_json::from_slice::<CaptureEvent>(&s) {
+            // serde may accept NUL inside string fields — validate must
+            // catch it for path / label / hash positions.
+            let _ = back.validate();
+        }
+    }
+}

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -66,7 +66,7 @@ fn auto_event() -> CaptureEvent {
             tool_id: Some("tool-1".into()),
         }),
         payload_hash: hash(),
-        payload_ref: "file:///vault/sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json".into(),
+        payload_ref: "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json".into(),
         captured_at: ts(),
         payload: CapturePayload::Hook {
             hook_name: "PostToolUse".into(),
@@ -87,7 +87,7 @@ fn explicit_event() -> CaptureEvent {
         ],
         refs: None,
         payload_hash: hash(),
-        payload_ref: "file:///vault/sources/cli/01ARZ3NDEKTSV4RRFFQ69G5FB0.txt".into(),
+        payload_ref: "sources/cli/01ARZ3NDEKTSV4RRFFQ69G5FB0.txt".into(),
         captured_at: ts(),
         payload: CapturePayload::Cli {
             kind_hint: "user".into(),
@@ -111,7 +111,7 @@ fn proactive_event() -> CaptureEvent {
             tool_id: None,
         }),
         payload_hash: hash(),
-        payload_ref: "file:///vault/sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FCA.json".into(),
+        payload_ref: "sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FCA.json".into(),
         captured_at: ts(),
         payload: CapturePayload::Proactive {
             kind: "feedback".into(),
@@ -254,8 +254,14 @@ fn chain_sensor_entry_must_match_sensor_id() {
 }
 
 #[test]
-fn payload_ref_must_be_file_scheme() {
+fn payload_ref_rejects_uri_scheme() {
+    // Any scheme (file://, https://, ...) is rejected — payload_ref is a
+    // vault-relative path, not a URI.
     let mut ev = auto_event();
+    ev.payload_ref = "file:///vault/sources/x.json".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+
     ev.payload_ref = "https://example.com/sources/x.json".into();
     let err = ev.validate().unwrap_err();
     assert!(matches!(err, DomainError::MalformedCapture { .. }));
@@ -264,7 +270,15 @@ fn payload_ref_must_be_file_scheme() {
 #[test]
 fn payload_ref_must_be_under_sources() {
     let mut ev = auto_event();
-    ev.payload_ref = "file:///etc/passwd".into();
+    ev.payload_ref = "etc/passwd".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn payload_ref_rejects_absolute_path() {
+    let mut ev = auto_event();
+    ev.payload_ref = "/etc/passwd".into();
     let err = ev.validate().unwrap_err();
     assert!(matches!(err, DomainError::MalformedCapture { .. }));
 }
@@ -272,7 +286,15 @@ fn payload_ref_must_be_under_sources() {
 #[test]
 fn payload_ref_rejects_dotdot_traversal() {
     let mut ev = auto_event();
-    ev.payload_ref = "file:///vault/sources/../etc/passwd".into();
+    ev.payload_ref = "sources/../etc/passwd".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn payload_ref_rejects_double_slash() {
+    let mut ev = auto_event();
+    ev.payload_ref = "sources//hook/x.json".into();
     let err = ev.validate().unwrap_err();
     assert!(matches!(err, DomainError::MalformedCapture { .. }));
 }
@@ -280,46 +302,121 @@ fn payload_ref_rejects_dotdot_traversal() {
 #[test]
 fn payload_ref_rejects_query_and_fragment() {
     let mut ev = auto_event();
-    ev.payload_ref = "file:///vault/sources/x.json?evil=1".into();
+    ev.payload_ref = "sources/x.json?evil=1".into();
     let err = ev.validate().unwrap_err();
     assert!(matches!(err, DomainError::MalformedCapture { .. }));
 }
 
 #[test]
-fn payload_ref_rejects_non_empty_authority() {
-    // file://attacker-host/... must be rejected — the authority component
-    // can resolve to a different host on URI-aware consumers.
+fn payload_ref_rejects_nul_byte() {
     let mut ev = auto_event();
-    ev.payload_ref = "file://attacker-host/vault/sources/x.json".into();
+    ev.payload_ref = "sources/hook/x\0.json".into();
     let err = ev.validate().unwrap_err();
     assert!(matches!(err, DomainError::MalformedCapture { .. }));
 }
 
 #[test]
-fn payload_ref_rejects_localhost_authority() {
-    // Even `localhost` is rejected — we require empty authority for a
-    // single canonical local-file shape.
+fn voice_confidence_out_of_range_rejected() {
     let mut ev = auto_event();
-    ev.payload_ref = "file://localhost/vault/sources/x.json".into();
+    ev.sensor_id = Identity::parse("snr:local:voice:default:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:voice:default:v1")];
+    ev.source_family = SourceFamily::Voice;
+    ev.payload = CapturePayload::Voice {
+        speaker_id: "alice".into(),
+        duration_ms: 100,
+        confidence: 42.0,
+    };
     let err = ev.validate().unwrap_err();
-    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+    assert!(matches!(
+        err,
+        DomainError::OutOfRange {
+            field: "confidence",
+            ..
+        }
+    ));
 }
 
 #[test]
-fn payload_ref_rejects_percent_encoded_traversal() {
-    // %2e%2e decodes to `..` — must not slip past the segment scan.
+fn voice_confidence_nan_rejected() {
     let mut ev = auto_event();
-    ev.payload_ref = "file:///vault/sources/%2e%2e/etc/passwd".into();
+    ev.sensor_id = Identity::parse("snr:local:voice:default:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:voice:default:v1")];
+    ev.source_family = SourceFamily::Voice;
+    ev.payload = CapturePayload::Voice {
+        speaker_id: "alice".into(),
+        duration_ms: 100,
+        confidence: f32::NAN,
+    };
     let err = ev.validate().unwrap_err();
-    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+    assert!(matches!(
+        err,
+        DomainError::OutOfRange {
+            field: "confidence",
+            ..
+        }
+    ));
 }
 
 #[test]
-fn payload_ref_rejects_malformed_percent_encoding() {
+fn empty_hook_name_rejected() {
     let mut ev = auto_event();
-    ev.payload_ref = "file:///vault/sources/x%2".into();
+    ev.payload = CapturePayload::Hook {
+        hook_name: String::new(),
+        tool_name: None,
+    };
     let err = ev.validate().unwrap_err();
-    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+    assert!(matches!(
+        err,
+        DomainError::EmptyField { field: "hook_name" }
+    ));
+}
+
+#[test]
+fn empty_cli_kind_hint_rejected() {
+    let mut ev = explicit_event();
+    ev.payload = CapturePayload::Cli {
+        kind_hint: String::new(),
+    };
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(
+        err,
+        DomainError::EmptyField { field: "kind_hint" }
+    ));
+}
+
+#[test]
+fn empty_proactive_rationale_rejected() {
+    let mut ev = proactive_event();
+    ev.payload = CapturePayload::Proactive {
+        kind: "feedback".into(),
+        rationale: String::new(),
+    };
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(
+        err,
+        DomainError::EmptyField { field: "rationale" }
+    ));
+}
+
+#[test]
+fn zero_recording_duration_rejected() {
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:local:recording:batch:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:recording:batch:v1")];
+    ev.source_family = SourceFamily::RecordingBatch;
+    ev.payload = CapturePayload::RecordingBatch {
+        recording_path: "sources/recording/x.mp4".into(),
+        segment_start_ms: 0,
+        segment_duration_ms: 0,
+    };
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(
+        err,
+        DomainError::OutOfRange {
+            field: "segment_duration_ms",
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -505,6 +505,28 @@ fn proactive_sensor_agent_match_passes() {
 }
 
 #[test]
+fn captureevent_rejects_structurally_valid_but_unregistered_sensor() {
+    // `snr:local:hook:any-instance:v1` is structurally well-formed but
+    // is not in `P0_CANONICAL_LABELS`. `CaptureEvent::validate` must
+    // close that gap pre-#50 — otherwise a producer can mint trusted
+    // events under fabricated sensor identities.
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:local:hook:any-instance:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:hook:any-instance:v1")];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+}
+
+#[test]
+fn captureevent_rejects_unregistered_proactive_agent() {
+    let mut ev = proactive_event();
+    ev.sensor_id = Identity::parse("snr:local:proactive:rogue-agent:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "agt:rogue-agent:m:role:v1")];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+}
+
+#[test]
 fn arbitrary_suffix_under_declared_family_rejected() {
     // `snr:local:hook:anything` has the right family prefix but no
     // version segment — must not pass manifest validation.

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -484,6 +484,25 @@ fn debug_redacts_sensitive_payload_fields() {
 }
 
 #[test]
+fn debug_redacts_payload_ref() {
+    // `payload_ref` is a vault-relative path whose filename portion is
+    // chosen by the producer and may carry user-derived content (e.g.
+    // `sources/cli/remember-my-ssn.txt`). The `Debug` impl must not
+    // leak it into tracing/panic dumps.
+    let mut ev = auto_event();
+    ev.payload_ref = "sources/hook/remember-my-ssn-123-45-6789.json".into();
+    let dump = format!("{ev:?}");
+    assert!(
+        !dump.contains("remember-my-ssn"),
+        "Debug must redact payload_ref: {dump}"
+    );
+    assert!(
+        !dump.contains("123-45-6789"),
+        "Debug must redact payload_ref: {dump}"
+    );
+}
+
+#[test]
 fn proactive_sensor_agent_must_match_author_agent() {
     // sensor_id = snr:local:proactive:claude-code:v1 but author is a
     // codex agent — must be rejected to block cross-agent spoofing.

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -234,7 +234,9 @@ fn auto_mode_author_must_equal_sensor_id() {
     // Sensor declared in `sensor_id` differs from the sensor that
     // appears as `Author` in the chain — Mode A authorship spoofing.
     let mut ev = auto_event();
-    ev.sensor_id = Identity::parse("snr:local:hook:other-host:v1").expect("valid");
+    // Use a *different* canonical hook label to prove the author-vs-sensor
+    // mismatch is what catches this, not a manifest miss.
+    ev.sensor_id = Identity::parse("snr:local:hook:codex-session:v1").expect("valid");
     let err = ev.validate().unwrap_err();
     assert!(matches!(err, DomainError::AttributionMismatch { .. }));
 }
@@ -438,6 +440,27 @@ fn payload_ref_rejects_pure_backslash() {
 }
 
 #[test]
+fn proactive_sensor_agent_must_match_author_agent() {
+    // sensor_id = snr:local:proactive:claude-code:v1 but author is a
+    // codex agent — must be rejected to block cross-agent spoofing.
+    let mut ev = proactive_event();
+    ev.actor_chain = vec![entry(ChainRole::Author, "agt:codex:gpt-5:main:v1")];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+}
+
+#[test]
+fn proactive_sensor_agent_match_passes() {
+    // Aligned agent — claude-code label, claude-code author.
+    let mut ev = proactive_event();
+    ev.actor_chain = vec![entry(
+        ChainRole::Author,
+        "agt:claude-code:opus-4-7:reviewer:v2",
+    )];
+    ev.validate().expect("agent slugs match");
+}
+
+#[test]
 fn arbitrary_suffix_under_declared_family_rejected() {
     // `snr:local:hook:anything` has the right family prefix but no
     // version segment — must not pass manifest validation.
@@ -510,8 +533,11 @@ fn neuroskill_sensor_pinned_to_hook_family() {
     // local:neuroskill:* is now pinned to Hook — emitting any other
     // family from a neuroskill sensor must fail.
     let mut ev = auto_event();
-    ev.sensor_id = Identity::parse("snr:local:neuroskill:harness:v1").expect("valid");
-    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:neuroskill:harness:v1")];
+    ev.sensor_id = Identity::parse("snr:local:neuroskill:cc-session:v1").expect("valid");
+    ev.actor_chain = vec![entry(
+        ChainRole::Author,
+        "snr:local:neuroskill:cc-session:v1",
+    )];
     // Hook payload — should pass.
     ev.validate().expect("neuroskill emitting Hook is valid");
 

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -420,6 +420,35 @@ fn zero_recording_duration_rejected() {
 }
 
 #[test]
+fn payload_ref_rejects_backslash_traversal() {
+    // sources/..\..\Windows\win.ini — backslash-separated parent hops
+    // would slip past a forward-slash-only segment scan.
+    let mut ev = auto_event();
+    ev.payload_ref = "sources/..\\..\\Windows\\win.ini".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn payload_ref_rejects_pure_backslash() {
+    let mut ev = auto_event();
+    ev.payload_ref = "sources\\hook\\x.json".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn arbitrary_suffix_under_declared_family_rejected() {
+    // `snr:local:hook:anything` has the right family prefix but no
+    // version segment — must not pass manifest validation.
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:local:hook:anything").expect("valid syntactic");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:hook:anything")];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+}
+
+#[test]
 fn captureeventid_rejects_overflow_first_char() {
     // ULID first char must be `0`-`7`. `8...` overflows 128 bits.
     let err = CaptureEventId::parse("8ARZ3NDEKTSV4RRFFQ69G5FAVZ").unwrap_err();

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -195,6 +195,97 @@ fn validate_rejects_undeclared_sensor_in_event() {
 }
 
 #[test]
+fn mode_family_mismatch_rejected() {
+    // Mode A cannot carry an `cli` family (that's Mode B's surface).
+    let mut ev = explicit_event();
+    ev.capture_mode = CaptureMode::Auto;
+    // Patch the chain so the attribution check would otherwise pass —
+    // we want to prove the mode/family pairing is what catches this.
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:cli:default:v1")];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn proactive_with_screen_family_rejected() {
+    let mut ev = auto_event();
+    ev.capture_mode = CaptureMode::Proactive;
+    ev.actor_chain = vec![entry(ChainRole::Author, "agt:claude-code:opus-4-7:main:v1")];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn sensor_label_family_mismatch_rejected() {
+    // CLI sensor declaring a screen payload — declared family ≠ event family.
+    let mut ev = explicit_event();
+    ev.source_family = SourceFamily::Screen;
+    ev.payload = CapturePayload::Screen {
+        app: "com.apple.Safari".into(),
+        window_title: "spoof".into(),
+        url: None,
+    };
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn auto_mode_author_must_equal_sensor_id() {
+    // Sensor declared in `sensor_id` differs from the sensor that
+    // appears as `Author` in the chain — Mode A authorship spoofing.
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:local:hook:other-host:v1").expect("valid");
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+}
+
+#[test]
+fn chain_sensor_entry_must_match_sensor_id() {
+    // Mode B with a Sensor entry that points to a different sensor than
+    // the one declared in `sensor_id`.
+    let mut ev = explicit_event();
+    ev.actor_chain.push(ActorChainEntry {
+        role: ChainRole::Sensor,
+        identity: Identity::parse("snr:local:hook:cc-session:v1").expect("valid"),
+        at: ts(),
+    });
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+}
+
+#[test]
+fn payload_ref_must_be_file_scheme() {
+    let mut ev = auto_event();
+    ev.payload_ref = "https://example.com/sources/x.json".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn payload_ref_must_be_under_sources() {
+    let mut ev = auto_event();
+    ev.payload_ref = "file:///etc/passwd".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn payload_ref_rejects_dotdot_traversal() {
+    let mut ev = auto_event();
+    ev.payload_ref = "file:///vault/sources/../etc/passwd".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn payload_ref_rejects_query_and_fragment() {
+    let mut ev = auto_event();
+    ev.payload_ref = "file:///vault/sources/x.json?evil=1".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
 fn payload_family_mismatch_rejected() {
     let mut ev = auto_event();
     ev.source_family = SourceFamily::Voice;

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -406,8 +406,8 @@ fn zero_recording_duration_rejected() {
     ev.sensor_id = Identity::parse("snr:local:recording:batch:v1").expect("valid");
     ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:recording:batch:v1")];
     ev.source_family = SourceFamily::RecordingBatch;
+    ev.payload_ref = "sources/recording/x.mp4".into();
     ev.payload = CapturePayload::RecordingBatch {
-        recording_path: "sources/recording/x.mp4".into(),
         segment_start_ms: 0,
         segment_duration_ms: 0,
     };
@@ -550,33 +550,77 @@ fn captureeventid_accepts_max_valid_first_char() {
 }
 
 #[test]
-fn recording_path_must_be_vault_relative() {
+fn recording_payload_ref_must_be_vault_relative() {
+    // The source recording is now bound to the envelope-level
+    // `payload_ref` — its trust boundary is the same shared check.
     let mut ev = auto_event();
     ev.sensor_id = Identity::parse("snr:local:recording:batch:v1").expect("valid");
     ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:recording:batch:v1")];
     ev.source_family = SourceFamily::RecordingBatch;
     ev.payload = CapturePayload::RecordingBatch {
-        recording_path: "/tmp/attacker/x.mp4".into(),
         segment_start_ms: 0,
         segment_duration_ms: 1000,
     };
+    ev.payload_ref = "/tmp/attacker/x.mp4".into();
     let err = ev.validate().unwrap_err();
     assert!(matches!(err, DomainError::MalformedCapture { .. }));
 }
 
 #[test]
-fn recording_path_rejects_dotdot() {
+fn empty_string_session_ref_rejected() {
+    // CaptureRefs absences are `None`; `Some("")` is malformed because
+    // downstream ordering/dedup keys off these values.
     let mut ev = auto_event();
-    ev.sensor_id = Identity::parse("snr:local:recording:batch:v1").expect("valid");
-    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:recording:batch:v1")];
-    ev.source_family = SourceFamily::RecordingBatch;
-    ev.payload = CapturePayload::RecordingBatch {
-        recording_path: "sources/recording/../../etc/passwd".into(),
-        segment_start_ms: 0,
-        segment_duration_ms: 1000,
-    };
+    ev.refs = Some(CaptureRefs {
+        session_id: Some(String::new()),
+        ..Default::default()
+    });
     let err = ev.validate().unwrap_err();
-    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+    assert!(matches!(
+        err,
+        DomainError::EmptyField {
+            field: "refs.session_id"
+        }
+    ));
+}
+
+#[test]
+fn whitespace_only_turn_ref_rejected() {
+    let mut ev = auto_event();
+    ev.refs = Some(CaptureRefs {
+        turn_id: Some("   ".into()),
+        ..Default::default()
+    });
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(
+        err,
+        DomainError::EmptyField {
+            field: "refs.turn_id"
+        }
+    ));
+}
+
+#[test]
+fn try_new_runs_validate() {
+    // Smart constructor enforces every invariant — caller cannot skip
+    // it the way field-literal construction would.
+    let res = CaptureEvent::try_new(
+        ulid_a(),
+        Identity::parse("snr:local:hook:cc-session:v1").expect("valid"),
+        CaptureMode::Auto,
+        vec![entry(ChainRole::Author, "snr:local:hook:cc-session:v1")],
+        None,
+        hash(),
+        // Off-vault path — must be rejected.
+        "/etc/passwd".into(),
+        ts(),
+        CapturePayload::Hook {
+            hook_name: "PostToolUse".into(),
+            tool_name: None,
+        },
+        SourceFamily::Hook,
+    );
+    assert!(matches!(res, Err(DomainError::MalformedCapture { .. })));
 }
 
 #[test]

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -1,0 +1,276 @@
+//! Integration tests for the typed [`cairn_core::domain::CaptureEvent`].
+//!
+//! Covers the issue #71 acceptance criteria:
+//! - Every captured event can be traced to a sensor / user / agent
+//!   identity and source mode (attribution rule from §5.0.a).
+//! - `CaptureEvent` serialization round-trips for replay and eval
+//!   fixtures.
+//! - Invalid or undeclared sensor labels are rejected before any pipeline
+//!   stage observes them.
+//!
+//! Snapshot fixtures live under `fixtures/capture_events/`. They are
+//! replayed here through `serde_json::from_str` so the same byte-for-byte
+//! envelope can be consumed by the downstream extractor / filter / WAL
+//! tests as they land.
+
+#![allow(missing_docs)]
+
+use std::path::Path;
+
+use cairn_core::domain::{
+    ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs,
+    ChainRole, DomainError, Identity, IdentityKind, PayloadHash, Rfc3339Timestamp, SensorLabel,
+    SourceFamily, attribute, validate_label,
+};
+use proptest::prelude::*;
+
+const FIXTURE_DIR: &str = "../../fixtures/capture_events";
+
+fn ts() -> Rfc3339Timestamp {
+    Rfc3339Timestamp::parse("2026-04-22T14:02:11Z").expect("valid")
+}
+
+fn ulid_a() -> CaptureEventId {
+    CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid ULID")
+}
+
+fn ulid_b() -> CaptureEventId {
+    CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FB0").expect("valid ULID")
+}
+
+fn ulid_c() -> CaptureEventId {
+    CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FCA").expect("valid ULID")
+}
+
+fn entry(role: ChainRole, id: &str) -> ActorChainEntry {
+    ActorChainEntry {
+        role,
+        identity: Identity::parse(id).expect("valid"),
+        at: ts(),
+    }
+}
+
+fn hash() -> PayloadHash {
+    PayloadHash::parse(format!("sha256:{}", "ab".repeat(32))).expect("valid")
+}
+
+fn auto_event() -> CaptureEvent {
+    CaptureEvent {
+        event_id: ulid_a(),
+        sensor_id: Identity::parse("snr:local:hook:cc-session:v1").expect("valid"),
+        capture_mode: CaptureMode::Auto,
+        actor_chain: vec![entry(ChainRole::Author, "snr:local:hook:cc-session:v1")],
+        refs: Some(CaptureRefs {
+            session_id: Some("sess-42".into()),
+            turn_id: Some("turn-7".into()),
+            tool_id: Some("tool-1".into()),
+        }),
+        payload_hash: hash(),
+        payload_ref: "file:///vault/sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json".into(),
+        captured_at: ts(),
+        payload: CapturePayload::Hook {
+            hook_name: "PostToolUse".into(),
+            tool_name: Some("Read".into()),
+        },
+        source_family: SourceFamily::Hook,
+    }
+}
+
+fn explicit_event() -> CaptureEvent {
+    CaptureEvent {
+        event_id: ulid_b(),
+        sensor_id: Identity::parse("snr:local:cli:default:v1").expect("valid"),
+        capture_mode: CaptureMode::Explicit,
+        actor_chain: vec![
+            entry(ChainRole::Delegator, "agt:claude-code:opus-4-7:main:v1"),
+            entry(ChainRole::Author, "usr:tafeng"),
+        ],
+        refs: None,
+        payload_hash: hash(),
+        payload_ref: "file:///vault/sources/cli/01ARZ3NDEKTSV4RRFFQ69G5FB0.txt".into(),
+        captured_at: ts(),
+        payload: CapturePayload::Cli {
+            kind_hint: "user".into(),
+        },
+        source_family: SourceFamily::Cli,
+    }
+}
+
+fn proactive_event() -> CaptureEvent {
+    CaptureEvent {
+        event_id: ulid_c(),
+        sensor_id: Identity::parse("snr:local:proactive:claude-code:v1").expect("valid"),
+        capture_mode: CaptureMode::Proactive,
+        actor_chain: vec![entry(
+            ChainRole::Author,
+            "agt:claude-code:opus-4-7:reviewer:v1",
+        )],
+        refs: Some(CaptureRefs {
+            session_id: Some("sess-42".into()),
+            turn_id: Some("turn-7".into()),
+            tool_id: None,
+        }),
+        payload_hash: hash(),
+        payload_ref: "file:///vault/sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FCA.json".into(),
+        captured_at: ts(),
+        payload: CapturePayload::Proactive {
+            kind: "feedback".into(),
+            rationale: "user corrected the agent — high-salience".into(),
+        },
+        source_family: SourceFamily::Proactive,
+    }
+}
+
+#[test]
+fn auto_event_validates_and_traces_to_sensor() {
+    let ev = auto_event();
+    ev.validate().expect("valid auto event");
+
+    let author = attribute(ev.capture_mode, &ev.actor_chain).expect("attributed");
+    assert_eq!(author.identity.kind(), IdentityKind::Sensor);
+}
+
+#[test]
+fn explicit_event_validates_and_traces_to_human() {
+    let ev = explicit_event();
+    ev.validate().expect("valid explicit event");
+
+    let author = attribute(ev.capture_mode, &ev.actor_chain).expect("attributed");
+    assert_eq!(author.identity.kind(), IdentityKind::Human);
+    assert_eq!(author.identity.as_str(), "usr:tafeng");
+}
+
+#[test]
+fn proactive_event_validates_and_traces_to_agent() {
+    let ev = proactive_event();
+    ev.validate().expect("valid proactive event");
+
+    let author = attribute(ev.capture_mode, &ev.actor_chain).expect("attributed");
+    assert_eq!(author.identity.kind(), IdentityKind::Agent);
+}
+
+#[test]
+fn explicit_event_with_only_sensor_chain_is_rejected() {
+    // Mode B requires a human author — a sensor-only chain must fail.
+    let mut ev = explicit_event();
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:hook:cc-session:v1")];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+}
+
+#[test]
+fn auto_event_with_human_author_is_rejected() {
+    let mut ev = auto_event();
+    ev.actor_chain = vec![entry(ChainRole::Author, "usr:tafeng")];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+}
+
+#[test]
+fn proactive_event_with_sensor_author_is_rejected() {
+    let mut ev = proactive_event();
+    ev.actor_chain = vec![entry(
+        ChainRole::Author,
+        "snr:local:proactive:claude-code:v1",
+    )];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::AttributionMismatch { .. }));
+}
+
+#[test]
+fn undeclared_sensor_label_rejected() {
+    // `local:slack:` is not in the P0 manifest.
+    let bad = SensorLabel::parse("remote:slack:default:v1").expect("syntactic");
+    let err = validate_label(&bad).unwrap_err();
+    assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+}
+
+#[test]
+fn validate_rejects_undeclared_sensor_in_event() {
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:remote:slack:default:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:remote:slack:default:v1")];
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+}
+
+#[test]
+fn payload_family_mismatch_rejected() {
+    let mut ev = auto_event();
+    ev.source_family = SourceFamily::Voice;
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn round_trips_each_mode_through_json() {
+    for ev in [auto_event(), explicit_event(), proactive_event()] {
+        let s = serde_json::to_string(&ev).expect("ser");
+        let back: CaptureEvent = serde_json::from_str(&s).expect("de");
+        assert_eq!(back, ev);
+    }
+}
+
+#[test]
+fn snapshot_each_mode() {
+    insta::assert_json_snapshot!("capture_event_auto", auto_event());
+    insta::assert_json_snapshot!("capture_event_explicit", explicit_event());
+    insta::assert_json_snapshot!("capture_event_proactive", proactive_event());
+}
+
+#[test]
+fn fixtures_replay_and_revalidate() {
+    let dir = Path::new(FIXTURE_DIR);
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("fixture dir `{}` should exist: {e}", dir.display()));
+    let mut count = 0;
+    for entry in entries {
+        let entry = entry.expect("readdir");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read fixture `{}`: {e}", path.display()));
+        let ev: CaptureEvent = serde_json::from_str(&raw)
+            .unwrap_or_else(|e| panic!("parse fixture `{}`: {e}", path.display()));
+        ev.validate()
+            .unwrap_or_else(|e| panic!("validate fixture `{}`: {e}", path.display()));
+        count += 1;
+    }
+    assert!(count >= 3, "expected at least 3 fixtures, found {count}");
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Any event we hand-construct round-trips byte-for-byte through JSON.
+    #[test]
+    fn serde_round_trip_is_total(seed in 0u32..1000) {
+        let ev = match seed % 3 {
+            0 => auto_event(),
+            1 => explicit_event(),
+            _ => proactive_event(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        let back: CaptureEvent = serde_json::from_str(&s).unwrap();
+        prop_assert_eq!(back, ev);
+    }
+
+    /// Any 64-char lowercase-hex tail is a valid `PayloadHash`; mutating
+    /// any byte to an invalid one (uppercase or non-hex) is rejected.
+    #[test]
+    fn payload_hash_invariants(
+        idx in 0usize..64,
+        bad in prop::char::range('g', 'z')
+    ) {
+        let good = format!("sha256:{}", "a".repeat(64));
+        PayloadHash::parse(&good).expect("baseline valid");
+
+        let mut bytes = good.into_bytes();
+        bytes[7 + idx] = bad as u8;
+        let mutated = String::from_utf8(bytes).unwrap();
+        let res = PayloadHash::parse(mutated);
+        prop_assert!(res.is_err());
+    }
+}

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -440,6 +440,50 @@ fn payload_ref_rejects_pure_backslash() {
 }
 
 #[test]
+fn deserialize_runs_validate() {
+    // A JSON event whose mode/family pair would violate §5.0.a must be
+    // rejected at `serde_json::from_str` time, not silently materialized
+    // into a `CaptureEvent`. This proves the `try_from` gate works.
+    let mut ev = explicit_event();
+    ev.capture_mode = CaptureMode::Auto;
+    let json = serde_json::to_string(&ev).expect("ser");
+    let res: Result<CaptureEvent, _> = serde_json::from_str(&json);
+    assert!(res.is_err(), "deserialization must run validate()");
+}
+
+#[test]
+fn deserialize_rejects_undeclared_sensor() {
+    let mut ev = auto_event();
+    // Construct an envelope whose sensor label does not match the
+    // structural rule (no version segment).
+    ev.sensor_id = Identity::parse("snr:local:hook:bare").expect("syntactic");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:hook:bare")];
+    let json = serde_json::to_string(&ev).expect("ser");
+    let res: Result<CaptureEvent, _> = serde_json::from_str(&json);
+    assert!(res.is_err());
+}
+
+#[test]
+fn debug_redacts_sensitive_payload_fields() {
+    // Any of `Terminal.command`, `Screen.window_title/url`, or
+    // `Proactive.rationale` reaching a `Debug` dump would be a
+    // user-data leak. The Debug impl must not contain the secret.
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:local:terminal:default:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:terminal:default:v1")];
+    ev.source_family = SourceFamily::Terminal;
+    ev.payload = CapturePayload::Terminal {
+        command: "echo SUPER_SECRET_TOKEN_42".into(),
+        exit_code: Some(0),
+    };
+    let dump = format!("{ev:?}");
+    assert!(
+        !dump.contains("SUPER_SECRET_TOKEN_42"),
+        "Debug must redact terminal command: {dump}"
+    );
+}
+
+#[test]
 fn proactive_sensor_agent_must_match_author_agent() {
     // sensor_id = snr:local:proactive:claude-code:v1 but author is a
     // codex agent — must be rejected to block cross-agent spoofing.

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -286,6 +286,64 @@ fn payload_ref_rejects_query_and_fragment() {
 }
 
 #[test]
+fn payload_ref_rejects_non_empty_authority() {
+    // file://attacker-host/... must be rejected — the authority component
+    // can resolve to a different host on URI-aware consumers.
+    let mut ev = auto_event();
+    ev.payload_ref = "file://attacker-host/vault/sources/x.json".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn payload_ref_rejects_localhost_authority() {
+    // Even `localhost` is rejected — we require empty authority for a
+    // single canonical local-file shape.
+    let mut ev = auto_event();
+    ev.payload_ref = "file://localhost/vault/sources/x.json".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn payload_ref_rejects_percent_encoded_traversal() {
+    // %2e%2e decodes to `..` — must not slip past the segment scan.
+    let mut ev = auto_event();
+    ev.payload_ref = "file:///vault/sources/%2e%2e/etc/passwd".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn payload_ref_rejects_malformed_percent_encoding() {
+    let mut ev = auto_event();
+    ev.payload_ref = "file:///vault/sources/x%2".into();
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn neuroskill_sensor_pinned_to_hook_family() {
+    // local:neuroskill:* is now pinned to Hook — emitting any other
+    // family from a neuroskill sensor must fail.
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:local:neuroskill:harness:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:neuroskill:harness:v1")];
+    // Hook payload — should pass.
+    ev.validate().expect("neuroskill emitting Hook is valid");
+
+    // Now flip to a Voice payload + family. Neuroskill must be rejected.
+    ev.source_family = SourceFamily::Voice;
+    ev.payload = CapturePayload::Voice {
+        speaker_id: "x".into(),
+        duration_ms: 0,
+        confidence: 1.0,
+    };
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
 fn payload_family_mismatch_rejected() {
     let mut ev = auto_event();
     ev.source_family = SourceFamily::Voice;

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -420,6 +420,63 @@ fn zero_recording_duration_rejected() {
 }
 
 #[test]
+fn captureeventid_rejects_overflow_first_char() {
+    // ULID first char must be `0`-`7`. `8...` overflows 128 bits.
+    let err = CaptureEventId::parse("8ARZ3NDEKTSV4RRFFQ69G5FAVZ").unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn captureeventid_accepts_max_valid_first_char() {
+    CaptureEventId::parse("7ZZZZZZZZZZZZZZZZZZZZZZZZZ").expect("first char `7` is the max");
+}
+
+#[test]
+fn recording_path_must_be_vault_relative() {
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:local:recording:batch:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:recording:batch:v1")];
+    ev.source_family = SourceFamily::RecordingBatch;
+    ev.payload = CapturePayload::RecordingBatch {
+        recording_path: "/tmp/attacker/x.mp4".into(),
+        segment_start_ms: 0,
+        segment_duration_ms: 1000,
+    };
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn recording_path_rejects_dotdot() {
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:local:recording:batch:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:recording:batch:v1")];
+    ev.source_family = SourceFamily::RecordingBatch;
+    ev.payload = CapturePayload::RecordingBatch {
+        recording_path: "sources/recording/../../etc/passwd".into(),
+        segment_start_ms: 0,
+        segment_duration_ms: 1000,
+    };
+    let err = ev.validate().unwrap_err();
+    assert!(matches!(err, DomainError::MalformedCapture { .. }));
+}
+
+#[test]
+fn screen_window_title_can_be_empty_for_redaction() {
+    // Privacy-redacted screen captures legitimately ship empty titles.
+    let mut ev = auto_event();
+    ev.sensor_id = Identity::parse("snr:local:screen:default:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:screen:default:v1")];
+    ev.source_family = SourceFamily::Screen;
+    ev.payload = CapturePayload::Screen {
+        app: "com.apple.Safari".into(),
+        window_title: String::new(),
+        url: None,
+    };
+    ev.validate().expect("redacted title must not block ingest");
+}
+
+#[test]
 fn neuroskill_sensor_pinned_to_hook_family() {
     // local:neuroskill:* is now pinned to Hook — emitting any other
     // family from a neuroskill sensor must fail.

--- a/crates/cairn-core/tests/capture_event.rs
+++ b/crates/cairn-core/tests/capture_event.rs
@@ -524,25 +524,30 @@ fn proactive_sensor_agent_match_passes() {
 }
 
 #[test]
-fn captureevent_rejects_structurally_valid_but_unregistered_sensor() {
-    // `snr:local:hook:any-instance:v1` is structurally well-formed but
-    // is not in `P0_CANONICAL_LABELS`. `CaptureEvent::validate` must
-    // close that gap pre-#50 — otherwise a producer can mint trusted
-    // events under fabricated sensor identities.
+fn captureevent_accepts_structurally_valid_unregistered_sensor() {
+    // Schema-level admission is structural only:
+    // `local:<family>:<instance>(:<sub>)*:v<digits>` is sufficient.
+    // Closed-list / instance-version authorization belongs to the
+    // runtime sensor registry (#50) and the keychain-backed signing
+    // layer — `cairn-core` must not block host-specific instances or
+    // producer-side version bumps. Deployments that need a closed list
+    // pre-#50 can pair `validate_label_in_registry` at their ingress.
     let mut ev = auto_event();
-    ev.sensor_id = Identity::parse("snr:local:hook:any-instance:v1").expect("valid");
-    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:hook:any-instance:v1")];
-    let err = ev.validate().unwrap_err();
-    assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    ev.sensor_id = Identity::parse("snr:local:hook:custom-host:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "snr:local:hook:custom-host:v1")];
+    ev.validate().expect("structurally valid sensor accepted");
 }
 
 #[test]
-fn captureevent_rejects_unregistered_proactive_agent() {
+fn captureevent_accepts_proactive_with_matching_slug() {
+    // Proactive binding is slug-match (sensor agent slug = author agent
+    // slug), not closed-list. Any `agt:<slug>:...` author paired with
+    // `snr:local:proactive:<slug>:v1` passes; cross-slug pairs fail
+    // (proven by `proactive_sensor_agent_must_match_author_agent`).
     let mut ev = proactive_event();
-    ev.sensor_id = Identity::parse("snr:local:proactive:rogue-agent:v1").expect("valid");
-    ev.actor_chain = vec![entry(ChainRole::Author, "agt:rogue-agent:m:role:v1")];
-    let err = ev.validate().unwrap_err();
-    assert!(matches!(err, DomainError::UndeclaredSensor { .. }));
+    ev.sensor_id = Identity::parse("snr:local:proactive:custom-agent:v1").expect("valid");
+    ev.actor_chain = vec![entry(ChainRole::Author, "agt:custom-agent:m:role:v1")];
+    ev.validate().expect("matching slugs accepted");
 }
 
 #[test]

--- a/crates/cairn-core/tests/snapshots/capture_event__capture_event_auto.snap
+++ b/crates/cairn-core/tests/snapshots/capture_event__capture_event_auto.snap
@@ -1,0 +1,30 @@
+---
+source: crates/cairn-core/tests/capture_event.rs
+expression: auto_event()
+---
+{
+  "event_id": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  "sensor_id": "snr:local:hook:cc-session:v1",
+  "capture_mode": "auto",
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "snr:local:hook:cc-session:v1",
+      "at": "2026-04-22T14:02:11Z"
+    }
+  ],
+  "refs": {
+    "session_id": "sess-42",
+    "turn_id": "turn-7",
+    "tool_id": "tool-1"
+  },
+  "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
+  "payload_ref": "file:///vault/sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json",
+  "captured_at": "2026-04-22T14:02:11Z",
+  "payload": {
+    "source_family": "hook",
+    "hook_name": "PostToolUse",
+    "tool_name": "Read"
+  },
+  "source_family": "hook"
+}

--- a/crates/cairn-core/tests/snapshots/capture_event__capture_event_auto.snap
+++ b/crates/cairn-core/tests/snapshots/capture_event__capture_event_auto.snap
@@ -19,7 +19,7 @@ expression: auto_event()
     "tool_id": "tool-1"
   },
   "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
-  "payload_ref": "file:///vault/sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json",
+  "payload_ref": "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json",
   "captured_at": "2026-04-22T14:02:11Z",
   "payload": {
     "source_family": "hook",

--- a/crates/cairn-core/tests/snapshots/capture_event__capture_event_explicit.snap
+++ b/crates/cairn-core/tests/snapshots/capture_event__capture_event_explicit.snap
@@ -19,7 +19,7 @@ expression: explicit_event()
     }
   ],
   "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
-  "payload_ref": "file:///vault/sources/cli/01ARZ3NDEKTSV4RRFFQ69G5FB0.txt",
+  "payload_ref": "sources/cli/01ARZ3NDEKTSV4RRFFQ69G5FB0.txt",
   "captured_at": "2026-04-22T14:02:11Z",
   "payload": {
     "source_family": "cli",

--- a/crates/cairn-core/tests/snapshots/capture_event__capture_event_explicit.snap
+++ b/crates/cairn-core/tests/snapshots/capture_event__capture_event_explicit.snap
@@ -1,0 +1,29 @@
+---
+source: crates/cairn-core/tests/capture_event.rs
+expression: explicit_event()
+---
+{
+  "event_id": "01ARZ3NDEKTSV4RRFFQ69G5FB0",
+  "sensor_id": "snr:local:cli:default:v1",
+  "capture_mode": "explicit",
+  "actor_chain": [
+    {
+      "role": "delegator",
+      "identity": "agt:claude-code:opus-4-7:main:v1",
+      "at": "2026-04-22T14:02:11Z"
+    },
+    {
+      "role": "author",
+      "identity": "usr:tafeng",
+      "at": "2026-04-22T14:02:11Z"
+    }
+  ],
+  "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
+  "payload_ref": "file:///vault/sources/cli/01ARZ3NDEKTSV4RRFFQ69G5FB0.txt",
+  "captured_at": "2026-04-22T14:02:11Z",
+  "payload": {
+    "source_family": "cli",
+    "kind_hint": "user"
+  },
+  "source_family": "cli"
+}

--- a/crates/cairn-core/tests/snapshots/capture_event__capture_event_proactive.snap
+++ b/crates/cairn-core/tests/snapshots/capture_event__capture_event_proactive.snap
@@ -1,0 +1,29 @@
+---
+source: crates/cairn-core/tests/capture_event.rs
+expression: proactive_event()
+---
+{
+  "event_id": "01ARZ3NDEKTSV4RRFFQ69G5FCA",
+  "sensor_id": "snr:local:proactive:claude-code:v1",
+  "capture_mode": "proactive",
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "agt:claude-code:opus-4-7:reviewer:v1",
+      "at": "2026-04-22T14:02:11Z"
+    }
+  ],
+  "refs": {
+    "session_id": "sess-42",
+    "turn_id": "turn-7"
+  },
+  "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
+  "payload_ref": "file:///vault/sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FCA.json",
+  "captured_at": "2026-04-22T14:02:11Z",
+  "payload": {
+    "source_family": "proactive",
+    "kind": "feedback",
+    "rationale": "user corrected the agent — high-salience"
+  },
+  "source_family": "proactive"
+}

--- a/crates/cairn-core/tests/snapshots/capture_event__capture_event_proactive.snap
+++ b/crates/cairn-core/tests/snapshots/capture_event__capture_event_proactive.snap
@@ -18,7 +18,7 @@ expression: proactive_event()
     "turn_id": "turn-7"
   },
   "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
-  "payload_ref": "file:///vault/sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FCA.json",
+  "payload_ref": "sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FCA.json",
   "captured_at": "2026-04-22T14:02:11Z",
   "payload": {
     "source_family": "proactive",

--- a/fixtures/capture_events/README.md
+++ b/fixtures/capture_events/README.md
@@ -1,0 +1,22 @@
+# `CaptureEvent` fixtures
+
+Replayable JSON envelopes for the §5.0.a / §9 ingestion pipeline. Each
+fixture is a single `CaptureEvent` serialized via `serde_json` from
+`cairn_core::domain::CaptureEvent`. The integration test
+`crates/cairn-core/tests/capture_event.rs::fixtures_replay_and_revalidate`
+parses every `*.json` file in this directory and re-runs `validate()`,
+so adding a fixture here exercises the full domain-layer invariants
+without further wiring.
+
+The set is intentionally minimal: one fixture per capture mode (auto,
+explicit, proactive) and one per source family that downstream pipeline
+crates need a worked example for. Adding a fixture is cheap; ripping one
+out should require updating the consuming test.
+
+| File | Mode | Family | Why |
+|------|------|--------|-----|
+| `auto_hook.json` | auto | hook | the canonical Mode A event from a `PostToolUse` harness hook |
+| `explicit_cli.json` | explicit | cli | Mode B event from `cairn ingest --kind user --body …` with an agent delegator |
+| `proactive_feedback.json` | proactive | proactive | Mode C event the agent emits when the user corrects it |
+| `auto_voice.json` | auto | voice | Mode A event from the voice sensor — exercises the per-modality payload variant |
+| `auto_screen.json` | auto | screen | Mode A event from the screen sensor with a URL hint |

--- a/fixtures/capture_events/auto_hook.json
+++ b/fixtures/capture_events/auto_hook.json
@@ -1,0 +1,26 @@
+{
+  "event_id": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  "sensor_id": "snr:local:hook:cc-session:v1",
+  "capture_mode": "auto",
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "snr:local:hook:cc-session:v1",
+      "at": "2026-04-22T14:02:11Z"
+    }
+  ],
+  "refs": {
+    "session_id": "sess-42",
+    "turn_id": "turn-7",
+    "tool_id": "tool-1"
+  },
+  "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
+  "payload_ref": "file:///vault/sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json",
+  "captured_at": "2026-04-22T14:02:11Z",
+  "payload": {
+    "source_family": "hook",
+    "hook_name": "PostToolUse",
+    "tool_name": "Read"
+  },
+  "source_family": "hook"
+}

--- a/fixtures/capture_events/auto_hook.json
+++ b/fixtures/capture_events/auto_hook.json
@@ -15,7 +15,7 @@
     "tool_id": "tool-1"
   },
   "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
-  "payload_ref": "file:///vault/sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json",
+  "payload_ref": "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json",
   "captured_at": "2026-04-22T14:02:11Z",
   "payload": {
     "source_family": "hook",

--- a/fixtures/capture_events/auto_screen.json
+++ b/fixtures/capture_events/auto_screen.json
@@ -1,0 +1,22 @@
+{
+  "event_id": "01ARZ3NDEKTSV4RRFFQ69G5FE0",
+  "sensor_id": "snr:local:screen:default:v1",
+  "capture_mode": "auto",
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "snr:local:screen:default:v1",
+      "at": "2026-04-22T14:02:11Z"
+    }
+  ],
+  "payload_hash": "sha256:efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef",
+  "payload_ref": "file:///vault/sources/screen/01ARZ3NDEKTSV4RRFFQ69G5FE0.png",
+  "captured_at": "2026-04-22T14:02:11Z",
+  "payload": {
+    "source_family": "screen",
+    "app": "com.apple.Safari",
+    "window_title": "Cairn — design brief",
+    "url": "https://cairn.dev/docs/design"
+  },
+  "source_family": "screen"
+}

--- a/fixtures/capture_events/auto_screen.json
+++ b/fixtures/capture_events/auto_screen.json
@@ -10,7 +10,7 @@
     }
   ],
   "payload_hash": "sha256:efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef",
-  "payload_ref": "file:///vault/sources/screen/01ARZ3NDEKTSV4RRFFQ69G5FE0.png",
+  "payload_ref": "sources/screen/01ARZ3NDEKTSV4RRFFQ69G5FE0.png",
   "captured_at": "2026-04-22T14:02:11Z",
   "payload": {
     "source_family": "screen",

--- a/fixtures/capture_events/auto_voice.json
+++ b/fixtures/capture_events/auto_voice.json
@@ -13,7 +13,7 @@
     "session_id": "sess-42"
   },
   "payload_hash": "sha256:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
-  "payload_ref": "file:///vault/sources/voice/01ARZ3NDEKTSV4RRFFQ69G5FD0.wav",
+  "payload_ref": "sources/voice/01ARZ3NDEKTSV4RRFFQ69G5FD0.wav",
   "captured_at": "2026-04-22T14:02:11Z",
   "payload": {
     "source_family": "voice",

--- a/fixtures/capture_events/auto_voice.json
+++ b/fixtures/capture_events/auto_voice.json
@@ -1,0 +1,25 @@
+{
+  "event_id": "01ARZ3NDEKTSV4RRFFQ69G5FD0",
+  "sensor_id": "snr:local:voice:default:v1",
+  "capture_mode": "auto",
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "snr:local:voice:default:v1",
+      "at": "2026-04-22T14:02:11Z"
+    }
+  ],
+  "refs": {
+    "session_id": "sess-42"
+  },
+  "payload_hash": "sha256:cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+  "payload_ref": "file:///vault/sources/voice/01ARZ3NDEKTSV4RRFFQ69G5FD0.wav",
+  "captured_at": "2026-04-22T14:02:11Z",
+  "payload": {
+    "source_family": "voice",
+    "speaker_id": "unknown_speaker_01HQZ",
+    "duration_ms": 4200,
+    "confidence": 0.82
+  },
+  "source_family": "voice"
+}

--- a/fixtures/capture_events/explicit_cli.json
+++ b/fixtures/capture_events/explicit_cli.json
@@ -1,0 +1,25 @@
+{
+  "event_id": "01ARZ3NDEKTSV4RRFFQ69G5FB0",
+  "sensor_id": "snr:local:cli:default:v1",
+  "capture_mode": "explicit",
+  "actor_chain": [
+    {
+      "role": "delegator",
+      "identity": "agt:claude-code:opus-4-7:main:v1",
+      "at": "2026-04-22T14:02:11Z"
+    },
+    {
+      "role": "author",
+      "identity": "usr:tafeng",
+      "at": "2026-04-22T14:02:11Z"
+    }
+  ],
+  "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
+  "payload_ref": "file:///vault/sources/cli/01ARZ3NDEKTSV4RRFFQ69G5FB0.txt",
+  "captured_at": "2026-04-22T14:02:11Z",
+  "payload": {
+    "source_family": "cli",
+    "kind_hint": "user"
+  },
+  "source_family": "cli"
+}

--- a/fixtures/capture_events/explicit_cli.json
+++ b/fixtures/capture_events/explicit_cli.json
@@ -15,7 +15,7 @@
     }
   ],
   "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
-  "payload_ref": "file:///vault/sources/cli/01ARZ3NDEKTSV4RRFFQ69G5FB0.txt",
+  "payload_ref": "sources/cli/01ARZ3NDEKTSV4RRFFQ69G5FB0.txt",
   "captured_at": "2026-04-22T14:02:11Z",
   "payload": {
     "source_family": "cli",

--- a/fixtures/capture_events/proactive_feedback.json
+++ b/fixtures/capture_events/proactive_feedback.json
@@ -14,7 +14,7 @@
     "turn_id": "turn-7"
   },
   "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
-  "payload_ref": "file:///vault/sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FCA.json",
+  "payload_ref": "sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FCA.json",
   "captured_at": "2026-04-22T14:02:11Z",
   "payload": {
     "source_family": "proactive",

--- a/fixtures/capture_events/proactive_feedback.json
+++ b/fixtures/capture_events/proactive_feedback.json
@@ -1,0 +1,25 @@
+{
+  "event_id": "01ARZ3NDEKTSV4RRFFQ69G5FCA",
+  "sensor_id": "snr:local:proactive:claude-code:v1",
+  "capture_mode": "proactive",
+  "actor_chain": [
+    {
+      "role": "author",
+      "identity": "agt:claude-code:opus-4-7:reviewer:v1",
+      "at": "2026-04-22T14:02:11Z"
+    }
+  ],
+  "refs": {
+    "session_id": "sess-42",
+    "turn_id": "turn-7"
+  },
+  "payload_hash": "sha256:abababababababababababababababababababababababababababababababab",
+  "payload_ref": "file:///vault/sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FCA.json",
+  "captured_at": "2026-04-22T14:02:11Z",
+  "payload": {
+    "source_family": "proactive",
+    "kind": "feedback",
+    "rationale": "user corrected the agent — high-salience"
+  },
+  "source_family": "proactive"
+}


### PR DESCRIPTION
Closes #71.

## Summary
- Define the typed `CaptureEvent` envelope every sensor + the explicit CLI / MCP / proactive-agent surfaces emit into the §5.2 ingestion pipeline (brief §5.0.a, §9).
- Enforce the §5.0.a attribution rule (Auto→Sensor, Explicit→Human, Proactive→Agent) and validate sensor labels against a closed P0 manifest.
- Ship 5 replayable JSON fixtures + 14 integration tests so downstream extractor / filter / WAL work can consume the schema verbatim.

## Brief sections
- §5.0.a Three capture modes — auto, explicit, proactive
- §9 Sensors (and §9.1.a recording-to-text)
- §4.2 Identity / actor chain (re-used unchanged)

## Invariants touched
- (4) Seven contracts, pure functions otherwise — all new code is pure data + validation, no I/O, no new contract.
- (8) No `unwrap()` / `expect()` in `cairn-core` — preserved.
- (9) Privacy by construction — payload bodies live behind `payload_ref` + `payload_hash`, never inlined into the envelope; safe to log envelope at `info`.
- Adds 6 new variants to the `#[non_exhaustive]` `DomainError` enum.

## Out of scope
- Extractor implementations beyond schema intake (per issue notes).
- IDL plumbing for `events/capture_event.json` — deferred. Follows the MemoryRecord (#37) precedent of hand-rolling domain types without an IDL counterpart until a wire surface needs the envelope. Worth a follow-up issue.

## Dependency note
- #37 (MemoryRecord schema) — closed, consumed via `Identity` / `ActorChainEntry` / `Rfc3339Timestamp`.
- #50 (runtime sensor identity provisioning) — independent. This PR validates label syntax and manifest membership; runtime keychain-backed signing layers on top.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — no issues
- [x] `cargo test --workspace --locked --no-fail-fast` — 638 passed, 1 ignored
- [x] `cargo test --doc --workspace --locked`
- [x] `./scripts/check-core-boundary.sh` — clean
- [x] `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check` — 48 files match
- [x] `RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" cargo doc --workspace --no-deps --document-private-items --locked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
