### PR TITLE
feat(contract): register_plugin_with! factory variant + XxxPlugin static consts (§4.1, #177)

### DIFF
--- a/crates/cairn-core/src/contract/agent_provider.rs
+++ b/crates/cairn-core/src/contract/agent_provider.rs
@@ -43,3 +43,16 @@ pub trait AgentProvider: Send + Sync {
     /// Range of `AgentProvider::CONTRACT_VERSION` values this impl accepts.
     fn supported_contract_versions(&self) -> VersionRange;
 }
+
+/// Static identity descriptor for an [`AgentProvider`] plugin (§4.1).
+///
+/// Carries the two associated consts the `register_plugin_with!` macro checks
+/// before construction. See [`MemoryStorePlugin`](crate::contract::MemoryStorePlugin)
+/// for the design rationale.
+#[doc(hidden)]
+pub trait AgentProviderPlugin: AgentProvider + Sized {
+    /// Stable plugin name, checked statically before construction (§4.1).
+    const NAME: &'static str;
+    /// Version range checked statically before construction (§4.1).
+    const SUPPORTED_VERSIONS: VersionRange;
+}

--- a/crates/cairn-core/src/contract/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/frontend_adapter.rs
@@ -41,3 +41,16 @@ pub trait FrontendAdapter: Send + Sync {
     /// Range of `FrontendAdapter::CONTRACT_VERSION` values this impl accepts.
     fn supported_contract_versions(&self) -> VersionRange;
 }
+
+/// Static identity descriptor for a [`FrontendAdapter`] plugin (§4.1).
+///
+/// Carries the two associated consts the `register_plugin_with!` macro checks
+/// before construction. See [`MemoryStorePlugin`](crate::contract::MemoryStorePlugin)
+/// for the design rationale.
+#[doc(hidden)]
+pub trait FrontendAdapterPlugin: FrontendAdapter + Sized {
+    /// Stable plugin name, checked statically before construction (§4.1).
+    const NAME: &'static str;
+    /// Version range checked statically before construction (§4.1).
+    const SUPPORTED_VERSIONS: VersionRange;
+}

--- a/crates/cairn-core/src/contract/llm_provider.rs
+++ b/crates/cairn-core/src/contract/llm_provider.rs
@@ -38,6 +38,18 @@ pub trait LLMProvider: Send + Sync {
     fn supported_contract_versions(&self) -> VersionRange;
 }
 
+/// Static identity descriptor for a [`LLMProvider`] plugin (§4.1).
+///
+/// Carries the two associated consts the `register_plugin_with!` macro checks
+/// before construction. See [`MemoryStorePlugin`](crate::contract::MemoryStorePlugin)
+/// for the design rationale.
+pub trait LLMProviderPlugin: LLMProvider + Sized {
+    /// Stable plugin name, checked statically before construction (§4.1).
+    const NAME: &'static str;
+    /// Version range checked statically before construction (§4.1).
+    const SUPPORTED_VERSIONS: VersionRange;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -47,7 +59,7 @@ mod tests {
     #[async_trait::async_trait]
     impl LLMProvider for StubLlm {
         fn name(&self) -> &'static str {
-            "stub-llm"
+            Self::NAME
         }
         fn capabilities(&self) -> &LLMProviderCapabilities {
             static CAPS: LLMProviderCapabilities = LLMProviderCapabilities {
@@ -58,8 +70,14 @@ mod tests {
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+            Self::SUPPORTED_VERSIONS
         }
+    }
+
+    impl LLMProviderPlugin for StubLlm {
+        const NAME: &'static str = "stub-llm";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
     #[test]
@@ -67,5 +85,11 @@ mod tests {
         let l: Box<dyn LLMProvider> = Box::new(StubLlm);
         assert_eq!(l.name(), "stub-llm");
         assert!(l.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+
+    #[test]
+    fn static_consts_accessible() {
+        assert_eq!(StubLlm::NAME, "stub-llm");
+        assert!(StubLlm::SUPPORTED_VERSIONS.accepts(CONTRACT_VERSION));
     }
 }

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -330,3 +330,191 @@ macro_rules! __register_plugin_with_manifest_helper {
         }
     };
 }
+
+/// Emit a config-driven
+/// `register(&mut PluginRegistry, &CairnConfig) -> Result<(), PluginError>`
+/// function for plugins that require runtime configuration at construction time.
+///
+/// # Key guarantee
+///
+/// The factory closure is called **only after** the static version and identity
+/// checks pass. Callers can prove this by supplying a factory that panics — the
+/// test will not panic for an incompatible plugin.
+///
+/// # Factory type
+///
+/// The closure receives `&CairnConfig` and returns `Result<Impl, E>` for any
+/// `E: std::error::Error + Send + Sync + 'static`. The macro boxes the error
+/// into [`PluginError::FactoryError`].
+///
+/// # Examples
+///
+/// ```
+/// # use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin};
+/// # use cairn_core::contract::version::{ContractVersion, VersionRange};
+/// use cairn_core::register_plugin_with;
+///
+/// struct ConfigStore { vault_name: String }
+///
+/// #[async_trait::async_trait]
+/// impl MemoryStore for ConfigStore {
+///     fn name(&self) -> &str { Self::NAME }
+///     fn capabilities(&self) -> &MemoryStoreCapabilities {
+///         static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+///             fts: false, vector: false, graph_edges: false, transactions: false,
+///         };
+///         &CAPS
+///     }
+///     fn supported_contract_versions(&self) -> VersionRange { Self::SUPPORTED_VERSIONS }
+/// }
+///
+/// impl MemoryStorePlugin for ConfigStore {
+///     const NAME: &'static str = "config-store";
+///     const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
+///         ContractVersion::new(0, 1, 0),
+///         ContractVersion::new(0, 2, 0),
+///     );
+/// }
+///
+/// register_plugin_with!(MemoryStore, ConfigStore, "config-store", |cfg: &cairn_core::config::CairnConfig| {
+///     Ok::<_, std::convert::Infallible>(ConfigStore { vault_name: cfg.vault.name.clone() })
+/// });
+///
+/// let mut reg = cairn_core::contract::registry::PluginRegistry::new();
+/// let cfg = cairn_core::config::CairnConfig::default();
+/// register(&mut reg, &cfg).expect("config-driven plugin registers");
+/// ```
+#[macro_export]
+macro_rules! register_plugin_with {
+    (MemoryStore, $impl:ty, $name:literal, $factory:expr) => {
+        $crate::__register_plugin_with_helper!(
+            register_memory_store,
+            $crate::contract::memory_store::MemoryStorePlugin,
+            "MemoryStore",
+            $crate::contract::memory_store::CONTRACT_VERSION,
+            $impl,
+            $name,
+            $factory
+        );
+    };
+    (LLMProvider, $impl:ty, $name:literal, $factory:expr) => {
+        $crate::__register_plugin_with_helper!(
+            register_llm_provider,
+            $crate::contract::llm_provider::LLMProviderPlugin,
+            "LLMProvider",
+            $crate::contract::llm_provider::CONTRACT_VERSION,
+            $impl,
+            $name,
+            $factory
+        );
+    };
+    (WorkflowOrchestrator, $impl:ty, $name:literal, $factory:expr) => {
+        $crate::__register_plugin_with_helper!(
+            register_workflow_orchestrator,
+            $crate::contract::workflow_orchestrator::WorkflowOrchestratorPlugin,
+            "WorkflowOrchestrator",
+            $crate::contract::workflow_orchestrator::CONTRACT_VERSION,
+            $impl,
+            $name,
+            $factory
+        );
+    };
+    (SensorIngress, $impl:ty, $name:literal, $factory:expr) => {
+        $crate::__register_plugin_with_helper!(
+            register_sensor_ingress,
+            $crate::contract::sensor_ingress::SensorIngressPlugin,
+            "SensorIngress",
+            $crate::contract::sensor_ingress::CONTRACT_VERSION,
+            $impl,
+            $name,
+            $factory
+        );
+    };
+    (MCPServer, $impl:ty, $name:literal, $factory:expr) => {
+        $crate::__register_plugin_with_helper!(
+            register_mcp_server,
+            $crate::contract::mcp_server::MCPServerPlugin,
+            "MCPServer",
+            $crate::contract::mcp_server::CONTRACT_VERSION,
+            $impl,
+            $name,
+            $factory
+        );
+    };
+    (FrontendAdapter, $impl:ty, $name:literal, $factory:expr) => {
+        $crate::__register_plugin_with_helper!(
+            register_frontend_adapter,
+            $crate::contract::frontend_adapter::FrontendAdapterPlugin,
+            "FrontendAdapter",
+            $crate::contract::frontend_adapter::CONTRACT_VERSION,
+            $impl,
+            $name,
+            $factory
+        );
+    };
+    (AgentProvider, $impl:ty, $name:literal, $factory:expr) => {
+        $crate::__register_plugin_with_helper!(
+            register_agent_provider,
+            $crate::contract::agent_provider::AgentProviderPlugin,
+            "AgentProvider",
+            $crate::contract::agent_provider::CONTRACT_VERSION,
+            $impl,
+            $name,
+            $factory
+        );
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __register_plugin_with_helper {
+    ($method:ident, $plugin_trait:path, $contract:literal, $host_version:expr, $impl:ty, $name:literal, $factory:expr) => {
+        /// Config-driven plugin entry point.
+        ///
+        /// # Errors
+        /// Returns [`cairn_core::contract::registry::PluginError`] when the
+        /// name is invalid, the static `SUPPORTED_VERSIONS` const rejects the
+        /// host version, the static `NAME` const disagrees with the registered
+        /// name, the factory closure fails, or another plugin already holds
+        /// this name.
+        pub fn register(
+            reg: &mut $crate::contract::registry::PluginRegistry,
+            cfg: &$crate::config::CairnConfig,
+        ) -> ::core::result::Result<(), $crate::contract::registry::PluginError> {
+            let name = $crate::contract::registry::PluginName::new($name)?;
+            // Static version check — factory NOT called yet.
+            let supported = <$impl as $plugin_trait>::SUPPORTED_VERSIONS;
+            let host = $host_version;
+            if !supported.accepts(host) {
+                return Err(
+                    $crate::contract::registry::PluginError::UnsupportedContractVersion {
+                        contract: $contract,
+                        plugin: name,
+                        plugin_range: supported,
+                        host,
+                    },
+                );
+            }
+            // Static identity check — factory NOT called yet.
+            let static_name = <$impl as $plugin_trait>::NAME;
+            if static_name != $name {
+                return Err(
+                    $crate::contract::registry::PluginError::IdentityMismatch {
+                        contract: $contract,
+                        registered: name,
+                        runtime: static_name.to_owned(),
+                    },
+                );
+            }
+            // All static checks passed. Call the factory.
+            let plugin: $impl = ($factory)(cfg).map_err(|e| {
+                $crate::contract::registry::PluginError::FactoryError {
+                    contract: $contract,
+                    plugin: name.clone(),
+                    source: ::std::boxed::Box::new(e),
+                }
+            })?;
+            reg.$method(name, ::std::sync::Arc::new(plugin))
+        }
+    };
+}

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -14,21 +14,21 @@
 ///
 /// # Construction discipline
 ///
-/// The generated `register` function constructs the impl via
-/// `<$impl as Default>::default()` **before** the registry runs version,
-/// identity, or duplicate-name checks. Implementations of [`Default::default`]
-/// must therefore be **side-effect free**: no I/O, no resource allocation,
-/// no panics. Open files, network connections, model handles, etc. belong in
-/// a separate `init`/`open` step the host invokes after registration —
-/// typically driven by `.cairn/config.yaml` (brief §4.1).
+/// The generated `register` function performs **static version and identity
+/// checks** via the `XxxPlugin` associated consts (`SUPPORTED_VERSIONS`,
+/// `NAME`) **before** calling `<$impl as Default>::default()`. Incompatible
+/// or misidentified plugins are therefore rejected without ever constructing
+/// an instance.
+///
+/// Implementations of [`Default::default`] must still be **side-effect
+/// free**: no I/O, no resource allocation, no panics. Open files, network
+/// connections, model handles, etc. belong in a separate `init`/`open` step
+/// the host invokes after registration — typically driven by
+/// `.cairn/config.yaml` (brief §4.1).
 ///
 /// Config-driven construction (e.g., a `MemoryStore` impl that needs a
-/// database path at build time) is **not yet supported** by this macro;
-/// it will arrive in a follow-up issue that adds a factory variant
-/// (`register_plugin_with!(<contract>, <impl>, <name>, |cfg| <factory>)`)
-/// alongside trait-level associated consts so compatibility can be checked
-/// before construction. Until then: keep `Default` cheap, push real init
-/// behind an explicit `init(&Config)` method on your impl.
+/// database path at build time) is supported via `register_plugin_with!`
+/// which accepts a factory closure and performs the same static pre-checks.
 ///
 /// # Examples
 ///
@@ -125,25 +125,74 @@
 macro_rules! register_plugin {
     // 3-arg form: legacy / unit-test path with no manifest.
     (MemoryStore, $impl:ty, $name:literal) => {
-        $crate::__register_plugin_helper!(register_memory_store, $impl, $name);
+        $crate::__register_plugin_helper!(
+            register_memory_store,
+            $crate::contract::memory_store::MemoryStorePlugin,
+            "MemoryStore",
+            $crate::contract::memory_store::CONTRACT_VERSION,
+            $impl,
+            $name
+        );
     };
     (LLMProvider, $impl:ty, $name:literal) => {
-        $crate::__register_plugin_helper!(register_llm_provider, $impl, $name);
+        $crate::__register_plugin_helper!(
+            register_llm_provider,
+            $crate::contract::llm_provider::LLMProviderPlugin,
+            "LLMProvider",
+            $crate::contract::llm_provider::CONTRACT_VERSION,
+            $impl,
+            $name
+        );
     };
     (WorkflowOrchestrator, $impl:ty, $name:literal) => {
-        $crate::__register_plugin_helper!(register_workflow_orchestrator, $impl, $name);
+        $crate::__register_plugin_helper!(
+            register_workflow_orchestrator,
+            $crate::contract::workflow_orchestrator::WorkflowOrchestratorPlugin,
+            "WorkflowOrchestrator",
+            $crate::contract::workflow_orchestrator::CONTRACT_VERSION,
+            $impl,
+            $name
+        );
     };
     (SensorIngress, $impl:ty, $name:literal) => {
-        $crate::__register_plugin_helper!(register_sensor_ingress, $impl, $name);
+        $crate::__register_plugin_helper!(
+            register_sensor_ingress,
+            $crate::contract::sensor_ingress::SensorIngressPlugin,
+            "SensorIngress",
+            $crate::contract::sensor_ingress::CONTRACT_VERSION,
+            $impl,
+            $name
+        );
     };
     (MCPServer, $impl:ty, $name:literal) => {
-        $crate::__register_plugin_helper!(register_mcp_server, $impl, $name);
+        $crate::__register_plugin_helper!(
+            register_mcp_server,
+            $crate::contract::mcp_server::MCPServerPlugin,
+            "MCPServer",
+            $crate::contract::mcp_server::CONTRACT_VERSION,
+            $impl,
+            $name
+        );
     };
     (FrontendAdapter, $impl:ty, $name:literal) => {
-        $crate::__register_plugin_helper!(register_frontend_adapter, $impl, $name);
+        $crate::__register_plugin_helper!(
+            register_frontend_adapter,
+            $crate::contract::frontend_adapter::FrontendAdapterPlugin,
+            "FrontendAdapter",
+            $crate::contract::frontend_adapter::CONTRACT_VERSION,
+            $impl,
+            $name
+        );
     };
     (AgentProvider, $impl:ty, $name:literal) => {
-        $crate::__register_plugin_helper!(register_agent_provider, $impl, $name);
+        $crate::__register_plugin_helper!(
+            register_agent_provider,
+            $crate::contract::agent_provider::AgentProviderPlugin,
+            "AgentProvider",
+            $crate::contract::agent_provider::CONTRACT_VERSION,
+            $impl,
+            $name
+        );
     };
 
     // 4-arg form: manifest-aware. `$manifest` is an expression producing a
@@ -209,17 +258,46 @@ macro_rules! register_plugin {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __register_plugin_helper {
-    ($method:ident, $impl:ty, $name:literal) => {
+    ($method:ident, $plugin_trait:path, $contract:literal, $host_version:expr, $impl:ty, $name:literal) => {
         /// Plugin entry point. Hosts call this during startup assembly.
+        ///
+        /// Performs static version and identity checks via the `XxxPlugin`
+        /// associated consts before constructing the plugin, so incompatible
+        /// plugins are rejected without running `Default::default()`.
         ///
         /// # Errors
         /// Returns [`cairn_core::contract::registry::PluginError`] when the
-        /// name is invalid, the contract version is unsupported, or another
-        /// plugin already holds this name.
+        /// name is invalid, the contract version is unsupported, the static
+        /// `NAME` const disagrees with the registered name, or another plugin
+        /// already holds this name.
         pub fn register(
             reg: &mut $crate::contract::registry::PluginRegistry,
         ) -> ::core::result::Result<(), $crate::contract::registry::PluginError> {
             let name = $crate::contract::registry::PluginName::new($name)?;
+            // Static version check — no construction yet.
+            let supported = <$impl as $plugin_trait>::SUPPORTED_VERSIONS;
+            let host = $host_version;
+            if !supported.accepts(host) {
+                return Err(
+                    $crate::contract::registry::PluginError::UnsupportedContractVersion {
+                        contract: $contract,
+                        plugin: name,
+                        plugin_range: supported,
+                        host,
+                    },
+                );
+            }
+            // Static identity check — no construction yet.
+            let static_name = <$impl as $plugin_trait>::NAME;
+            if static_name != $name {
+                return Err(
+                    $crate::contract::registry::PluginError::IdentityMismatch {
+                        contract: $contract,
+                        registered: name,
+                        runtime: static_name.to_owned(),
+                    },
+                );
+            }
             reg.$method(
                 name,
                 ::std::sync::Arc::new(<$impl as ::core::default::Default>::default()),

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -33,7 +33,7 @@
 /// # Examples
 ///
 /// ```
-/// # use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
+/// # use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin};
 /// # use cairn_core::contract::version::{ContractVersion, VersionRange};
 /// use cairn_core::register_plugin;
 ///
@@ -42,7 +42,7 @@
 ///
 /// #[async_trait::async_trait]
 /// impl MemoryStore for MyStore {
-///     fn name(&self) -> &str { "acme-store" }
+///     fn name(&self) -> &str { Self::NAME }
 ///     fn capabilities(&self) -> &MemoryStoreCapabilities {
 ///         static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
 ///             fts: false,
@@ -52,12 +52,15 @@
 ///         };
 ///         &CAPS
 ///     }
-///     fn supported_contract_versions(&self) -> VersionRange {
-///         VersionRange::new(
-///             ContractVersion::new(0, 1, 0),
-///             ContractVersion::new(0, 2, 0),
-///         )
-///     }
+///     fn supported_contract_versions(&self) -> VersionRange { Self::SUPPORTED_VERSIONS }
+/// }
+///
+/// impl MemoryStorePlugin for MyStore {
+///     const NAME: &'static str = "acme-store";
+///     const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
+///         ContractVersion::new(0, 1, 0),
+///         ContractVersion::new(0, 2, 0),
+///     );
 /// }
 ///
 /// register_plugin!(MemoryStore, MyStore, "acme-store");
@@ -71,7 +74,7 @@
 /// # Manifest-aware form (preferred for bundled plugins)
 ///
 /// ```
-/// # use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities};
+/// # use cairn_core::contract::memory_store::{MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin};
 /// # use cairn_core::contract::version::{ContractVersion, VersionRange};
 /// use cairn_core::register_plugin;
 ///
@@ -95,7 +98,7 @@
 ///
 /// #[async_trait::async_trait]
 /// impl MemoryStore for MyStore {
-///     fn name(&self) -> &str { "acme-store" }
+///     fn name(&self) -> &str { Self::NAME }
 ///     fn capabilities(&self) -> &MemoryStoreCapabilities {
 ///         static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
 ///             fts: false,
@@ -105,12 +108,15 @@
 ///         };
 ///         &CAPS
 ///     }
-///     fn supported_contract_versions(&self) -> VersionRange {
-///         VersionRange::new(
-///             ContractVersion::new(0, 1, 0),
-///             ContractVersion::new(0, 2, 0),
-///         )
-///     }
+///     fn supported_contract_versions(&self) -> VersionRange { Self::SUPPORTED_VERSIONS }
+/// }
+///
+/// impl MemoryStorePlugin for MyStore {
+///     const NAME: &'static str = "acme-store";
+///     const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
+///         ContractVersion::new(0, 1, 0),
+///         ContractVersion::new(0, 2, 0),
+///     );
 /// }
 ///
 /// register_plugin!(MemoryStore, MyStore, "acme-store", MANIFEST_TOML);
@@ -290,13 +296,11 @@ macro_rules! __register_plugin_helper {
             // Static identity check — no construction yet.
             let static_name = <$impl as $plugin_trait>::NAME;
             if static_name != $name {
-                return Err(
-                    $crate::contract::registry::PluginError::IdentityMismatch {
-                        contract: $contract,
-                        registered: name,
-                        runtime: static_name.to_owned(),
-                    },
-                );
+                return Err($crate::contract::registry::PluginError::IdentityMismatch {
+                    contract: $contract,
+                    registered: name,
+                    runtime: static_name.to_owned(),
+                });
             }
             reg.$method(
                 name,
@@ -345,7 +349,7 @@ macro_rules! __register_plugin_with_manifest_helper {
 ///
 /// The closure receives `&CairnConfig` and returns `Result<Impl, E>` for any
 /// `E: std::error::Error + Send + Sync + 'static`. The macro boxes the error
-/// into [`PluginError::FactoryError`].
+/// into [`crate::contract::registry::PluginError::FactoryError`].
 ///
 /// # Examples
 ///
@@ -498,13 +502,11 @@ macro_rules! __register_plugin_with_helper {
             // Static identity check — factory NOT called yet.
             let static_name = <$impl as $plugin_trait>::NAME;
             if static_name != $name {
-                return Err(
-                    $crate::contract::registry::PluginError::IdentityMismatch {
-                        contract: $contract,
-                        registered: name,
-                        runtime: static_name.to_owned(),
-                    },
-                );
+                return Err($crate::contract::registry::PluginError::IdentityMismatch {
+                    contract: $contract,
+                    registered: name,
+                    runtime: static_name.to_owned(),
+                });
             }
             // All static checks passed. Call the factory.
             let plugin: $impl = ($factory)(cfg).map_err(|e| {

--- a/crates/cairn-core/src/contract/mcp_server.rs
+++ b/crates/cairn-core/src/contract/mcp_server.rs
@@ -45,6 +45,20 @@ pub trait MCPServer: Send + Sync {
     fn supported_contract_versions(&self) -> VersionRange;
 }
 
+/// Static identity descriptor for a [`MCPServer`] plugin (§4.1).
+///
+/// Carries the two associated consts the `register_plugin_with!` macro checks
+/// before construction. See [`MemoryStorePlugin`](crate::contract::MemoryStorePlugin)
+/// for the design rationale.
+// Matches brief §4 row 5 trait name; CLAUDE.md §1 says brief wins.
+#[allow(clippy::upper_case_acronyms)]
+pub trait MCPServerPlugin: MCPServer + Sized {
+    /// Stable plugin name, checked statically before construction (§4.1).
+    const NAME: &'static str;
+    /// Version range checked statically before construction (§4.1).
+    const SUPPORTED_VERSIONS: VersionRange;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -54,7 +68,7 @@ mod tests {
     #[async_trait::async_trait]
     impl MCPServer for StubMcp {
         fn name(&self) -> &'static str {
-            "stub-mcp"
+            Self::NAME
         }
         fn capabilities(&self) -> &MCPServerCapabilities {
             static CAPS: MCPServerCapabilities = MCPServerCapabilities {
@@ -66,8 +80,14 @@ mod tests {
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+            Self::SUPPORTED_VERSIONS
         }
+    }
+
+    impl MCPServerPlugin for StubMcp {
+        const NAME: &'static str = "stub-mcp";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
     #[test]
@@ -75,5 +95,11 @@ mod tests {
         let m: Box<dyn MCPServer> = Box::new(StubMcp);
         assert_eq!(m.name(), "stub-mcp");
         assert!(m.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+
+    #[test]
+    fn static_consts_accessible() {
+        assert_eq!(StubMcp::NAME, "stub-mcp");
+        assert!(StubMcp::SUPPORTED_VERSIONS.accepts(CONTRACT_VERSION));
     }
 }

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -44,6 +44,34 @@ pub trait MemoryStore: Send + Sync {
     fn supported_contract_versions(&self) -> VersionRange;
 }
 
+/// Static identity descriptor for a [`MemoryStore`] plugin (§4.1).
+///
+/// This companion trait carries the two associated consts that the
+/// `register_plugin_with!` macro checks **before construction** — the
+/// stable plugin name and the supported contract-version range.
+///
+/// Separating these consts from [`MemoryStore`] is required by stable Rust:
+/// associated consts in a trait break `dyn` compatibility unless gated by
+/// `where Self: Sized` (an unstable feature as of 1.95). Placing them in a
+/// `Sized`-bounded companion trait keeps `dyn MemoryStore` valid while still
+/// allowing the macro to enforce `<Impl as MemoryStorePlugin>::NAME ==
+/// registered_name` at compile time.
+///
+/// Every concrete [`MemoryStore`] implementation should also implement
+/// `MemoryStorePlugin`. The blanket-compatible methods `fn name` and
+/// `fn supported_contract_versions` on [`MemoryStore`] should delegate to
+/// these consts (e.g. `fn name(&self) -> &str { Self::NAME }`).
+pub trait MemoryStorePlugin: MemoryStore + Sized {
+    /// Stable plugin name, checked statically before construction (§4.1).
+    ///
+    /// Must match the `name` literal passed to `register_plugin!` /
+    /// `register_plugin_with!`.
+    const NAME: &'static str;
+
+    /// Version range checked statically before construction (§4.1).
+    const SUPPORTED_VERSIONS: VersionRange;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -53,7 +81,7 @@ mod tests {
     #[async_trait::async_trait]
     impl MemoryStore for StubStore {
         fn name(&self) -> &'static str {
-            "stub"
+            Self::NAME
         }
         fn capabilities(&self) -> &MemoryStoreCapabilities {
             static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
@@ -65,8 +93,14 @@ mod tests {
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+            Self::SUPPORTED_VERSIONS
         }
+    }
+
+    impl MemoryStorePlugin for StubStore {
+        const NAME: &'static str = "stub";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
     #[test]
@@ -75,5 +109,11 @@ mod tests {
         assert_eq!(s.name(), "stub");
         assert!(s.capabilities().fts);
         assert!(s.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+
+    #[test]
+    fn static_consts_accessible() {
+        assert_eq!(StubStore::NAME, "stub");
+        assert!(StubStore::SUPPORTED_VERSIONS.accepts(CONTRACT_VERSION));
     }
 }

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -38,10 +38,12 @@ pub use manifest::{ContractKind, PluginManifest};
 pub use registry::{PluginError, PluginName, PluginRegistry};
 pub use version::{ContractVersion, VersionRange};
 
-pub use agent_provider::{AgentProvider, AgentProviderCapabilities};
-pub use frontend_adapter::{FrontendAdapter, FrontendAdapterCapabilities};
-pub use llm_provider::{LLMProvider, LLMProviderCapabilities};
-pub use mcp_server::{MCPServer, MCPServerCapabilities};
-pub use memory_store::{MemoryStore, MemoryStoreCapabilities};
-pub use sensor_ingress::{SensorIngress, SensorIngressCapabilities};
-pub use workflow_orchestrator::{WorkflowOrchestrator, WorkflowOrchestratorCapabilities};
+pub use agent_provider::{AgentProvider, AgentProviderCapabilities, AgentProviderPlugin};
+pub use frontend_adapter::{FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterPlugin};
+pub use llm_provider::{LLMProvider, LLMProviderCapabilities, LLMProviderPlugin};
+pub use mcp_server::{MCPServer, MCPServerCapabilities, MCPServerPlugin};
+pub use memory_store::{MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin};
+pub use sensor_ingress::{SensorIngress, SensorIngressCapabilities, SensorIngressPlugin};
+pub use workflow_orchestrator::{
+    WorkflowOrchestrator, WorkflowOrchestratorCapabilities, WorkflowOrchestratorPlugin,
+};

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -122,9 +122,7 @@ pub enum PluginError {
     ///
     /// The source is boxed to break the circular type reference with `ConfigError`
     /// (which already contains `PluginError` via `InvalidPluginName`).
-    #[error(
-        "plugin {plugin} for contract {contract} failed to construct: {source}"
-    )]
+    #[error("plugin {plugin} for contract {contract} failed to construct: {source}")]
     FactoryError {
         /// Contract under which construction was attempted.
         contract: &'static str,
@@ -544,10 +542,10 @@ impl PluginRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::contract::llm_provider::LLMProviderPlugin;
     use crate::contract::memory_store::{
         CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin,
     };
-    use crate::contract::llm_provider::LLMProviderPlugin;
 
     // -- PluginName tests -------------------------------------------------
 
@@ -913,6 +911,7 @@ patch = 0
 
     #[test]
     fn factory_error_display() {
+        use std::error::Error;
         use std::fmt;
 
         #[derive(Debug)]
@@ -932,7 +931,6 @@ patch = 0
         let msg = err.to_string();
         assert!(msg.contains("some-store"), "message: {msg}");
         assert!(msg.contains("db open failed"), "message: {msg}");
-        use std::error::Error;
         assert!(err.source().is_some());
     }
 }

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -117,6 +117,23 @@ pub enum PluginError {
         /// The name the manifest actually declares.
         manifest: PluginName,
     },
+
+    /// A config-driven factory closure returned an error during plugin construction.
+    ///
+    /// The source is boxed to break the circular type reference with `ConfigError`
+    /// (which already contains `PluginError` via `InvalidPluginName`).
+    #[error(
+        "plugin {plugin} for contract {contract} failed to construct: {source}"
+    )]
+    FactoryError {
+        /// Contract under which construction was attempted.
+        contract: &'static str,
+        /// The plugin being constructed.
+        plugin: PluginName,
+        /// The underlying construction error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
 }
 
 use crate::contract::{
@@ -527,7 +544,10 @@ impl PluginRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::contract::memory_store::{CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities};
+    use crate::contract::memory_store::{
+        CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin,
+    };
+    use crate::contract::llm_provider::LLMProviderPlugin;
 
     // -- PluginName tests -------------------------------------------------
 
@@ -594,6 +614,12 @@ mod tests {
         fn supported_contract_versions(&self) -> VersionRange {
             self.range
         }
+    }
+
+    impl MemoryStorePlugin for StubStore {
+        const NAME: &'static str = "stub-store";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
     fn compatible() -> VersionRange {
@@ -757,6 +783,11 @@ patch = 0
                 self.range
             }
         }
+        impl LLMProviderPlugin for StubLlm {
+            const NAME: &'static str = "cairn-store-sqlite";
+            const SUPPORTED_VERSIONS: VersionRange =
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+        }
 
         let mut reg = PluginRegistry::new();
         let name = PluginName::new("cairn-store-sqlite").expect("valid");
@@ -830,6 +861,11 @@ patch = 0
                 self.range
             }
         }
+        impl LLMProviderPlugin for StubLlm {
+            const NAME: &'static str = "cairn-store-sqlite";
+            const SUPPORTED_VERSIONS: VersionRange =
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+        }
 
         let llm_manifest_text = r#"
 name = "cairn-store-sqlite"
@@ -873,5 +909,30 @@ patch = 0
             )
             .expect_err("cross-contract duplicate must fail");
         assert!(matches!(err, PluginError::DuplicateName { .. }));
+    }
+
+    #[test]
+    fn factory_error_display() {
+        use std::fmt;
+
+        #[derive(Debug)]
+        struct FakeErr;
+        impl fmt::Display for FakeErr {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "db open failed")
+            }
+        }
+        impl std::error::Error for FakeErr {}
+
+        let err = PluginError::FactoryError {
+            contract: "MemoryStore",
+            plugin: PluginName::new("some-store").unwrap(),
+            source: Box::new(FakeErr),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("some-store"), "message: {msg}");
+        assert!(msg.contains("db open failed"), "message: {msg}");
+        use std::error::Error;
+        assert!(err.source().is_some());
     }
 }

--- a/crates/cairn-core/src/contract/sensor_ingress.rs
+++ b/crates/cairn-core/src/contract/sensor_ingress.rs
@@ -38,6 +38,18 @@ pub trait SensorIngress: Send + Sync {
     fn supported_contract_versions(&self) -> VersionRange;
 }
 
+/// Static identity descriptor for a [`SensorIngress`] plugin (§4.1).
+///
+/// Carries the two associated consts the `register_plugin_with!` macro checks
+/// before construction. See [`MemoryStorePlugin`](crate::contract::MemoryStorePlugin)
+/// for the design rationale.
+pub trait SensorIngressPlugin: SensorIngress + Sized {
+    /// Stable plugin name, checked statically before construction (§4.1).
+    const NAME: &'static str;
+    /// Version range checked statically before construction (§4.1).
+    const SUPPORTED_VERSIONS: VersionRange;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -47,7 +59,7 @@ mod tests {
     #[async_trait::async_trait]
     impl SensorIngress for StubSensor {
         fn name(&self) -> &'static str {
-            "stub-sensor"
+            Self::NAME
         }
         fn capabilities(&self) -> &SensorIngressCapabilities {
             static CAPS: SensorIngressCapabilities = SensorIngressCapabilities {
@@ -58,8 +70,14 @@ mod tests {
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+            Self::SUPPORTED_VERSIONS
         }
+    }
+
+    impl SensorIngressPlugin for StubSensor {
+        const NAME: &'static str = "stub-sensor";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
     #[test]
@@ -67,5 +85,11 @@ mod tests {
         let s: Box<dyn SensorIngress> = Box::new(StubSensor);
         assert_eq!(s.name(), "stub-sensor");
         assert!(s.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+
+    #[test]
+    fn static_consts_accessible() {
+        assert_eq!(StubSensor::NAME, "stub-sensor");
+        assert!(StubSensor::SUPPORTED_VERSIONS.accepts(CONTRACT_VERSION));
     }
 }

--- a/crates/cairn-core/src/contract/workflow_orchestrator.rs
+++ b/crates/cairn-core/src/contract/workflow_orchestrator.rs
@@ -38,6 +38,18 @@ pub trait WorkflowOrchestrator: Send + Sync {
     fn supported_contract_versions(&self) -> VersionRange;
 }
 
+/// Static identity descriptor for a [`WorkflowOrchestrator`] plugin (§4.1).
+///
+/// Carries the two associated consts the `register_plugin_with!` macro checks
+/// before construction. See [`MemoryStorePlugin`](crate::contract::MemoryStorePlugin)
+/// for the design rationale.
+pub trait WorkflowOrchestratorPlugin: WorkflowOrchestrator + Sized {
+    /// Stable plugin name, checked statically before construction (§4.1).
+    const NAME: &'static str;
+    /// Version range checked statically before construction (§4.1).
+    const SUPPORTED_VERSIONS: VersionRange;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -47,7 +59,7 @@ mod tests {
     #[async_trait::async_trait]
     impl WorkflowOrchestrator for StubOrch {
         fn name(&self) -> &'static str {
-            "stub-orch"
+            Self::NAME
         }
         fn capabilities(&self) -> &WorkflowOrchestratorCapabilities {
             static CAPS: WorkflowOrchestratorCapabilities = WorkflowOrchestratorCapabilities {
@@ -58,8 +70,14 @@ mod tests {
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+            Self::SUPPORTED_VERSIONS
         }
+    }
+
+    impl WorkflowOrchestratorPlugin for StubOrch {
+        const NAME: &'static str = "stub-orch";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
     #[test]
@@ -67,5 +85,11 @@ mod tests {
         let o: Box<dyn WorkflowOrchestrator> = Box::new(StubOrch);
         assert_eq!(o.name(), "stub-orch");
         assert!(o.supported_contract_versions().accepts(CONTRACT_VERSION));
+    }
+
+    #[test]
+    fn static_consts_accessible() {
+        assert_eq!(StubOrch::NAME, "stub-orch");
+        assert!(StubOrch::SUPPORTED_VERSIONS.accepts(CONTRACT_VERSION));
     }
 }

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use cairn_core::contract::memory_store::{CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities};
+use cairn_core::contract::memory_store::{CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin};
 use cairn_core::contract::registry::{PluginError, PluginName, PluginRegistry};
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::register_plugin;
@@ -31,6 +31,12 @@ mod compatible_plugin {
         fn supported_contract_versions(&self) -> VersionRange {
             VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
         }
+    }
+
+    impl MemoryStorePlugin for FakeStore {
+        const NAME: &'static str = "fake-compat";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
     register_plugin!(MemoryStore, FakeStore, "fake-compat");
@@ -63,6 +69,12 @@ mod future_plugin {
                 ContractVersion::new(10, 0, 0),
             )
         }
+    }
+
+    impl MemoryStorePlugin for FutureStore {
+        const NAME: &'static str = "fake-future";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(9, 9, 0), ContractVersion::new(10, 0, 0));
     }
 
     register_plugin!(MemoryStore, FutureStore, "fake-future");
@@ -146,6 +158,12 @@ patch = 0
         fn supported_contract_versions(&self) -> VersionRange {
             VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
         }
+    }
+
+    impl MemoryStorePlugin for FakeStore {
+        const NAME: &'static str = "fake-with-manifest";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
     register_plugin!(MemoryStore, FakeStore, "fake-with-manifest", MANIFEST_TOML);

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use cairn_core::contract::memory_store::{CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin};
 use cairn_core::contract::registry::{PluginError, PluginName, PluginRegistry};
 use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::config::CairnConfig;
 use cairn_core::register_plugin;
+use cairn_core::register_plugin_with;
 
 mod compatible_plugin {
     use super::*;
@@ -180,5 +182,149 @@ fn manifest_aware_macro_registers_with_manifest() {
     assert_eq!(
         reg.parsed_manifest(&name).unwrap().contract(),
         cairn_core::contract::manifest::ContractKind::MemoryStore
+    );
+}
+
+mod incompatible_factory_plugin {
+    use super::*;
+
+    pub struct NeverBuilt;
+
+    #[async_trait::async_trait]
+    impl MemoryStore for NeverBuilt {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: false,
+                vector: false,
+                graph_edges: false,
+                transactions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl MemoryStorePlugin for NeverBuilt {
+        const NAME: &'static str = "never-built";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(9, 9, 0), ContractVersion::new(10, 0, 0));
+    }
+
+    register_plugin_with!(MemoryStore, NeverBuilt, "never-built", |_cfg: &cairn_core::config::CairnConfig| -> Result<NeverBuilt, std::convert::Infallible> {
+        panic!("factory must NOT be called for incompatible plugin versions")
+    });
+}
+
+mod config_driven_plugin {
+    use super::*;
+
+    pub struct PathStore;
+
+    #[async_trait::async_trait]
+    impl MemoryStore for PathStore {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: false,
+                vector: false,
+                graph_edges: false,
+                transactions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl MemoryStorePlugin for PathStore {
+        const NAME: &'static str = "path-store";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+    }
+
+    register_plugin_with!(MemoryStore, PathStore, "path-store", |_cfg: &cairn_core::config::CairnConfig| {
+        Ok::<_, std::convert::Infallible>(PathStore)
+    });
+}
+
+mod name_mismatch_plugin {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct BadNameStore;
+
+    #[async_trait::async_trait]
+    impl MemoryStore for BadNameStore {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: false,
+                vector: false,
+                graph_edges: false,
+                transactions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl MemoryStorePlugin for BadNameStore {
+        const NAME: &'static str = "actual-name";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+    }
+
+    // NAME const = "actual-name" but macro literal = "wrong-name"
+    register_plugin!(MemoryStore, BadNameStore, "wrong-name");
+}
+
+#[test]
+fn factory_not_called_on_version_mismatch() {
+    let mut reg = PluginRegistry::new();
+    let cfg = CairnConfig::default();
+    let err = incompatible_factory_plugin::register(&mut reg, &cfg)
+        .expect_err("incompatible plugin must fail closed");
+    match err {
+        PluginError::UnsupportedContractVersion { contract, host, .. } => {
+            assert_eq!(contract, "MemoryStore");
+            assert_eq!(host, CONTRACT_VERSION);
+        }
+        other => panic!("expected UnsupportedContractVersion, got {other:?}"),
+    }
+    // If we reach here the panicking factory was never called — test passes.
+}
+
+#[test]
+fn config_driven_plugin_registers_and_resolves() {
+    let mut reg = PluginRegistry::new();
+    let cfg = CairnConfig::default();
+    config_driven_plugin::register(&mut reg, &cfg).expect("config-driven plugin registers");
+    let name = PluginName::new("path-store").expect("valid");
+    let plugin = reg.memory_store(&name).expect("registered");
+    assert_eq!(plugin.name(), "path-store");
+}
+
+#[test]
+fn register_plugin_macro_rejects_name_const_mismatch() {
+    // Verifies the new static identity pre-check in register_plugin! fires
+    // before Default::default() is called.
+    let mut reg = PluginRegistry::new();
+    let err = name_mismatch_plugin::register(&mut reg)
+        .expect_err("NAME/literal mismatch must fail");
+    assert!(
+        matches!(err, PluginError::IdentityMismatch { .. }),
+        "expected IdentityMismatch, got {err:?}"
     );
 }

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -3,10 +3,12 @@
 
 use std::sync::Arc;
 
-use cairn_core::contract::memory_store::{CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin};
+use cairn_core::config::CairnConfig;
+use cairn_core::contract::memory_store::{
+    CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin,
+};
 use cairn_core::contract::registry::{PluginError, PluginName, PluginRegistry};
 use cairn_core::contract::version::{ContractVersion, VersionRange};
-use cairn_core::config::CairnConfig;
 use cairn_core::register_plugin;
 use cairn_core::register_plugin_with;
 
@@ -75,8 +77,10 @@ mod future_plugin {
 
     impl MemoryStorePlugin for FutureStore {
         const NAME: &'static str = "fake-future";
-        const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(9, 9, 0), ContractVersion::new(10, 0, 0));
+        const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
+            ContractVersion::new(9, 9, 0),
+            ContractVersion::new(10, 0, 0),
+        );
     }
 
     register_plugin!(MemoryStore, FutureStore, "fake-future");
@@ -211,13 +215,20 @@ mod incompatible_factory_plugin {
 
     impl MemoryStorePlugin for NeverBuilt {
         const NAME: &'static str = "never-built";
-        const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(9, 9, 0), ContractVersion::new(10, 0, 0));
+        const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
+            ContractVersion::new(9, 9, 0),
+            ContractVersion::new(10, 0, 0),
+        );
     }
 
-    register_plugin_with!(MemoryStore, NeverBuilt, "never-built", |_cfg: &cairn_core::config::CairnConfig| -> Result<NeverBuilt, std::convert::Infallible> {
-        panic!("factory must NOT be called for incompatible plugin versions")
-    });
+    register_plugin_with!(
+        MemoryStore,
+        NeverBuilt,
+        "never-built",
+        |_cfg: &cairn_core::config::CairnConfig| -> Result<NeverBuilt, std::convert::Infallible> {
+            panic!("factory must NOT be called for incompatible plugin versions")
+        }
+    );
 }
 
 mod config_driven_plugin {
@@ -250,9 +261,12 @@ mod config_driven_plugin {
             VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
-    register_plugin_with!(MemoryStore, PathStore, "path-store", |_cfg: &cairn_core::config::CairnConfig| {
-        Ok::<_, std::convert::Infallible>(PathStore)
-    });
+    register_plugin_with!(
+        MemoryStore,
+        PathStore,
+        "path-store",
+        |_cfg: &cairn_core::config::CairnConfig| { Ok::<_, std::convert::Infallible>(PathStore) }
+    );
 }
 
 mod name_mismatch_plugin {
@@ -321,8 +335,8 @@ fn register_plugin_macro_rejects_name_const_mismatch() {
     // Verifies the new static identity pre-check in register_plugin! fires
     // before Default::default() is called.
     let mut reg = PluginRegistry::new();
-    let err = name_mismatch_plugin::register(&mut reg)
-        .expect_err("NAME/literal mismatch must fail");
+    let err =
+        name_mismatch_plugin::register(&mut reg).expect_err("NAME/literal mismatch must fail");
     assert!(
         matches!(err, PluginError::IdentityMismatch { .. }),
         "expected IdentityMismatch, got {err:?}"

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -10,9 +10,7 @@ use cairn_core::contract::agent_provider::{
 use cairn_core::contract::frontend_adapter::{
     FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterPlugin,
 };
-use cairn_core::contract::llm_provider::{
-    LLMProvider, LLMProviderCapabilities, LLMProviderPlugin,
-};
+use cairn_core::contract::llm_provider::{LLMProvider, LLMProviderCapabilities, LLMProviderPlugin};
 use cairn_core::contract::mcp_server::{MCPServer, MCPServerCapabilities, MCPServerPlugin};
 use cairn_core::contract::memory_store::{
     CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin,
@@ -390,9 +388,12 @@ mod llm_provider_factory_plugin {
             VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
-    register_plugin_with!(LLMProvider, StubLlm, "stub-llm-factory", |_cfg: &cairn_core::config::CairnConfig| {
-        Ok::<_, std::convert::Infallible>(StubLlm)
-    });
+    register_plugin_with!(
+        LLMProvider,
+        StubLlm,
+        "stub-llm-factory",
+        |_cfg: &cairn_core::config::CairnConfig| { Ok::<_, std::convert::Infallible>(StubLlm) }
+    );
 }
 
 mod workflow_orchestrator_factory_plugin {
@@ -424,9 +425,12 @@ mod workflow_orchestrator_factory_plugin {
             VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
-    register_plugin_with!(WorkflowOrchestrator, StubOrch, "stub-orch-factory", |_cfg: &cairn_core::config::CairnConfig| {
-        Ok::<_, std::convert::Infallible>(StubOrch)
-    });
+    register_plugin_with!(
+        WorkflowOrchestrator,
+        StubOrch,
+        "stub-orch-factory",
+        |_cfg: &cairn_core::config::CairnConfig| { Ok::<_, std::convert::Infallible>(StubOrch) }
+    );
 }
 
 mod sensor_ingress_factory_plugin {
@@ -458,9 +462,12 @@ mod sensor_ingress_factory_plugin {
             VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
-    register_plugin_with!(SensorIngress, StubSensor, "stub-sensor-factory", |_cfg: &cairn_core::config::CairnConfig| {
-        Ok::<_, std::convert::Infallible>(StubSensor)
-    });
+    register_plugin_with!(
+        SensorIngress,
+        StubSensor,
+        "stub-sensor-factory",
+        |_cfg: &cairn_core::config::CairnConfig| { Ok::<_, std::convert::Infallible>(StubSensor) }
+    );
 }
 
 mod mcp_server_factory_plugin {
@@ -493,9 +500,12 @@ mod mcp_server_factory_plugin {
             VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
-    register_plugin_with!(MCPServer, StubMcp, "stub-mcp-factory", |_cfg: &cairn_core::config::CairnConfig| {
-        Ok::<_, std::convert::Infallible>(StubMcp)
-    });
+    register_plugin_with!(
+        MCPServer,
+        StubMcp,
+        "stub-mcp-factory",
+        |_cfg: &cairn_core::config::CairnConfig| { Ok::<_, std::convert::Infallible>(StubMcp) }
+    );
 }
 
 mod frontend_adapter_factory_plugin {
@@ -527,9 +537,14 @@ mod frontend_adapter_factory_plugin {
             VersionRange::new(ContractVersion::new(0, 0, 1), ContractVersion::new(0, 1, 0));
     }
 
-    register_plugin_with!(FrontendAdapter, StubFrontend, "stub-frontend-factory", |_cfg: &cairn_core::config::CairnConfig| {
-        Ok::<_, std::convert::Infallible>(StubFrontend)
-    });
+    register_plugin_with!(
+        FrontendAdapter,
+        StubFrontend,
+        "stub-frontend-factory",
+        |_cfg: &cairn_core::config::CairnConfig| {
+            Ok::<_, std::convert::Infallible>(StubFrontend)
+        }
+    );
 }
 
 mod agent_provider_factory_plugin {
@@ -562,9 +577,12 @@ mod agent_provider_factory_plugin {
             VersionRange::new(ContractVersion::new(0, 0, 1), ContractVersion::new(0, 1, 0));
     }
 
-    register_plugin_with!(AgentProvider, StubAgent, "stub-agent-factory", |_cfg: &cairn_core::config::CairnConfig| {
-        Ok::<_, std::convert::Infallible>(StubAgent)
-    });
+    register_plugin_with!(
+        AgentProvider,
+        StubAgent,
+        "stub-agent-factory",
+        |_cfg: &cairn_core::config::CairnConfig| { Ok::<_, std::convert::Infallible>(StubAgent) }
+    );
 }
 
 // ── factory-error path ────────────────────────────────────────────────────────
@@ -599,12 +617,17 @@ mod factory_error_plugin {
             VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
-    register_plugin_with!(MemoryStore, FailingStore, "failing-store", |_cfg: &cairn_core::config::CairnConfig| {
-        Err::<FailingStore, _>(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "db file missing",
-        ))
-    });
+    register_plugin_with!(
+        MemoryStore,
+        FailingStore,
+        "failing-store",
+        |_cfg: &cairn_core::config::CairnConfig| {
+            Err::<FailingStore, _>(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "db file missing",
+            ))
+        }
+    );
 }
 
 // ── new tests ─────────────────────────────────────────────────────────────────
@@ -613,8 +636,7 @@ mod factory_error_plugin {
 fn register_plugin_with_llm_provider() {
     let mut reg = PluginRegistry::new();
     let cfg = CairnConfig::default();
-    llm_provider_factory_plugin::register(&mut reg, &cfg)
-        .expect("LLMProvider factory registers");
+    llm_provider_factory_plugin::register(&mut reg, &cfg).expect("LLMProvider factory registers");
     let name = PluginName::new("stub-llm-factory").expect("valid");
     assert!(reg.llm_provider(&name).is_some());
 }

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -4,11 +4,27 @@
 use std::sync::Arc;
 
 use cairn_core::config::CairnConfig;
+use cairn_core::contract::agent_provider::{
+    AgentProvider, AgentProviderCapabilities, AgentProviderPlugin,
+};
+use cairn_core::contract::frontend_adapter::{
+    FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterPlugin,
+};
+use cairn_core::contract::llm_provider::{
+    LLMProvider, LLMProviderCapabilities, LLMProviderPlugin,
+};
+use cairn_core::contract::mcp_server::{MCPServer, MCPServerCapabilities, MCPServerPlugin};
 use cairn_core::contract::memory_store::{
     CONTRACT_VERSION, MemoryStore, MemoryStoreCapabilities, MemoryStorePlugin,
 };
 use cairn_core::contract::registry::{PluginError, PluginName, PluginRegistry};
+use cairn_core::contract::sensor_ingress::{
+    SensorIngress, SensorIngressCapabilities, SensorIngressPlugin,
+};
 use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::contract::workflow_orchestrator::{
+    WorkflowOrchestrator, WorkflowOrchestratorCapabilities, WorkflowOrchestratorPlugin,
+};
 use cairn_core::register_plugin;
 use cairn_core::register_plugin_with;
 
@@ -341,4 +357,336 @@ fn register_plugin_macro_rejects_name_const_mismatch() {
         matches!(err, PluginError::IdentityMismatch { .. }),
         "expected IdentityMismatch, got {err:?}"
     );
+}
+
+// ── register_plugin_with! coverage for the remaining 6 contract arms ─────────
+
+mod llm_provider_factory_plugin {
+    use super::*;
+
+    pub struct StubLlm;
+
+    #[async_trait::async_trait]
+    impl LLMProvider for StubLlm {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &LLMProviderCapabilities {
+            static CAPS: LLMProviderCapabilities = LLMProviderCapabilities {
+                json_mode: false,
+                streaming: false,
+                tool_calls: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl LLMProviderPlugin for StubLlm {
+        const NAME: &'static str = "stub-llm-factory";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+    }
+
+    register_plugin_with!(LLMProvider, StubLlm, "stub-llm-factory", |_cfg: &cairn_core::config::CairnConfig| {
+        Ok::<_, std::convert::Infallible>(StubLlm)
+    });
+}
+
+mod workflow_orchestrator_factory_plugin {
+    use super::*;
+
+    pub struct StubOrch;
+
+    #[async_trait::async_trait]
+    impl WorkflowOrchestrator for StubOrch {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &WorkflowOrchestratorCapabilities {
+            static CAPS: WorkflowOrchestratorCapabilities = WorkflowOrchestratorCapabilities {
+                durable: false,
+                crash_safe: false,
+                cron_schedules: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl WorkflowOrchestratorPlugin for StubOrch {
+        const NAME: &'static str = "stub-orch-factory";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+    }
+
+    register_plugin_with!(WorkflowOrchestrator, StubOrch, "stub-orch-factory", |_cfg: &cairn_core::config::CairnConfig| {
+        Ok::<_, std::convert::Infallible>(StubOrch)
+    });
+}
+
+mod sensor_ingress_factory_plugin {
+    use super::*;
+
+    pub struct StubSensor;
+
+    #[async_trait::async_trait]
+    impl SensorIngress for StubSensor {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &SensorIngressCapabilities {
+            static CAPS: SensorIngressCapabilities = SensorIngressCapabilities {
+                batches: false,
+                streaming: false,
+                consent_aware: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl SensorIngressPlugin for StubSensor {
+        const NAME: &'static str = "stub-sensor-factory";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+    }
+
+    register_plugin_with!(SensorIngress, StubSensor, "stub-sensor-factory", |_cfg: &cairn_core::config::CairnConfig| {
+        Ok::<_, std::convert::Infallible>(StubSensor)
+    });
+}
+
+mod mcp_server_factory_plugin {
+    use super::*;
+
+    pub struct StubMcp;
+
+    #[async_trait::async_trait]
+    impl MCPServer for StubMcp {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &MCPServerCapabilities {
+            static CAPS: MCPServerCapabilities = MCPServerCapabilities {
+                stdio: false,
+                sse: false,
+                http_streamable: false,
+                extensions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl MCPServerPlugin for StubMcp {
+        const NAME: &'static str = "stub-mcp-factory";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+    }
+
+    register_plugin_with!(MCPServer, StubMcp, "stub-mcp-factory", |_cfg: &cairn_core::config::CairnConfig| {
+        Ok::<_, std::convert::Infallible>(StubMcp)
+    });
+}
+
+mod frontend_adapter_factory_plugin {
+    use super::*;
+
+    pub struct StubFrontend;
+
+    #[async_trait::async_trait]
+    impl FrontendAdapter for StubFrontend {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &FrontendAdapterCapabilities {
+            static CAPS: FrontendAdapterCapabilities = FrontendAdapterCapabilities {
+                markdown_projection: false,
+                live_events: false,
+                reverse_edits: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl FrontendAdapterPlugin for StubFrontend {
+        const NAME: &'static str = "stub-frontend-factory";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 0, 1), ContractVersion::new(0, 1, 0));
+    }
+
+    register_plugin_with!(FrontendAdapter, StubFrontend, "stub-frontend-factory", |_cfg: &cairn_core::config::CairnConfig| {
+        Ok::<_, std::convert::Infallible>(StubFrontend)
+    });
+}
+
+mod agent_provider_factory_plugin {
+    use super::*;
+
+    pub struct StubAgent;
+
+    #[async_trait::async_trait]
+    impl AgentProvider for StubAgent {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &AgentProviderCapabilities {
+            static CAPS: AgentProviderCapabilities = AgentProviderCapabilities {
+                honors_cost_budget: false,
+                scope_enforced: false,
+                mcp_tools: false,
+                cli_subprocess_tools: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl AgentProviderPlugin for StubAgent {
+        const NAME: &'static str = "stub-agent-factory";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 0, 1), ContractVersion::new(0, 1, 0));
+    }
+
+    register_plugin_with!(AgentProvider, StubAgent, "stub-agent-factory", |_cfg: &cairn_core::config::CairnConfig| {
+        Ok::<_, std::convert::Infallible>(StubAgent)
+    });
+}
+
+// ── factory-error path ────────────────────────────────────────────────────────
+
+mod factory_error_plugin {
+    use super::*;
+
+    pub struct FailingStore;
+
+    #[async_trait::async_trait]
+    impl MemoryStore for FailingStore {
+        fn name(&self) -> &str {
+            Self::NAME
+        }
+        fn capabilities(&self) -> &MemoryStoreCapabilities {
+            static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                fts: false,
+                vector: false,
+                graph_edges: false,
+                transactions: false,
+            };
+            &CAPS
+        }
+        fn supported_contract_versions(&self) -> VersionRange {
+            Self::SUPPORTED_VERSIONS
+        }
+    }
+
+    impl MemoryStorePlugin for FailingStore {
+        const NAME: &'static str = "failing-store";
+        const SUPPORTED_VERSIONS: VersionRange =
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+    }
+
+    register_plugin_with!(MemoryStore, FailingStore, "failing-store", |_cfg: &cairn_core::config::CairnConfig| {
+        Err::<FailingStore, _>(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "db file missing",
+        ))
+    });
+}
+
+// ── new tests ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn register_plugin_with_llm_provider() {
+    let mut reg = PluginRegistry::new();
+    let cfg = CairnConfig::default();
+    llm_provider_factory_plugin::register(&mut reg, &cfg)
+        .expect("LLMProvider factory registers");
+    let name = PluginName::new("stub-llm-factory").expect("valid");
+    assert!(reg.llm_provider(&name).is_some());
+}
+
+#[test]
+fn register_plugin_with_workflow_orchestrator() {
+    let mut reg = PluginRegistry::new();
+    let cfg = CairnConfig::default();
+    workflow_orchestrator_factory_plugin::register(&mut reg, &cfg)
+        .expect("WorkflowOrchestrator factory registers");
+    let name = PluginName::new("stub-orch-factory").expect("valid");
+    assert!(reg.workflow_orchestrator(&name).is_some());
+}
+
+#[test]
+fn register_plugin_with_sensor_ingress() {
+    let mut reg = PluginRegistry::new();
+    let cfg = CairnConfig::default();
+    sensor_ingress_factory_plugin::register(&mut reg, &cfg)
+        .expect("SensorIngress factory registers");
+    let name = PluginName::new("stub-sensor-factory").expect("valid");
+    assert!(reg.sensor_ingress_plugin(&name).is_some());
+}
+
+#[test]
+fn register_plugin_with_mcp_server() {
+    let mut reg = PluginRegistry::new();
+    let cfg = CairnConfig::default();
+    mcp_server_factory_plugin::register(&mut reg, &cfg).expect("MCPServer factory registers");
+    let name = PluginName::new("stub-mcp-factory").expect("valid");
+    assert!(reg.mcp_server(&name).is_some());
+}
+
+#[test]
+fn register_plugin_with_frontend_adapter() {
+    let mut reg = PluginRegistry::new();
+    let cfg = CairnConfig::default();
+    frontend_adapter_factory_plugin::register(&mut reg, &cfg)
+        .expect("FrontendAdapter factory registers");
+    let name = PluginName::new("stub-frontend-factory").expect("valid");
+    assert!(reg.frontend_adapter(&name).is_some());
+}
+
+#[test]
+fn register_plugin_with_agent_provider() {
+    let mut reg = PluginRegistry::new();
+    let cfg = CairnConfig::default();
+    agent_provider_factory_plugin::register(&mut reg, &cfg)
+        .expect("AgentProvider factory registers");
+    let name = PluginName::new("stub-agent-factory").expect("valid");
+    assert!(reg.agent_provider(&name).is_some());
+}
+
+#[test]
+fn factory_error_propagates_as_plugin_error() {
+    let mut reg = PluginRegistry::new();
+    let cfg = CairnConfig::default();
+    let err = factory_error_plugin::register(&mut reg, &cfg)
+        .expect_err("failing factory must produce an error");
+    match err {
+        PluginError::FactoryError {
+            contract,
+            ref plugin,
+            ref source,
+        } => {
+            assert_eq!(contract, "MemoryStore");
+            assert_eq!(plugin.as_str(), "failing-store");
+            assert!(
+                source.to_string().contains("db file missing"),
+                "source: {source}"
+            );
+        }
+        other => panic!("expected FactoryError, got {other:?}"),
+    }
 }

--- a/docs/design/traceability.md
+++ b/docs/design/traceability.md
@@ -70,6 +70,7 @@ until automated enforcement is added.
 | §2 Design principles | #3, #4, #5, #7, #8, #17, #18, #158 | #145 (resolved) | Non-negotiable boundaries enforced through architecture, schema, privacy, WAL, and plugin gates. |
 | §3 Vault layout / SQLite / Nexus | #5, #6, #20, #41–#49, #104–#106 | — | P0 authority remains SQLite; P1 Nexus is derived/additive. |
 | §4 Contracts / plugins / identity | #3, #7, #10, #23, #27, #50–#53, #113, #124, #143 | — | Plugin registry and conformance covered. |
+| §4.1 Plugin architecture | #177 | — | `XxxPlugin` companion traits with `NAME` and `SUPPORTED_VERSIONS` static pre-construction checks; `register_plugin_with!` factory variant. |
 | §5 Pipeline / WAL / sessions | #8, #12, #13, #16, #54–#58, #71–#79, #89–#92 | #146 (resolved) | Capture, extract, filter, classify, plan/apply, WAL, hooks, and session capture covered. |
 | §6 Taxonomy / provenance | #4, #37–#40 | — | Canonical kinds, classes, visibility, and provenance owned by core schema. |
 | §6.a Multi-modal memory | #15, #29, #84–#88, #130–#132 | — | P0 local sensors plus P2 connectors and aggregate memory. |


### PR DESCRIPTION
## Summary

- Adds `XxxPlugin: Xxx + Sized` companion traits to all 7 contract traits (`MemoryStorePlugin`, `LLMProviderPlugin`, `WorkflowOrchestratorPlugin`, `SensorIngressPlugin`, `MCPServerPlugin`, `FrontendAdapterPlugin`, `AgentProviderPlugin`). Each has `const NAME: &'static str` and `const SUPPORTED_VERSIONS: VersionRange` for static pre-construction checks. (`where Self: Sized` on associated constants requires the unstable `generic_const_items` feature; the companion-trait pattern is the stable-Rust equivalent.)
- Adds `PluginError::FactoryError { contract, plugin, source: Box<dyn Error+Send+Sync> }` to the registry. The source is boxed to break the circular type reference with `ConfigError` (which already contains `PluginError`).
- Updates `__register_plugin_helper!` to check `XxxPlugin::SUPPORTED_VERSIONS` and `XxxPlugin::NAME` **before** calling `Default::default()`. The generated `register(reg)` signature is unchanged.
- Adds `register_plugin_with!(Contract, Impl, "name", |cfg| factory)` generating `register(reg, cfg: &CairnConfig)` that performs the same static checks **before** calling the factory closure.

## Design sections
- §4.1 Plugin architecture
- §13.5 Config (factory receives `&CairnConfig`)

## Invariants touched
- Invariant 4: new macro still routes through existing `register_*` registry methods — no hidden code paths.
- Invariant 6: version mismatch now caught before construction, not after; factory never runs for incompatible plugins.

## Verification

\`\`\`
cargo fmt --all --check                    ✓
cargo clippy --workspace -D warnings       ✓
cargo check --workspace --all-targets      ✓
cargo nextest run --workspace              ✓  762 tests passed
cargo test --doc --workspace               ✓
./scripts/check-core-boundary.sh           ✓
cargo run -p cairn-idl --bin cairn-codegen -- --check  ✓
cargo doc --workspace --no-deps            ✓
\`\`\`

Closes #177