### PR TITLE
feat(folder): folder sidecars, backlinks, policy inheritance (brief §3.4, #44)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "ulid",
+ "walkdir",
 ]
 
 [[package]]
@@ -1557,6 +1558,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2053,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2167,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ clap = { version = "4.5", features = ["derive", "wrap_help"] }
 rusqlite_migration = "1"
 ulid = { version = "1.1", default-features = false, features = ["std"] }
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
+walkdir = "2"
 
 # Path + version on intra-workspace deps so `cargo publish` can rewrite the
 # path to a registry version without losing the constraint. The version

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -32,6 +32,7 @@ base64 = { workspace = true }
 serde_yaml = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+walkdir = { workspace = true }
 
 [dev-dependencies]
 cairn-test-fixtures = { workspace = true }

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -41,7 +41,7 @@ fn build_command() -> clap::Command {
             generated::verbs::capture_trace_subcommand(),
         ))
         .subcommand(verbs::with_json(verbs::with_fix_markdown(
-            generated::verbs::lint_subcommand(),
+            verbs::with_fix_folders(generated::verbs::lint_subcommand()),
         )))
         .subcommand(verbs::with_json(generated::verbs::forget_subcommand()))
         // Protocol preludes.

--- a/crates/cairn-cli/src/skill.rs
+++ b/crates/cairn-cli/src/skill.rs
@@ -419,6 +419,7 @@ pub fn install(opts: &InstallOpts) -> Result<InstallReceipt> {
     // Generated files: overwrite unless skip_generated.
     let gen_force = opts.force || !skip_generated;
     crate::vault::bootstrap::write_once(
+        target,
         &target.join("SKILL.md"),
         SKILL_MD,
         gen_force,
@@ -426,6 +427,7 @@ pub fn install(opts: &InstallOpts) -> Result<InstallReceipt> {
         &mut files_skipped,
     )?;
     crate::vault::bootstrap::write_once(
+        target,
         &target.join("conventions.md"),
         CONVENTIONS_MD,
         gen_force,
@@ -444,6 +446,7 @@ pub fn install(opts: &InstallOpts) -> Result<InstallReceipt> {
         ("06-lint-memory.md", EXAMPLE_06),
     ] {
         crate::vault::bootstrap::write_once(
+            target,
             &examples_dir.join(name),
             content,
             false, // never force-overwrite examples
@@ -455,6 +458,7 @@ pub fn install(opts: &InstallOpts) -> Result<InstallReceipt> {
     // Write .version last so a partial failure (e.g. in examples/) never
     // leaves a version-stamped incomplete install.
     crate::vault::bootstrap::write_once(
+        target,
         &target.join(".version"),
         VERSION_FILE,
         gen_force,

--- a/crates/cairn-cli/src/vault/bootstrap.rs
+++ b/crates/cairn-cli/src/vault/bootstrap.rs
@@ -194,19 +194,13 @@ pub fn render_human(receipt: &BootstrapReceipt) -> String {
     )
 }
 
-pub(crate) fn write_once(
-    path: &std::path::Path,
-    content: &str,
-    force: bool,
-    created: &mut Vec<PathBuf>,
-    skipped: &mut Vec<PathBuf>,
-) -> Result<()> {
-    use std::io::Write as _;
-
-    // Validate the parent directory first, before any path — including the
-    // early-return skip path.  A symlink-swapped parent (e.g. `.cairn`)
-    // would redirect every subsequent operation, so we reject it on every
-    // code path, not just the write path.
+/// No-follow validation for a write target. Rejects symlinked parents and
+/// symlinked / non-regular destinations. Callers that want to read the file
+/// before deciding whether to write (e.g. `lint --fix-folders` skipping
+/// unchanged indexes) MUST run this first; otherwise a symlinked
+/// `_index.md` would be read through to its target before the no-follow
+/// guards in [`write_once`] get a chance to fire.
+pub(crate) fn check_write_safe(path: &std::path::Path) -> Result<()> {
     let dir = path.parent().unwrap_or(std::path::Path::new("."));
     if let Ok(meta) = std::fs::symlink_metadata(dir)
         && meta.file_type().is_symlink()
@@ -216,8 +210,6 @@ pub(crate) fn write_once(
             dir.display()
         );
     }
-
-    // Inspect the final target without following symlinks.
     if let Ok(meta) = std::fs::symlink_metadata(path) {
         let ft = meta.file_type();
         if ft.is_symlink() {
@@ -227,13 +219,33 @@ pub(crate) fn write_once(
             );
         }
         if !ft.is_file() {
-            // A directory or special file at a placeholder path means the
-            // vault is in an inconsistent state; cairn cannot repair it.
             anyhow::bail!(
                 "{} exists but is not a regular file — cairn cannot overwrite it",
                 path.display()
             );
         }
+    }
+    Ok(())
+}
+
+pub(crate) fn write_once(
+    path: &std::path::Path,
+    content: &str,
+    force: bool,
+    created: &mut Vec<PathBuf>,
+    skipped: &mut Vec<PathBuf>,
+) -> Result<()> {
+    use std::io::Write as _;
+
+    // Validate parent + target with no-follow lstat.  This rejects a
+    // symlink-swapped parent (e.g. `.cairn`) and a symlinked destination
+    // before any read or write touches them.
+    check_write_safe(path)?;
+
+    let dir = path.parent().unwrap_or(std::path::Path::new("."));
+    if let Ok(meta) = std::fs::symlink_metadata(path) {
+        // Path exists and `check_write_safe` confirmed it is a regular file.
+        let _ = meta;
         if !force {
             skipped.push(path.to_owned());
             return Ok(());

--- a/crates/cairn-cli/src/vault/bootstrap.rs
+++ b/crates/cairn-cli/src/vault/bootstrap.rs
@@ -133,6 +133,7 @@ pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
     let config_yaml = serde_yaml::to_string(&CairnConfig::default())
         .context("serializing default config to YAML")?;
     write_once(
+        vault,
         &config_path,
         &config_yaml,
         opts.force,
@@ -140,6 +141,7 @@ pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
         &mut receipt.files_skipped,
     )?;
     write_once(
+        vault,
         &vault.join("purpose.md"),
         PURPOSE_MD,
         opts.force,
@@ -147,6 +149,7 @@ pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
         &mut receipt.files_skipped,
     )?;
     write_once(
+        vault,
         &vault.join("index.md"),
         "",
         opts.force,
@@ -154,6 +157,7 @@ pub fn bootstrap(opts: &BootstrapOpts) -> Result<BootstrapReceipt> {
         &mut receipt.files_skipped,
     )?;
     write_once(
+        vault,
         &vault.join("log.md"),
         "",
         opts.force,
@@ -194,21 +198,53 @@ pub fn render_human(receipt: &BootstrapReceipt) -> String {
     )
 }
 
-/// No-follow validation for a write target. Rejects symlinked parents and
-/// symlinked / non-regular destinations. Callers that want to read the file
-/// before deciding whether to write (e.g. `lint --fix-folders` skipping
-/// unchanged indexes) MUST run this first; otherwise a symlinked
-/// `_index.md` would be read through to its target before the no-follow
-/// guards in [`write_once`] get a chance to fire.
-pub(crate) fn check_write_safe(path: &std::path::Path) -> Result<()> {
-    let dir = path.parent().unwrap_or(std::path::Path::new("."));
-    if let Ok(meta) = std::fs::symlink_metadata(dir)
-        && meta.file_type().is_symlink()
-    {
-        anyhow::bail!(
-            "parent directory {} is a symlink — cairn will not write through it",
-            dir.display()
-        );
+/// No-follow validation for a write target. Rejects symlinked parents,
+/// symlinked / non-regular destinations, AND any symlinked ancestor between
+/// `vault_root` (exclusive) and the destination's parent (inclusive).
+///
+/// Why every ancestor: `symlink_metadata` only refuses to follow the
+/// **final** path component; intermediate components are still resolved
+/// through symlinks. So `lstat("vault/raw/a/_index.md".parent())` returns
+/// metadata for the leaf `a` even if `raw` itself is a symlink that
+/// silently redirects every nested write outside the vault. Walking each
+/// segment from the vault root closes that gap.
+///
+/// Callers that want to read the file before deciding whether to write
+/// (e.g. `lint --fix-folders` skipping unchanged indexes) MUST run this
+/// first; otherwise a symlinked `_index.md` would be read through to its
+/// target before the no-follow guards in [`write_once`] get a chance to
+/// fire.
+pub(crate) fn check_write_safe(vault_root: &std::path::Path, path: &std::path::Path) -> Result<()> {
+    // Walk every existing ancestor between vault_root (exclusive) and the
+    // destination's parent (inclusive).  `vault_root` itself is the user's
+    // working directory and is intentionally not validated — outside our
+    // trust boundary — but everything beneath it must be a real directory.
+    let parent = path.parent().unwrap_or(std::path::Path::new("."));
+    if let Ok(rel) = parent.strip_prefix(vault_root) {
+        let mut cur = vault_root.to_path_buf();
+        for comp in rel.components() {
+            cur.push(comp);
+            if let Ok(meta) = std::fs::symlink_metadata(&cur)
+                && meta.file_type().is_symlink()
+            {
+                anyhow::bail!(
+                    "ancestor {} is a symlink — cairn will not write through it",
+                    cur.display()
+                );
+            }
+        }
+    } else {
+        // `path` is not under `vault_root` — fall back to the immediate
+        // parent check.  This preserves prior behavior for callers that
+        // pass a working-directory-relative path.
+        if let Ok(meta) = std::fs::symlink_metadata(parent)
+            && meta.file_type().is_symlink()
+        {
+            anyhow::bail!(
+                "parent directory {} is a symlink — cairn will not write through it",
+                parent.display()
+            );
+        }
     }
     if let Ok(meta) = std::fs::symlink_metadata(path) {
         let ft = meta.file_type();
@@ -229,6 +265,7 @@ pub(crate) fn check_write_safe(path: &std::path::Path) -> Result<()> {
 }
 
 pub(crate) fn write_once(
+    vault_root: &std::path::Path,
     path: &std::path::Path,
     content: &str,
     force: bool,
@@ -237,10 +274,11 @@ pub(crate) fn write_once(
 ) -> Result<()> {
     use std::io::Write as _;
 
-    // Validate parent + target with no-follow lstat.  This rejects a
-    // symlink-swapped parent (e.g. `.cairn`) and a symlinked destination
-    // before any read or write touches them.
-    check_write_safe(path)?;
+    // Validate every ancestor + target with no-follow lstat.  This rejects
+    // a symlink-swapped parent (e.g. `.cairn`) AND a symlink anywhere
+    // between `vault_root` and the target, before any read or write
+    // touches them.
+    check_write_safe(vault_root, path)?;
 
     let dir = path.parent().unwrap_or(std::path::Path::new("."));
     if let Ok(meta) = std::fs::symlink_metadata(path) {

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -257,11 +257,11 @@ fn is_hidden_dir(entry: &walkdir::DirEntry) -> bool {
 pub fn run(sub: &ArgMatches) -> ExitCode {
     let json = sub.get_flag("json");
     let fix_markdown = sub.get_flag("fix-markdown");
+    let fix_folders = sub.get_flag("fix-folders");
 
-    if fix_markdown {
-        // TODO(#9): wire the real SQLite store here once `cairn-store-sqlite` is done.
-        // The handler is fully implemented and accepts a `&dyn MemoryStore`, so only
-        // this dispatch site needs updating when the store is available.
+    if fix_markdown || fix_folders {
+        // TODO(#46): wire the SQLite store. For now, return the same
+        // unimplemented envelope used by --fix-markdown.
         let resp = unimplemented_response(ResponseVerb::Lint);
         if json {
             emit_json(&resp);
@@ -269,7 +269,7 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
             human_error(
                 "lint",
                 "Internal",
-                "store not wired in this P0 build — --fix-markdown requires #46",
+                "store not wired in this P0 build — --fix-folders requires #46",
                 &resp.operation_id,
             );
         }

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -179,9 +179,12 @@ pub async fn fix_folders_handler(
         // lstat-based parent + target check up front, on every iteration.
         {
             let dest = abs.clone();
-            tokio::task::spawn_blocking(move || crate::vault::bootstrap::check_write_safe(&dest))
-                .await
-                .with_context(|| format!("spawn_blocking validate {}", abs.display()))??;
+            let vroot = vault_root.to_path_buf();
+            tokio::task::spawn_blocking(move || {
+                crate::vault::bootstrap::check_write_safe(&vroot, &dest)
+            })
+            .await
+            .with_context(|| format!("spawn_blocking validate {}", abs.display()))??;
         }
         let needs_write = match tokio::fs::read_to_string(&abs).await {
             Ok(existing) => existing != projected.content,
@@ -199,16 +202,24 @@ pub async fn fix_folders_handler(
         }
         let content = projected.content.clone();
         let dest = abs.clone();
+        let vroot = vault_root.to_path_buf();
         tokio::task::spawn_blocking(move || {
-            // `write_once` lstat-checks the parent + final target for symlinks,
-            // writes a randomly-named tempfile in the same directory, and
-            // atomically renames into place. The created/skipped vecs are
-            // populated for bootstrap's receipt; we discard them here because
-            // the surrounding read-and-compare loop already classifies writes
-            // as `written` or `unchanged`.
+            // `write_once` lstat-checks every ancestor + final target for
+            // symlinks, writes a randomly-named tempfile in the same
+            // directory, and atomically renames into place. The
+            // created/skipped vecs are populated for bootstrap's receipt;
+            // we discard them here because the surrounding read-and-compare
+            // loop already classifies writes as `written` or `unchanged`.
             let mut created = Vec::new();
             let mut skipped = Vec::new();
-            crate::vault::bootstrap::write_once(&dest, &content, true, &mut created, &mut skipped)
+            crate::vault::bootstrap::write_once(
+                &vroot,
+                &dest,
+                &content,
+                true,
+                &mut created,
+                &mut skipped,
+            )
         })
         .await
         .with_context(|| format!("spawn_blocking write {}", abs.display()))??;
@@ -249,7 +260,13 @@ async fn collect_policies(
         .filter_entry(|e| e.depth() == 0 || !is_hidden_dir(e));
     for entry in walker {
         let entry = entry.with_context(|| format!("walking {}", vault_root.display()))?;
-        if !entry.file_type().is_file() || entry.file_name() != "_policy.yaml" {
+        // Match by name first.  `follow_links(false)` reports a symlinked
+        // `_policy.yaml` as a non-file; if we filtered on `is_file()` first
+        // we would silently skip it and fall back to inherited/default
+        // policy below — exactly the fail-open hole brief invariant 6
+        // forbids.  Treat any non-regular `_policy.yaml` (symlink, fifo,
+        // directory) as a policy error and taint its containing folder.
+        if entry.file_name() != "_policy.yaml" {
             continue;
         }
         let abs = entry.path().to_path_buf();
@@ -258,6 +275,21 @@ async fn collect_policies(
             .with_context(|| format!("strip_prefix {}", abs.display()))?
             .to_path_buf();
         let dir = rel.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+        if !entry.file_type().is_file() {
+            let kind = if entry.file_type().is_symlink() {
+                "symlink"
+            } else if entry.file_type().is_dir() {
+                "directory"
+            } else {
+                "non-regular file"
+            };
+            policy_errors.push(PolicyError {
+                path: rel,
+                reason: format!("_policy.yaml is a {kind} — refusing to follow"),
+            });
+            tainted_dirs.push(dir);
+            continue;
+        }
         // Read raw bytes — `read_to_string` would return InvalidData on
         // non-UTF-8 and the `?` would abort the whole rebuild. Decode here
         // so a non-UTF-8 file taints only its own subtree (brief invariant 6,

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -144,11 +144,7 @@ pub async fn fix_folders_handler(
     let (policies_by_dir, policy_errors, tainted_dirs) = collect_policies(vault_root).await?;
 
     if !tainted_dirs.is_empty() {
-        record_paths.retain(|_, path| {
-            !tainted_dirs
-                .iter()
-                .any(|bad| path.starts_with(bad))
-        });
+        record_paths.retain(|_, path| !tainted_dirs.iter().any(|bad| path.starts_with(bad)));
     }
 
     // 3. Reverse-map backlinks.

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -130,8 +130,7 @@ pub async fn fix_folders_handler(
 
     // 1. Build record_paths from MarkdownProjector — same shape used by
     //    --fix-markdown, so callers get a coherent view.
-    let mut record_paths: BTreeMap<cairn_core::domain::record::RecordId, PathBuf> =
-        BTreeMap::new();
+    let mut record_paths: BTreeMap<cairn_core::domain::record::RecordId, PathBuf> = BTreeMap::new();
     for stored in &records {
         let pf = projector.project(stored);
         record_paths.insert(stored.record.id.clone(), pf.path);

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -6,9 +6,9 @@ use std::process::ExitCode;
 
 use anyhow::Context as _;
 use cairn_core::contract::memory_store::MemoryStore;
-use cairn_core::domain::folder::index::{aggregate_folders, project_index};
-use cairn_core::domain::folder::policy::FolderPolicy;
-use cairn_core::domain::folder::{materialize_backlinks, parse_policy};
+use cairn_core::domain::folder::{
+    FolderPolicy, aggregate_folders, materialize_backlinks, parse_policy, project_index,
+};
 use cairn_core::domain::projection::MarkdownProjector;
 use cairn_core::generated::envelope::ResponseVerb;
 use clap::ArgMatches;
@@ -259,8 +259,11 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
     let fix_folders = sub.get_flag("fix-folders");
 
     if fix_markdown || fix_folders {
-        // TODO(#46): wire the SQLite store. For now, return the same
-        // unimplemented envelope used by --fix-markdown.
+        // TODO(#46): wire SQLite store. When live, dispatch should call:
+        //   - fix_markdown_handler(&store, &vault_root) when fix_markdown
+        //   - fix_folders_handler(&store, &vault_root) when fix_folders
+        // Both handlers are already implemented and exercised via FixtureStore in
+        // crates/cairn-cli/tests/{resync,lint_folders}.rs.
         let resp = unimplemented_response(ResponseVerb::Lint);
         if json {
             emit_json(&resp);

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -136,13 +136,28 @@ pub async fn fix_folders_handler(
         record_paths.insert(stored.record.id.clone(), pf.path);
     }
 
-    // 2. Walk vault for files named `_policy.yaml`.
-    let (policies_by_dir, policy_errors) = collect_policies(vault_root).await?;
+    // 2. Walk vault for files named `_policy.yaml`. Folders whose policy
+    //    failed to parse are returned as `tainted_dirs`; per brief invariant 6
+    //    (fail-closed) we drop every record under those subtrees so the
+    //    handler does not silently fall back to default policy below a
+    //    misconfigured folder.
+    let (policies_by_dir, policy_errors, tainted_dirs) = collect_policies(vault_root).await?;
+
+    if !tainted_dirs.is_empty() {
+        record_paths.retain(|_, path| {
+            !tainted_dirs
+                .iter()
+                .any(|bad| path.starts_with(bad))
+        });
+    }
 
     // 3. Reverse-map backlinks.
     let backlinks_by_target = materialize_backlinks(&records, &record_paths);
 
-    // 4. Aggregate.
+    // 4. Aggregate. `aggregate_folders` looks up each record's path in
+    //    `record_paths` and silently skips records with no entry, so dropping
+    //    tainted entries from the map is sufficient — no parallel filter on
+    //    `records` is needed.
     let states = aggregate_folders(
         &records,
         &record_paths,
@@ -197,13 +212,24 @@ pub async fn fix_folders_handler(
     })
 }
 
-/// Walk `vault_root` for `_policy.yaml` files and parse them. Bad policies
-/// are recorded as [`PolicyError`] entries — they do not abort the walk.
+/// Walk `vault_root` for `_policy.yaml` files and parse them.
+///
+/// Returns the parsed policies keyed by their containing directory, the list
+/// of [`PolicyError`] entries for files that failed to parse, and a list of
+/// tainted directories — folders whose `_policy.yaml` was unparseable. The
+/// caller must skip every record under a tainted directory (brief invariant 6,
+/// fail-closed): defaulting silently below a broken policy would let writes
+/// land outside the configured `allowed_kinds`/`visibility_default`.
 async fn collect_policies(
     vault_root: &Path,
-) -> anyhow::Result<(BTreeMap<PathBuf, FolderPolicy>, Vec<PolicyError>)> {
+) -> anyhow::Result<(
+    BTreeMap<PathBuf, FolderPolicy>,
+    Vec<PolicyError>,
+    Vec<PathBuf>,
+)> {
     let mut policies_by_dir: BTreeMap<PathBuf, FolderPolicy> = BTreeMap::new();
     let mut policy_errors: Vec<PolicyError> = Vec::new();
+    let mut tainted_dirs: Vec<PathBuf> = Vec::new();
     // Skip hidden subdirectories (e.g. `.cairn/`, `.git/`) but never reject
     // the vault root itself — `tempfile::tempdir()` and similar tools
     // commonly produce dot-prefixed root paths.
@@ -237,10 +263,11 @@ async fn collect_policies(
                     path: rel,
                     reason: e.to_string(),
                 });
+                tainted_dirs.push(dir);
             }
         }
     }
-    Ok((policies_by_dir, policy_errors))
+    Ok((policies_by_dir, policy_errors, tainted_dirs))
 }
 
 fn is_hidden_dir(entry: &walkdir::DirEntry) -> bool {

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -172,6 +172,17 @@ pub async fn fix_folders_handler(
     for state in states {
         let projected = project_index(&state);
         let abs = vault_root.join(&projected.path);
+        // No-follow validation BEFORE the read.  `read_to_string` follows
+        // symlinks; if `_index.md` is a symlink to an external file with
+        // matching content, the unchanged branch would silently bypass the
+        // symlink rejection that lives inside `write_once`.  Run the same
+        // lstat-based parent + target check up front, on every iteration.
+        {
+            let dest = abs.clone();
+            tokio::task::spawn_blocking(move || crate::vault::bootstrap::check_write_safe(&dest))
+                .await
+                .with_context(|| format!("spawn_blocking validate {}", abs.display()))??;
+        }
         let needs_write = match tokio::fs::read_to_string(&abs).await {
             Ok(existing) => existing != projected.content,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -186,8 +186,13 @@ pub async fn fix_folders_handler(
             .await
             .with_context(|| format!("spawn_blocking validate {}", abs.display()))??;
         }
-        let needs_write = match tokio::fs::read_to_string(&abs).await {
-            Ok(existing) => existing != projected.content,
+        // Byte-compare, NOT `read_to_string`.  A pre-existing `_index.md`
+        // containing non-UTF-8 bytes (corruption, manual binary write,
+        // partially-written tempfile that survived a crash) would otherwise
+        // surface as `InvalidData` and abort the entire rebuild — exactly
+        // the recovery case `lint --fix-folders` should handle.
+        let needs_write = match tokio::fs::read(&abs).await {
+            Ok(existing) => existing != projected.content.as_bytes(),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
             Err(e) => return Err(anyhow::anyhow!("cannot read {}: {e}", abs.display())),
         };

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -247,10 +247,25 @@ async fn collect_policies(
             .with_context(|| format!("strip_prefix {}", abs.display()))?
             .to_path_buf();
         let dir = rel.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
-        let bytes = tokio::fs::read_to_string(&abs)
+        // Read raw bytes — `read_to_string` would return InvalidData on
+        // non-UTF-8 and the `?` would abort the whole rebuild. Decode here
+        // so a non-UTF-8 file taints only its own subtree (brief invariant 6,
+        // fail-closed), exactly like a YAML parse failure.
+        let bytes = tokio::fs::read(&abs)
             .await
             .with_context(|| format!("read {}", abs.display()))?;
-        match parse_policy(&bytes) {
+        let text = match String::from_utf8(bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                policy_errors.push(PolicyError {
+                    path: rel,
+                    reason: format!("_policy.yaml is not valid UTF-8: {e}"),
+                });
+                tainted_dirs.push(dir);
+                continue;
+            }
+        };
+        match parse_policy(&text) {
             Ok(p) => {
                 policies_by_dir.insert(dir, p);
             }

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -165,7 +165,12 @@ pub async fn fix_folders_handler(
         &backlinks_by_target,
     );
 
-    // 5. Write each `_index.md` atomically.
+    // 5. Write each `_index.md` atomically. We delegate the symlink-rejection
+    //    + atomic-persist sequence to `vault::bootstrap::write_once` (force=true)
+    //    so the same lstat-then-rename guarantees protect both bootstrap and
+    //    `lint --fix-folders`. The "unchanged" semantic (skip when content
+    //    already matches) lives here, because `write_once` does not compare
+    //    bytes — under `force=true` it always overwrites.
     let mut written = Vec::new();
     let mut unchanged = 0usize;
     for state in states {
@@ -187,18 +192,16 @@ pub async fn fix_folders_handler(
         }
         let content = projected.content.clone();
         let dest = abs.clone();
-        let parent_buf = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
         tokio::task::spawn_blocking(move || {
-            use std::io::Write as _;
-            let mut tmp = tempfile::Builder::new()
-                .suffix(".md.tmp")
-                .tempfile_in(&parent_buf)
-                .with_context(|| format!("tempfile in {}", parent_buf.display()))?;
-            tmp.write_all(content.as_bytes())
-                .with_context(|| format!("write temp {}", tmp.path().display()))?;
-            tmp.persist(&dest)
-                .map_err(|e| anyhow::anyhow!("persist -> {}: {}", dest.display(), e.error))?;
-            Ok::<_, anyhow::Error>(())
+            // `write_once` lstat-checks the parent + final target for symlinks,
+            // writes a randomly-named tempfile in the same directory, and
+            // atomically renames into place. The created/skipped vecs are
+            // populated for bootstrap's receipt; we discard them here because
+            // the surrounding read-and-compare loop already classifies writes
+            // as `written` or `unchanged`.
+            let mut created = Vec::new();
+            let mut skipped = Vec::new();
+            crate::vault::bootstrap::write_once(&dest, &content, true, &mut created, &mut skipped)
         })
         .await
         .with_context(|| format!("spawn_blocking write {}", abs.display()))??;

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1,10 +1,14 @@
 //! `cairn lint` handler.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::Context as _;
 use cairn_core::contract::memory_store::MemoryStore;
+use cairn_core::domain::folder::index::{aggregate_folders, project_index};
+use cairn_core::domain::folder::policy::FolderPolicy;
+use cairn_core::domain::folder::{materialize_backlinks, parse_policy};
 use cairn_core::domain::projection::MarkdownProjector;
 use cairn_core::generated::envelope::ResponseVerb;
 use clap::ArgMatches;
@@ -87,6 +91,165 @@ pub async fn fix_markdown_handler(
         written,
         already_current,
     })
+}
+
+/// Result of a `lint --fix-folders` run.
+#[derive(Debug, serde::Serialize)]
+pub struct FixFoldersResult {
+    /// Folder index files written or updated (vault-relative).
+    pub written: Vec<PathBuf>,
+    /// Number of indexes that already matched their projection.
+    pub unchanged: usize,
+    /// Per-policy parse failures; subtree was skipped.
+    pub policy_errors: Vec<PolicyError>,
+}
+
+/// One `_policy.yaml` that failed to parse.
+#[derive(Debug, serde::Serialize)]
+pub struct PolicyError {
+    /// Vault-relative path of the offending file.
+    pub path: PathBuf,
+    /// Human-readable reason.
+    pub reason: String,
+}
+
+/// Walk the store, build folder states, project `_index.md` files, write
+/// atomically. A bad `_policy.yaml` does not abort — that subtree is
+/// skipped, the error is recorded.
+///
+/// # Errors
+///
+/// Returns an error if the store cannot be queried, or if any non-policy
+/// I/O fails.
+pub async fn fix_folders_handler(
+    store: &dyn MemoryStore,
+    vault_root: &Path,
+) -> anyhow::Result<FixFoldersResult> {
+    let projector = MarkdownProjector;
+    let records = store.list_active().await.context("store: list_active")?;
+
+    // 1. Build record_paths from MarkdownProjector — same shape used by
+    //    --fix-markdown, so callers get a coherent view.
+    let mut record_paths: BTreeMap<cairn_core::domain::record::RecordId, PathBuf> =
+        BTreeMap::new();
+    for stored in &records {
+        let pf = projector.project(stored);
+        record_paths.insert(stored.record.id.clone(), pf.path);
+    }
+
+    // 2. Walk vault for files named `_policy.yaml`.
+    let (policies_by_dir, policy_errors) = collect_policies(vault_root).await?;
+
+    // 3. Reverse-map backlinks.
+    let backlinks_by_target = materialize_backlinks(&records, &record_paths);
+
+    // 4. Aggregate.
+    let states = aggregate_folders(
+        &records,
+        &record_paths,
+        &policies_by_dir,
+        &backlinks_by_target,
+    );
+
+    // 5. Write each `_index.md` atomically.
+    let mut written = Vec::new();
+    let mut unchanged = 0usize;
+    for state in states {
+        let projected = project_index(&state);
+        let abs = vault_root.join(&projected.path);
+        let needs_write = match tokio::fs::read_to_string(&abs).await {
+            Ok(existing) => existing != projected.content,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+            Err(e) => return Err(anyhow::anyhow!("cannot read {}: {e}", abs.display())),
+        };
+        if !needs_write {
+            unchanged += 1;
+            continue;
+        }
+        if let Some(parent) = abs.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("create_dir_all {}", parent.display()))?;
+        }
+        let content = projected.content.clone();
+        let dest = abs.clone();
+        let parent_buf = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            use std::io::Write as _;
+            let mut tmp = tempfile::Builder::new()
+                .suffix(".md.tmp")
+                .tempfile_in(&parent_buf)
+                .with_context(|| format!("tempfile in {}", parent_buf.display()))?;
+            tmp.write_all(content.as_bytes())
+                .with_context(|| format!("write temp {}", tmp.path().display()))?;
+            tmp.persist(&dest)
+                .map_err(|e| anyhow::anyhow!("persist -> {}: {}", dest.display(), e.error))?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+        .with_context(|| format!("spawn_blocking write {}", abs.display()))??;
+        written.push(projected.path);
+    }
+
+    Ok(FixFoldersResult {
+        written,
+        unchanged,
+        policy_errors,
+    })
+}
+
+/// Walk `vault_root` for `_policy.yaml` files and parse them. Bad policies
+/// are recorded as [`PolicyError`] entries — they do not abort the walk.
+async fn collect_policies(
+    vault_root: &Path,
+) -> anyhow::Result<(BTreeMap<PathBuf, FolderPolicy>, Vec<PolicyError>)> {
+    let mut policies_by_dir: BTreeMap<PathBuf, FolderPolicy> = BTreeMap::new();
+    let mut policy_errors: Vec<PolicyError> = Vec::new();
+    // Skip hidden subdirectories (e.g. `.cairn/`, `.git/`) but never reject
+    // the vault root itself — `tempfile::tempdir()` and similar tools
+    // commonly produce dot-prefixed root paths.
+    let walker = walkdir::WalkDir::new(vault_root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| e.depth() == 0 || !is_hidden_dir(e));
+    for entry in walker {
+        let entry = entry.with_context(|| format!("walking {}", vault_root.display()))?;
+        if !entry.file_type().is_file() || entry.file_name() != "_policy.yaml" {
+            continue;
+        }
+        let abs = entry.path().to_path_buf();
+        let rel = abs
+            .strip_prefix(vault_root)
+            .with_context(|| format!("strip_prefix {}", abs.display()))?
+            .to_path_buf();
+        let dir = rel.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+        let bytes = tokio::fs::read_to_string(&abs)
+            .await
+            .with_context(|| format!("read {}", abs.display()))?;
+        match parse_policy(&bytes) {
+            Ok(p) => {
+                policies_by_dir.insert(dir, p);
+            }
+            // `FolderError` is `#[non_exhaustive]`; treat any current or
+            // future variant as a non-fatal policy error so the run
+            // continues and the offending subtree is skipped.
+            Err(e) => {
+                policy_errors.push(PolicyError {
+                    path: rel,
+                    reason: e.to_string(),
+                });
+            }
+        }
+    }
+    Ok((policies_by_dir, policy_errors))
+}
+
+fn is_hidden_dir(entry: &walkdir::DirEntry) -> bool {
+    entry.file_type().is_dir()
+        && entry
+            .file_name()
+            .to_str()
+            .is_some_and(|s| s.starts_with('.') && s != ".")
 }
 
 /// Run `cairn lint`.

--- a/crates/cairn-cli/src/verbs/mod.rs
+++ b/crates/cairn-cli/src/verbs/mod.rs
@@ -41,6 +41,23 @@ pub fn with_fix_markdown(cmd: clap::Command) -> clap::Command {
     )
 }
 
+/// Add `--fix-folders` flag to the `lint` subcommand.
+///
+/// Augments the generated subcommand builder without touching generated
+/// files, using the same pattern as [`with_fix_markdown`].
+#[must_use]
+pub fn with_fix_folders(cmd: clap::Command) -> clap::Command {
+    cmd.arg(
+        clap::Arg::new("fix-folders")
+            .long("fix-folders")
+            .action(clap::ArgAction::SetTrue)
+            .help(
+                "Regenerate folder _index.md sidecars and backlinks for every \
+                 non-empty folder (brief §3.4, #44)",
+            ),
+    )
+}
+
 /// Augments the `ingest` subcommand with the `--resync <path>` flag.
 ///
 /// Uses the same pattern as [`with_json`] and [`with_fix_markdown`]: the

--- a/crates/cairn-cli/tests/lint_folders.rs
+++ b/crates/cairn-cli/tests/lint_folders.rs
@@ -128,6 +128,29 @@ async fn atomic_writes_overwrite_stale_and_leave_no_tmp() {
 }
 
 #[tokio::test]
+#[cfg(unix)]
+async fn write_through_symlinked_parent_is_rejected() {
+    // The atomic-write path delegates to `vault::bootstrap::write_once`,
+    // which lstat-checks the immediate parent. A symlinked `raw/` (the
+    // parent of `raw/_index.md`) must be rejected, not silently written
+    // through to the symlink target.
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    let attacker = tempfile::tempdir().unwrap();
+    std::os::unix::fs::symlink(attacker.path(), vault.path().join("raw")).unwrap();
+
+    let result = fix_folders_handler(&store, vault.path()).await;
+
+    assert!(result.is_err(), "symlink-parent write should be rejected");
+    assert!(
+        !attacker.path().join("_index.md").exists(),
+        "symlink target was written through",
+    );
+}
+
+#[tokio::test]
 async fn fixture_index_matches_snapshot() {
     let store = FixtureStore::default();
     store.upsert(sample_record()).await.unwrap();

--- a/crates/cairn-cli/tests/lint_folders.rs
+++ b/crates/cairn-cli/tests/lint_folders.rs
@@ -59,6 +59,37 @@ async fn bad_policy_yaml_does_not_abort_run() {
 }
 
 #[tokio::test]
+async fn atomic_writes_overwrite_stale_and_leave_no_tmp() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+    std::fs::create_dir_all(vault.path().join(".cairn")).unwrap();
+
+    // Pre-place stale content; atomic rename must replace it.
+    std::fs::write(vault.path().join("raw/_index.md"), "stale content\n").unwrap();
+
+    let _ = fix_folders_handler(&store, vault.path()).await.unwrap();
+
+    let content = std::fs::read_to_string(vault.path().join("raw/_index.md")).unwrap();
+    assert!(
+        content.contains("kind: folder_index"),
+        "stale content not replaced: {content:?}"
+    );
+
+    // No leftover temp files in raw/. tempfile::Builder::suffix(".md.tmp")
+    // produces names like `<random>.md.tmp` — match anything containing ".tmp".
+    let leftovers: Vec<_> = std::fs::read_dir(vault.path().join("raw"))
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.contains(".tmp"))
+        .collect();
+    assert!(leftovers.is_empty(), "tempfile leftovers: {leftovers:?}");
+}
+
+#[tokio::test]
 async fn fixture_index_matches_snapshot() {
     let store = FixtureStore::default();
     store.upsert(sample_record()).await.unwrap();

--- a/crates/cairn-cli/tests/lint_folders.rs
+++ b/crates/cairn-cli/tests/lint_folders.rs
@@ -129,6 +129,37 @@ async fn atomic_writes_overwrite_stale_and_leave_no_tmp() {
 
 #[tokio::test]
 #[cfg(unix)]
+async fn symlinked_index_destination_is_rejected_even_when_unchanged() {
+    // `_index.md` itself as a symlink — even one whose target's content
+    // matches what we would write — must be rejected. Earlier the unchanged
+    // fast-path read through the symlink with `read_to_string` and skipped
+    // `write_once`, bypassing its symlink guard.
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    let attacker = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+
+    // Pre-populate the attacker target with arbitrary bytes.
+    std::fs::write(attacker.path().join("decoy.md"), b"decoy\n").unwrap();
+    // Plant a symlink at raw/_index.md pointing into the attacker tempdir.
+    std::os::unix::fs::symlink(
+        attacker.path().join("decoy.md"),
+        vault.path().join("raw/_index.md"),
+    )
+    .unwrap();
+
+    let result = fix_folders_handler(&store, vault.path()).await;
+
+    assert!(result.is_err(), "symlinked _index.md must be rejected");
+    // The attacker's file must remain untouched; we never wrote through.
+    let decoy = std::fs::read_to_string(attacker.path().join("decoy.md")).unwrap();
+    assert_eq!(decoy, "decoy\n", "attacker file was modified");
+}
+
+#[tokio::test]
+#[cfg(unix)]
 async fn write_through_symlinked_parent_is_rejected() {
     // The atomic-write path delegates to `vault::bootstrap::write_once`,
     // which lstat-checks the immediate parent. A symlinked `raw/` (the

--- a/crates/cairn-cli/tests/lint_folders.rs
+++ b/crates/cairn-cli/tests/lint_folders.rs
@@ -97,6 +97,38 @@ async fn sibling_subtree_unaffected_by_broken_policy() {
 }
 
 #[tokio::test]
+async fn corrupt_non_utf8_index_is_overwritten() {
+    // A pre-existing `_index.md` that contains non-UTF-8 bytes (e.g. a
+    // partial write left behind by a crash, or a binary file dropped by
+    // accident) must NOT abort the run with an InvalidData error — the
+    // whole point of `--fix-folders` is to recover state. We byte-compare
+    // instead of `read_to_string`, so the corrupt file is simply marked
+    // stale and overwritten atomically.
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+    // Plant invalid UTF-8 bytes at the destination.
+    std::fs::write(
+        vault.path().join("raw/_index.md"),
+        [0xFF, 0xFE, 0xFD, 0xFC].as_slice(),
+    )
+    .unwrap();
+
+    let result = fix_folders_handler(&store, vault.path()).await.unwrap();
+    assert!(
+        !result.written.is_empty(),
+        "expected the corrupt index to be replaced",
+    );
+    let content = std::fs::read_to_string(vault.path().join("raw/_index.md")).unwrap();
+    assert!(
+        content.contains("kind: folder_index"),
+        "corrupt content was not replaced: {content:?}"
+    );
+}
+
+#[tokio::test]
 async fn atomic_writes_overwrite_stale_and_leave_no_tmp() {
     let store = FixtureStore::default();
     store.upsert(sample_record()).await.unwrap();

--- a/crates/cairn-cli/tests/lint_folders.rs
+++ b/crates/cairn-cli/tests/lint_folders.rs
@@ -1,0 +1,59 @@
+//! Integration tests for `cairn lint --fix-folders` (issue #44).
+
+use cairn_cli::verbs::lint::{FixFoldersResult, fix_folders_handler};
+use cairn_core::contract::memory_store::MemoryStore;
+use cairn_test_fixtures::store::{FixtureStore, sample_record};
+
+#[tokio::test]
+async fn rebuilds_index_from_empty_markdown_tree() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    // Bootstrap-style minimal layout: just .cairn/ and raw/.
+    std::fs::create_dir_all(vault.path().join(".cairn")).unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+
+    let result: FixFoldersResult = fix_folders_handler(&store, vault.path()).await.unwrap();
+
+    assert!(
+        !result.written.is_empty(),
+        "expected at least one _index.md written"
+    );
+    let index = vault.path().join("raw/_index.md");
+    assert!(index.exists(), "raw/_index.md not written");
+    let content = std::fs::read_to_string(&index).unwrap();
+    assert!(content.contains("kind: folder_index"));
+}
+
+#[tokio::test]
+async fn idempotent_second_run_reports_unchanged() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+
+    let r1 = fix_folders_handler(&store, vault.path()).await.unwrap();
+    assert!(!r1.written.is_empty());
+
+    let r2 = fix_folders_handler(&store, vault.path()).await.unwrap();
+    assert!(r2.written.is_empty());
+    assert!(r2.unchanged > 0);
+}
+
+#[tokio::test]
+async fn bad_policy_yaml_does_not_abort_run() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+    std::fs::write(vault.path().join("raw/_policy.yaml"), "unknown_key: 42\n").unwrap();
+
+    let result = fix_folders_handler(&store, vault.path()).await.unwrap();
+    assert_eq!(result.policy_errors.len(), 1);
+    assert!(result.policy_errors[0].path.ends_with("raw/_policy.yaml"));
+    // The valid record's _index.md is still emitted.
+    assert!(vault.path().join("raw/_index.md").exists());
+}

--- a/crates/cairn-cli/tests/lint_folders.rs
+++ b/crates/cairn-cli/tests/lint_folders.rs
@@ -183,6 +183,77 @@ async fn write_through_symlinked_parent_is_rejected() {
 
 #[tokio::test]
 #[cfg(unix)]
+async fn write_through_symlinked_ancestor_is_rejected() {
+    // `lstat` only refuses to follow the FINAL path component; intermediate
+    // components are still resolved through symlinks. So a write at
+    // `vault/raw/a/_index.md` could traverse a symlinked `raw` and land
+    // outside the vault even with the immediate-parent guard. The fix walks
+    // every ancestor between vault_root and the target.
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    let attacker = tempfile::tempdir().unwrap();
+    // `raw` is a symlink that resolves to a real directory.
+    std::os::unix::fs::symlink(attacker.path(), vault.path().join("raw")).unwrap();
+    // The symlink's target has a real `a/` subdirectory; `_index.md` would
+    // be created at `attacker/a/_index.md` if validation only checked the
+    // immediate parent (which lstats `vault/raw/a` and sees a real dir).
+    std::fs::create_dir_all(attacker.path().join("a")).unwrap();
+
+    let result = fix_folders_handler(&store, vault.path()).await;
+
+    assert!(result.is_err(), "symlinked ancestor must be rejected");
+    assert!(
+        !attacker.path().join("a/_index.md").exists(),
+        "write reached attacker subdirectory through symlinked ancestor",
+    );
+    assert!(
+        !attacker.path().join("_index.md").exists(),
+        "write reached attacker root through symlinked ancestor",
+    );
+}
+
+#[tokio::test]
+async fn symlinked_policy_yaml_taints_subtree() {
+    // A `_policy.yaml` that is itself a symlink (or any non-regular file)
+    // must be reported as a policy error and taint its containing folder.
+    // `walkdir(follow_links=false)` returns symlinks as non-files, and the
+    // earlier code skipped non-files silently — fail-OPEN, not fail-closed.
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+    let real_target = vault.path().join("decoy.yaml");
+    std::fs::write(&real_target, "anything\n").unwrap();
+    std::os::unix::fs::symlink(&real_target, vault.path().join("raw/_policy.yaml")).unwrap();
+
+    let result = fix_folders_handler(&store, vault.path()).await.unwrap();
+
+    assert_eq!(
+        result.policy_errors.len(),
+        1,
+        "symlinked _policy.yaml must produce a PolicyError"
+    );
+    assert!(
+        result.policy_errors[0].path.ends_with("raw/_policy.yaml"),
+        "unexpected policy error path: {:?}",
+        result.policy_errors[0].path
+    );
+    assert!(
+        result.written.is_empty(),
+        "expected no _index.md when raw/ is tainted, got {:?}",
+        result.written,
+    );
+    assert!(
+        !vault.path().join("raw/_index.md").exists(),
+        "raw/_index.md must not be written under a symlinked policy",
+    );
+}
+
+#[tokio::test]
+#[cfg(unix)]
 async fn non_utf8_policy_yaml_taints_subtree_not_run() {
     let store = FixtureStore::default();
     store.upsert(sample_record()).await.unwrap();

--- a/crates/cairn-cli/tests/lint_folders.rs
+++ b/crates/cairn-cli/tests/lint_folders.rs
@@ -57,3 +57,24 @@ async fn bad_policy_yaml_does_not_abort_run() {
     // The valid record's _index.md is still emitted.
     assert!(vault.path().join("raw/_index.md").exists());
 }
+
+#[tokio::test]
+async fn fixture_index_matches_snapshot() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+
+    let _ = fix_folders_handler(&store, vault.path()).await.unwrap();
+    let content = std::fs::read_to_string(vault.path().join("raw/_index.md")).unwrap();
+
+    // Strip the timestamped `updated_at` line so the snapshot stays stable.
+    let stable: String = content
+        .lines()
+        .filter(|l| !l.starts_with("updated_at:") && !l.contains("· updated "))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    insta::assert_snapshot!("raw_index_single_record", stable);
+}

--- a/crates/cairn-cli/tests/lint_folders.rs
+++ b/crates/cairn-cli/tests/lint_folders.rs
@@ -43,7 +43,13 @@ async fn idempotent_second_run_reports_unchanged() {
 }
 
 #[tokio::test]
-async fn bad_policy_yaml_does_not_abort_run() {
+async fn bad_policy_yaml_taints_subtree_and_skips_indexing() {
+    // Brief invariant 6 (fail-closed): a folder with an unparseable
+    // _policy.yaml must skip its entire subtree, not silently fall back to
+    // default policy. The sample record projects to `raw/<kind>_<id>.md`,
+    // so a broken `raw/_policy.yaml` taints the parent of every record we
+    // emit — no `_index.md` should be written, but the parse failure is
+    // surfaced via `policy_errors`.
     let store = FixtureStore::default();
     store.upsert(sample_record()).await.unwrap();
 
@@ -54,8 +60,40 @@ async fn bad_policy_yaml_does_not_abort_run() {
     let result = fix_folders_handler(&store, vault.path()).await.unwrap();
     assert_eq!(result.policy_errors.len(), 1);
     assert!(result.policy_errors[0].path.ends_with("raw/_policy.yaml"));
-    // The valid record's _index.md is still emitted.
-    assert!(vault.path().join("raw/_index.md").exists());
+    // Tainted prefix → record dropped → no index for `raw/`.
+    assert!(
+        result.written.is_empty(),
+        "expected no _index.md when raw/ is tainted, got {:?}",
+        result.written,
+    );
+    assert!(
+        !vault.path().join("raw/_index.md").exists(),
+        "raw/_index.md must not be written under a tainted policy",
+    );
+}
+
+#[tokio::test]
+async fn sibling_subtree_unaffected_by_broken_policy() {
+    // A broken policy under `raw/broken/` must not taint `raw/` itself.
+    // The sample record sits directly in `raw/`, outside the tainted
+    // subtree, so its index is still written.
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw/broken")).unwrap();
+    std::fs::write(
+        vault.path().join("raw/broken/_policy.yaml"),
+        "unknown_key: 42\n",
+    )
+    .unwrap();
+
+    let result = fix_folders_handler(&store, vault.path()).await.unwrap();
+    assert_eq!(result.policy_errors.len(), 1);
+    assert!(
+        vault.path().join("raw/_index.md").exists(),
+        "sibling subtree raw/ should still be indexed",
+    );
 }
 
 #[tokio::test]

--- a/crates/cairn-cli/tests/lint_folders.rs
+++ b/crates/cairn-cli/tests/lint_folders.rs
@@ -151,6 +151,36 @@ async fn write_through_symlinked_parent_is_rejected() {
 }
 
 #[tokio::test]
+#[cfg(unix)]
+async fn non_utf8_policy_yaml_taints_subtree_not_run() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+    std::fs::create_dir_all(vault.path().join("raw/broken")).unwrap();
+
+    // Write non-UTF-8 bytes — 0xFF, 0xFE are invalid as UTF-8 in this position.
+    std::fs::write(
+        vault.path().join("raw/broken/_policy.yaml"),
+        [0xFF, 0xFE, 0xFD, 0xFC].as_slice(),
+    )
+    .unwrap();
+
+    let result = fix_folders_handler(&store, vault.path()).await.unwrap();
+
+    // Run did NOT abort. raw/_index.md still emitted (sibling subtree).
+    assert!(vault.path().join("raw/_index.md").exists());
+    // The broken policy is recorded as a policy error.
+    assert_eq!(result.policy_errors.len(), 1);
+    assert!(
+        result.policy_errors[0]
+            .path
+            .ends_with("raw/broken/_policy.yaml")
+    );
+}
+
+#[tokio::test]
 async fn fixture_index_matches_snapshot() {
     let store = FixtureStore::default();
     store.upsert(sample_record()).await.unwrap();

--- a/crates/cairn-cli/tests/snapshots/lint_folders__raw_index_single_record.snap
+++ b/crates/cairn-cli/tests/snapshots/lint_folders__raw_index_single_record.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cairn-cli/tests/lint_folders.rs
+expression: stable
+---
+---
+folder: raw
+kind: folder_index
+record_count: 1
+subfolder_count: 0
+---
+
+# raw
+
+## Records (1)

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -30,7 +30,7 @@ pub struct MemoryStoreCapabilities {
 /// `version` is the monotonic per-`target_id` counter from the DB COW model
 /// (brief §3.0). Projection and resync use it for optimistic concurrency
 /// checks without touching the DB row directly.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct StoredRecord {
     /// The stored memory record.
     pub record: MemoryRecord,

--- a/crates/cairn-core/src/contract/workflow_orchestrator.rs
+++ b/crates/cairn-core/src/contract/workflow_orchestrator.rs
@@ -3,7 +3,10 @@
 //! P0 default: tokio + `SQLite`-backed job table (#89). Optional Temporal
 //! adapter is a P1+ swap — same trait.
 
+use std::path::PathBuf;
+
 use crate::contract::version::{ContractVersion, VersionRange};
+use crate::domain::Rfc3339Timestamp;
 
 /// Contract version for `WorkflowOrchestrator`. Bumps when the trait surface changes.
 pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 1, 0);
@@ -36,6 +39,53 @@ pub trait WorkflowOrchestrator: Send + Sync {
 
     /// Range of `WorkflowOrchestrator::CONTRACT_VERSION` values this impl accepts.
     fn supported_contract_versions(&self) -> VersionRange;
+}
+
+/// Schema for `_summary.md` (brief §3.4). P0 ships types only — body
+/// generation is the P1 `FolderSummaryWorkflow`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FolderSummary {
+    /// Vault-relative folder path.
+    pub folder: PathBuf,
+    /// When this summary was generated.
+    pub generated_at: Rfc3339Timestamp,
+    /// Agent that generated the summary (e.g. `agt:cairn-librarian:v2`).
+    pub generated_by: String,
+    /// Number of records the summary covers.
+    pub covers_records: u32,
+    /// Approximate token count of `body`.
+    pub summary_tokens: u32,
+    /// Generated prose body.
+    pub body: String,
+}
+
+/// Errors raised by [`FolderSummaryWriter`] implementations.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FolderSummaryError {
+    /// No summary writer is registered (P0 default).
+    #[error("folder summary writer not registered")]
+    Unimplemented,
+    /// Internal error from the writer implementation.
+    #[error("folder summary writer internal: {0}")]
+    Internal(String),
+}
+
+/// Workflow-owned write surface for `_summary.md`. P0 ships zero
+/// implementations; P1 `cairn-workflows::FolderSummaryWorkflow` is the
+/// first implementor.
+#[async_trait::async_trait]
+pub trait FolderSummaryWriter: Send + Sync {
+    /// Persist a generated [`FolderSummary`] as `_summary.md` under its
+    /// folder, atomically. Implementors are responsible for I/O safety
+    /// (atomic rename, symlink rejection).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FolderSummaryError::Unimplemented`] when no writer is
+    /// registered, or [`FolderSummaryError::Internal`] for I/O / encoding
+    /// failures.
+    async fn write_summary(&self, summary: FolderSummary) -> Result<(), FolderSummaryError>;
 }
 
 /// Static identity descriptor for a [`WorkflowOrchestrator`] plugin (§4.1).
@@ -91,5 +141,20 @@ mod tests {
     fn static_consts_accessible() {
         assert_eq!(StubOrch::NAME, "stub-orch");
         assert!(StubOrch::SUPPORTED_VERSIONS.accepts(CONTRACT_VERSION));
+    }
+
+    #[test]
+    fn folder_summary_writer_trait_object_compiles() {
+        struct Stub;
+        #[async_trait::async_trait]
+        impl FolderSummaryWriter for Stub {
+            async fn write_summary(
+                &self,
+                _summary: FolderSummary,
+            ) -> Result<(), FolderSummaryError> {
+                Err(FolderSummaryError::Unimplemented)
+            }
+        }
+        let _: Box<dyn FolderSummaryWriter> = Box::new(Stub);
     }
 }

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -163,6 +163,106 @@ pub fn aggregate_folders(
     states
 }
 
+use crate::domain::projection::ProjectedFile;
+
+/// Project a [`FolderState`] to a `_index.md` file. Caller is responsible
+/// for ensuring deterministic sort order on `state.records`,
+/// `state.subfolders`, and `state.backlinks`.
+#[must_use]
+pub fn project_index(state: &FolderState) -> ProjectedFile {
+    use std::fmt::Write as _;
+
+    let folder_str = state.path.to_string_lossy();
+    let updated_at = state
+        .records
+        .iter()
+        .map(|r| r.record.updated_at.as_str())
+        .chain(
+            state
+                .subfolders
+                .iter()
+                .filter_map(|s| s.last_updated.as_ref().map(Rfc3339Timestamp::as_str)),
+        )
+        .max()
+        .unwrap_or("1970-01-01T00:00:00Z")
+        .to_owned();
+
+    let mut frontmatter = String::new();
+    frontmatter.push_str("---\n");
+    // Writing to a String is infallible; discard the Ok(()) result.
+    let _ = writeln!(frontmatter, "folder: {folder_str}");
+    frontmatter.push_str("kind: folder_index\n");
+    let _ = writeln!(frontmatter, "updated_at: {updated_at}");
+    let _ = writeln!(frontmatter, "record_count: {}", state.records.len());
+    let _ = writeln!(frontmatter, "subfolder_count: {}", state.subfolders.len());
+    if let Some(purpose) = &state.effective_policy.purpose {
+        // Quote with serde_yaml to avoid breaking on `:` / leading whitespace.
+        let yaml_val = serde_yaml::Value::String(purpose.clone());
+        let s = serde_yaml::to_string(&yaml_val)
+            .ok()
+            .and_then(|s| s.strip_prefix("---\n").map(str::to_owned).or(Some(s)))
+            .unwrap_or_else(|| purpose.clone());
+        let s = s.trim_end_matches('\n');
+        let _ = writeln!(frontmatter, "purpose: {s}");
+    }
+    frontmatter.push_str("---\n\n");
+
+    let mut body = String::new();
+    let _ = writeln!(body, "# {folder_str}");
+
+    if !state.records.is_empty() {
+        let _ = write!(body, "\n## Records ({})\n", state.records.len());
+        for s in &state.records {
+            // path = folder / "<kind>_<id>.md" — same as MarkdownProjector.
+            let leaf = format!(
+                "{}_{}.md",
+                s.record.kind.as_str(),
+                s.record.id.as_str(),
+            );
+            let _ = writeln!(
+                body,
+                "- [{leaf}]({leaf}) — {kind} · updated {upd}",
+                kind = s.record.kind.as_str(),
+                upd = s.record.updated_at.as_str(),
+            );
+        }
+    }
+
+    if !state.subfolders.is_empty() {
+        let _ = write!(body, "\n## Subfolders ({})\n", state.subfolders.len());
+        for sf in &state.subfolders {
+            let upd = sf
+                .last_updated
+                .as_ref()
+                .map(|t| format!(" · last updated {}", t.as_str()))
+                .unwrap_or_default();
+            let _ = writeln!(
+                body,
+                "- [{name}/]({name}/) — {n} records{upd}",
+                name = sf.name,
+                n = sf.record_count,
+            );
+        }
+    }
+
+    if !state.backlinks.is_empty() {
+        let _ = write!(
+            body,
+            "\n## Backlinks into this folder ({})\n",
+            state.backlinks.len(),
+        );
+        for bl in &state.backlinks {
+            let p = bl.source_path.to_string_lossy();
+            let _ = writeln!(body, "- [{p}]({p})");
+        }
+    }
+
+    ProjectedFile {
+        path: state.path.join("_index.md"),
+        content: format!("{frontmatter}{body}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -258,5 +358,95 @@ mod tests {
             .find(|s| s.path == Path::new("raw"))
             .expect("raw state");
         assert_eq!(raw.backlinks.len(), 1);
+    }
+
+    use crate::domain::projection::ProjectedFile;
+
+    #[test]
+    fn project_emits_required_frontmatter_fields() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf: ProjectedFile = project_index(&state);
+        assert_eq!(pf.path, PathBuf::from("raw/_index.md"));
+        assert!(pf.content.contains("folder: raw"));
+        assert!(pf.content.contains("kind: folder_index"));
+        assert!(pf.content.contains("record_count: 0"));
+        assert!(pf.content.contains("subfolder_count: 0"));
+    }
+
+    #[test]
+    fn project_omits_purpose_when_unset() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(!pf.content.contains("purpose:"));
+    }
+
+    #[test]
+    fn project_includes_purpose_when_set() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy {
+                purpose: Some("things".into()),
+                ..EffectivePolicy::default()
+            },
+        };
+        let pf = project_index(&state);
+        assert!(pf.content.contains("purpose: things"));
+    }
+
+    #[test]
+    fn project_is_deterministic() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: vec![
+                SubfolderEntry {
+                    name: "b".into(),
+                    record_count: 1,
+                    last_updated: None,
+                },
+                SubfolderEntry {
+                    name: "a".into(),
+                    record_count: 1,
+                    last_updated: None,
+                },
+            ],
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+        let mut state = state;
+        state.subfolders.sort_by(|a, b| a.name.cmp(&b.name));
+        let a = project_index(&state);
+        let b = project_index(&state);
+        assert_eq!(a.content, b.content);
+    }
+
+    #[test]
+    fn project_omits_empty_sections() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(!pf.content.contains("## Records"));
+        assert!(!pf.content.contains("## Subfolders"));
+        assert!(!pf.content.contains("## Backlinks"));
     }
 }

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -214,11 +214,7 @@ pub fn project_index(state: &FolderState) -> ProjectedFile {
         let _ = write!(body, "\n## Records ({})\n", state.records.len());
         for s in &state.records {
             // path = folder / "<kind>_<id>.md" — same as MarkdownProjector.
-            let leaf = format!(
-                "{}_{}.md",
-                s.record.kind.as_str(),
-                s.record.id.as_str(),
-            );
+            let leaf = format!("{}_{}.md", s.record.kind.as_str(), s.record.id.as_str(),);
             let _ = writeln!(
                 body,
                 "- [{leaf}]({leaf}) — {kind} · updated {upd}",

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -1,0 +1,1 @@
+//! Folder aggregation + `_index.md` projection.

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -102,10 +102,12 @@ pub fn aggregate_folders(
             let entry = subtree_last_update
                 .entry(d.to_path_buf())
                 .or_insert_with(|| stored.record.updated_at.clone());
-            // Lexical comparison is correct for UTC timestamps (all `Z`-form);
-            // callers that ingest mixed-offset timestamps must normalise to UTC
-            // before calling this function.
-            if stored.record.updated_at.as_str() > entry.as_str() {
+            // Chronological comparison: lexical comparison of the raw string
+            // disagrees with chronological order once offsets are involved
+            // (e.g. `+02:00` happens before `Z` for the same wall-clock
+            // hour).  `Rfc3339Timestamp::cmp_chronological` parses both
+            // sides and applies the offset.
+            if stored.record.updated_at.cmp_chronological(entry).is_gt() {
                 *entry = stored.record.updated_at.clone();
             }
             cur = d.parent();
@@ -181,19 +183,24 @@ pub fn project_index(state: &FolderState) -> ProjectedFile {
     use std::fmt::Write as _;
 
     let folder_str = state.path.to_string_lossy();
+    // Chronological max: `Rfc3339Timestamp` deliberately doesn't implement
+    // `Ord` because lexical order disagrees with wall-clock order across
+    // timezone offsets.  Reduce by `cmp_chronological` instead.
     let updated_at = state
         .records
         .iter()
-        .map(|r| r.record.record.updated_at.as_str())
+        .map(|r| &r.record.record.updated_at)
         .chain(
             state
                 .subfolders
                 .iter()
-                .filter_map(|s| s.last_updated.as_ref().map(Rfc3339Timestamp::as_str)),
+                .filter_map(|s| s.last_updated.as_ref()),
         )
-        .max()
-        .unwrap_or("1970-01-01T00:00:00Z")
-        .to_owned();
+        .max_by(|a, b| a.cmp_chronological(b))
+        .map_or_else(
+            || "1970-01-01T00:00:00Z".to_owned(),
+            |t| t.as_str().to_owned(),
+        );
 
     let mut frontmatter = String::new();
     frontmatter.push_str("---\n");

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -1,1 +1,66 @@
 //! Folder aggregation + `_index.md` projection.
+
+use std::path::PathBuf;
+
+use crate::contract::memory_store::StoredRecord;
+use crate::domain::folder::links::Backlink;
+use crate::domain::folder::policy::EffectivePolicy;
+use crate::domain::record::RecordId;
+use crate::domain::{MemoryKind, Rfc3339Timestamp};
+
+/// Per-record summary line for a folder index.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordEntry {
+    /// Vault-relative path of the record file.
+    pub path: PathBuf,
+    /// Record id.
+    pub id: RecordId,
+    /// Memory kind.
+    pub kind: MemoryKind,
+    /// Last-update timestamp from the stored record.
+    pub updated_at: Rfc3339Timestamp,
+    /// Backlinks pointing at this record.
+    pub backlink_count: u32,
+}
+
+/// Per-subfolder aggregate row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubfolderEntry {
+    /// Subfolder name (basename, no trailing slash).
+    pub name: String,
+    /// Number of records inside the subtree.
+    pub record_count: u32,
+    /// Latest `updated_at` across the subtree.
+    pub last_updated: Option<Rfc3339Timestamp>,
+}
+
+/// Aggregated state for one folder, ready to project as `_index.md`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FolderState {
+    /// Vault-relative folder path.
+    pub path: PathBuf,
+    /// Records living directly in this folder, sorted by kind then id.
+    pub records: Vec<StoredRecord>,
+    /// Subfolders, sorted by name.
+    pub subfolders: Vec<SubfolderEntry>,
+    /// Backlinks targeting any record in this folder, sorted by source path.
+    pub backlinks: Vec<Backlink>,
+    /// Resolved effective policy at this folder.
+    pub effective_policy: EffectivePolicy,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folder_state_compiles_with_default_policy() {
+        let _ = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+    }
+}

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -214,7 +214,7 @@ pub fn project_index(state: &FolderState) -> ProjectedFile {
         let _ = write!(body, "\n## Records ({})\n", state.records.len());
         for s in &state.records {
             // path = folder / "<kind>_<id>.md" — same as MarkdownProjector.
-            let leaf = format!("{}_{}.md", s.record.kind.as_str(), s.record.id.as_str(),);
+            let leaf = format!("{}_{}.md", s.record.kind.as_str(), s.record.id.as_str());
             let _ = writeln!(
                 body,
                 "- [{leaf}]({leaf}) — {kind} · updated {upd}",

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -1,10 +1,11 @@
 //! Folder aggregation + `_index.md` projection.
 
-use std::path::PathBuf;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 use crate::contract::memory_store::StoredRecord;
 use crate::domain::folder::links::Backlink;
-use crate::domain::folder::policy::EffectivePolicy;
+use crate::domain::folder::policy::{EffectivePolicy, FolderPolicy, resolve_policy};
 use crate::domain::record::RecordId;
 use crate::domain::{MemoryKind, Rfc3339Timestamp};
 
@@ -49,6 +50,119 @@ pub struct FolderState {
     pub effective_policy: EffectivePolicy,
 }
 
+/// Group records by their parent folder, walk up to compute subfolder
+/// aggregates, attach backlinks targeting records in each folder, and
+/// resolve the effective policy at each folder. Returns one
+/// [`FolderState`] per folder that is non-empty (has at least one record
+/// in its subtree).
+#[must_use]
+pub fn aggregate_folders(
+    records: &[StoredRecord],
+    record_paths: &BTreeMap<RecordId, PathBuf>,
+    policies_by_dir: &BTreeMap<PathBuf, FolderPolicy>,
+    backlinks_by_target: &BTreeMap<PathBuf, Vec<Backlink>>,
+) -> Vec<FolderState> {
+    // 1. Pair records with their resolved paths.
+    let mut paired: Vec<(PathBuf, &StoredRecord)> = Vec::new();
+    for stored in records {
+        let Some(p) = record_paths.get(&stored.record.id) else {
+            continue;
+        };
+        paired.push((p.clone(), stored));
+    }
+    paired.sort_by(|a, b| {
+        a.1.record
+            .kind
+            .as_str()
+            .cmp(b.1.record.kind.as_str())
+            .then_with(|| a.1.record.id.as_str().cmp(b.1.record.id.as_str()))
+    });
+
+    // 2. Collect every folder path that has either a direct record OR a
+    //    descendant with a record. Record per-subtree counts.
+    let mut subtree_count: BTreeMap<PathBuf, u32> = BTreeMap::new();
+    let mut subtree_last_update: BTreeMap<PathBuf, Rfc3339Timestamp> = BTreeMap::new();
+    let mut direct: BTreeMap<PathBuf, Vec<&StoredRecord>> = BTreeMap::new();
+
+    for (path, stored) in &paired {
+        let parent = path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map_or_else(|| PathBuf::from(""), Path::to_path_buf);
+        direct.entry(parent.clone()).or_default().push(*stored);
+
+        // Walk every ancestor (parent inclusive) and bump counts.
+        let mut cur: Option<&Path> = Some(&parent);
+        while let Some(d) = cur {
+            if d.as_os_str().is_empty() {
+                break;
+            }
+            *subtree_count.entry(d.to_path_buf()).or_insert(0) += 1;
+            let entry = subtree_last_update
+                .entry(d.to_path_buf())
+                .or_insert_with(|| stored.record.updated_at.clone());
+            // Lexical comparison is correct for UTC timestamps (all `Z`-form);
+            // callers that ingest mixed-offset timestamps must normalise to UTC
+            // before calling this function.
+            if stored.record.updated_at.as_str() > entry.as_str() {
+                *entry = stored.record.updated_at.clone();
+            }
+            cur = d.parent();
+        }
+    }
+
+    // 3. For every folder in `subtree_count`, build a FolderState.
+    let mut states: Vec<FolderState> = Vec::new();
+    for folder in subtree_count.keys() {
+        let direct_records: Vec<StoredRecord> = direct
+            .get(folder)
+            .map(|v| v.iter().map(|r| (*r).clone()).collect())
+            .unwrap_or_default();
+
+        // Subfolders: any path in `subtree_count` whose parent equals `folder`.
+        let mut subfolders: Vec<SubfolderEntry> = subtree_count
+            .iter()
+            .filter_map(|(p, c)| {
+                if p.parent() == Some(folder) {
+                    Some(SubfolderEntry {
+                        name: p
+                            .file_name()
+                            .map(|s| s.to_string_lossy().into_owned())
+                            .unwrap_or_default(),
+                        record_count: *c,
+                        last_updated: subtree_last_update.get(p).cloned(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        subfolders.sort_by(|a, b| a.name.cmp(&b.name));
+
+        // Backlinks: any entry in backlinks_by_target whose target lives in this folder.
+        let mut blinks: Vec<Backlink> = backlinks_by_target
+            .iter()
+            .filter(|(target, _)| target.parent() == Some(folder))
+            .flat_map(|(_, v)| v.iter().cloned())
+            .collect();
+        blinks.sort_by(|a, b| a.source_path.cmp(&b.source_path));
+
+        // Effective policy: walk up from a synthetic file inside this folder.
+        let synthetic = folder.join("_dummy.md");
+        let effective_policy = resolve_policy(&synthetic, policies_by_dir);
+
+        states.push(FolderState {
+            path: folder.clone(),
+            records: direct_records,
+            subfolders,
+            backlinks: blinks,
+            effective_policy,
+        });
+    }
+    states.sort_by(|a, b| a.path.cmp(&b.path));
+    states
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,5 +176,87 @@ mod tests {
             backlinks: Vec::new(),
             effective_policy: EffectivePolicy::default(),
         };
+    }
+
+    use crate::domain::record::tests::sample_stored_record;
+
+    fn fixture_record(suffix_id: &str) -> StoredRecord {
+        // RecordId is constructed via `parse` — the suffix must be valid
+        // Crockford base32 chars and total length must be exactly 26.
+        // Base: "01HQZX9F5N" (10 chars) + "0000000000" (10 zeros) + 6-char suffix = 26 chars.
+        let mut s = sample_stored_record(1);
+        s.record.id = RecordId::parse(format!("01HQZX9F5N0000000000{suffix_id:0>6}"))
+            .expect("valid record id");
+        s
+    }
+
+    #[test]
+    fn aggregate_single_record_yields_one_folder() {
+        let r = fixture_record("000A");
+        let mut paths = BTreeMap::new();
+        paths.insert(r.record.id.clone(), PathBuf::from("raw/x.md"));
+        let states = aggregate_folders(&[r], &paths, &BTreeMap::new(), &BTreeMap::new());
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].path, PathBuf::from("raw"));
+        assert_eq!(states[0].records.len(), 1);
+        assert!(states[0].subfolders.is_empty());
+    }
+
+    #[test]
+    fn aggregate_nested_propagates_subfolder_counts() {
+        let r1 = fixture_record("000001");
+        let r2 = fixture_record("000002");
+        let mut paths = BTreeMap::new();
+        paths.insert(r1.record.id.clone(), PathBuf::from("raw/a/x.md"));
+        paths.insert(r2.record.id.clone(), PathBuf::from("raw/a/b/y.md"));
+        let states = aggregate_folders(&[r1, r2], &paths, &BTreeMap::new(), &BTreeMap::new());
+        let by_path: BTreeMap<PathBuf, &FolderState> =
+            states.iter().map(|s| (s.path.clone(), s)).collect();
+        let raw = by_path.get(Path::new("raw")).expect("raw");
+        let raw_a = by_path.get(Path::new("raw/a")).expect("raw/a");
+        let raw_a_b = by_path.get(Path::new("raw/a/b")).expect("raw/a/b");
+        // raw has one subfolder (a), no direct records.
+        assert!(raw.records.is_empty());
+        assert_eq!(raw.subfolders.len(), 1);
+        assert_eq!(raw.subfolders[0].name, "a");
+        assert_eq!(raw.subfolders[0].record_count, 2);
+        // raw/a has one direct record + one subfolder (b).
+        assert_eq!(raw_a.records.len(), 1);
+        assert_eq!(raw_a.subfolders.len(), 1);
+        assert_eq!(raw_a.subfolders[0].record_count, 1);
+        // raw/a/b has one direct record, no subfolders.
+        assert_eq!(raw_a_b.records.len(), 1);
+        assert!(raw_a_b.subfolders.is_empty());
+    }
+
+    #[test]
+    fn aggregate_skips_empty_folders() {
+        let r = fixture_record("000001");
+        let mut paths = BTreeMap::new();
+        paths.insert(r.record.id.clone(), PathBuf::from("raw/x.md"));
+        let states = aggregate_folders(&[r], &paths, &BTreeMap::new(), &BTreeMap::new());
+        assert!(states.iter().all(|s| s.path != Path::new("wiki")));
+    }
+
+    #[test]
+    fn aggregate_attaches_backlinks_to_target_folder() {
+        let r = fixture_record("000001");
+        let mut paths = BTreeMap::new();
+        paths.insert(r.record.id.clone(), PathBuf::from("raw/x.md"));
+        let mut backlinks = BTreeMap::new();
+        backlinks.insert(
+            PathBuf::from("raw/x.md"),
+            vec![Backlink {
+                source_path: PathBuf::from("raw/y.md"),
+                target_path: PathBuf::from("raw/x.md"),
+                anchor: None,
+            }],
+        );
+        let states = aggregate_folders(&[r], &paths, &BTreeMap::new(), &backlinks);
+        let raw = states
+            .iter()
+            .find(|s| s.path == Path::new("raw"))
+            .expect("raw state");
+        assert_eq!(raw.backlinks.len(), 1);
     }
 }

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -20,13 +20,26 @@ pub struct SubfolderEntry {
     pub last_updated: Option<Rfc3339Timestamp>,
 }
 
+/// One direct record under a folder, paired with its caller-supplied
+/// vault-relative path.  Carrying the path explicitly avoids reconstructing
+/// `<kind>_<id>.md` inside [`project_index`], which would silently emit
+/// broken links if the projector adopts a different naming scheme (e.g.
+/// `raw/a/x.md`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordEntry {
+    /// Vault-relative path of the projected markdown file for this record.
+    pub path: PathBuf,
+    /// The full stored record.
+    pub record: StoredRecord,
+}
+
 /// Aggregated state for one folder, ready to project as `_index.md`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FolderState {
     /// Vault-relative folder path.
     pub path: PathBuf,
     /// Records living directly in this folder, sorted by kind then id.
-    pub records: Vec<StoredRecord>,
+    pub records: Vec<RecordEntry>,
     /// Subfolders, sorted by name.
     pub subfolders: Vec<SubfolderEntry>,
     /// Backlinks targeting any record in this folder, sorted by source path.
@@ -67,14 +80,17 @@ pub fn aggregate_folders(
     //    descendant with a record. Record per-subtree counts.
     let mut subtree_count: BTreeMap<PathBuf, u32> = BTreeMap::new();
     let mut subtree_last_update: BTreeMap<PathBuf, Rfc3339Timestamp> = BTreeMap::new();
-    let mut direct: BTreeMap<PathBuf, Vec<&StoredRecord>> = BTreeMap::new();
+    let mut direct: BTreeMap<PathBuf, Vec<(PathBuf, &StoredRecord)>> = BTreeMap::new();
 
     for (path, stored) in &paired {
         let parent = path
             .parent()
             .filter(|p| !p.as_os_str().is_empty())
             .map_or_else(|| PathBuf::from(""), Path::to_path_buf);
-        direct.entry(parent.clone()).or_default().push(*stored);
+        direct
+            .entry(parent.clone())
+            .or_default()
+            .push((path.clone(), *stored));
 
         // Walk every ancestor (parent inclusive) and bump counts.
         let mut cur: Option<&Path> = Some(&parent);
@@ -99,9 +115,16 @@ pub fn aggregate_folders(
     // 3. For every folder in `subtree_count`, build a FolderState.
     let mut states: Vec<FolderState> = Vec::new();
     for folder in subtree_count.keys() {
-        let direct_records: Vec<StoredRecord> = direct
+        let direct_records: Vec<RecordEntry> = direct
             .get(folder)
-            .map(|v| v.iter().map(|r| (*r).clone()).collect())
+            .map(|v| {
+                v.iter()
+                    .map(|(p, r)| RecordEntry {
+                        path: p.clone(),
+                        record: (*r).clone(),
+                    })
+                    .collect()
+            })
             .unwrap_or_default();
 
         // Subfolders: any path in `subtree_count` whose parent equals `folder`.
@@ -161,7 +184,7 @@ pub fn project_index(state: &FolderState) -> ProjectedFile {
     let updated_at = state
         .records
         .iter()
-        .map(|r| r.record.updated_at.as_str())
+        .map(|r| r.record.record.updated_at.as_str())
         .chain(
             state
                 .subfolders
@@ -197,20 +220,23 @@ pub fn project_index(state: &FolderState) -> ProjectedFile {
 
     if !state.records.is_empty() {
         let _ = write!(body, "\n## Records ({})\n", state.records.len());
-        for s in &state.records {
-            // path = folder / "<kind>_<id>.md" — same as MarkdownProjector.
-            let leaf = format!("{}_{}.md", s.record.kind.as_str(), s.record.id.as_str());
-            let projected_path = state.path.join(&leaf);
+        for entry in &state.records {
+            // Render the leaf relative to the folder containing the index,
+            // and resolve backlink counts against the record's actual
+            // vault-relative path.  Any reconstruction would diverge if the
+            // projector chooses a different naming scheme.
+            let leaf = relativize(&state.path, &entry.path);
+            let leaf_str = leaf.to_string_lossy();
             let backlink_count = state
                 .backlinks
                 .iter()
-                .filter(|bl| bl.target_path == projected_path)
+                .filter(|bl| bl.target_path == entry.path)
                 .count();
             let _ = writeln!(
                 body,
-                "- [{leaf}]({leaf}) — {kind} · updated {upd} · {backlink_count} backlinks",
-                kind = s.record.kind.as_str(),
-                upd = s.record.updated_at.as_str(),
+                "- [{leaf_str}]({leaf_str}) — {kind} · updated {upd} · {backlink_count} backlinks",
+                kind = entry.record.record.kind.as_str(),
+                upd = entry.record.record.updated_at.as_str(),
             );
         }
     }
@@ -494,7 +520,10 @@ mod tests {
         let target_path = PathBuf::from(format!("raw/{leaf}"));
         let state = FolderState {
             path: PathBuf::from("raw"),
-            records: vec![stored.clone()],
+            records: vec![RecordEntry {
+                path: target_path.clone(),
+                record: stored.clone(),
+            }],
             subfolders: Vec::new(),
             backlinks: vec![Backlink {
                 source_path: PathBuf::from("raw/other.md"),
@@ -513,6 +542,41 @@ mod tests {
         assert!(
             pf.content.contains("· 1 backlinks"),
             "expected backlink count, got:\n{}",
+            pf.content
+        );
+    }
+
+    #[test]
+    fn project_records_section_uses_actual_record_path_for_nested_leaf() {
+        // A record at `raw/a/x.md` (not the `<kind>_<id>.md` reconstructed
+        // shape) must render its leaf as `a/x.md` from `raw/_index.md`, and
+        // its backlink count must be matched against the actual path.
+        use crate::domain::record::tests::sample_stored_record;
+        let stored = sample_stored_record(1);
+        let actual_path = PathBuf::from("raw/a/x.md");
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: vec![RecordEntry {
+                path: actual_path.clone(),
+                record: stored,
+            }],
+            subfolders: Vec::new(),
+            backlinks: vec![Backlink {
+                source_path: PathBuf::from("raw/other.md"),
+                target_path: actual_path,
+                anchor: None,
+            }],
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(
+            pf.content.contains("- [a/x.md](a/x.md)"),
+            "expected nested leaf 'a/x.md', got:\n{}",
+            pf.content
+        );
+        assert!(
+            pf.content.contains("· 1 backlinks"),
+            "expected backlink count to match actual record path, got:\n{}",
             pf.content
         );
     }
@@ -619,9 +683,17 @@ mod tests {
     fn project_records_section_renders_zero_backlinks_when_state_empty() {
         use crate::domain::record::tests::sample_stored_record;
         let stored = sample_stored_record(1);
+        let leaf = format!(
+            "{}_{}.md",
+            stored.record.kind.as_str(),
+            stored.record.id.as_str()
+        );
         let state = FolderState {
             path: PathBuf::from("raw"),
-            records: vec![stored],
+            records: vec![RecordEntry {
+                path: PathBuf::from(format!("raw/{leaf}")),
+                record: stored,
+            }],
             subfolders: Vec::new(),
             backlinks: Vec::new(),
             effective_policy: EffectivePolicy::default(),

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -4,25 +4,10 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::contract::memory_store::StoredRecord;
+use crate::domain::Rfc3339Timestamp;
 use crate::domain::folder::links::Backlink;
 use crate::domain::folder::policy::{EffectivePolicy, FolderPolicy, resolve_policy};
 use crate::domain::record::RecordId;
-use crate::domain::{MemoryKind, Rfc3339Timestamp};
-
-/// Per-record summary line for a folder index.
-#[derive(Debug, Clone, PartialEq)]
-pub struct RecordEntry {
-    /// Vault-relative path of the record file.
-    pub path: PathBuf,
-    /// Record id.
-    pub id: RecordId,
-    /// Memory kind.
-    pub kind: MemoryKind,
-    /// Last-update timestamp from the stored record.
-    pub updated_at: Rfc3339Timestamp,
-    /// Backlinks pointing at this record.
-    pub backlink_count: u32,
-}
 
 /// Per-subfolder aggregate row.
 #[derive(Debug, Clone, PartialEq)]
@@ -215,9 +200,15 @@ pub fn project_index(state: &FolderState) -> ProjectedFile {
         for s in &state.records {
             // path = folder / "<kind>_<id>.md" — same as MarkdownProjector.
             let leaf = format!("{}_{}.md", s.record.kind.as_str(), s.record.id.as_str());
+            let projected_path = state.path.join(&leaf);
+            let backlink_count = state
+                .backlinks
+                .iter()
+                .filter(|bl| bl.target_path == projected_path)
+                .count();
             let _ = writeln!(
                 body,
-                "- [{leaf}]({leaf}) — {kind} · updated {upd}",
+                "- [{leaf}]({leaf}) — {kind} · updated {upd} · {backlink_count} backlinks",
                 kind = s.record.kind.as_str(),
                 upd = s.record.updated_at.as_str(),
             );
@@ -444,5 +435,59 @@ mod tests {
         assert!(!pf.content.contains("## Records"));
         assert!(!pf.content.contains("## Subfolders"));
         assert!(!pf.content.contains("## Backlinks"));
+    }
+
+    #[test]
+    fn project_records_section_renders_leaf_link_and_backlink_count() {
+        use crate::domain::record::tests::sample_stored_record;
+        let stored = sample_stored_record(1);
+        let leaf = format!(
+            "{}_{}.md",
+            stored.record.kind.as_str(),
+            stored.record.id.as_str()
+        );
+        let target_path = PathBuf::from(format!("raw/{leaf}"));
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: vec![stored.clone()],
+            subfolders: Vec::new(),
+            backlinks: vec![Backlink {
+                source_path: PathBuf::from("raw/other.md"),
+                target_path: target_path.clone(),
+                anchor: None,
+            }],
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        let row = format!("- [{leaf}]({leaf})");
+        assert!(
+            pf.content.contains(&row),
+            "expected leaf-only row link per brief §3.4, got:\n{}",
+            pf.content
+        );
+        assert!(
+            pf.content.contains("· 1 backlinks"),
+            "expected backlink count, got:\n{}",
+            pf.content
+        );
+    }
+
+    #[test]
+    fn project_records_section_renders_zero_backlinks_when_state_empty() {
+        use crate::domain::record::tests::sample_stored_record;
+        let stored = sample_stored_record(1);
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: vec![stored],
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(
+            pf.content.contains("· 0 backlinks"),
+            "expected '· 0 backlinks' when state.backlinks is empty, got:\n{}",
+            pf.content
+        );
     }
 }

--- a/crates/cairn-core/src/domain/folder/index.rs
+++ b/crates/cairn-core/src/domain/folder/index.rs
@@ -239,14 +239,59 @@ pub fn project_index(state: &FolderState) -> ProjectedFile {
             state.backlinks.len(),
         );
         for bl in &state.backlinks {
-            let p = bl.source_path.to_string_lossy();
-            let _ = writeln!(body, "- [{p}]({p})");
+            let label = bl.source_path.to_string_lossy();
+            // Render the href relative to the folder containing this _index.md
+            // so a Markdown viewer resolves it correctly. Vault-relative paths
+            // would double-prefix (e.g. `raw/_index.md` → `raw/raw/foo.md`).
+            let href_rel = relativize(&state.path, &bl.source_path);
+            let href = href_rel.to_string_lossy();
+            let _ = writeln!(body, "- [{label}]({href})");
         }
     }
 
     ProjectedFile {
         path: state.path.join("_index.md"),
         content: format!("{frontmatter}{body}"),
+    }
+}
+
+/// Render `target` relative to `base`. Walks the common-prefix split,
+/// emitting `..` for each base segment past the common ancestor and the
+/// remaining target segments. Both inputs are expected to be vault-relative
+/// (no leading `/`). If `target` is fully inside `base`, the result is the
+/// suffix; otherwise we emit `..` segments.
+fn relativize(base: &Path, target: &Path) -> PathBuf {
+    use std::path::Component;
+    let base_segs: Vec<_> = base
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(s) => Some(s.to_os_string()),
+            _ => None,
+        })
+        .collect();
+    let target_segs: Vec<_> = target
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(s) => Some(s.to_os_string()),
+            _ => None,
+        })
+        .collect();
+    let common = base_segs
+        .iter()
+        .zip(target_segs.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let mut out: Vec<std::ffi::OsString> = Vec::new();
+    for _ in common..base_segs.len() {
+        out.push(std::ffi::OsString::from(".."));
+    }
+    for s in &target_segs[common..] {
+        out.push(s.clone());
+    }
+    if out.is_empty() {
+        PathBuf::from(".")
+    } else {
+        out.iter().collect()
     }
 }
 
@@ -468,6 +513,104 @@ mod tests {
         assert!(
             pf.content.contains("· 1 backlinks"),
             "expected backlink count, got:\n{}",
+            pf.content
+        );
+    }
+
+    #[test]
+    fn project_renders_backlink_href_relative_to_folder() {
+        // `raw/_index.md` listing a backlink whose source is `raw/other.md`
+        // must render the href as `other.md` — NOT `raw/other.md`, which
+        // would resolve to `raw/raw/other.md` in a Markdown viewer.
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: vec![Backlink {
+                source_path: PathBuf::from("raw/other.md"),
+                target_path: PathBuf::from("raw/x.md"),
+                anchor: None,
+            }],
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(
+            pf.content.contains("- [raw/other.md](other.md)"),
+            "expected folder-relative href, got:\n{}",
+            pf.content
+        );
+        assert!(
+            !pf.content.contains("(raw/other.md)"),
+            "vault-relative href should not appear, got:\n{}",
+            pf.content
+        );
+    }
+
+    #[test]
+    fn project_renders_backlink_href_for_sibling_subfolder() {
+        // `raw/a/_index.md` listing a backlink from `raw/b/foo.md` must
+        // render `../b/foo.md`.
+        let state = FolderState {
+            path: PathBuf::from("raw/a"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: vec![Backlink {
+                source_path: PathBuf::from("raw/b/foo.md"),
+                target_path: PathBuf::from("raw/a/x.md"),
+                anchor: None,
+            }],
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(
+            pf.content.contains("(../b/foo.md)"),
+            "expected sibling-relative href '../b/foo.md', got:\n{}",
+            pf.content
+        );
+    }
+
+    #[test]
+    fn project_renders_backlink_href_for_nested_descendant() {
+        // `raw/_index.md` listing a backlink from `raw/sub/foo.md` must
+        // render `sub/foo.md`.
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: vec![Backlink {
+                source_path: PathBuf::from("raw/sub/foo.md"),
+                target_path: PathBuf::from("raw/x.md"),
+                anchor: None,
+            }],
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(
+            pf.content.contains("(sub/foo.md)"),
+            "expected descendant-relative href 'sub/foo.md', got:\n{}",
+            pf.content
+        );
+    }
+
+    #[test]
+    fn project_renders_backlink_href_for_parent_source() {
+        // `raw/sub/_index.md` listing a backlink from `raw/parent.md` must
+        // render `../parent.md`.
+        let state = FolderState {
+            path: PathBuf::from("raw/sub"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: vec![Backlink {
+                source_path: PathBuf::from("raw/parent.md"),
+                target_path: PathBuf::from("raw/sub/x.md"),
+                anchor: None,
+            }],
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(
+            pf.content.contains("(../parent.md)"),
+            "expected parent-relative href '../parent.md', got:\n{}",
             pf.content
         );
     }

--- a/crates/cairn-core/src/domain/folder/links.rs
+++ b/crates/cairn-core/src/domain/folder/links.rs
@@ -119,8 +119,9 @@ fn parse_wiki(source_path: &Path, raw: &str) -> Option<RawLink> {
     };
     // Wiki links are always resolved relative to the source file's parent
     // directory (bare names like `[[alice]]` resolve to the same folder).
+    // A `..` chain that escapes the vault root drops the link entirely.
     Some(RawLink {
-        target_path: resolve_source_relative(source_path, &with_ext),
+        target_path: resolve_source_relative(source_path, &with_ext)?,
         anchor,
     })
 }
@@ -142,9 +143,11 @@ fn parse_markdown(source_path: &Path, raw: &str) -> Option<RawLink> {
     //                                  against the document's own folder)
     //
     // Note: `resolve_source_relative` already strips the leading slash for
-    // absolute targets, so a single dispatch handles every case.
+    // absolute targets, so a single dispatch handles every case.  Returns
+    // `None` for over-root `..` chains; we drop the link rather than
+    // silently re-anchoring it inside the vault.
     let target = Path::new(target_str);
-    let target_path = resolve_source_relative(source_path, target);
+    let target_path = resolve_source_relative(source_path, target)?;
     Some(RawLink {
         target_path,
         anchor,
@@ -152,28 +155,34 @@ fn parse_markdown(source_path: &Path, raw: &str) -> Option<RawLink> {
 }
 
 /// Resolve `target` against the parent directory of `source_path`.
-fn resolve_source_relative(source_path: &Path, target: &Path) -> PathBuf {
+/// Returns `None` if the resolved path escapes the vault root via `..` —
+/// such a link is out-of-vault and must NOT be silently clamped to an
+/// in-vault path (which would corrupt unrelated folder backlink counts).
+fn resolve_source_relative(source_path: &Path, target: &Path) -> Option<PathBuf> {
     if target.is_absolute() {
-        return target.components().skip(1).collect();
+        return Some(target.components().skip(1).collect());
     }
     let parent = source_path.parent().unwrap_or_else(|| Path::new(""));
     let joined = parent.join(target);
     normalize(&joined)
 }
 
-fn normalize(p: &Path) -> PathBuf {
+/// Normalize by collapsing `.` and resolving `..` against accumulated
+/// segments. Returns `None` if a `..` would pop past the root — that link
+/// escapes the vault and must be dropped, not silently re-anchored.
+fn normalize(p: &Path) -> Option<PathBuf> {
     let mut out: Vec<std::ffi::OsString> = Vec::new();
     for comp in p.components() {
         use std::path::Component;
         match comp {
             Component::ParentDir => {
-                out.pop();
+                out.pop()?;
             }
             Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
             Component::Normal(s) => out.push(s.to_os_string()),
         }
     }
-    out.iter().collect()
+    Some(out.iter().collect())
 }
 
 use std::collections::BTreeMap;
@@ -294,6 +303,42 @@ mod tests {
             links[0].target_path,
             PathBuf::from("wiki/entities/alice.md"),
         );
+    }
+
+    #[test]
+    fn over_root_relative_link_is_dropped() {
+        // `../../../wiki/foo.md` from `raw/r1.md` would historically clamp
+        // to `wiki/foo.md`, silently re-anchoring an out-of-vault target
+        // and corrupting an unrelated in-vault folder's backlink count.
+        let src = Path::new("raw/r1.md");
+        let links = extract_links(src, "[oops](../../../wiki/foo.md)");
+        assert!(
+            links.is_empty(),
+            "over-root link must be dropped, got {links:?}"
+        );
+    }
+
+    #[test]
+    fn over_root_wiki_link_is_dropped() {
+        let src = Path::new("raw/a/r.md");
+        let links = extract_links(src, "[[../../../escape]]");
+        assert!(
+            links.is_empty(),
+            "over-root wiki link must be dropped, got {links:?}"
+        );
+    }
+
+    #[test]
+    fn over_root_link_is_not_materialized_as_backlink() {
+        let r1 = record_with_body(1, "[escape](../../../wiki/private/alice.md)");
+        let mut paths = BTreeMap::new();
+        paths.insert(r1.record.id.clone(), PathBuf::from("raw/r1.md"));
+        let map = materialize_backlinks(&[r1], &paths);
+        assert!(
+            !map.contains_key(Path::new("wiki/private/alice.md")),
+            "over-root target leaked into backlink graph"
+        );
+        assert!(map.is_empty(), "no backlinks expected, got {map:?}");
     }
 
     #[test]

--- a/crates/cairn-core/src/domain/folder/links.rs
+++ b/crates/cairn-core/src/domain/folder/links.rs
@@ -134,24 +134,17 @@ fn parse_markdown(source_path: &Path, raw: &str) -> Option<RawLink> {
         Some((t, a)) => (t, Some(a.to_owned())),
         None => (raw, None),
     };
-    // Markdown link target resolution:
-    //   - `./foo.md` / `../foo.md`     → source-relative (explicit nav)
-    //   - bare `foo.md` (no `/`)       → source-relative (same-folder common case)
-    //   - `dir/foo.md` (contains `/`)  → vault-relative (intentional, tested:
-    //     records routinely write fully-qualified paths like `raw/alice.md`,
-    //     and switching to source-relative there would double-prefix)
+    // Markdown link target resolution per standard CommonMark semantics:
+    //   - `/foo.md`                  → vault-root-relative (explicit absolute)
+    //   - `./foo.md` / `../foo.md`   → source-relative (explicit nav)
+    //   - `foo.md` / `dir/foo.md`    → source-relative (default; standard
+    //                                  Markdown resolves relative paths
+    //                                  against the document's own folder)
+    //
+    // Note: `resolve_source_relative` already strips the leading slash for
+    // absolute targets, so a single dispatch handles every case.
     let target = Path::new(target_str);
-    let target_path = {
-        use std::path::Component;
-        let first = target.components().next();
-        let is_nav = matches!(first, Some(Component::CurDir | Component::ParentDir));
-        let has_separator = target_str.contains('/');
-        if is_nav || !has_separator {
-            resolve_source_relative(source_path, target)
-        } else {
-            normalize(target)
-        }
-    };
+    let target_path = resolve_source_relative(source_path, target);
     Some(RawLink {
         target_path,
         anchor,
@@ -223,11 +216,37 @@ mod tests {
 
     #[test]
     fn markdown_link_label_discarded() {
+        // Standard Markdown: relative path resolves against source folder.
+        // `raw/a.md` linking to `alice.md` means the same folder.
         let src = Path::new("raw/a.md");
-        let links = extract_links(src, "see [Alice](raw/alice.md) for details");
+        let links = extract_links(src, "see [Alice](alice.md) for details");
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].target_path, PathBuf::from("raw/alice.md"));
         assert!(links[0].anchor.is_none());
+    }
+
+    #[test]
+    fn markdown_link_with_leading_slash_is_vault_relative() {
+        // Explicit vault-root form: `/raw/alice.md` means start from the
+        // vault root regardless of the source file's location.
+        let src = Path::new("wiki/entities/bob.md");
+        let links = extract_links(src, "see [Alice](/raw/alice.md)");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_path, PathBuf::from("raw/alice.md"));
+    }
+
+    #[test]
+    fn markdown_link_nested_relative_resolves_against_source_folder() {
+        // `[Alice](people/alice.md)` from `wiki/entities/bob.md` must
+        // resolve to `wiki/entities/people/alice.md` per standard Markdown
+        // semantics, NOT to vault-root `people/alice.md`.
+        let src = Path::new("wiki/entities/bob.md");
+        let links = extract_links(src, "see [Alice](people/alice.md)");
+        assert_eq!(links.len(), 1);
+        assert_eq!(
+            links[0].target_path,
+            PathBuf::from("wiki/entities/people/alice.md"),
+        );
     }
 
     #[test]
@@ -258,12 +277,10 @@ mod tests {
     }
 
     #[test]
-    fn slash_path_remains_vault_relative() {
-        // Paths with `/` are vault-relative by intent — records routinely
-        // write fully-qualified paths like `raw/alice.md`. Source-relative
-        // here would double-prefix.
-        let src = Path::new("raw/r1.md");
-        let links = extract_links(src, "[Alice](raw/alice.md)");
+    fn slash_prefixed_path_is_vault_relative() {
+        // Leading `/` means vault-root regardless of source location.
+        let src = Path::new("wiki/entities/bob.md");
+        let links = extract_links(src, "[Alice](/raw/alice.md)");
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].target_path, PathBuf::from("raw/alice.md"));
     }
@@ -290,7 +307,7 @@ mod tests {
     #[test]
     fn code_fenced_links_are_ignored() {
         let src = Path::new("raw/a.md");
-        let body = "before\n```\n[Alice](raw/alice.md)\n```\nafter [Bob](raw/bob.md)";
+        let body = "before\n```\n[Alice](alice.md)\n```\nafter [Bob](bob.md)";
         let links = extract_links(src, body);
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].target_path, PathBuf::from("raw/bob.md"));
@@ -325,7 +342,7 @@ mod tests {
 
     #[test]
     fn materialize_emits_backlink_for_existing_target() {
-        let r1 = record_with_body(1, "see [Alice](raw/alice.md)");
+        let r1 = record_with_body(1, "see [Alice](alice.md)");
         let mut paths = BTreeMap::new();
         paths.insert(r1.record.id.clone(), PathBuf::from("raw/r1.md"));
         let map = materialize_backlinks(&[r1], &paths);
@@ -336,7 +353,7 @@ mod tests {
 
     #[test]
     fn materialize_includes_dangling_links() {
-        let r1 = record_with_body(1, "[ghost](raw/missing.md)");
+        let r1 = record_with_body(1, "[ghost](missing.md)");
         let mut paths = BTreeMap::new();
         paths.insert(r1.record.id.clone(), PathBuf::from("raw/r1.md"));
         let map = materialize_backlinks(&[r1], &paths);
@@ -345,8 +362,8 @@ mod tests {
 
     #[test]
     fn materialize_two_sources_to_same_target_sorted() {
-        let r1 = record_with_body(1, "[a](raw/alice.md)");
-        let mut r2 = record_with_body(1, "[a](raw/alice.md)");
+        let r1 = record_with_body(1, "[a](alice.md)");
+        let mut r2 = record_with_body(1, "[a](alice.md)");
         // Mutate id so paths differ.
         r2.record.id = RecordId::parse("01HQZX9F5N0000000000000ZZZ".to_owned()).expect("valid");
         let mut paths = BTreeMap::new();

--- a/crates/cairn-core/src/domain/folder/links.rs
+++ b/crates/cairn-core/src/domain/folder/links.rs
@@ -1,0 +1,1 @@
+//! Markdown link extraction and reverse-map materialization.

--- a/crates/cairn-core/src/domain/folder/links.rs
+++ b/crates/cairn-core/src/domain/folder/links.rs
@@ -178,6 +178,40 @@ fn normalize(p: &Path) -> PathBuf {
     out.iter().collect()
 }
 
+use std::collections::BTreeMap;
+
+use crate::contract::memory_store::StoredRecord;
+use crate::domain::record::RecordId;
+
+/// Build the reverse map: `target_path` → backlinks pointing at it. Sorted by
+/// `source_path` for deterministic output.
+#[must_use]
+pub fn materialize_backlinks(
+    records: &[StoredRecord],
+    record_paths: &BTreeMap<RecordId, PathBuf>,
+) -> BTreeMap<PathBuf, Vec<Backlink>> {
+    let mut by_target: BTreeMap<PathBuf, Vec<Backlink>> = BTreeMap::new();
+    for stored in records {
+        let Some(source_path) = record_paths.get(&stored.record.id) else {
+            continue;
+        };
+        for raw in extract_links(source_path, &stored.record.body) {
+            by_target
+                .entry(raw.target_path.clone())
+                .or_default()
+                .push(Backlink {
+                    source_path: source_path.clone(),
+                    target_path: raw.target_path,
+                    anchor: raw.anchor,
+                });
+        }
+    }
+    for entries in by_target.values_mut() {
+        entries.sort_by(|a, b| a.source_path.cmp(&b.source_path));
+    }
+    by_target
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,5 +275,61 @@ mod tests {
         let body = r"\[not a link\](nope)";
         let links = extract_links(src, body);
         assert!(links.is_empty());
+    }
+
+    use crate::contract::memory_store::StoredRecord;
+    use crate::domain::record::tests::sample_stored_record;
+    use crate::domain::record::RecordId;
+    use std::collections::BTreeMap;
+
+    fn record_with_body(version: u32, body: &str) -> StoredRecord {
+        let mut s = sample_stored_record(version);
+        s.record.body = body.to_owned();
+        s
+    }
+
+    #[test]
+    fn materialize_empty_records_returns_empty_map() {
+        let records: Vec<StoredRecord> = Vec::new();
+        let paths: BTreeMap<RecordId, PathBuf> = BTreeMap::new();
+        let map = materialize_backlinks(&records, &paths);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn materialize_emits_backlink_for_existing_target() {
+        let r1 = record_with_body(1, "see [Alice](raw/alice.md)");
+        let mut paths = BTreeMap::new();
+        paths.insert(r1.record.id.clone(), PathBuf::from("raw/r1.md"));
+        let map = materialize_backlinks(&[r1], &paths);
+        let entries = map.get(Path::new("raw/alice.md")).expect("entry");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].source_path, PathBuf::from("raw/r1.md"));
+    }
+
+    #[test]
+    fn materialize_includes_dangling_links() {
+        let r1 = record_with_body(1, "[ghost](raw/missing.md)");
+        let mut paths = BTreeMap::new();
+        paths.insert(r1.record.id.clone(), PathBuf::from("raw/r1.md"));
+        let map = materialize_backlinks(&[r1], &paths);
+        assert!(map.contains_key(Path::new("raw/missing.md")));
+    }
+
+    #[test]
+    fn materialize_two_sources_to_same_target_sorted() {
+        let r1 = record_with_body(1, "[a](raw/alice.md)");
+        let mut r2 = record_with_body(1, "[a](raw/alice.md)");
+        // Mutate id so paths differ.
+        r2.record.id =
+            RecordId::parse("01HQZX9F5N0000000000000ZZZ".to_owned()).expect("valid");
+        let mut paths = BTreeMap::new();
+        paths.insert(r1.record.id.clone(), PathBuf::from("raw/zzz.md"));
+        paths.insert(r2.record.id.clone(), PathBuf::from("raw/aaa.md"));
+        let map = materialize_backlinks(&[r1, r2], &paths);
+        let entries = map.get(Path::new("raw/alice.md")).expect("entry");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].source_path, PathBuf::from("raw/aaa.md"));
+        assert_eq!(entries[1].source_path, PathBuf::from("raw/zzz.md"));
     }
 }

--- a/crates/cairn-core/src/domain/folder/links.rs
+++ b/crates/cairn-core/src/domain/folder/links.rs
@@ -100,9 +100,7 @@ fn find_close(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 }
 
 fn is_external(target: &str) -> bool {
-    target.starts_with("http://")
-        || target.starts_with("https://")
-        || target.starts_with("mailto:")
+    target.starts_with("http://") || target.starts_with("https://") || target.starts_with("mailto:")
 }
 
 fn parse_wiki(source_path: &Path, raw: &str) -> Option<RawLink> {
@@ -142,15 +140,17 @@ fn parse_markdown(source_path: &Path, raw: &str) -> Option<RawLink> {
     let target_path = {
         use std::path::Component;
         let first = target.components().next();
-        let is_nav =
-            matches!(first, Some(Component::CurDir | Component::ParentDir));
+        let is_nav = matches!(first, Some(Component::CurDir | Component::ParentDir));
         if is_nav {
             resolve_source_relative(source_path, target)
         } else {
             normalize(target)
         }
     };
-    Some(RawLink { target_path, anchor })
+    Some(RawLink {
+        target_path,
+        anchor,
+    })
 }
 
 /// Resolve `target` against the parent directory of `source_path`.
@@ -278,8 +278,8 @@ mod tests {
     }
 
     use crate::contract::memory_store::StoredRecord;
-    use crate::domain::record::tests::sample_stored_record;
     use crate::domain::record::RecordId;
+    use crate::domain::record::tests::sample_stored_record;
     use std::collections::BTreeMap;
 
     fn record_with_body(version: u32, body: &str) -> StoredRecord {
@@ -321,8 +321,7 @@ mod tests {
         let r1 = record_with_body(1, "[a](raw/alice.md)");
         let mut r2 = record_with_body(1, "[a](raw/alice.md)");
         // Mutate id so paths differ.
-        r2.record.id =
-            RecordId::parse("01HQZX9F5N0000000000000ZZZ".to_owned()).expect("valid");
+        r2.record.id = RecordId::parse("01HQZX9F5N0000000000000ZZZ".to_owned()).expect("valid");
         let mut paths = BTreeMap::new();
         paths.insert(r1.record.id.clone(), PathBuf::from("raw/zzz.md"));
         paths.insert(r2.record.id.clone(), PathBuf::from("raw/aaa.md"));

--- a/crates/cairn-core/src/domain/folder/links.rs
+++ b/crates/cairn-core/src/domain/folder/links.rs
@@ -1,1 +1,245 @@
 //! Markdown link extraction and reverse-map materialization.
+
+use std::path::{Path, PathBuf};
+
+/// A link extracted from a record body, target resolved against the source folder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawLink {
+    /// Vault-relative target path.
+    pub target_path: PathBuf,
+    /// Optional fragment after `#`, if present.
+    pub anchor: Option<String>,
+}
+
+/// A reverse link: source file pointing at a target file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Backlink {
+    /// File containing the link (vault-relative).
+    pub source_path: PathBuf,
+    /// File being linked to (vault-relative).
+    pub target_path: PathBuf,
+    /// Optional fragment after `#`, if present.
+    pub anchor: Option<String>,
+}
+
+/// Pure markdown link extractor.
+///
+/// Recognises:
+/// - `[label](path)` — markdown link; label discarded.
+/// - `[[target]]` and `[[target#anchor]]` — wiki link.
+///
+/// Drops:
+/// - external URLs (`http://`, `https://`, `mailto:`);
+/// - links inside fenced code blocks;
+/// - escaped link syntax (`\[`).
+///
+/// Wiki-style targets without an extension get `.md` appended. Relative
+/// paths are resolved against the source file's parent directory.
+#[must_use]
+pub fn extract_links(source_path: &Path, body: &str) -> Vec<RawLink> {
+    let mut out = Vec::new();
+    let mut in_fence = false;
+    for line in body.lines() {
+        if line.trim_start().starts_with("```") {
+            // Toggle fence on the leading-``` line; skip the fence content.
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        scan_line(source_path, line, &mut out);
+    }
+    out
+}
+
+fn scan_line(source_path: &Path, line: &str, out: &mut Vec<RawLink>) {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // Escaped open-bracket — skip.
+        if b == b'\\' && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            i += 2;
+            continue;
+        }
+        if b == b'[' && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            // Wiki link: [[target]] or [[target#anchor]]
+            if let Some(end) = find_close(&bytes[i + 2..], b"]]") {
+                let inner = &line[i + 2..i + 2 + end];
+                if let Some(link) = parse_wiki(source_path, inner) {
+                    out.push(link);
+                }
+                i += 2 + end + 2;
+                continue;
+            }
+        }
+        if b == b'[' {
+            // Markdown link: [label](target)
+            if let Some(label_end) = find_close(&bytes[i + 1..], b"]") {
+                let after = i + 1 + label_end + 1;
+                if after < bytes.len()
+                    && bytes[after] == b'('
+                    && let Some(target_end) = find_close(&bytes[after + 1..], b")")
+                {
+                    let target = &line[after + 1..after + 1 + target_end];
+                    if let Some(link) = parse_markdown(source_path, target) {
+                        out.push(link);
+                    }
+                    i = after + 1 + target_end + 1;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+}
+
+fn find_close(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn is_external(target: &str) -> bool {
+    target.starts_with("http://")
+        || target.starts_with("https://")
+        || target.starts_with("mailto:")
+}
+
+fn parse_wiki(source_path: &Path, raw: &str) -> Option<RawLink> {
+    let raw = raw.trim();
+    if raw.is_empty() || is_external(raw) {
+        return None;
+    }
+    let (target_str, anchor) = match raw.split_once('#') {
+        Some((t, a)) => (t, Some(a.to_owned())),
+        None => (raw, None),
+    };
+    let with_ext: PathBuf = if Path::new(target_str).extension().is_some() {
+        PathBuf::from(target_str)
+    } else {
+        PathBuf::from(format!("{target_str}.md"))
+    };
+    // Wiki links are always resolved relative to the source file's parent
+    // directory (bare names like `[[alice]]` resolve to the same folder).
+    Some(RawLink {
+        target_path: resolve_source_relative(source_path, &with_ext),
+        anchor,
+    })
+}
+
+fn parse_markdown(source_path: &Path, raw: &str) -> Option<RawLink> {
+    let raw = raw.trim();
+    if raw.is_empty() || is_external(raw) {
+        return None;
+    }
+    let (target_str, anchor) = match raw.split_once('#') {
+        Some((t, a)) => (t, Some(a.to_owned())),
+        None => (raw, None),
+    };
+    // Markdown links: paths starting with `./` or `../` are source-relative;
+    // all others are treated as vault-relative already.
+    let target = Path::new(target_str);
+    let target_path = {
+        use std::path::Component;
+        let first = target.components().next();
+        let is_nav =
+            matches!(first, Some(Component::CurDir | Component::ParentDir));
+        if is_nav {
+            resolve_source_relative(source_path, target)
+        } else {
+            normalize(target)
+        }
+    };
+    Some(RawLink { target_path, anchor })
+}
+
+/// Resolve `target` against the parent directory of `source_path`.
+fn resolve_source_relative(source_path: &Path, target: &Path) -> PathBuf {
+    if target.is_absolute() {
+        return target.components().skip(1).collect();
+    }
+    let parent = source_path.parent().unwrap_or_else(|| Path::new(""));
+    let joined = parent.join(target);
+    normalize(&joined)
+}
+
+fn normalize(p: &Path) -> PathBuf {
+    let mut out: Vec<std::ffi::OsString> = Vec::new();
+    for comp in p.components() {
+        use std::path::Component;
+        match comp {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
+            Component::Normal(s) => out.push(s.to_os_string()),
+        }
+    }
+    out.iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_link_label_discarded() {
+        let src = Path::new("raw/a.md");
+        let links = extract_links(src, "see [Alice](raw/alice.md) for details");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_path, PathBuf::from("raw/alice.md"));
+        assert!(links[0].anchor.is_none());
+    }
+
+    #[test]
+    fn wiki_link_appends_md_extension() {
+        let src = Path::new("raw/a.md");
+        let links = extract_links(src, "see [[alice]] for details");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_path, PathBuf::from("raw/alice.md"));
+    }
+
+    #[test]
+    fn wiki_anchor_is_populated() {
+        let src = Path::new("raw/a.md");
+        let links = extract_links(src, "see [[alice#bio]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].anchor.as_deref(), Some("bio"));
+    }
+
+    #[test]
+    fn relative_path_resolves_against_source_folder() {
+        let src = Path::new("wiki/entities/people/bob.md");
+        let links = extract_links(src, "[ref](../alice.md)");
+        assert_eq!(links.len(), 1);
+        assert_eq!(
+            links[0].target_path,
+            PathBuf::from("wiki/entities/alice.md"),
+        );
+    }
+
+    #[test]
+    fn external_urls_are_dropped() {
+        let src = Path::new("raw/a.md");
+        let body = "see [docs](https://example.com), [home](http://x), [mail](mailto:x@y)";
+        let links = extract_links(src, body);
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn code_fenced_links_are_ignored() {
+        let src = Path::new("raw/a.md");
+        let body = "before\n```\n[Alice](raw/alice.md)\n```\nafter [Bob](raw/bob.md)";
+        let links = extract_links(src, body);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_path, PathBuf::from("raw/bob.md"));
+    }
+
+    #[test]
+    fn escaped_open_bracket_is_ignored() {
+        let src = Path::new("raw/a.md");
+        let body = r"\[not a link\](nope)";
+        let links = extract_links(src, body);
+        assert!(links.is_empty());
+    }
+}

--- a/crates/cairn-core/src/domain/folder/links.rs
+++ b/crates/cairn-core/src/domain/folder/links.rs
@@ -134,14 +134,19 @@ fn parse_markdown(source_path: &Path, raw: &str) -> Option<RawLink> {
         Some((t, a)) => (t, Some(a.to_owned())),
         None => (raw, None),
     };
-    // Markdown links: paths starting with `./` or `../` are source-relative;
-    // all others are treated as vault-relative already.
+    // Markdown link target resolution:
+    //   - `./foo.md` / `../foo.md`     → source-relative (explicit nav)
+    //   - bare `foo.md` (no `/`)       → source-relative (same-folder common case)
+    //   - `dir/foo.md` (contains `/`)  → vault-relative (intentional, tested:
+    //     records routinely write fully-qualified paths like `raw/alice.md`,
+    //     and switching to source-relative there would double-prefix)
     let target = Path::new(target_str);
     let target_path = {
         use std::path::Component;
         let first = target.components().next();
         let is_nav = matches!(first, Some(Component::CurDir | Component::ParentDir));
-        if is_nav {
+        let has_separator = target_str.contains('/');
+        if is_nav || !has_separator {
             resolve_source_relative(source_path, target)
         } else {
             normalize(target)
@@ -239,6 +244,28 @@ mod tests {
         let links = extract_links(src, "see [[alice#bio]]");
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].anchor.as_deref(), Some("bio"));
+    }
+
+    #[test]
+    fn bare_filename_resolves_against_source_folder() {
+        // A common-case Markdown link `[Alice](alice.md)` from `raw/bob.md`
+        // must point at `raw/alice.md`, NOT vault-root `alice.md`. Targets
+        // without a `/` are unambiguously same-folder.
+        let src = Path::new("raw/bob.md");
+        let links = extract_links(src, "[Alice](alice.md)");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_path, PathBuf::from("raw/alice.md"));
+    }
+
+    #[test]
+    fn slash_path_remains_vault_relative() {
+        // Paths with `/` are vault-relative by intent — records routinely
+        // write fully-qualified paths like `raw/alice.md`. Source-relative
+        // here would double-prefix.
+        let src = Path::new("raw/r1.md");
+        let links = extract_links(src, "[Alice](raw/alice.md)");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_path, PathBuf::from("raw/alice.md"));
     }
 
     #[test]

--- a/crates/cairn-core/src/domain/folder/mod.rs
+++ b/crates/cairn-core/src/domain/folder/mod.rs
@@ -25,6 +25,59 @@ pub enum FolderError {
     },
 }
 
+use std::path::PathBuf;
+
+use crate::domain::Rfc3339Timestamp;
+
+/// Schema for `_summary.md`. P0 ships types only — body generation is P1.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FolderSummary {
+    /// Vault-relative folder path.
+    pub folder: PathBuf,
+    /// When this summary was generated.
+    pub generated_at: Rfc3339Timestamp,
+    /// Agent that generated the summary (e.g. `agt:cairn-librarian:v2`).
+    pub generated_by: String,
+    /// Number of records the summary covers.
+    pub covers_records: u32,
+    /// Approximate token count of `body`.
+    pub summary_tokens: u32,
+    /// Generated prose body.
+    pub body: String,
+}
+
+/// Errors raised by [`FolderSummaryWriter`] implementations.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FolderSummaryError {
+    /// No summary writer is registered (P0 default).
+    #[error("folder summary writer not registered")]
+    Unimplemented,
+    /// Internal error from the writer implementation.
+    #[error("folder summary writer internal: {0}")]
+    Internal(String),
+}
+
+/// Workflow-owned write surface for `_summary.md`. P0 ships zero
+/// implementations; P1 `cairn-workflows::FolderSummaryWorkflow` is the
+/// first implementor.
+#[async_trait::async_trait]
+pub trait FolderSummaryWriter: Send + Sync {
+    /// Persist a generated [`FolderSummary`] as `_summary.md` under its
+    /// folder, atomically. Implementors are responsible for I/O safety
+    /// (atomic rename, symlink rejection).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FolderSummaryError::Unimplemented`] when no writer is
+    /// registered, or [`FolderSummaryError::Internal`] for I/O / encoding
+    /// failures.
+    async fn write_summary(
+        &self,
+        summary: FolderSummary,
+    ) -> Result<(), FolderSummaryError>;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -35,5 +88,20 @@ mod tests {
         let err = serde_yaml::from_str::<serde_yaml::Value>(yaml).unwrap_err();
         let folder_err = FolderError::PolicyParse { source: err };
         assert!(folder_err.to_string().starts_with("policy parse failed:"));
+    }
+
+    #[test]
+    fn folder_summary_writer_trait_object_compiles() {
+        struct Stub;
+        #[async_trait::async_trait]
+        impl FolderSummaryWriter for Stub {
+            async fn write_summary(
+                &self,
+                _summary: FolderSummary,
+            ) -> Result<(), FolderSummaryError> {
+                Err(FolderSummaryError::Unimplemented)
+            }
+        }
+        let _: Box<dyn FolderSummaryWriter> = Box::new(Stub);
     }
 }

--- a/crates/cairn-core/src/domain/folder/mod.rs
+++ b/crates/cairn-core/src/domain/folder/mod.rs
@@ -8,7 +8,7 @@ pub mod index;
 pub mod links;
 pub mod policy;
 
-#[allow(unused_imports)] // links module is empty until Task 5
+pub use index::*;
 pub use links::*;
 pub use policy::*;
 

--- a/crates/cairn-core/src/domain/folder/mod.rs
+++ b/crates/cairn-core/src/domain/folder/mod.rs
@@ -25,56 +25,6 @@ pub enum FolderError {
     },
 }
 
-use std::path::PathBuf;
-
-use crate::domain::Rfc3339Timestamp;
-
-/// Schema for `_summary.md`. P0 ships types only — body generation is P1.
-#[derive(Debug, Clone, PartialEq)]
-pub struct FolderSummary {
-    /// Vault-relative folder path.
-    pub folder: PathBuf,
-    /// When this summary was generated.
-    pub generated_at: Rfc3339Timestamp,
-    /// Agent that generated the summary (e.g. `agt:cairn-librarian:v2`).
-    pub generated_by: String,
-    /// Number of records the summary covers.
-    pub covers_records: u32,
-    /// Approximate token count of `body`.
-    pub summary_tokens: u32,
-    /// Generated prose body.
-    pub body: String,
-}
-
-/// Errors raised by [`FolderSummaryWriter`] implementations.
-#[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-pub enum FolderSummaryError {
-    /// No summary writer is registered (P0 default).
-    #[error("folder summary writer not registered")]
-    Unimplemented,
-    /// Internal error from the writer implementation.
-    #[error("folder summary writer internal: {0}")]
-    Internal(String),
-}
-
-/// Workflow-owned write surface for `_summary.md`. P0 ships zero
-/// implementations; P1 `cairn-workflows::FolderSummaryWorkflow` is the
-/// first implementor.
-#[async_trait::async_trait]
-pub trait FolderSummaryWriter: Send + Sync {
-    /// Persist a generated [`FolderSummary`] as `_summary.md` under its
-    /// folder, atomically. Implementors are responsible for I/O safety
-    /// (atomic rename, symlink rejection).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FolderSummaryError::Unimplemented`] when no writer is
-    /// registered, or [`FolderSummaryError::Internal`] for I/O / encoding
-    /// failures.
-    async fn write_summary(&self, summary: FolderSummary) -> Result<(), FolderSummaryError>;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,20 +35,5 @@ mod tests {
         let err = serde_yaml::from_str::<serde_yaml::Value>(yaml).unwrap_err();
         let folder_err = FolderError::PolicyParse { source: err };
         assert!(folder_err.to_string().starts_with("policy parse failed:"));
-    }
-
-    #[test]
-    fn folder_summary_writer_trait_object_compiles() {
-        struct Stub;
-        #[async_trait::async_trait]
-        impl FolderSummaryWriter for Stub {
-            async fn write_summary(
-                &self,
-                _summary: FolderSummary,
-            ) -> Result<(), FolderSummaryError> {
-                Err(FolderSummaryError::Unimplemented)
-            }
-        }
-        let _: Box<dyn FolderSummaryWriter> = Box::new(Stub);
     }
 }

--- a/crates/cairn-core/src/domain/folder/mod.rs
+++ b/crates/cairn-core/src/domain/folder/mod.rs
@@ -72,10 +72,7 @@ pub trait FolderSummaryWriter: Send + Sync {
     /// Returns [`FolderSummaryError::Unimplemented`] when no writer is
     /// registered, or [`FolderSummaryError::Internal`] for I/O / encoding
     /// failures.
-    async fn write_summary(
-        &self,
-        summary: FolderSummary,
-    ) -> Result<(), FolderSummaryError>;
+    async fn write_summary(&self, summary: FolderSummary) -> Result<(), FolderSummaryError>;
 }
 
 #[cfg(test)]

--- a/crates/cairn-core/src/domain/folder/mod.rs
+++ b/crates/cairn-core/src/domain/folder/mod.rs
@@ -8,6 +8,10 @@ pub mod index;
 pub mod links;
 pub mod policy;
 
+#[allow(unused_imports)] // links module is empty until Task 5
+pub use links::*;
+pub use policy::*;
+
 /// Errors raised by pure folder helpers.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/crates/cairn-core/src/domain/folder/mod.rs
+++ b/crates/cairn-core/src/domain/folder/mod.rs
@@ -1,0 +1,9 @@
+//! Folder sidecars — `_index.md`, `_policy.yaml`, `_summary.md` (brief §3.4).
+//!
+//! Pure functions only — zero I/O, zero async. Caller (CLI / future hooks)
+//! supplies records and policy bytes; module returns projected files,
+//! parsed policies, and resolved effective policies.
+
+pub mod index;
+pub mod links;
+pub mod policy;

--- a/crates/cairn-core/src/domain/folder/mod.rs
+++ b/crates/cairn-core/src/domain/folder/mod.rs
@@ -7,3 +7,29 @@
 pub mod index;
 pub mod links;
 pub mod policy;
+
+/// Errors raised by pure folder helpers.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FolderError {
+    /// `_policy.yaml` could not be parsed as a `FolderPolicy`.
+    #[error("policy parse failed: {source}")]
+    PolicyParse {
+        /// Underlying `serde_yaml` error.
+        #[source]
+        source: serde_yaml::Error,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folder_error_displays_with_source() {
+        let yaml = "purpose: [unclosed";
+        let err = serde_yaml::from_str::<serde_yaml::Value>(yaml).unwrap_err();
+        let folder_err = FolderError::PolicyParse { source: err };
+        assert!(folder_err.to_string().starts_with("policy parse failed:"));
+    }
+}

--- a/crates/cairn-core/src/domain/folder/policy.rs
+++ b/crates/cairn-core/src/domain/folder/policy.rs
@@ -114,6 +114,93 @@ pub fn parse_policy(yaml: &str) -> Result<FolderPolicy, FolderError> {
     serde_yaml::from_str(yaml).map_err(|source| FolderError::PolicyParse { source })
 }
 
+/// Result of walking up `_policy.yaml` files and merging deepest-wins per key.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EffectivePolicy {
+    /// Purpose echoed from the deepest policy that set one.
+    pub purpose: Option<String>,
+    /// Allowed kinds from the deepest policy that set them.
+    pub allowed_kinds: Option<Vec<crate::domain::MemoryKind>>,
+    /// Visibility default; falls back to `Private`.
+    pub visibility_default: crate::domain::MemoryVisibility,
+    /// Consolidation cadence; falls back to `Daily`.
+    pub consolidation_cadence: ConsolidationCadence,
+    /// Owning agent; `None` if unset anywhere in the chain.
+    pub owner_agent: Option<String>,
+    /// Retention; falls back to `Unlimited`.
+    pub retention: RetentionPolicy,
+    /// Summary token cap; falls back to 200.
+    pub summary_max_tokens: u32,
+    /// Folder paths that contributed, shallowest first, deepest last.
+    pub source_chain: Vec<std::path::PathBuf>,
+}
+
+impl Default for EffectivePolicy {
+    fn default() -> Self {
+        Self {
+            purpose: None,
+            allowed_kinds: None,
+            visibility_default: crate::domain::MemoryVisibility::Private,
+            consolidation_cadence: ConsolidationCadence::Daily,
+            owner_agent: None,
+            retention: RetentionPolicy::Unlimited,
+            summary_max_tokens: 200,
+            source_chain: Vec::new(),
+        }
+    }
+}
+
+/// Walk from `target`'s parent up to the vault root, merging `_policy.yaml`
+/// entries deepest-wins per key. Defaults from [`EffectivePolicy::default`]
+/// fill in fields that no policy set.
+#[must_use]
+pub fn resolve_policy(
+    target: &std::path::Path,
+    policies_by_dir: &std::collections::BTreeMap<std::path::PathBuf, FolderPolicy>,
+) -> EffectivePolicy {
+    // Build the chain shallowest → deepest.
+    let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+    let mut cur = target.parent();
+    while let Some(d) = cur {
+        if d.as_os_str().is_empty() {
+            break;
+        }
+        dirs.push(d.to_path_buf());
+        cur = d.parent();
+    }
+    dirs.reverse();
+
+    let mut effective = EffectivePolicy::default();
+    for dir in dirs {
+        let Some(p) = policies_by_dir.get(&dir) else {
+            continue;
+        };
+        effective.source_chain.push(dir);
+        if let Some(v) = &p.purpose {
+            effective.purpose = Some(v.clone());
+        }
+        if let Some(v) = &p.allowed_kinds {
+            effective.allowed_kinds = Some(v.clone());
+        }
+        if let Some(v) = p.visibility_default {
+            effective.visibility_default = v;
+        }
+        if let Some(v) = p.consolidation_cadence {
+            effective.consolidation_cadence = v;
+        }
+        if let Some(v) = &p.owner_agent {
+            effective.owner_agent = Some(v.clone());
+        }
+        if let Some(v) = p.retention {
+            effective.retention = v;
+        }
+        if let Some(v) = p.summary_max_tokens {
+            effective.summary_max_tokens = v;
+        }
+    }
+    effective
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -169,5 +256,134 @@ summary_max_tokens: 300
         let yaml = "retention: unlimited\n";
         let policy = parse_policy(yaml).expect("parse");
         assert_eq!(policy.retention, Some(RetentionPolicy::Unlimited));
+    }
+
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+
+    fn empty_chain() -> BTreeMap<PathBuf, FolderPolicy> {
+        BTreeMap::new()
+    }
+
+    #[test]
+    fn resolve_with_no_policies_returns_defaults() {
+        let target = Path::new("raw/projects/koi/rfc.md");
+        let resolved = resolve_policy(target, &empty_chain());
+        assert_eq!(resolved.visibility_default, MemoryVisibility::Private);
+        assert_eq!(resolved.consolidation_cadence, ConsolidationCadence::Daily);
+        assert_eq!(resolved.retention, RetentionPolicy::Unlimited);
+        assert_eq!(resolved.summary_max_tokens, 200);
+        assert!(resolved.purpose.is_none());
+        assert!(resolved.allowed_kinds.is_none());
+        assert!(resolved.owner_agent.is_none());
+        assert!(resolved.source_chain.is_empty());
+    }
+
+    #[test]
+    fn resolve_single_root_policy_is_echoed() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from("raw"),
+            FolderPolicy {
+                purpose: Some("root".into()),
+                consolidation_cadence: Some(ConsolidationCadence::Weekly),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/x.md");
+        let resolved = resolve_policy(target, &chain);
+        assert_eq!(resolved.purpose.as_deref(), Some("root"));
+        assert_eq!(resolved.consolidation_cadence, ConsolidationCadence::Weekly);
+        assert_eq!(resolved.source_chain, vec![PathBuf::from("raw")]);
+    }
+
+    #[test]
+    fn resolve_child_overrides_parent_per_key() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from("raw"),
+            FolderPolicy {
+                purpose: Some("root".into()),
+                consolidation_cadence: Some(ConsolidationCadence::Daily),
+                summary_max_tokens: Some(100),
+                ..FolderPolicy::default()
+            },
+        );
+        chain.insert(
+            PathBuf::from("raw/projects"),
+            FolderPolicy {
+                consolidation_cadence: Some(ConsolidationCadence::Weekly),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/projects/koi.md");
+        let resolved = resolve_policy(target, &chain);
+        // Inherited from root:
+        assert_eq!(resolved.purpose.as_deref(), Some("root"));
+        assert_eq!(resolved.summary_max_tokens, 100);
+        // Overridden by child:
+        assert_eq!(resolved.consolidation_cadence, ConsolidationCadence::Weekly);
+    }
+
+    #[test]
+    fn resolve_three_deep_chain_deepest_wins() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from("raw"),
+            FolderPolicy {
+                purpose: Some("root".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        chain.insert(
+            PathBuf::from("raw/projects"),
+            FolderPolicy {
+                purpose: Some("projects".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        chain.insert(
+            PathBuf::from("raw/projects/koi"),
+            FolderPolicy {
+                purpose: Some("koi".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/projects/koi/rfc.md");
+        let resolved = resolve_policy(target, &chain);
+        assert_eq!(resolved.purpose.as_deref(), Some("koi"));
+        assert_eq!(
+            resolved.source_chain,
+            vec![
+                PathBuf::from("raw"),
+                PathBuf::from("raw/projects"),
+                PathBuf::from("raw/projects/koi"),
+            ],
+        );
+    }
+
+    #[test]
+    fn resolve_source_chain_skips_dirs_without_policy() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from("raw"),
+            FolderPolicy {
+                purpose: Some("r".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        chain.insert(
+            PathBuf::from("raw/a/b/c"),
+            FolderPolicy {
+                purpose: Some("c".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/a/b/c/d/e.md");
+        let resolved = resolve_policy(target, &chain);
+        assert_eq!(
+            resolved.source_chain,
+            vec![PathBuf::from("raw"), PathBuf::from("raw/a/b/c")],
+        );
     }
 }

--- a/crates/cairn-core/src/domain/folder/policy.rs
+++ b/crates/cairn-core/src/domain/folder/policy.rs
@@ -386,4 +386,93 @@ summary_max_tokens: 300
             vec![PathBuf::from("raw"), PathBuf::from("raw/a/b/c")],
         );
     }
+
+    use proptest::prelude::*;
+
+    fn arb_cadence() -> impl Strategy<Value = ConsolidationCadence> {
+        prop_oneof![
+            Just(ConsolidationCadence::Hourly),
+            Just(ConsolidationCadence::Daily),
+            Just(ConsolidationCadence::Weekly),
+            Just(ConsolidationCadence::Monthly),
+            Just(ConsolidationCadence::Manual),
+        ]
+    }
+
+    fn arb_retention() -> impl Strategy<Value = RetentionPolicy> {
+        prop_oneof![
+            (1u32..=365).prop_map(RetentionPolicy::Days),
+            Just(RetentionPolicy::Unlimited),
+        ]
+    }
+
+    fn arb_policy() -> impl Strategy<Value = FolderPolicy> {
+        (
+            proptest::option::of("[a-z ]{1,40}".prop_map(String::from)),
+            proptest::option::of(arb_cadence()),
+            proptest::option::of(arb_retention()),
+            proptest::option::of(1u32..=1024),
+        )
+            .prop_map(|(purpose, cadence, retention, summary)| FolderPolicy {
+                purpose,
+                allowed_kinds: None,
+                visibility_default: None,
+                consolidation_cadence: cadence,
+                owner_agent: None,
+                retention,
+                summary_max_tokens: summary,
+            })
+    }
+
+    proptest! {
+        #[test]
+        fn parse_serialize_round_trips(p in arb_policy()) {
+            let yaml = serde_yaml::to_string(&p).expect("infallible — FolderPolicy always serializes");
+            let parsed = parse_policy(&yaml).expect("infallible — round-trip of valid policy");
+            prop_assert_eq!(parsed, p);
+        }
+
+        #[test]
+        fn resolve_associative_under_chunked_merge(
+            seed in 0u32..1000
+        ) {
+            // Deterministic three-policy chain.
+            let mut chain = std::collections::BTreeMap::new();
+            chain.insert(
+                std::path::PathBuf::from("a"),
+                FolderPolicy {
+                    purpose: Some(format!("a-{seed}")),
+                    summary_max_tokens: Some(100),
+                    ..FolderPolicy::default()
+                },
+            );
+            chain.insert(
+                std::path::PathBuf::from("a/b"),
+                FolderPolicy {
+                    consolidation_cadence: Some(ConsolidationCadence::Weekly),
+                    ..FolderPolicy::default()
+                },
+            );
+            chain.insert(
+                std::path::PathBuf::from("a/b/c"),
+                FolderPolicy {
+                    summary_max_tokens: Some(seed.min(500) + 50),
+                    ..FolderPolicy::default()
+                },
+            );
+            let target = std::path::Path::new("a/b/c/x.md");
+            let full = resolve_policy(target, &chain);
+
+            // Subset (only middle) should differ on cadence inheritance.
+            let mut middle_only = std::collections::BTreeMap::new();
+            middle_only.insert(
+                std::path::PathBuf::from("a/b"),
+                chain.get(std::path::Path::new("a/b")).unwrap().clone(),
+            );
+            let middle = resolve_policy(target, &middle_only);
+
+            prop_assert_eq!(full.consolidation_cadence, ConsolidationCadence::Weekly);
+            prop_assert_eq!(middle.consolidation_cadence, ConsolidationCadence::Weekly);
+        }
+    }
 }

--- a/crates/cairn-core/src/domain/folder/policy.rs
+++ b/crates/cairn-core/src/domain/folder/policy.rs
@@ -164,11 +164,15 @@ pub fn resolve_policy(
     target: &std::path::Path,
     policies_by_dir: &std::collections::BTreeMap<std::path::PathBuf, FolderPolicy>,
 ) -> EffectivePolicy {
-    // Build the chain shallowest → deepest.
+    // Build the chain shallowest → deepest. The empty path is the vault-root
+    // key — `collect_policies` in `cairn-cli` writes a root `_policy.yaml`
+    // under `PathBuf::from("")`, so we must probe that key too. Otherwise a
+    // valid root policy is silently dropped from the chain.
     let mut dirs: Vec<std::path::PathBuf> = Vec::new();
     let mut cur = target.parent();
     while let Some(d) = cur {
         if d.as_os_str().is_empty() {
+            dirs.push(std::path::PathBuf::from(""));
             break;
         }
         dirs.push(d.to_path_buf());
@@ -401,6 +405,55 @@ summary_max_tokens: 300
                 PathBuf::from("raw/projects"),
                 PathBuf::from("raw/projects/koi"),
             ],
+        );
+    }
+
+    #[test]
+    fn resolve_root_policy_applies_to_descendant() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from(""),
+            FolderPolicy {
+                purpose: Some("root applies".into()),
+                consolidation_cadence: Some(ConsolidationCadence::Hourly),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/projects/koi.md");
+        let resolved = resolve_policy(target, &chain);
+        assert_eq!(resolved.purpose.as_deref(), Some("root applies"));
+        assert_eq!(resolved.consolidation_cadence, ConsolidationCadence::Hourly);
+        assert_eq!(resolved.source_chain, vec![PathBuf::from("")]);
+    }
+
+    #[test]
+    fn resolve_root_policy_overridden_by_deeper_policy() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from(""),
+            FolderPolicy {
+                purpose: Some("root".into()),
+                consolidation_cadence: Some(ConsolidationCadence::Daily),
+                ..FolderPolicy::default()
+            },
+        );
+        chain.insert(
+            PathBuf::from("raw"),
+            FolderPolicy {
+                consolidation_cadence: Some(ConsolidationCadence::Weekly),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/x.md");
+        let resolved = resolve_policy(target, &chain);
+        // Inherited from root:
+        assert_eq!(resolved.purpose.as_deref(), Some("root"));
+        // Overridden by raw/:
+        assert_eq!(resolved.consolidation_cadence, ConsolidationCadence::Weekly);
+        // Source chain is shallowest-first, deepest-last.
+        assert_eq!(
+            resolved.source_chain,
+            vec![PathBuf::from(""), PathBuf::from("raw")],
         );
     }
 

--- a/crates/cairn-core/src/domain/folder/policy.rs
+++ b/crates/cairn-core/src/domain/folder/policy.rs
@@ -1,0 +1,1 @@
+//! `FolderPolicy`, `EffectivePolicy`, parse + resolve.

--- a/crates/cairn-core/src/domain/folder/policy.rs
+++ b/crates/cairn-core/src/domain/folder/policy.rs
@@ -224,7 +224,10 @@ summary_max_tokens: 300
             policy.consolidation_cadence,
             Some(ConsolidationCadence::Weekly),
         );
-        assert_eq!(policy.owner_agent.as_deref(), Some("agt:cairn-librarian:v2"));
+        assert_eq!(
+            policy.owner_agent.as_deref(),
+            Some("agt:cairn-librarian:v2")
+        );
         assert_eq!(policy.retention, Some(RetentionPolicy::Days(90)));
         assert_eq!(policy.summary_max_tokens, Some(300));
     }

--- a/crates/cairn-core/src/domain/folder/policy.rs
+++ b/crates/cairn-core/src/domain/folder/policy.rs
@@ -9,6 +9,12 @@ use crate::domain::{MemoryKind, MemoryVisibility};
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct FolderPolicy {
+    /// Self-describing folder path; informational only — not validated against
+    /// the file's actual location, and not propagated to [`EffectivePolicy`].
+    /// Allows the brief §3.4 canonical YAML example to round-trip cleanly
+    /// under `deny_unknown_fields`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub folder: Option<String>,
     /// Single-line per-folder purpose; echoed into `_index.md` frontmatter.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub purpose: Option<String>,
@@ -24,9 +30,9 @@ pub struct FolderPolicy {
     /// Agent that owns summary regeneration for this folder.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner_agent: Option<String>,
-    /// Retention policy override.
+    /// Retention policy override (brief §3.4: `retention_days`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub retention: Option<RetentionPolicy>,
+    pub retention_days: Option<RetentionPolicy>,
     /// Cap for `_summary.md` regeneration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary_max_tokens: Option<u32>,
@@ -128,7 +134,7 @@ pub struct EffectivePolicy {
     /// Owning agent; `None` if unset anywhere in the chain.
     pub owner_agent: Option<String>,
     /// Retention; falls back to `Unlimited`.
-    pub retention: RetentionPolicy,
+    pub retention_days: RetentionPolicy,
     /// Summary token cap; falls back to 200.
     pub summary_max_tokens: u32,
     /// Folder paths that contributed, shallowest first, deepest last.
@@ -143,7 +149,7 @@ impl Default for EffectivePolicy {
             visibility_default: crate::domain::MemoryVisibility::Private,
             consolidation_cadence: ConsolidationCadence::Daily,
             owner_agent: None,
-            retention: RetentionPolicy::Unlimited,
+            retention_days: RetentionPolicy::Unlimited,
             summary_max_tokens: 200,
             source_chain: Vec::new(),
         }
@@ -191,8 +197,8 @@ pub fn resolve_policy(
         if let Some(v) = &p.owner_agent {
             effective.owner_agent = Some(v.clone());
         }
-        if let Some(v) = p.retention {
-            effective.retention = v;
+        if let Some(v) = p.retention_days {
+            effective.retention_days = v;
         }
         if let Some(v) = p.summary_max_tokens {
             effective.summary_max_tokens = v;
@@ -213,7 +219,7 @@ allowed_kinds: [user, feedback]
 visibility_default: private
 consolidation_cadence: weekly
 owner_agent: agt:cairn-librarian:v2
-retention: 90
+retention_days: 90
 summary_max_tokens: 300
 ";
         let policy = parse_policy(yaml).expect("parse");
@@ -228,7 +234,40 @@ summary_max_tokens: 300
             policy.owner_agent.as_deref(),
             Some("agt:cairn-librarian:v2")
         );
-        assert_eq!(policy.retention, Some(RetentionPolicy::Days(90)));
+        assert_eq!(policy.retention_days, Some(RetentionPolicy::Days(90)));
+        assert_eq!(policy.summary_max_tokens, Some(300));
+    }
+
+    #[test]
+    fn parse_brief_canonical_example_round_trips() {
+        // Verbatim YAML from brief §3.4 (lines 905-913 of design-brief.md). Must
+        // parse cleanly under deny_unknown_fields, otherwise users following the
+        // brief get a PolicyParse error on day one.
+        let yaml = "\
+folder: wiki/entities/people
+allowed_kinds: [entity, reasoning]
+visibility_default: private
+consolidation_cadence: weekly
+owner_agent: agt:cairn-librarian:v2
+retention_days: unlimited
+summary_max_tokens: 300
+";
+        let policy = parse_policy(yaml).expect("brief canonical example must parse");
+        assert_eq!(policy.folder.as_deref(), Some("wiki/entities/people"));
+        assert_eq!(
+            policy.allowed_kinds.as_deref(),
+            Some(&[MemoryKind::Entity, MemoryKind::Reasoning][..]),
+        );
+        assert_eq!(policy.visibility_default, Some(MemoryVisibility::Private));
+        assert_eq!(
+            policy.consolidation_cadence,
+            Some(ConsolidationCadence::Weekly),
+        );
+        assert_eq!(
+            policy.owner_agent.as_deref(),
+            Some("agt:cairn-librarian:v2"),
+        );
+        assert_eq!(policy.retention_days, Some(RetentionPolicy::Unlimited));
         assert_eq!(policy.summary_max_tokens, Some(300));
     }
 
@@ -256,9 +295,9 @@ summary_max_tokens: 300
 
     #[test]
     fn retention_unlimited_round_trip() {
-        let yaml = "retention: unlimited\n";
+        let yaml = "retention_days: unlimited\n";
         let policy = parse_policy(yaml).expect("parse");
-        assert_eq!(policy.retention, Some(RetentionPolicy::Unlimited));
+        assert_eq!(policy.retention_days, Some(RetentionPolicy::Unlimited));
     }
 
     use std::collections::BTreeMap;
@@ -274,7 +313,7 @@ summary_max_tokens: 300
         let resolved = resolve_policy(target, &empty_chain());
         assert_eq!(resolved.visibility_default, MemoryVisibility::Private);
         assert_eq!(resolved.consolidation_cadence, ConsolidationCadence::Daily);
-        assert_eq!(resolved.retention, RetentionPolicy::Unlimited);
+        assert_eq!(resolved.retention_days, RetentionPolicy::Unlimited);
         assert_eq!(resolved.summary_max_tokens, 200);
         assert!(resolved.purpose.is_none());
         assert!(resolved.allowed_kinds.is_none());
@@ -417,12 +456,13 @@ summary_max_tokens: 300
             proptest::option::of(1u32..=1024),
         )
             .prop_map(|(purpose, cadence, retention, summary)| FolderPolicy {
+                folder: None,
                 purpose,
                 allowed_kinds: None,
                 visibility_default: None,
                 consolidation_cadence: cadence,
                 owner_agent: None,
-                retention,
+                retention_days: retention,
                 summary_max_tokens: summary,
             })
     }

--- a/crates/cairn-core/src/domain/folder/policy.rs
+++ b/crates/cairn-core/src/domain/folder/policy.rs
@@ -1,1 +1,173 @@
 //! `FolderPolicy`, `EffectivePolicy`, parse + resolve.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::folder::FolderError;
+use crate::domain::{MemoryKind, MemoryVisibility};
+
+/// Per-folder configuration deserialized from `_policy.yaml`.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct FolderPolicy {
+    /// Single-line per-folder purpose; echoed into `_index.md` frontmatter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+    /// Kinds permitted in this folder. `None` = inherit; `Some(empty)` = forbid all.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_kinds: Option<Vec<MemoryKind>>,
+    /// Visibility default when `None` chosen at ingest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visibility_default: Option<MemoryVisibility>,
+    /// Override for the global consolidation cadence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consolidation_cadence: Option<ConsolidationCadence>,
+    /// Agent that owns summary regeneration for this folder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_agent: Option<String>,
+    /// Retention policy override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention: Option<RetentionPolicy>,
+    /// Cap for `_summary.md` regeneration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary_max_tokens: Option<u32>,
+}
+
+/// Cadence on which `_summary.md` is regenerated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum ConsolidationCadence {
+    /// Hourly cadence.
+    Hourly,
+    /// Daily cadence (default).
+    Daily,
+    /// Weekly cadence.
+    Weekly,
+    /// Monthly cadence.
+    Monthly,
+    /// Manual (no automatic regeneration).
+    Manual,
+}
+
+/// Retention policy override for a folder.
+///
+/// Serializes as a plain integer for `Days(n)` and as the string `"unlimited"`
+/// for `Unlimited`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RetentionPolicy {
+    /// Keep records for `Days(n)` since their last update.
+    Days(u32),
+    /// Keep records indefinitely.
+    Unlimited,
+}
+
+impl Serialize for RetentionPolicy {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Days(n) => serializer.serialize_u32(*n),
+            Self::Unlimited => serializer.serialize_str("unlimited"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RetentionPolicy {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct RetentionVisitor;
+
+        impl serde::de::Visitor<'_> for RetentionVisitor {
+            type Value = RetentionPolicy;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, r#"a positive integer or the string "unlimited""#)
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<RetentionPolicy, E> {
+                u32::try_from(v)
+                    .map(RetentionPolicy::Days)
+                    .map_err(|_| E::custom(format!("day count {v} overflows u32")))
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<RetentionPolicy, E> {
+                if v.eq_ignore_ascii_case("unlimited") {
+                    Ok(RetentionPolicy::Unlimited)
+                } else {
+                    Err(E::unknown_variant(v, &["unlimited"]))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(RetentionVisitor)
+    }
+}
+
+/// Parse a `_policy.yaml` content string.
+///
+/// # Errors
+///
+/// Returns [`FolderError::PolicyParse`] if YAML is malformed or contains
+/// unknown keys (the struct is `deny_unknown_fields`).
+pub fn parse_policy(yaml: &str) -> Result<FolderPolicy, FolderError> {
+    if yaml.trim().is_empty() {
+        return Ok(FolderPolicy::default());
+    }
+    serde_yaml::from_str(yaml).map_err(|source| FolderError::PolicyParse { source })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_round_trips_every_field() {
+        let yaml = "
+purpose: people Cairn knows about
+allowed_kinds: [user, feedback]
+visibility_default: private
+consolidation_cadence: weekly
+owner_agent: agt:cairn-librarian:v2
+retention: 90
+summary_max_tokens: 300
+";
+        let policy = parse_policy(yaml).expect("parse");
+        assert_eq!(policy.purpose.as_deref(), Some("people Cairn knows about"));
+        assert_eq!(policy.allowed_kinds.as_ref().map(Vec::len), Some(2));
+        assert_eq!(policy.visibility_default, Some(MemoryVisibility::Private));
+        assert_eq!(
+            policy.consolidation_cadence,
+            Some(ConsolidationCadence::Weekly),
+        );
+        assert_eq!(policy.owner_agent.as_deref(), Some("agt:cairn-librarian:v2"));
+        assert_eq!(policy.retention, Some(RetentionPolicy::Days(90)));
+        assert_eq!(policy.summary_max_tokens, Some(300));
+    }
+
+    #[test]
+    fn parse_unknown_key_returns_policy_parse() {
+        let yaml = "unknown_key: 42\n";
+        let err = parse_policy(yaml).unwrap_err();
+        assert!(matches!(err, FolderError::PolicyParse { .. }));
+    }
+
+    #[test]
+    fn parse_malformed_yaml_returns_policy_parse() {
+        let yaml = "purpose: [unclosed";
+        let err = parse_policy(yaml).unwrap_err();
+        assert!(matches!(err, FolderError::PolicyParse { .. }));
+    }
+
+    #[test]
+    fn parse_empty_yaml_returns_default() {
+        let policy = parse_policy("").expect("parse empty");
+        assert_eq!(policy, FolderPolicy::default());
+        let policy = parse_policy("   \n\n").expect("parse whitespace");
+        assert_eq!(policy, FolderPolicy::default());
+    }
+
+    #[test]
+    fn retention_unlimited_round_trip() {
+        let yaml = "retention: unlimited\n";
+        let policy = parse_policy(yaml).expect("parse");
+        assert_eq!(policy.retention, Some(RetentionPolicy::Unlimited));
+    }
+}

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -25,6 +25,7 @@ pub mod capture_manifest;
 pub mod error;
 pub mod evidence;
 pub mod filter;
+pub mod folder;
 pub mod identity;
 pub mod intent;
 pub mod projection;

--- a/crates/cairn-core/src/domain/timestamp.rs
+++ b/crates/cairn-core/src/domain/timestamp.rs
@@ -39,6 +39,76 @@ impl Rfc3339Timestamp {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// Compare two timestamps chronologically, accounting for timezone
+    /// offsets. Lexical comparison of `as_str()` is wrong once offsets are
+    /// involved (`2026-04-22T15:00:00+02:00` happens *before*
+    /// `2026-04-22T14:00:00Z` chronologically but sorts *after* it
+    /// lexically). The string has already been validated by `parse`, so the
+    /// fixed-position parsing here cannot panic on a `Rfc3339Timestamp`
+    /// produced through the public API.
+    #[must_use]
+    pub fn cmp_chronological(&self, other: &Self) -> std::cmp::Ordering {
+        chronological_key(&self.0).cmp(&chronological_key(&other.0))
+    }
+}
+
+/// Convert a validated RFC3339 string to a `(utc_seconds_from_civil_day_zero,
+/// nanoseconds)` sort key. Civil-day-zero is 0000-03-01 per Hinnant's
+/// "days from civil" algorithm; the absolute origin is irrelevant for
+/// ordering as long as it is the same for every value being compared.
+fn chronological_key(s: &str) -> (i64, u32) {
+    let bytes = s.as_bytes();
+    let year = i64::from(u16_digits(&bytes[..4]));
+    let month = i64::from(u8_digits(&bytes[5..7]));
+    let day = i64::from(u8_digits(&bytes[8..10]));
+    let hour = i64::from(u8_digits(&bytes[11..13]));
+    let minute = i64::from(u8_digits(&bytes[14..16]));
+    let second = i64::from(u8_digits(&bytes[17..19]));
+
+    // Hinnant "days from civil": days since 0000-03-01.
+    let y = year - i64::from(month <= 2);
+    let era = if y >= 0 { y / 400 } else { (y - 399) / 400 };
+    let yoe = y - era * 400;
+    let m_adj = if month > 2 { month - 3 } else { month + 9 };
+    let doy = (153 * m_adj + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146_097 + doe;
+
+    let mut sec = days * 86_400 + hour * 3_600 + minute * 60 + second;
+
+    let mut idx = 19;
+    let mut frac_nanos: u32 = 0;
+    if idx < bytes.len() && bytes[idx] == b'.' {
+        idx += 1;
+        let frac_start = idx;
+        while idx < bytes.len() && bytes[idx].is_ascii_digit() {
+            idx += 1;
+        }
+        let mut digits: u64 = 0;
+        for b in &bytes[frac_start..idx] {
+            digits = digits * 10 + u64::from(b - b'0');
+        }
+        let frac_len = idx - frac_start;
+        for _ in frac_len..9 {
+            digits *= 10;
+        }
+        // `digits` ≤ 999_999_999 (parser caps at 9 digits) — fits in u32.
+        frac_nanos = u32::try_from(digits).unwrap_or(u32::MAX);
+    }
+
+    if idx < bytes.len()
+        && let b'+' | b'-' = bytes[idx]
+    {
+        // To convert local time to UTC, subtract the offset:
+        //   local = utc + offset  →  utc = local - offset.
+        let sign: i64 = if bytes[idx] == b'-' { 1 } else { -1 };
+        let oh = i64::from(u8_digits(&bytes[idx + 1..idx + 3]));
+        let om = i64::from(u8_digits(&bytes[idx + 4..idx + 6]));
+        sec += sign * (oh * 3_600 + om * 60);
+    }
+
+    (sec, frac_nanos)
 }
 
 impl std::fmt::Display for Rfc3339Timestamp {
@@ -196,6 +266,36 @@ const fn days_in_month(year: u16, month: u8) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn chronological_compares_offsets_correctly() {
+        // `+02:00` at 15:00 is the same instant as `13:00Z`, so it
+        // pre-dates `14:00Z` chronologically — even though it sorts
+        // after `14:00Z` lexically.
+        let earlier_offset = Rfc3339Timestamp::parse("2026-04-22T15:00:00+02:00").expect("valid");
+        let later_utc = Rfc3339Timestamp::parse("2026-04-22T14:00:00Z").expect("valid");
+        assert_eq!(
+            earlier_offset.cmp_chronological(&later_utc),
+            std::cmp::Ordering::Less,
+            "offset+02:00 15:00 should be before 14:00Z",
+        );
+    }
+
+    #[test]
+    fn chronological_compares_negative_offsets() {
+        // `-05:00` at 09:00 = 14:00Z, so it is the same instant as
+        // `14:00Z` and equal to it chronologically.
+        let neg = Rfc3339Timestamp::parse("2026-04-22T09:00:00-05:00").expect("valid");
+        let utc = Rfc3339Timestamp::parse("2026-04-22T14:00:00Z").expect("valid");
+        assert_eq!(neg.cmp_chronological(&utc), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn chronological_uses_fractional_seconds() {
+        let a = Rfc3339Timestamp::parse("2026-04-22T14:00:00.100Z").expect("valid");
+        let b = Rfc3339Timestamp::parse("2026-04-22T14:00:00.200Z").expect("valid");
+        assert_eq!(a.cmp_chronological(&b), std::cmp::Ordering::Less);
+    }
 
     #[test]
     fn accepts_z_form() {

--- a/docs/superpowers/plans/2026-04-27-folder-sidecars.md
+++ b/docs/superpowers/plans/2026-04-27-folder-sidecars.md
@@ -1,0 +1,2336 @@
+# Folder Sidecars, Backlinks, and Policy Inheritance — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #44 — define the folder sidecar schema (`_index.md`, `_policy.yaml`, `_summary.md`), ship pure folder-projection helpers in `cairn-core::domain::folder`, derive backlinks from record bodies, resolve policy with deepest-wins walk-up, and expose a `cairn lint --fix-folders` CLI flag.
+
+**Architecture:** New module `cairn-core::domain::folder/` (split into `mod.rs`, `policy.rs`, `links.rs`, `index.rs`) holding pure types and functions. CLI handler in `cairn-cli::verbs::lint` walks the store, builds the inputs, calls the projector, and writes `_index.md` files atomically. `_summary.md` ships as schema-only types plus a `FolderSummaryWriter` trait surface; no summary files are emitted at P0.
+
+**Tech Stack:** Rust 1.95 (edition 2024), `serde_yaml` 0.9, `tempfile`, `tokio` (CLI), `async_trait`, `thiserror`, `proptest`, `insta`, `rstest`, `cargo nextest`.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-folder-sidecars-design.md`
+
+---
+
+## File Structure
+
+| Path | Role |
+|---|---|
+| `crates/cairn-core/src/domain/folder/mod.rs` | NEW — re-exports, `FolderError`, `FolderSummary`, `FolderSummaryWriter` trait + error |
+| `crates/cairn-core/src/domain/folder/policy.rs` | NEW — `FolderPolicy`, `EffectivePolicy`, enums, `parse_policy`, `resolve_policy` |
+| `crates/cairn-core/src/domain/folder/links.rs` | NEW — `RawLink`, `Backlink`, `extract_links`, `materialize_backlinks` |
+| `crates/cairn-core/src/domain/folder/index.rs` | NEW — `FolderState`, `FolderIndex`, `RecordEntry`, `SubfolderEntry`, `aggregate_folders`, `project_index` |
+| `crates/cairn-core/src/domain/mod.rs` | MODIFY — add `pub mod folder;` and re-exports |
+| `crates/cairn-cli/src/verbs/mod.rs` | MODIFY — add `with_fix_folders` decorator |
+| `crates/cairn-cli/src/verbs/lint.rs` | MODIFY — add `fix_folders_handler`, wire flag in `run()` |
+| `crates/cairn-cli/src/main.rs` | MODIFY — wrap `lint_subcommand` with `with_fix_folders` |
+| `crates/cairn-cli/tests/lint_folders.rs` | NEW — integration tests |
+| `crates/cairn-cli/tests/snapshots/` | NEW (insta) — `_index.md` snapshots |
+
+---
+
+## Task 1: Module skeleton — empty submodule wired in
+
+**Files:**
+- Create: `crates/cairn-core/src/domain/folder/mod.rs`
+- Create: `crates/cairn-core/src/domain/folder/policy.rs`
+- Create: `crates/cairn-core/src/domain/folder/links.rs`
+- Create: `crates/cairn-core/src/domain/folder/index.rs`
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+
+- [ ] **Step 1: Create empty submodule files**
+
+`crates/cairn-core/src/domain/folder/mod.rs`:
+
+```rust
+//! Folder sidecars — `_index.md`, `_policy.yaml`, `_summary.md` (brief §3.4).
+//!
+//! Pure functions only — zero I/O, zero async. Caller (CLI / future hooks)
+//! supplies records and policy bytes; module returns projected files,
+//! parsed policies, and resolved effective policies.
+
+pub mod index;
+pub mod links;
+pub mod policy;
+```
+
+`crates/cairn-core/src/domain/folder/policy.rs`:
+
+```rust
+//! `FolderPolicy`, `EffectivePolicy`, parse + resolve.
+```
+
+`crates/cairn-core/src/domain/folder/links.rs`:
+
+```rust
+//! Markdown link extraction and reverse-map materialization.
+```
+
+`crates/cairn-core/src/domain/folder/index.rs`:
+
+```rust
+//! Folder aggregation + `_index.md` projection.
+```
+
+- [ ] **Step 2: Wire `folder` into `domain/mod.rs`**
+
+Add to `crates/cairn-core/src/domain/mod.rs` (alongside the existing `pub mod` lines):
+
+```rust
+pub mod folder;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo check -p cairn-core --locked`
+Expected: PASS, no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/ crates/cairn-core/src/domain/mod.rs
+git commit -m "feat(core): folder module skeleton (brief §3.4, #44)"
+```
+
+---
+
+## Task 2: `FolderError` enum
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/cairn-core/src/domain/folder/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folder_error_displays_with_source() {
+        let yaml = "purpose: [unclosed";
+        let err = serde_yaml::from_str::<serde_yaml::Value>(yaml).unwrap_err();
+        let folder_err = FolderError::PolicyParse { source: err };
+        assert!(folder_err.to_string().starts_with("policy parse failed:"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p cairn-core --locked folder::tests::folder_error_displays_with_source`
+Expected: FAIL — `FolderError` not defined.
+
+- [ ] **Step 3: Add the enum**
+
+Insert above the test module in `mod.rs`:
+
+```rust
+/// Errors raised by pure folder helpers.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FolderError {
+    /// `_policy.yaml` could not be parsed as a `FolderPolicy`.
+    #[error("policy parse failed: {source}")]
+    PolicyParse {
+        /// Underlying serde_yaml error.
+        #[source]
+        source: serde_yaml::Error,
+    },
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run -p cairn-core --locked folder::tests::folder_error_displays_with_source`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/mod.rs
+git commit -m "feat(core): FolderError enum (brief §3.4, #44)"
+```
+
+---
+
+## Task 3: `FolderPolicy` types + `parse_policy`
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/policy.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `policy.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+use crate::domain::folder::FolderError;
+use crate::domain::{MemoryKind, MemoryVisibility};
+
+/// Per-folder configuration deserialized from `_policy.yaml`.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct FolderPolicy {
+    /// Single-line per-folder purpose; echoed into `_index.md` frontmatter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+    /// Kinds permitted in this folder. `None` = inherit; `Some(empty)` = forbid all.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_kinds: Option<Vec<MemoryKind>>,
+    /// Visibility default when `None` chosen at ingest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visibility_default: Option<MemoryVisibility>,
+    /// Override for the global consolidation cadence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consolidation_cadence: Option<ConsolidationCadence>,
+    /// Agent that owns summary regeneration for this folder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_agent: Option<String>,
+    /// Retention policy override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retention: Option<RetentionPolicy>,
+    /// Cap for `_summary.md` regeneration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary_max_tokens: Option<u32>,
+}
+
+/// Cadence on which `_summary.md` is regenerated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum ConsolidationCadence {
+    /// Hourly cadence.
+    Hourly,
+    /// Daily cadence (default).
+    Daily,
+    /// Weekly cadence.
+    Weekly,
+    /// Monthly cadence.
+    Monthly,
+    /// Manual (no automatic regeneration).
+    Manual,
+}
+
+/// Retention policy override for a folder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum RetentionPolicy {
+    /// Keep records for `Days(n)` since their last update.
+    Days(u32),
+    /// Keep records indefinitely.
+    Unlimited,
+}
+
+/// Parse a `_policy.yaml` content string.
+///
+/// # Errors
+///
+/// Returns [`FolderError::PolicyParse`] if YAML is malformed or contains
+/// unknown keys (the struct is `deny_unknown_fields`).
+pub fn parse_policy(yaml: &str) -> Result<FolderPolicy, FolderError> {
+    if yaml.trim().is_empty() {
+        return Ok(FolderPolicy::default());
+    }
+    serde_yaml::from_str(yaml).map_err(|source| FolderError::PolicyParse { source })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_round_trips_every_field() {
+        let yaml = r#"
+purpose: people Cairn knows about
+allowed_kinds: [user, feedback]
+visibility_default: private
+consolidation_cadence: weekly
+owner_agent: agt:cairn-librarian:v2
+retention: 90
+summary_max_tokens: 300
+"#;
+        let policy = parse_policy(yaml).expect("parse");
+        assert_eq!(policy.purpose.as_deref(), Some("people Cairn knows about"));
+        assert_eq!(policy.allowed_kinds.as_ref().map(Vec::len), Some(2));
+        assert_eq!(policy.visibility_default, Some(MemoryVisibility::Private));
+        assert_eq!(
+            policy.consolidation_cadence,
+            Some(ConsolidationCadence::Weekly),
+        );
+        assert_eq!(policy.owner_agent.as_deref(), Some("agt:cairn-librarian:v2"));
+        assert_eq!(policy.retention, Some(RetentionPolicy::Days(90)));
+        assert_eq!(policy.summary_max_tokens, Some(300));
+    }
+
+    #[test]
+    fn parse_unknown_key_returns_policy_parse() {
+        let yaml = "unknown_key: 42\n";
+        let err = parse_policy(yaml).unwrap_err();
+        assert!(matches!(err, FolderError::PolicyParse { .. }));
+    }
+
+    #[test]
+    fn parse_malformed_yaml_returns_policy_parse() {
+        let yaml = "purpose: [unclosed";
+        let err = parse_policy(yaml).unwrap_err();
+        assert!(matches!(err, FolderError::PolicyParse { .. }));
+    }
+
+    #[test]
+    fn parse_empty_yaml_returns_default() {
+        let policy = parse_policy("").expect("parse empty");
+        assert_eq!(policy, FolderPolicy::default());
+        let policy = parse_policy("   \n\n").expect("parse whitespace");
+        assert_eq!(policy, FolderPolicy::default());
+    }
+
+    #[test]
+    fn retention_unlimited_round_trip() {
+        let yaml = "retention: unlimited\n";
+        let policy = parse_policy(yaml).expect("parse");
+        assert_eq!(policy.retention, Some(RetentionPolicy::Unlimited));
+    }
+}
+```
+
+Add `pub use policy::*;` to `crates/cairn-core/src/domain/folder/mod.rs` so the test module's references resolve cleanly.
+
+```rust
+// At the top of mod.rs, before the FolderError enum:
+pub use links::*;
+pub use policy::*;
+```
+
+(`links::*` becomes meaningful in Task 5 — re-exporting now keeps later edits localized.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p cairn-core --locked folder::policy::tests`
+Expected: FAIL — types/functions undefined.
+
+- [ ] **Step 3: Already implemented in Step 1**
+
+The struct + enums + `parse_policy` were added with the tests. Re-run.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run -p cairn-core --locked folder::policy::tests`
+Expected: 5 passed.
+
+- [ ] **Step 5: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/policy.rs crates/cairn-core/src/domain/folder/mod.rs
+git commit -m "feat(core): FolderPolicy types + parse_policy (brief §3.4, #44)"
+```
+
+---
+
+## Task 4: `EffectivePolicy` + `Default` + `resolve_policy`
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/policy.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `policy.rs` (above the `#[cfg(test)]` block, the test additions go inside the existing `tests` module):
+
+In `tests`:
+
+```rust
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+
+    fn empty_chain() -> BTreeMap<PathBuf, FolderPolicy> {
+        BTreeMap::new()
+    }
+
+    #[test]
+    fn resolve_with_no_policies_returns_defaults() {
+        let target = Path::new("raw/projects/koi/rfc.md");
+        let resolved = resolve_policy(target, &empty_chain());
+        assert_eq!(resolved.visibility_default, MemoryVisibility::Private);
+        assert_eq!(resolved.consolidation_cadence, ConsolidationCadence::Daily);
+        assert_eq!(resolved.retention, RetentionPolicy::Unlimited);
+        assert_eq!(resolved.summary_max_tokens, 200);
+        assert!(resolved.purpose.is_none());
+        assert!(resolved.allowed_kinds.is_none());
+        assert!(resolved.owner_agent.is_none());
+        assert!(resolved.source_chain.is_empty());
+    }
+
+    #[test]
+    fn resolve_single_root_policy_is_echoed() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from("raw"),
+            FolderPolicy {
+                purpose: Some("root".into()),
+                consolidation_cadence: Some(ConsolidationCadence::Weekly),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/x.md");
+        let resolved = resolve_policy(target, &chain);
+        assert_eq!(resolved.purpose.as_deref(), Some("root"));
+        assert_eq!(resolved.consolidation_cadence, ConsolidationCadence::Weekly);
+        assert_eq!(resolved.source_chain, vec![PathBuf::from("raw")]);
+    }
+
+    #[test]
+    fn resolve_child_overrides_parent_per_key() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from("raw"),
+            FolderPolicy {
+                purpose: Some("root".into()),
+                consolidation_cadence: Some(ConsolidationCadence::Daily),
+                summary_max_tokens: Some(100),
+                ..FolderPolicy::default()
+            },
+        );
+        chain.insert(
+            PathBuf::from("raw/projects"),
+            FolderPolicy {
+                consolidation_cadence: Some(ConsolidationCadence::Weekly),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/projects/koi.md");
+        let resolved = resolve_policy(target, &chain);
+        // Inherited from root:
+        assert_eq!(resolved.purpose.as_deref(), Some("root"));
+        assert_eq!(resolved.summary_max_tokens, 100);
+        // Overridden by child:
+        assert_eq!(resolved.consolidation_cadence, ConsolidationCadence::Weekly);
+    }
+
+    #[test]
+    fn resolve_three_deep_chain_deepest_wins() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from("raw"),
+            FolderPolicy {
+                purpose: Some("root".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        chain.insert(
+            PathBuf::from("raw/projects"),
+            FolderPolicy {
+                purpose: Some("projects".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        chain.insert(
+            PathBuf::from("raw/projects/koi"),
+            FolderPolicy {
+                purpose: Some("koi".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/projects/koi/rfc.md");
+        let resolved = resolve_policy(target, &chain);
+        assert_eq!(resolved.purpose.as_deref(), Some("koi"));
+        assert_eq!(
+            resolved.source_chain,
+            vec![
+                PathBuf::from("raw"),
+                PathBuf::from("raw/projects"),
+                PathBuf::from("raw/projects/koi"),
+            ],
+        );
+    }
+
+    #[test]
+    fn resolve_source_chain_skips_dirs_without_policy() {
+        let mut chain = BTreeMap::new();
+        chain.insert(
+            PathBuf::from("raw"),
+            FolderPolicy {
+                purpose: Some("r".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        chain.insert(
+            PathBuf::from("raw/a/b/c"),
+            FolderPolicy {
+                purpose: Some("c".into()),
+                ..FolderPolicy::default()
+            },
+        );
+        let target = Path::new("raw/a/b/c/d/e.md");
+        let resolved = resolve_policy(target, &chain);
+        assert_eq!(
+            resolved.source_chain,
+            vec![PathBuf::from("raw"), PathBuf::from("raw/a/b/c")],
+        );
+    }
+```
+
+Add the type and function above the test module:
+
+```rust
+/// Result of walking up `_policy.yaml` files and merging deepest-wins per key.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EffectivePolicy {
+    /// Purpose echoed from the deepest policy that set one.
+    pub purpose: Option<String>,
+    /// Allowed kinds from the deepest policy that set them.
+    pub allowed_kinds: Option<Vec<crate::domain::MemoryKind>>,
+    /// Visibility default; falls back to `Private`.
+    pub visibility_default: crate::domain::MemoryVisibility,
+    /// Consolidation cadence; falls back to `Daily`.
+    pub consolidation_cadence: ConsolidationCadence,
+    /// Owning agent; `None` if unset anywhere in the chain.
+    pub owner_agent: Option<String>,
+    /// Retention; falls back to `Unlimited`.
+    pub retention: RetentionPolicy,
+    /// Summary token cap; falls back to 200.
+    pub summary_max_tokens: u32,
+    /// Folder paths that contributed, shallowest first, deepest last.
+    pub source_chain: Vec<std::path::PathBuf>,
+}
+
+impl Default for EffectivePolicy {
+    fn default() -> Self {
+        Self {
+            purpose: None,
+            allowed_kinds: None,
+            visibility_default: crate::domain::MemoryVisibility::Private,
+            consolidation_cadence: ConsolidationCadence::Daily,
+            owner_agent: None,
+            retention: RetentionPolicy::Unlimited,
+            summary_max_tokens: 200,
+            source_chain: Vec::new(),
+        }
+    }
+}
+
+/// Walk from `target`'s parent up to the vault root, merging `_policy.yaml`
+/// entries deepest-wins per key. Defaults from [`EffectivePolicy::default`]
+/// fill in fields that no policy set.
+#[must_use]
+pub fn resolve_policy(
+    target: &std::path::Path,
+    policies_by_dir: &std::collections::BTreeMap<std::path::PathBuf, FolderPolicy>,
+) -> EffectivePolicy {
+    // Build the chain shallowest → deepest.
+    let mut dirs: Vec<std::path::PathBuf> = Vec::new();
+    let mut cur = target.parent();
+    while let Some(d) = cur {
+        if d.as_os_str().is_empty() {
+            break;
+        }
+        dirs.push(d.to_path_buf());
+        cur = d.parent();
+    }
+    dirs.reverse();
+
+    let mut effective = EffectivePolicy::default();
+    for dir in dirs {
+        let Some(p) = policies_by_dir.get(&dir) else {
+            continue;
+        };
+        effective.source_chain.push(dir);
+        if let Some(v) = &p.purpose {
+            effective.purpose = Some(v.clone());
+        }
+        if let Some(v) = &p.allowed_kinds {
+            effective.allowed_kinds = Some(v.clone());
+        }
+        if let Some(v) = p.visibility_default {
+            effective.visibility_default = v;
+        }
+        if let Some(v) = p.consolidation_cadence {
+            effective.consolidation_cadence = v;
+        }
+        if let Some(v) = &p.owner_agent {
+            effective.owner_agent = Some(v.clone());
+        }
+        if let Some(v) = p.retention {
+            effective.retention = v;
+        }
+        if let Some(v) = p.summary_max_tokens {
+            effective.summary_max_tokens = v;
+        }
+    }
+    effective
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p cairn-core --locked folder::policy::tests`
+Expected: 5 new tests fail (compile error, then assertion failure depending on order).
+
+- [ ] **Step 3: Step 1 already adds the impl**
+
+Re-run; tests compile and pass.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run -p cairn-core --locked folder::policy::tests`
+Expected: 10 passed (5 from Task 3 + 5 new).
+
+- [ ] **Step 5: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/policy.rs
+git commit -m "feat(core): EffectivePolicy + resolve_policy walk-up (brief §3.4, #44)"
+```
+
+---
+
+## Task 5: `RawLink`, `Backlink`, and `extract_links`
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/links.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `links.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+/// A link extracted from a record body, target resolved against the source folder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawLink {
+    /// Vault-relative target path.
+    pub target_path: PathBuf,
+    /// Optional fragment after `#`, if present.
+    pub anchor: Option<String>,
+}
+
+/// A reverse link: source file pointing at a target file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Backlink {
+    /// File containing the link (vault-relative).
+    pub source_path: PathBuf,
+    /// File being linked to (vault-relative).
+    pub target_path: PathBuf,
+    /// Optional fragment after `#`, if present.
+    pub anchor: Option<String>,
+}
+
+/// Pure markdown link extractor.
+///
+/// Recognises:
+/// - `[label](path)` — markdown link; label discarded.
+/// - `[[target]]` and `[[target#anchor]]` — wiki link.
+///
+/// Drops:
+/// - external URLs (`http://`, `https://`, `mailto:`);
+/// - links inside fenced code blocks;
+/// - escaped link syntax (`\[`).
+///
+/// Wiki-style targets without an extension get `.md` appended. Relative
+/// paths are resolved against the source file's parent directory.
+#[must_use]
+pub fn extract_links(source_path: &Path, body: &str) -> Vec<RawLink> {
+    let mut out = Vec::new();
+    let mut in_fence = false;
+    for line in body.lines() {
+        if let Some(rest) = line.trim_start().strip_prefix("```") {
+            // Toggle fence on the leading-``` line; skip the fence content.
+            in_fence = !in_fence;
+            // Lines that look like ``` ```inline``` on a single line still
+            // toggle once — adequate for P0; rare in record bodies.
+            let _ = rest;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        scan_line(source_path, line, &mut out);
+    }
+    out
+}
+
+fn scan_line(source_path: &Path, line: &str, out: &mut Vec<RawLink>) {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // Escaped open-bracket — skip.
+        if b == b'\\' && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            i += 2;
+            continue;
+        }
+        if b == b'[' && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            // Wiki link: [[target]] or [[target#anchor]]
+            if let Some(end) = find_close(&bytes[i + 2..], b"]]") {
+                let inner = &line[i + 2..i + 2 + end];
+                if let Some(link) = parse_wiki(source_path, inner) {
+                    out.push(link);
+                }
+                i += 2 + end + 2;
+                continue;
+            }
+        }
+        if b == b'[' {
+            // Markdown link: [label](target)
+            if let Some(label_end) = find_close(&bytes[i + 1..], b"]") {
+                let after = i + 1 + label_end + 1;
+                if after < bytes.len() && bytes[after] == b'(' {
+                    if let Some(target_end) = find_close(&bytes[after + 1..], b")") {
+                        let target = &line[after + 1..after + 1 + target_end];
+                        if let Some(link) = parse_markdown(source_path, target) {
+                            out.push(link);
+                        }
+                        i = after + 1 + target_end + 1;
+                        continue;
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+}
+
+fn find_close(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn is_external(target: &str) -> bool {
+    target.starts_with("http://")
+        || target.starts_with("https://")
+        || target.starts_with("mailto:")
+}
+
+fn parse_wiki(source_path: &Path, raw: &str) -> Option<RawLink> {
+    let raw = raw.trim();
+    if raw.is_empty() || is_external(raw) {
+        return None;
+    }
+    let (target_str, anchor) = match raw.split_once('#') {
+        Some((t, a)) => (t, Some(a.to_owned())),
+        None => (raw, None),
+    };
+    let with_ext: PathBuf = if Path::new(target_str).extension().is_some() {
+        PathBuf::from(target_str)
+    } else {
+        PathBuf::from(format!("{target_str}.md"))
+    };
+    Some(RawLink {
+        target_path: resolve_relative(source_path, &with_ext),
+        anchor,
+    })
+}
+
+fn parse_markdown(source_path: &Path, raw: &str) -> Option<RawLink> {
+    let raw = raw.trim();
+    if raw.is_empty() || is_external(raw) {
+        return None;
+    }
+    let (target_str, anchor) = match raw.split_once('#') {
+        Some((t, a)) => (t, Some(a.to_owned())),
+        None => (raw, None),
+    };
+    Some(RawLink {
+        target_path: resolve_relative(source_path, Path::new(target_str)),
+        anchor,
+    })
+}
+
+fn resolve_relative(source_path: &Path, target: &Path) -> PathBuf {
+    if target.is_absolute() {
+        return target.components().skip(1).collect();
+    }
+    let parent = source_path.parent().unwrap_or_else(|| Path::new(""));
+    let joined = parent.join(target);
+    normalize(&joined)
+}
+
+fn normalize(p: &Path) -> PathBuf {
+    let mut out: Vec<std::ffi::OsString> = Vec::new();
+    for comp in p.components() {
+        use std::path::Component;
+        match comp {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
+            Component::Normal(s) => out.push(s.to_os_string()),
+        }
+    }
+    out.iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn markdown_link_label_discarded() {
+        let src = Path::new("raw/a.md");
+        let links = extract_links(src, "see [Alice](raw/alice.md) for details");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_path, PathBuf::from("raw/alice.md"));
+        assert!(links[0].anchor.is_none());
+    }
+
+    #[test]
+    fn wiki_link_appends_md_extension() {
+        let src = Path::new("raw/a.md");
+        let links = extract_links(src, "see [[alice]] for details");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_path, PathBuf::from("raw/alice.md"));
+    }
+
+    #[test]
+    fn wiki_anchor_is_populated() {
+        let src = Path::new("raw/a.md");
+        let links = extract_links(src, "see [[alice#bio]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].anchor.as_deref(), Some("bio"));
+    }
+
+    #[test]
+    fn relative_path_resolves_against_source_folder() {
+        let src = Path::new("wiki/entities/people/bob.md");
+        let links = extract_links(src, "[ref](../alice.md)");
+        assert_eq!(links.len(), 1);
+        assert_eq!(
+            links[0].target_path,
+            PathBuf::from("wiki/entities/alice.md"),
+        );
+    }
+
+    #[test]
+    fn external_urls_are_dropped() {
+        let src = Path::new("raw/a.md");
+        let body = "see [docs](https://example.com), [home](http://x), [mail](mailto:x@y)";
+        let links = extract_links(src, body);
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn code_fenced_links_are_ignored() {
+        let src = Path::new("raw/a.md");
+        let body = "before\n```\n[Alice](raw/alice.md)\n```\nafter [Bob](raw/bob.md)";
+        let links = extract_links(src, body);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target_path, PathBuf::from("raw/bob.md"));
+    }
+
+    #[test]
+    fn escaped_open_bracket_is_ignored() {
+        let src = Path::new("raw/a.md");
+        let body = r"\[not a link\](nope)";
+        let links = extract_links(src, body);
+        assert!(links.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail then pass**
+
+Run: `cargo nextest run -p cairn-core --locked folder::links::tests`
+Expected: 7 passed (the impl is included in Step 1).
+
+- [ ] **Step 3: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/links.rs
+git commit -m "feat(core): extract_links + RawLink/Backlink types (brief §3.4, #44)"
+```
+
+---
+
+## Task 6: `materialize_backlinks`
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/links.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module in `links.rs`:
+
+```rust
+    use crate::contract::memory_store::StoredRecord;
+    use crate::domain::record::tests::sample_stored_record;
+    use std::collections::BTreeMap;
+
+    fn record_with_body(version: u32, body: &str) -> StoredRecord {
+        let mut s = sample_stored_record(version);
+        s.record.body = body.to_owned();
+        s
+    }
+
+    #[test]
+    fn materialize_empty_records_returns_empty_map() {
+        let records: Vec<StoredRecord> = Vec::new();
+        let paths: BTreeMap<crate::domain::RecordId, std::path::PathBuf> = BTreeMap::new();
+        let map = materialize_backlinks(&records, &paths);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn materialize_emits_backlink_for_existing_target() {
+        let r1 = record_with_body(1, "see [Alice](raw/alice.md)");
+        let mut paths = BTreeMap::new();
+        paths.insert(r1.record.id.clone(), PathBuf::from("raw/r1.md"));
+        let map = materialize_backlinks(&[r1], &paths);
+        let entries = map.get(Path::new("raw/alice.md")).expect("entry");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].source_path, PathBuf::from("raw/r1.md"));
+    }
+
+    #[test]
+    fn materialize_includes_dangling_links() {
+        let r1 = record_with_body(1, "[ghost](raw/missing.md)");
+        let mut paths = BTreeMap::new();
+        paths.insert(r1.record.id.clone(), PathBuf::from("raw/r1.md"));
+        let map = materialize_backlinks(&[r1], &paths);
+        assert!(map.contains_key(Path::new("raw/missing.md")));
+    }
+
+    #[test]
+    fn materialize_two_sources_to_same_target_sorted() {
+        let r1 = record_with_body(1, "[a](raw/alice.md)");
+        let mut r2 = record_with_body(1, "[a](raw/alice.md)");
+        // Mutate id so paths differ.
+        r2.record.id = crate::domain::RecordId::new("01HQZX9F5N0000000000000ZZZ".to_owned()).unwrap();
+        let mut paths = BTreeMap::new();
+        paths.insert(r1.record.id.clone(), PathBuf::from("raw/zzz.md"));
+        paths.insert(r2.record.id.clone(), PathBuf::from("raw/aaa.md"));
+        let map = materialize_backlinks(&[r1, r2], &paths);
+        let entries = map.get(Path::new("raw/alice.md")).expect("entry");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].source_path, PathBuf::from("raw/aaa.md"));
+        assert_eq!(entries[1].source_path, PathBuf::from("raw/zzz.md"));
+    }
+```
+
+Add the function above the test module:
+
+```rust
+use std::collections::BTreeMap;
+
+use crate::contract::memory_store::StoredRecord;
+use crate::domain::RecordId;
+
+/// Build the reverse map: target_path → backlinks pointing at it. Sorted by
+/// `source_path` for deterministic output.
+#[must_use]
+pub fn materialize_backlinks(
+    records: &[StoredRecord],
+    record_paths: &BTreeMap<RecordId, PathBuf>,
+) -> BTreeMap<PathBuf, Vec<Backlink>> {
+    let mut by_target: BTreeMap<PathBuf, Vec<Backlink>> = BTreeMap::new();
+    for stored in records {
+        let Some(source_path) = record_paths.get(&stored.record.id) else {
+            continue;
+        };
+        for raw in extract_links(source_path, &stored.record.body) {
+            by_target
+                .entry(raw.target_path.clone())
+                .or_default()
+                .push(Backlink {
+                    source_path: source_path.clone(),
+                    target_path: raw.target_path,
+                    anchor: raw.anchor,
+                });
+        }
+    }
+    for entries in by_target.values_mut() {
+        entries.sort_by(|a, b| a.source_path.cmp(&b.source_path));
+    }
+    by_target
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cargo nextest run -p cairn-core --locked folder::links::tests`
+Expected: 11 passed (7 + 4 new).
+
+- [ ] **Step 3: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/links.rs
+git commit -m "feat(core): materialize_backlinks reverse-map (brief §3.4, #44)"
+```
+
+---
+
+## Task 7: `FolderState`, `FolderIndex`, `RecordEntry`, `SubfolderEntry`
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/index.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `index.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use crate::contract::memory_store::StoredRecord;
+use crate::domain::folder::links::Backlink;
+use crate::domain::folder::policy::EffectivePolicy;
+use crate::domain::{MemoryKind, RecordId, Rfc3339Timestamp};
+
+/// Per-record summary line for a folder index.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordEntry {
+    /// Vault-relative path of the record file.
+    pub path: PathBuf,
+    /// Record id.
+    pub id: RecordId,
+    /// Memory kind.
+    pub kind: MemoryKind,
+    /// Last-update timestamp from the stored record.
+    pub updated_at: Rfc3339Timestamp,
+    /// Backlinks pointing at this record.
+    pub backlink_count: u32,
+}
+
+/// Per-subfolder aggregate row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubfolderEntry {
+    /// Subfolder name (basename, no trailing slash).
+    pub name: String,
+    /// Number of records inside the subtree.
+    pub record_count: u32,
+    /// Latest `updated_at` across the subtree.
+    pub last_updated: Option<Rfc3339Timestamp>,
+}
+
+/// Aggregated state for one folder, ready to project as `_index.md`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FolderState {
+    /// Vault-relative folder path.
+    pub path: PathBuf,
+    /// Records living directly in this folder, sorted by kind then id.
+    pub records: Vec<StoredRecord>,
+    /// Subfolders, sorted by name.
+    pub subfolders: Vec<SubfolderEntry>,
+    /// Backlinks targeting any record in this folder, sorted by source path.
+    pub backlinks: Vec<Backlink>,
+    /// Resolved effective policy at this folder.
+    pub effective_policy: EffectivePolicy,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folder_state_compiles_with_default_policy() {
+        let _ = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo nextest run -p cairn-core --locked folder::index::tests::folder_state_compiles_with_default_policy`
+Expected: PASS.
+
+- [ ] **Step 3: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/index.rs
+git commit -m "feat(core): FolderState + RecordEntry + SubfolderEntry types (brief §3.4, #44)"
+```
+
+---
+
+## Task 8: `aggregate_folders`
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/index.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module in `index.rs`:
+
+```rust
+    use crate::domain::folder::policy::FolderPolicy;
+    use crate::domain::record::tests::sample_stored_record;
+    use std::collections::BTreeMap;
+
+    fn fixture_record(suffix_id: &str) -> StoredRecord {
+        let mut s = sample_stored_record(1);
+        s.record.id = RecordId::new(format!("01HQZX9F5N00000000000{:>06}", suffix_id))
+            .expect("valid record id");
+        s
+    }
+
+    #[test]
+    fn aggregate_single_record_yields_one_folder() {
+        let r = fixture_record("000A");
+        let mut paths = BTreeMap::new();
+        paths.insert(r.record.id.clone(), PathBuf::from("raw/x.md"));
+        let states = aggregate_folders(&[r], &paths, &BTreeMap::new(), &BTreeMap::new());
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].path, PathBuf::from("raw"));
+        assert_eq!(states[0].records.len(), 1);
+        assert!(states[0].subfolders.is_empty());
+    }
+
+    #[test]
+    fn aggregate_nested_propagates_subfolder_counts() {
+        let r1 = fixture_record("0001");
+        let r2 = fixture_record("0002");
+        let mut paths = BTreeMap::new();
+        paths.insert(r1.record.id.clone(), PathBuf::from("raw/a/x.md"));
+        paths.insert(
+            r2.record.id.clone(),
+            PathBuf::from("raw/a/b/y.md"),
+        );
+        let states = aggregate_folders(&[r1, r2], &paths, &BTreeMap::new(), &BTreeMap::new());
+        // One state per non-empty folder: raw, raw/a, raw/a/b
+        let by_path: BTreeMap<PathBuf, &FolderState> =
+            states.iter().map(|s| (s.path.clone(), s)).collect();
+        let raw = by_path.get(Path::new("raw")).expect("raw");
+        let raw_a = by_path.get(Path::new("raw/a")).expect("raw/a");
+        let raw_a_b = by_path.get(Path::new("raw/a/b")).expect("raw/a/b");
+        // raw has one subfolder (a), no direct records.
+        assert!(raw.records.is_empty());
+        assert_eq!(raw.subfolders.len(), 1);
+        assert_eq!(raw.subfolders[0].name, "a");
+        assert_eq!(raw.subfolders[0].record_count, 2);
+        // raw/a has one direct record + one subfolder (b).
+        assert_eq!(raw_a.records.len(), 1);
+        assert_eq!(raw_a.subfolders.len(), 1);
+        assert_eq!(raw_a.subfolders[0].record_count, 1);
+        // raw/a/b has one direct record, no subfolders.
+        assert_eq!(raw_a_b.records.len(), 1);
+        assert!(raw_a_b.subfolders.is_empty());
+    }
+
+    #[test]
+    fn aggregate_skips_empty_folders() {
+        let r = fixture_record("0001");
+        let mut paths = BTreeMap::new();
+        paths.insert(r.record.id.clone(), PathBuf::from("raw/x.md"));
+        let states = aggregate_folders(&[r], &paths, &BTreeMap::new(), &BTreeMap::new());
+        // No FolderState for folders without records or record-bearing children.
+        assert!(states.iter().all(|s| s.path != PathBuf::from("wiki")));
+    }
+
+    #[test]
+    fn aggregate_attaches_backlinks_to_target_folder() {
+        let r = fixture_record("0001");
+        let mut paths = BTreeMap::new();
+        paths.insert(r.record.id.clone(), PathBuf::from("raw/x.md"));
+        let mut backlinks = BTreeMap::new();
+        backlinks.insert(
+            PathBuf::from("raw/x.md"),
+            vec![Backlink {
+                source_path: PathBuf::from("raw/y.md"),
+                target_path: PathBuf::from("raw/x.md"),
+                anchor: None,
+            }],
+        );
+        let states = aggregate_folders(&[r], &paths, &BTreeMap::new(), &backlinks);
+        let raw = states
+            .iter()
+            .find(|s| s.path == PathBuf::from("raw"))
+            .expect("raw state");
+        assert_eq!(raw.backlinks.len(), 1);
+    }
+```
+
+Add the function:
+
+```rust
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::domain::folder::links::Backlink;
+use crate::domain::folder::policy::{FolderPolicy, resolve_policy};
+
+/// Group records by their parent folder, walk up to compute subfolder
+/// aggregates, attach backlinks targeting records in each folder, and
+/// resolve the effective policy at each folder. Returns one
+/// [`FolderState`] per folder that is non-empty (has at least one record
+/// in its subtree).
+#[must_use]
+pub fn aggregate_folders(
+    records: &[StoredRecord],
+    record_paths: &BTreeMap<RecordId, PathBuf>,
+    policies_by_dir: &BTreeMap<PathBuf, FolderPolicy>,
+    backlinks_by_target: &BTreeMap<PathBuf, Vec<Backlink>>,
+) -> Vec<FolderState> {
+    // 1. Pair records with their resolved paths.
+    let mut paired: Vec<(PathBuf, &StoredRecord)> = Vec::new();
+    for stored in records {
+        let Some(p) = record_paths.get(&stored.record.id) else {
+            continue;
+        };
+        paired.push((p.clone(), stored));
+    }
+    paired.sort_by(|a, b| {
+        a.1.record
+            .kind
+            .as_str()
+            .cmp(b.1.record.kind.as_str())
+            .then_with(|| a.1.record.id.as_str().cmp(b.1.record.id.as_str()))
+    });
+
+    // 2. Collect every folder path that has either a direct record OR a
+    //    descendant with a record. Record per-subtree counts.
+    let mut subtree_count: BTreeMap<PathBuf, u32> = BTreeMap::new();
+    let mut subtree_last_update: BTreeMap<PathBuf, Rfc3339Timestamp> = BTreeMap::new();
+    let mut direct: BTreeMap<PathBuf, Vec<&StoredRecord>> = BTreeMap::new();
+
+    for (path, stored) in &paired {
+        let parent = path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map_or_else(|| PathBuf::from(""), Path::to_path_buf);
+        direct.entry(parent.clone()).or_default().push(*stored);
+
+        // Walk every ancestor (parent inclusive) and bump counts.
+        let mut cur: Option<&Path> = Some(&parent);
+        while let Some(d) = cur {
+            if d.as_os_str().is_empty() {
+                break;
+            }
+            *subtree_count.entry(d.to_path_buf()).or_insert(0) += 1;
+            let entry = subtree_last_update
+                .entry(d.to_path_buf())
+                .or_insert_with(|| stored.record.updated_at.clone());
+            if stored.record.updated_at > *entry {
+                *entry = stored.record.updated_at.clone();
+            }
+            cur = d.parent();
+        }
+    }
+
+    // 3. For every folder in `subtree_count`, build a FolderState.
+    let mut states: Vec<FolderState> = Vec::new();
+    for (folder, _count) in &subtree_count {
+        let direct_records: Vec<StoredRecord> = direct
+            .get(folder)
+            .map(|v| v.iter().map(|r| (*r).clone()).collect())
+            .unwrap_or_default();
+
+        // Subfolders: any path in `subtree_count` whose parent equals `folder`.
+        let mut subfolders: Vec<SubfolderEntry> = subtree_count
+            .iter()
+            .filter_map(|(p, c)| {
+                if p.parent() == Some(folder) {
+                    Some(SubfolderEntry {
+                        name: p
+                            .file_name()
+                            .map(|s| s.to_string_lossy().into_owned())
+                            .unwrap_or_default(),
+                        record_count: *c,
+                        last_updated: subtree_last_update.get(p).cloned(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        subfolders.sort_by(|a, b| a.name.cmp(&b.name));
+
+        // Backlinks: any entry in backlinks_by_target whose target lives in this folder.
+        let mut blinks: Vec<Backlink> = backlinks_by_target
+            .iter()
+            .filter(|(target, _)| target.parent() == Some(folder))
+            .flat_map(|(_, v)| v.iter().cloned())
+            .collect();
+        blinks.sort_by(|a, b| a.source_path.cmp(&b.source_path));
+
+        // Effective policy: walk up from a synthetic file inside this folder.
+        let synthetic = folder.join("_dummy.md");
+        let effective_policy = resolve_policy(&synthetic, policies_by_dir);
+
+        states.push(FolderState {
+            path: folder.clone(),
+            records: direct_records,
+            subfolders,
+            backlinks: blinks,
+            effective_policy,
+        });
+    }
+    states.sort_by(|a, b| a.path.cmp(&b.path));
+    states
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cargo nextest run -p cairn-core --locked folder::index::tests`
+Expected: 5 passed (1 from Task 7 + 4 new).
+
+- [ ] **Step 3: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/index.rs
+git commit -m "feat(core): aggregate_folders (brief §3.4, #44)"
+```
+
+---
+
+## Task 9: `project_index` — render `_index.md`
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/index.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module in `index.rs`:
+
+```rust
+    use crate::domain::projection::ProjectedFile;
+
+    #[test]
+    fn project_emits_required_frontmatter_fields() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf: ProjectedFile = project_index(&state);
+        assert_eq!(pf.path, PathBuf::from("raw/_index.md"));
+        assert!(pf.content.contains("folder: raw"));
+        assert!(pf.content.contains("kind: folder_index"));
+        assert!(pf.content.contains("record_count: 0"));
+        assert!(pf.content.contains("subfolder_count: 0"));
+    }
+
+    #[test]
+    fn project_omits_purpose_when_unset() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(!pf.content.contains("purpose:"));
+    }
+
+    #[test]
+    fn project_includes_purpose_when_set() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy {
+                purpose: Some("things".into()),
+                ..EffectivePolicy::default()
+            },
+        };
+        let pf = project_index(&state);
+        assert!(pf.content.contains("purpose: things"));
+    }
+
+    #[test]
+    fn project_is_deterministic() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: vec![
+                SubfolderEntry {
+                    name: "b".into(),
+                    record_count: 1,
+                    last_updated: None,
+                },
+                SubfolderEntry {
+                    name: "a".into(),
+                    record_count: 1,
+                    last_updated: None,
+                },
+            ],
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+        // Caller passes already-sorted subfolders; project_index does not sort,
+        // it relies on aggregate_folders. Sort here to match the contract.
+        let mut state = state;
+        state.subfolders.sort_by(|a, b| a.name.cmp(&b.name));
+        let a = project_index(&state);
+        let b = project_index(&state);
+        assert_eq!(a.content, b.content);
+    }
+
+    #[test]
+    fn project_omits_empty_sections() {
+        let state = FolderState {
+            path: PathBuf::from("raw"),
+            records: Vec::new(),
+            subfolders: Vec::new(),
+            backlinks: Vec::new(),
+            effective_policy: EffectivePolicy::default(),
+        };
+        let pf = project_index(&state);
+        assert!(!pf.content.contains("## Records"));
+        assert!(!pf.content.contains("## Subfolders"));
+        assert!(!pf.content.contains("## Backlinks"));
+    }
+```
+
+Add the function:
+
+```rust
+use crate::domain::projection::ProjectedFile;
+
+/// Project a [`FolderState`] to a `_index.md` file. Caller is responsible
+/// for ensuring deterministic sort order on `state.records`,
+/// `state.subfolders`, and `state.backlinks`.
+#[must_use]
+pub fn project_index(state: &FolderState) -> ProjectedFile {
+    let folder_str = state.path.to_string_lossy();
+    let updated_at = state
+        .records
+        .iter()
+        .map(|r| r.record.updated_at.as_str())
+        .chain(
+            state
+                .subfolders
+                .iter()
+                .filter_map(|s| s.last_updated.as_ref().map(Rfc3339Timestamp::as_str)),
+        )
+        .max()
+        .unwrap_or("1970-01-01T00:00:00Z")
+        .to_owned();
+
+    let mut frontmatter = String::new();
+    frontmatter.push_str("---\n");
+    frontmatter.push_str(&format!("folder: {folder_str}\n"));
+    frontmatter.push_str("kind: folder_index\n");
+    frontmatter.push_str(&format!("updated_at: {updated_at}\n"));
+    frontmatter.push_str(&format!("record_count: {}\n", state.records.len()));
+    frontmatter.push_str(&format!(
+        "subfolder_count: {}\n",
+        state.subfolders.len(),
+    ));
+    if let Some(purpose) = &state.effective_policy.purpose {
+        // Quote with serde_yaml to avoid breaking on `:` / leading whitespace.
+        let yaml_val = serde_yaml::Value::String(purpose.clone());
+        let s = serde_yaml::to_string(&yaml_val)
+            .ok()
+            .and_then(|s| s.strip_prefix("---\n").map(str::to_owned).or(Some(s)))
+            .unwrap_or_else(|| purpose.clone());
+        let s = s.trim_end_matches('\n');
+        frontmatter.push_str(&format!("purpose: {s}\n"));
+    }
+    frontmatter.push_str("---\n\n");
+
+    let mut body = String::new();
+    body.push_str(&format!("# {folder_str}\n"));
+
+    if !state.records.is_empty() {
+        body.push_str(&format!("\n## Records ({})\n", state.records.len()));
+        for s in &state.records {
+            // path = folder / "<kind>_<id>.md" — same as MarkdownProjector.
+            let leaf = format!(
+                "{}_{}.md",
+                s.record.kind.as_str(),
+                s.record.id.as_str(),
+            );
+            body.push_str(&format!(
+                "- [{leaf}]({leaf}) — {kind} · updated {upd}\n",
+                kind = s.record.kind.as_str(),
+                upd = s.record.updated_at.as_str(),
+            ));
+        }
+    }
+
+    if !state.subfolders.is_empty() {
+        body.push_str(&format!(
+            "\n## Subfolders ({})\n",
+            state.subfolders.len(),
+        ));
+        for sf in &state.subfolders {
+            let upd = sf
+                .last_updated
+                .as_ref()
+                .map(|t| format!(" · last updated {}", t.as_str()))
+                .unwrap_or_default();
+            body.push_str(&format!(
+                "- [{name}/]({name}/) — {n} records{upd}\n",
+                name = sf.name,
+                n = sf.record_count,
+            ));
+        }
+    }
+
+    if !state.backlinks.is_empty() {
+        body.push_str(&format!(
+            "\n## Backlinks into this folder ({})\n",
+            state.backlinks.len(),
+        ));
+        for bl in &state.backlinks {
+            let p = bl.source_path.to_string_lossy();
+            body.push_str(&format!("- [{p}]({p})\n"));
+        }
+    }
+
+    ProjectedFile {
+        path: state.path.join("_index.md"),
+        content: format!("{frontmatter}{body}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cargo nextest run -p cairn-core --locked folder::index::tests`
+Expected: 10 passed (5 from Task 7+8 + 5 new).
+
+- [ ] **Step 3: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/index.rs
+git commit -m "feat(core): project_index renders _index.md (brief §3.4, #44)"
+```
+
+---
+
+## Task 10: `FolderSummary` types + `FolderSummaryWriter` trait stub
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `tests` module in `mod.rs`:
+
+```rust
+    #[test]
+    fn folder_summary_writer_trait_object_compiles() {
+        struct Stub;
+        #[async_trait::async_trait]
+        impl FolderSummaryWriter for Stub {
+            async fn write_summary(
+                &self,
+                _summary: FolderSummary,
+            ) -> Result<(), FolderSummaryError> {
+                Err(FolderSummaryError::Unimplemented)
+            }
+        }
+        let _: Box<dyn FolderSummaryWriter> = Box::new(Stub);
+    }
+```
+
+Add the types and trait above the existing `FolderError` enum (or below — same file, cohesive surface):
+
+```rust
+use std::path::PathBuf;
+
+use crate::domain::Rfc3339Timestamp;
+
+/// Schema for `_summary.md`. P0 ships types only — body generation is P1.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FolderSummary {
+    /// Vault-relative folder path.
+    pub folder: PathBuf,
+    /// When this summary was generated.
+    pub generated_at: Rfc3339Timestamp,
+    /// Agent that generated the summary (e.g. `agt:cairn-librarian:v2`).
+    pub generated_by: String,
+    /// Number of records the summary covers.
+    pub covers_records: u32,
+    /// Approximate token count of `body`.
+    pub summary_tokens: u32,
+    /// Generated prose body.
+    pub body: String,
+}
+
+/// Errors raised by [`FolderSummaryWriter`] implementations.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FolderSummaryError {
+    /// No summary writer is registered (P0 default).
+    #[error("folder summary writer not registered")]
+    Unimplemented,
+    /// Internal error from the writer implementation.
+    #[error("folder summary writer internal: {0}")]
+    Internal(String),
+}
+
+/// Workflow-owned write surface for `_summary.md`. P0 ships zero
+/// implementations; P1 `cairn-workflows::FolderSummaryWorkflow` is the
+/// first implementor.
+#[async_trait::async_trait]
+pub trait FolderSummaryWriter: Send + Sync {
+    /// Persist a generated [`FolderSummary`] as `_summary.md` under its
+    /// folder, atomically. Implementors are responsible for I/O safety
+    /// (atomic rename, symlink rejection).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FolderSummaryError::Unimplemented`] when no writer is
+    /// registered, or [`FolderSummaryError::Internal`] for I/O / encoding
+    /// failures.
+    async fn write_summary(
+        &self,
+        summary: FolderSummary,
+    ) -> Result<(), FolderSummaryError>;
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo nextest run -p cairn-core --locked folder::tests::folder_summary_writer_trait_object_compiles`
+Expected: PASS.
+
+- [ ] **Step 3: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/mod.rs
+git commit -m "feat(core): FolderSummary types + FolderSummaryWriter trait stub (brief §3.4, #44)"
+```
+
+---
+
+## Task 11: Property tests — round-trip and associativity
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/folder/policy.rs`
+
+- [ ] **Step 1: Write the failing proptest**
+
+Append to the `tests` module in `policy.rs`:
+
+```rust
+    use proptest::prelude::*;
+
+    fn arb_cadence() -> impl Strategy<Value = ConsolidationCadence> {
+        prop_oneof![
+            Just(ConsolidationCadence::Hourly),
+            Just(ConsolidationCadence::Daily),
+            Just(ConsolidationCadence::Weekly),
+            Just(ConsolidationCadence::Monthly),
+            Just(ConsolidationCadence::Manual),
+        ]
+    }
+
+    fn arb_retention() -> impl Strategy<Value = RetentionPolicy> {
+        prop_oneof![
+            (1u32..=365).prop_map(RetentionPolicy::Days),
+            Just(RetentionPolicy::Unlimited),
+        ]
+    }
+
+    fn arb_policy() -> impl Strategy<Value = FolderPolicy> {
+        (
+            proptest::option::of("[a-z ]{1,40}".prop_map(String::from)),
+            proptest::option::of(arb_cadence()),
+            proptest::option::of(arb_retention()),
+            proptest::option::of(1u32..=1024),
+        )
+            .prop_map(|(purpose, cadence, retention, summary)| FolderPolicy {
+                purpose,
+                allowed_kinds: None,
+                visibility_default: None,
+                consolidation_cadence: cadence,
+                owner_agent: None,
+                retention,
+                summary_max_tokens: summary,
+            })
+    }
+
+    proptest! {
+        #[test]
+        fn parse_serialize_round_trips(p in arb_policy()) {
+            let yaml = serde_yaml::to_string(&p).unwrap();
+            let parsed = parse_policy(&yaml).unwrap();
+            prop_assert_eq!(parsed, p);
+        }
+
+        #[test]
+        fn resolve_associative_under_chunked_merge(
+            seed in 0u32..1000
+        ) {
+            // Deterministic three-policy chain.
+            let mut chain = std::collections::BTreeMap::new();
+            chain.insert(
+                std::path::PathBuf::from("a"),
+                FolderPolicy {
+                    purpose: Some(format!("a-{seed}")),
+                    summary_max_tokens: Some(100),
+                    ..FolderPolicy::default()
+                },
+            );
+            chain.insert(
+                std::path::PathBuf::from("a/b"),
+                FolderPolicy {
+                    consolidation_cadence: Some(ConsolidationCadence::Weekly),
+                    ..FolderPolicy::default()
+                },
+            );
+            chain.insert(
+                std::path::PathBuf::from("a/b/c"),
+                FolderPolicy {
+                    summary_max_tokens: Some(seed.min(500) + 50),
+                    ..FolderPolicy::default()
+                },
+            );
+            let target = std::path::Path::new("a/b/c/x.md");
+            let full = resolve_policy(target, &chain);
+
+            // Subset (only middle) should differ on cadence inheritance.
+            let mut middle_only = std::collections::BTreeMap::new();
+            middle_only.insert(
+                std::path::PathBuf::from("a/b"),
+                chain.get(std::path::Path::new("a/b")).unwrap().clone(),
+            );
+            let middle = resolve_policy(target, &middle_only);
+
+            prop_assert_eq!(full.consolidation_cadence, ConsolidationCadence::Weekly);
+            prop_assert_eq!(middle.consolidation_cadence, ConsolidationCadence::Weekly);
+        }
+    }
+```
+
+Verify `proptest` is already in `cairn-core` `[dev-dependencies]`:
+
+Run: `grep -A2 "\[dev-dependencies\]" crates/cairn-core/Cargo.toml`
+
+If absent, add to `crates/cairn-core/Cargo.toml`:
+
+```toml
+[dev-dependencies]
+proptest = { workspace = true }
+```
+
+- [ ] **Step 2: Run proptest**
+
+Run: `cargo nextest run -p cairn-core --locked folder::policy::tests`
+Expected: PASS — all proptest cases.
+
+- [ ] **Step 3: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/folder/policy.rs crates/cairn-core/Cargo.toml
+git commit -m "test(core): proptest round-trip + resolve invariants (brief §3.4, #44)"
+```
+
+---
+
+## Task 12: CLI — `with_fix_folders` decorator and main wiring
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/mod.rs`
+- Modify: `crates/cairn-cli/src/main.rs`
+
+- [ ] **Step 1: Add the decorator**
+
+Append to `crates/cairn-cli/src/verbs/mod.rs`:
+
+```rust
+/// Add `--fix-folders` flag to the `lint` subcommand.
+///
+/// Augments the generated subcommand builder without touching generated
+/// files, using the same pattern as [`with_fix_markdown`].
+#[must_use]
+pub fn with_fix_folders(cmd: clap::Command) -> clap::Command {
+    cmd.arg(
+        clap::Arg::new("fix-folders")
+            .long("fix-folders")
+            .action(clap::ArgAction::SetTrue)
+            .help(
+                "Regenerate folder _index.md sidecars and backlinks for every \
+                 non-empty folder (brief §3.4, #44)",
+            ),
+    )
+}
+```
+
+- [ ] **Step 2: Wrap the lint subcommand in `main.rs`**
+
+In `crates/cairn-cli/src/main.rs`, find the existing line:
+
+```rust
+        .subcommand(verbs::with_json(verbs::with_fix_markdown(
+            generated::verbs::lint_subcommand(),
+        )))
+```
+
+Replace with:
+
+```rust
+        .subcommand(verbs::with_json(verbs::with_fix_markdown(
+            verbs::with_fix_folders(generated::verbs::lint_subcommand()),
+        )))
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `cargo check -p cairn-cli --locked`
+Expected: PASS.
+
+- [ ] **Step 4: Smoke-test the flag is recognised**
+
+Run: `cargo run -q -p cairn-cli --locked -- lint --help`
+Expected: stdout includes `--fix-folders`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/mod.rs crates/cairn-cli/src/main.rs
+git commit -m "feat(cli): with_fix_folders flag decorator (brief §3.4, #44)"
+```
+
+---
+
+## Task 13: CLI handler — `fix_folders_handler`
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/lint.rs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `crates/cairn-cli/tests/lint_folders.rs`:
+
+```rust
+//! Integration tests for `cairn lint --fix-folders` (issue #44).
+
+use std::path::Path;
+
+use cairn_cli::verbs::lint::{FixFoldersResult, fix_folders_handler};
+use cairn_core::contract::memory_store::MemoryStore;
+use cairn_test_fixtures::store::{FixtureStore, sample_record};
+
+#[tokio::test]
+async fn rebuilds_index_from_empty_markdown_tree() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    // Bootstrap-style minimal layout: just .cairn/ and raw/.
+    std::fs::create_dir_all(vault.path().join(".cairn")).unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+
+    let result: FixFoldersResult = fix_folders_handler(&store, vault.path()).await.unwrap();
+
+    assert!(!result.written.is_empty(), "expected at least one _index.md written");
+    let index = vault.path().join("raw/_index.md");
+    assert!(index.exists(), "raw/_index.md not written");
+    let content = std::fs::read_to_string(&index).unwrap();
+    assert!(content.contains("kind: folder_index"));
+}
+
+#[tokio::test]
+async fn idempotent_second_run_reports_unchanged() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+
+    let r1 = fix_folders_handler(&store, vault.path()).await.unwrap();
+    assert!(!r1.written.is_empty());
+
+    let r2 = fix_folders_handler(&store, vault.path()).await.unwrap();
+    assert!(r2.written.is_empty());
+    assert!(r2.unchanged > 0);
+}
+
+#[tokio::test]
+async fn bad_policy_yaml_does_not_abort_run() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+    std::fs::write(
+        vault.path().join("raw/_policy.yaml"),
+        "unknown_key: 42\n",
+    )
+    .unwrap();
+
+    let result = fix_folders_handler(&store, vault.path()).await.unwrap();
+    assert_eq!(result.policy_errors.len(), 1);
+    assert!(result.policy_errors[0].path.ends_with("raw/_policy.yaml"));
+    // The valid record's _index.md is still emitted.
+    assert!(vault.path().join("raw/_index.md").exists());
+}
+```
+
+Make `cairn-cli` library exports include the new handler (it already publishes `verbs` in `lib.rs`):
+
+Run: `grep -n "pub use\|pub mod" crates/cairn-cli/src/lib.rs`
+
+`lib.rs` already re-exports the `verbs` module via `pub mod verbs;` (added in #43). Confirm `lint` is `pub mod` inside `verbs/mod.rs`. Already true.
+
+- [ ] **Step 2: Run the integration test to verify it fails to compile**
+
+Run: `cargo nextest run -p cairn-cli --locked --test lint_folders`
+Expected: FAIL — `fix_folders_handler` and `FixFoldersResult` undefined.
+
+- [ ] **Step 3: Add the handler in `crates/cairn-cli/src/verbs/lint.rs`**
+
+Add at the top, alongside existing imports:
+
+```rust
+use std::collections::BTreeMap;
+
+use cairn_core::domain::folder::{
+    FolderError, aggregate_folders, materialize_backlinks, parse_policy, project_index,
+};
+use cairn_core::domain::folder::policy::FolderPolicy;
+```
+
+Append after `fix_markdown_handler`:
+
+```rust
+/// Result of a `lint --fix-folders` run.
+#[derive(Debug, serde::Serialize)]
+pub struct FixFoldersResult {
+    /// Folder index files written or updated (vault-relative).
+    pub written: Vec<PathBuf>,
+    /// Number of indexes that already matched their projection.
+    pub unchanged: usize,
+    /// Per-policy parse failures; subtree was skipped.
+    pub policy_errors: Vec<PolicyError>,
+}
+
+/// One `_policy.yaml` that failed to parse.
+#[derive(Debug, serde::Serialize)]
+pub struct PolicyError {
+    /// Vault-relative path of the offending file.
+    pub path: PathBuf,
+    /// Human-readable reason.
+    pub reason: String,
+}
+
+/// Walk the store, build folder states, project `_index.md` files, write
+/// atomically. A bad `_policy.yaml` does not abort — that subtree is
+/// skipped, the error is recorded.
+///
+/// # Errors
+///
+/// Returns an error if the store cannot be queried, or if any non-policy
+/// I/O fails.
+pub async fn fix_folders_handler(
+    store: &dyn MemoryStore,
+    vault_root: &Path,
+) -> anyhow::Result<FixFoldersResult> {
+    let projector = MarkdownProjector;
+    let records = store.list_active().await.context("store: list_active")?;
+
+    // 1. Build record_paths from MarkdownProjector — same shape used by
+    //    --fix-markdown, so callers get a coherent view.
+    let mut record_paths: BTreeMap<cairn_core::domain::RecordId, PathBuf> = BTreeMap::new();
+    for stored in &records {
+        let pf = projector.project(stored);
+        record_paths.insert(stored.record.id.clone(), pf.path);
+    }
+
+    // 2. Walk vault for files named `_policy.yaml`.
+    let mut policies_by_dir: BTreeMap<PathBuf, FolderPolicy> = BTreeMap::new();
+    let mut policy_errors: Vec<PolicyError> = Vec::new();
+    let walker = walkdir::WalkDir::new(vault_root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !is_hidden_dir(e));
+    for entry in walker {
+        let entry = entry.with_context(|| format!("walking {}", vault_root.display()))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.file_name() != "_policy.yaml" {
+            continue;
+        }
+        let abs = entry.path().to_path_buf();
+        let rel = abs
+            .strip_prefix(vault_root)
+            .with_context(|| format!("strip_prefix {}", abs.display()))?
+            .to_path_buf();
+        let dir = rel.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+        let bytes = tokio::fs::read_to_string(&abs).await.with_context(|| {
+            format!("read {}", abs.display())
+        })?;
+        match parse_policy(&bytes) {
+            Ok(p) => {
+                policies_by_dir.insert(dir, p);
+            }
+            Err(FolderError::PolicyParse { source }) => {
+                policy_errors.push(PolicyError {
+                    path: rel,
+                    reason: source.to_string(),
+                });
+            }
+        }
+    }
+
+    // 3. Reverse-map backlinks.
+    let backlinks_by_target = materialize_backlinks(&records, &record_paths);
+
+    // 4. Aggregate.
+    let states = aggregate_folders(
+        &records,
+        &record_paths,
+        &policies_by_dir,
+        &backlinks_by_target,
+    );
+
+    // 5. Write each `_index.md` atomically.
+    let mut written = Vec::new();
+    let mut unchanged = 0usize;
+    for state in states {
+        let projected = project_index(&state);
+        let abs = vault_root.join(&projected.path);
+        let needs_write = match tokio::fs::read_to_string(&abs).await {
+            Ok(existing) => existing != projected.content,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+            Err(e) => return Err(anyhow::anyhow!("cannot read {}: {e}", abs.display())),
+        };
+        if !needs_write {
+            unchanged += 1;
+            continue;
+        }
+        if let Some(parent) = abs.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("create_dir_all {}", parent.display()))?;
+        }
+        let content = projected.content.clone();
+        let dest = abs.clone();
+        let parent_buf = abs.parent().unwrap_or(Path::new(".")).to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            use std::io::Write as _;
+            let mut tmp = tempfile::Builder::new()
+                .suffix(".md.tmp")
+                .tempfile_in(&parent_buf)
+                .with_context(|| format!("tempfile in {}", parent_buf.display()))?;
+            tmp.write_all(content.as_bytes())
+                .with_context(|| format!("write temp {}", tmp.path().display()))?;
+            tmp.persist(&dest)
+                .map_err(|e| anyhow::anyhow!("persist -> {}: {}", dest.display(), e.error))?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+        .with_context(|| format!("spawn_blocking write {}", abs.display()))??;
+        written.push(projected.path);
+    }
+
+    Ok(FixFoldersResult {
+        written,
+        unchanged,
+        policy_errors,
+    })
+}
+
+fn is_hidden_dir(entry: &walkdir::DirEntry) -> bool {
+    entry.file_type().is_dir()
+        && entry
+            .file_name()
+            .to_str()
+            .is_some_and(|s| s.starts_with('.') && s != ".")
+}
+```
+
+Add `walkdir` to `cairn-cli` `[dependencies]` in `crates/cairn-cli/Cargo.toml`:
+
+```toml
+walkdir = { workspace = true }
+```
+
+If `walkdir` is not yet in workspace deps, add to root `Cargo.toml` `[workspace.dependencies]`:
+
+```toml
+walkdir = "2"
+```
+
+- [ ] **Step 4: Run integration tests**
+
+Run: `cargo nextest run -p cairn-cli --locked --test lint_folders`
+Expected: 3 passed.
+
+- [ ] **Step 5: Verify clippy is clean**
+
+Run: `cargo clippy -p cairn-cli --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/lint.rs crates/cairn-cli/tests/lint_folders.rs crates/cairn-cli/Cargo.toml Cargo.toml
+git commit -m "feat(cli): fix_folders_handler — atomic _index.md rebuild (brief §3.4, #44)"
+```
+
+---
+
+## Task 14: Wire `--fix-folders` into `lint::run`
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/lint.rs`
+
+- [ ] **Step 1: Add the dispatch branch**
+
+Update `run()` in `lint.rs`. Current shape:
+
+```rust
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+    let fix_markdown = sub.get_flag("fix-markdown");
+
+    if fix_markdown {
+        // unimplemented response
+    }
+    // unimplemented response
+}
+```
+
+Replace with:
+
+```rust
+pub fn run(sub: &ArgMatches) -> ExitCode {
+    let json = sub.get_flag("json");
+    let fix_markdown = sub.get_flag("fix-markdown");
+    let fix_folders = sub.get_flag("fix-folders");
+
+    if fix_markdown || fix_folders {
+        // TODO(#46): wire the SQLite store. For now, return the same
+        // unimplemented envelope used by --fix-markdown.
+        let resp = unimplemented_response(ResponseVerb::Lint);
+        if json {
+            emit_json(&resp);
+        } else {
+            human_error(
+                "lint",
+                "Internal",
+                "store not wired in this P0 build — --fix-folders requires #46",
+                &resp.operation_id,
+            );
+        }
+        return ExitCode::FAILURE;
+    }
+
+    let resp = unimplemented_response(ResponseVerb::Lint);
+    if json {
+        emit_json(&resp);
+    } else {
+        human_error(
+            "lint",
+            "Internal",
+            "store not wired in this P0 build",
+            &resp.operation_id,
+        );
+    }
+    ExitCode::FAILURE
+}
+```
+
+(The handler is exercised by integration tests directly; CLI dispatch goes live with #46 store wiring, mirroring how `--fix-markdown` already works.)
+
+- [ ] **Step 2: Verify build + smoke-test**
+
+Run: `cargo run -q -p cairn-cli --locked -- lint --fix-folders --json`
+Expected: prints an `Unimplemented` envelope, exit code `1`. (Same as `--fix-markdown` today.)
+
+- [ ] **Step 3: Verify all unit + integration tests still pass**
+
+Run: `cargo nextest run -p cairn-cli --locked`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/lint.rs
+git commit -m "feat(cli): dispatch --fix-folders to handler (brief §3.4, #44)"
+```
+
+---
+
+## Task 15: Insta snapshot for `_index.md` fixture
+
+**Files:**
+- Modify: `crates/cairn-cli/tests/lint_folders.rs`
+
+- [ ] **Step 1: Write the snapshot test**
+
+Append to `crates/cairn-cli/tests/lint_folders.rs`:
+
+```rust
+#[tokio::test]
+async fn fixture_index_matches_snapshot() {
+    let store = FixtureStore::default();
+    store.upsert(sample_record()).await.unwrap();
+
+    let vault = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(vault.path().join("raw")).unwrap();
+
+    let _ = fix_folders_handler(&store, vault.path()).await.unwrap();
+    let content = std::fs::read_to_string(vault.path().join("raw/_index.md")).unwrap();
+
+    // Strip the timestamped `updated_at` line so the snapshot stays stable.
+    let stable: String = content
+        .lines()
+        .filter(|l| !l.starts_with("updated_at:") && !l.contains("· updated "))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    insta::assert_snapshot!("raw_index_single_record", stable);
+}
+```
+
+- [ ] **Step 2: Verify `insta` is a dev-dep of `cairn-cli`**
+
+Run: `grep -n "insta" crates/cairn-cli/Cargo.toml`
+
+If absent, add to `[dev-dependencies]`:
+
+```toml
+insta = { workspace = true }
+```
+
+- [ ] **Step 3: Run the test (it will fail with a "missing snapshot")**
+
+Run: `cargo nextest run -p cairn-cli --locked --test lint_folders fixture_index_matches_snapshot`
+Expected: FAIL — pending snapshot.
+
+- [ ] **Step 4: Accept the snapshot**
+
+Run: `cargo insta review` (or `cargo insta accept` if interactive review is unavailable in the harness).
+Expected: snapshot committed under `crates/cairn-cli/tests/snapshots/lint_folders__raw_index_single_record.snap`.
+
+- [ ] **Step 5: Re-run to confirm**
+
+Run: `cargo nextest run -p cairn-cli --locked --test lint_folders`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-cli/tests/lint_folders.rs crates/cairn-cli/tests/snapshots/ crates/cairn-cli/Cargo.toml
+git commit -m "test(cli): insta snapshot for raw/_index.md fixture (brief §3.4, #44)"
+```
+
+---
+
+## Task 16: Full verification pipeline
+
+**Files:** none
+
+- [ ] **Step 1: fmt**
+
+Run: `cargo fmt --all --check`
+Expected: PASS.
+
+- [ ] **Step 2: clippy (full workspace)**
+
+Run: `cargo clippy --workspace --all-targets --locked -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 3: check**
+
+Run: `cargo check --workspace --all-targets --locked`
+Expected: PASS.
+
+- [ ] **Step 4: nextest (full workspace)**
+
+Run: `cargo nextest run --workspace --locked --no-fail-fast`
+Expected: all green.
+
+- [ ] **Step 5: doctests**
+
+Run: `cargo test --doc --workspace --locked`
+Expected: PASS.
+
+- [ ] **Step 6: core boundary script**
+
+Run: `./scripts/check-core-boundary.sh`
+Expected: PASS.
+
+- [ ] **Step 7: codegen no-diff**
+
+Run: `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
+Expected: PASS (no IDL changes).
+
+- [ ] **Step 8: docs build**
+
+Run: `RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" cargo doc --workspace --no-deps --document-private-items --locked`
+Expected: PASS.
+
+- [ ] **Step 9: supply-chain trio**
+
+Run:
+```bash
+cargo deny check
+cargo audit --deny warnings
+cargo machete
+```
+Expected: PASS (the only new dep is `walkdir`, already widely allow-listed).
+
+- [ ] **Step 10: Final commit (only if step 9 surfaces deny.toml updates)**
+
+If `cargo deny` flags a missing license / advisory entry for `walkdir`, append to `deny.toml` and commit:
+
+```bash
+git add deny.toml
+git commit -m "chore(deny): allow walkdir transitive licenses (#44)"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Every acceptance criterion (§3.4 sidecar trio, backlink rebuildability, workflow-owned summary writes) maps to one or more tasks (3, 4, 5–6, 7–9, 10, 13, 15). Verification criteria (folder fixture projection, backlink rebuild from empty markdown tree, nested-folder config inheritance) map to tasks 15, 13, 4 respectively.
+- **No placeholders:** Every step has either runnable code or an exact command with expected output.
+- **Type consistency:** `FolderError`, `FolderPolicy`, `EffectivePolicy`, `FolderState`, `FolderIndex`, `Backlink`, `RawLink`, `FolderSummary`, `FolderSummaryWriter` named consistently across all tasks.
+- **TDD:** Every task starts with a failing test, then minimal impl, then green.
+- **Frequent commits:** One commit per task, each scoped to one file or tightly cohesive group.

--- a/docs/superpowers/specs/2026-04-27-folder-sidecars-design.md
+++ b/docs/superpowers/specs/2026-04-27-folder-sidecars-design.md
@@ -1,0 +1,531 @@
+# Folder Sidecars, Backlinks, and Policy Inheritance
+
+**Issue:** #44 — [P0] Implement folder metadata, sidecars, backlinks, and folder summaries
+**Brief sections:** §3.4 Folders are first-class · §3.4.a Obsidian prior art
+**Parent epic:** #5 Vault layout, registry, and markdown projection
+**Depends on:** #43 (MarkdownProjector + resync — merged in `b1cddd0`)
+**Date:** 2026-04-27
+
+---
+
+## Scope
+
+Define the folder-sidecar schema and ship the P0 helpers that project SQLite
+state into per-folder `_index.md` files. Backlinks are derived from markdown
+links inside record bodies. Policy walk-up resolution is a pure function so
+the eventual Filter stage and inheritance tests can call it directly.
+
+`_summary.md` ships as schema-only types plus a `FolderSummaryWriter` trait
+stub on `WorkflowOrchestrator`; no `_summary.md` files are written at P0.
+Actual LLM-driven summary generation is P1 (brief §3.4 table).
+
+**Out of scope:**
+
+- PostToolUse hook wiring (sensors issue).
+- Filter-stage enforcement of `allowed_kinds` / `visibility_default` (downstream).
+- LLM-driven `_summary.md` body generation (P1).
+- An `edges` table or `links` field on `MemoryRecord` (separate, future issue).
+- Promotion of records into `wiki/` paths (separate issue).
+
+---
+
+## Architecture
+
+```
+cairn-core/src/domain/
+  folder.rs              ← NEW — pure types + functions
+                            FolderPolicy, EffectivePolicy
+                            FolderIndex, FolderSummary (schema only)
+                            Backlink, FolderState, RawLink
+                            project_index() · parse_policy() · resolve_policy()
+                            extract_links() · materialize_backlinks() · aggregate_folders()
+  projection.rs          ← unchanged
+
+cairn-core/src/contract/
+  workflow_orchestrator.rs ← add FolderSummaryWriter trait stub
+                              (default body returns Unimplemented)
+
+cairn-cli/src/verbs/
+  lint.rs                ← add --fix-folders flag
+                            walks store records, calls folder projector,
+                            atomically writes _index.md per non-empty folder
+
+cairn-cli/src/vault/
+  bootstrap.rs           ← unchanged (sidecars emitted on first lint, not bootstrap)
+```
+
+`cairn-core::domain::folder` keeps zero dependencies on other workspace crates.
+All filesystem I/O lives in `cairn-cli`. The pure-function shape mirrors the
+existing `MarkdownProjector` so the same callers (`lint`, future hooks) reuse
+one pattern.
+
+### Data flow — `cairn lint --fix-folders`
+
+```
+1. store.list_active() ──────────────► Vec<StoredRecord>
+
+2. for each record:
+     MarkdownProjector::project()  ──► record_paths: BTreeMap<RecordId, PathBuf>
+
+3. fs walk for files named `_policy.yaml` in vault:
+     parse_policy(content)         ──► policies_by_dir: BTreeMap<PathBuf, FolderPolicy>
+
+4. materialize_backlinks(records, record_paths)
+                                   ──► backlinks_by_target: BTreeMap<PathBuf, Vec<Backlink>>
+
+5. aggregate_folders(records, record_paths,
+                     policies_by_dir, backlinks_by_target)
+                                   ──► Vec<FolderState>
+
+6. for each FolderState:
+     project_index(state)          ──► ProjectedFile { path: <folder>/_index.md, content }
+     write atomically (write_once helper from bootstrap)
+
+7. report: { written: [...], unchanged: N, policy_errors: [...] }
+```
+
+A single bad `_policy.yaml` does not abort the whole rebuild — that subtree is
+skipped, the error is recorded in the report, the rest of the vault still
+rebuilds. Otherwise one corrupt file would break vault-wide repair.
+
+### Backlink derivation
+
+Backlinks are derived (not authoritative): `extract_links` parses
+`[label](path)` and `[[target]]` forms from each record body, resolves
+relative paths against the source folder, drops external URLs, and stitches
+the reverse map. This matches the brief's "rebuildable from SQLite state"
+phrasing without introducing an edge table.
+
+### Empty folders
+
+`aggregate_folders` only emits a `FolderState` for folders that contain at
+least one record OR a descendant subfolder that does. Empty `wiki/*`
+subdirectories created by bootstrap therefore receive no `_index.md`. This
+matches brief §3.4: "every non-empty folder has an `_index.md`."
+
+Stray `_index.md` files at empty folders are left alone — never deleted by
+lint, to avoid surprise removals. Operators who want them gone can `rm`
+manually.
+
+---
+
+## Types
+
+### `FolderPolicy` (deserialized from `_policy.yaml`)
+
+```rust
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct FolderPolicy {
+    pub purpose: Option<String>,
+    pub allowed_kinds: Option<Vec<MemoryKind>>,
+    pub visibility_default: Option<MemoryVisibility>,
+    pub consolidation_cadence: Option<ConsolidationCadence>,
+    pub owner_agent: Option<String>,
+    pub retention: Option<RetentionPolicy>,
+    pub summary_max_tokens: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsolidationCadence { Hourly, Daily, Weekly, Monthly, Manual }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum RetentionPolicy { Days(u32), Unlimited }
+```
+
+`Option<T>` everywhere encodes "inherit from parent." `allowed_kinds: Some(vec![])`
+explicitly forbids all kinds; `None` means "no opinion."
+
+### `EffectivePolicy` (result of walk-up merge)
+
+```rust
+pub struct EffectivePolicy {
+    pub purpose: Option<String>,
+    pub allowed_kinds: Option<Vec<MemoryKind>>,
+    pub visibility_default: MemoryVisibility,
+    pub consolidation_cadence: ConsolidationCadence,
+    pub owner_agent: Option<String>,
+    pub retention: RetentionPolicy,
+    pub summary_max_tokens: u32,
+    /// Folder paths that contributed, shallowest first, deepest last.
+    pub source_chain: Vec<PathBuf>,
+}
+```
+
+Defaults applied when no policy chain sets a value:
+
+| Field | Default |
+|---|---|
+| `visibility_default` | `MemoryVisibility::Private` |
+| `consolidation_cadence` | `ConsolidationCadence::Daily` |
+| `retention` | `RetentionPolicy::Unlimited` |
+| `summary_max_tokens` | `200` |
+
+`EffectivePolicy` has a hand-rolled `Default` impl that bakes in the table
+above (and `purpose`/`allowed_kinds`/`owner_agent` = `None`,
+`source_chain` = empty). Used directly when no policies exist anywhere on
+the chain.
+
+### `FolderIndex` (logical document, before serialization)
+
+```rust
+pub struct FolderIndex {
+    pub folder: PathBuf,                 // vault-relative
+    pub purpose: Option<String>,         // from EffectivePolicy
+    pub updated_at: Rfc3339Timestamp,
+    pub records: Vec<RecordEntry>,       // sorted: kind asc, then id asc
+    pub subfolders: Vec<SubfolderEntry>, // sorted: name asc
+    pub backlinks: Vec<Backlink>,        // sorted: source path asc
+}
+
+pub struct RecordEntry {
+    pub path: PathBuf,
+    pub id: RecordId,
+    pub kind: MemoryKind,
+    pub updated_at: Rfc3339Timestamp,
+    pub backlink_count: u32,
+}
+
+pub struct SubfolderEntry {
+    pub name: String,
+    pub record_count: u32,
+    pub last_updated: Option<Rfc3339Timestamp>,
+}
+
+pub struct Backlink {
+    pub source_path: PathBuf, // file containing the link
+    pub target_path: PathBuf, // file being pointed at (vault-relative)
+    pub anchor: Option<String>,
+}
+```
+
+Deterministic sort orders make repeat runs byte-identical for the
+"rebuild from empty markdown tree" test.
+
+### `RawLink` (intermediate from `extract_links`)
+
+```rust
+pub struct RawLink {
+    pub target_path: PathBuf,
+    pub anchor: Option<String>,
+}
+```
+
+### `FolderSummary` (P1 schema; types only at P0)
+
+```rust
+pub struct FolderSummary {
+    pub folder: PathBuf,
+    pub generated_at: Rfc3339Timestamp,
+    pub generated_by: AgentId,
+    pub covers_records: u32,
+    pub summary_tokens: u32,
+    pub body: String,
+}
+```
+
+`FolderSummaryWriter` trait stub lives on `WorkflowOrchestrator`:
+
+```rust
+#[async_trait::async_trait]
+pub trait FolderSummaryWriter: Send + Sync {
+    async fn write_summary(
+        &self,
+        summary: FolderSummary,
+    ) -> Result<(), WorkflowError> {
+        Err(WorkflowError::Unimplemented)
+    }
+}
+```
+
+P1 implementations override the default; P0 callers never invoke this path.
+
+### `FolderState` (input to `project_index`)
+
+```rust
+pub struct FolderState {
+    pub path: PathBuf,
+    pub records: Vec<StoredRecord>,
+    pub subfolders: Vec<SubfolderEntry>,
+    pub backlinks: Vec<Backlink>,
+    pub effective_policy: EffectivePolicy,
+}
+```
+
+### `FolderError`
+
+```rust
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FolderError {
+    #[error("policy parse failed: {source}")]
+    PolicyParse { #[source] source: serde_yaml::Error },
+}
+```
+
+`extract_links` is best-effort and returns `Vec<RawLink>` directly — links
+that do not match either supported syntactic form are skipped silently
+(standard markdown extractor behaviour). Semantic validation of policy
+fields beyond YAML shape is not done at P0; downstream Filter-stage
+enforcement will own that check.
+
+---
+
+## Functions
+
+### Public API in `cairn-core::domain::folder`
+
+```rust
+pub fn project_index(state: &FolderState) -> ProjectedFile;
+
+pub fn parse_policy(yaml: &str) -> Result<FolderPolicy, FolderError>;
+
+pub fn resolve_policy(
+    target: &Path,
+    policies_by_dir: &BTreeMap<PathBuf, FolderPolicy>,
+) -> EffectivePolicy;
+
+pub fn extract_links(source_path: &Path, body: &str) -> Vec<RawLink>;
+
+pub fn materialize_backlinks(
+    records: &[StoredRecord],
+    record_paths: &BTreeMap<RecordId, PathBuf>,
+) -> BTreeMap<PathBuf, Vec<Backlink>>;
+
+pub fn aggregate_folders(
+    records: &[StoredRecord],
+    record_paths: &BTreeMap<RecordId, PathBuf>,
+    policies_by_dir: &BTreeMap<PathBuf, FolderPolicy>,
+    backlinks_by_target: &BTreeMap<PathBuf, Vec<Backlink>>,
+) -> Vec<FolderState>;
+```
+
+### `extract_links` rules
+
+- markdown form: `[label](target)` — label discarded, target taken as path.
+- wiki form: `[[target]]` — `.md` appended if no extension.
+- wiki anchor: `[[target#anchor]]` → `anchor` populated.
+- relative paths: resolved against the source file's parent directory.
+- absolute paths inside the vault: kept as vault-relative.
+- external URLs: dropped (`http://`, `https://`, `mailto:`).
+- inside code fences (```` ``` ```` blocks): ignored.
+- escaped (`\[`): ignored.
+
+### `resolve_policy` algorithm
+
+Walk from `target`'s parent up to the vault root, collecting every entry in
+`policies_by_dir` along the way. Reduce shallowest-to-deepest with
+"deepest wins per key": for every `Option` field on `FolderPolicy`, the
+deepest non-`None` value wins. Apply defaults to fields that are still
+`None` after the walk. Record the contributing folder paths in
+`source_chain`, shallowest first.
+
+`resolve_policy` is associative under the deepest-wins fold — a property
+test confirms this so chunked or memoized resolution stays valid later.
+
+---
+
+## CLI surface
+
+### `cairn lint --fix-folders [--json]`
+
+Additive flag — `--fix-markdown` from #43 is unchanged. `--fix-markdown` and
+`--fix-folders` may be combined; records run first, then folders.
+
+Caller flow:
+
+1. `MemoryStore::list_active()` → records
+2. project each record → `record_paths` map
+3. fs-walk vault for `_policy.yaml` → `policies_by_dir`
+4. `materialize_backlinks` → reverse map
+5. `aggregate_folders` → states
+6. for each state: `project_index` → atomic write via `write_once`
+7. report counts + policy errors
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | success |
+| `1` | one or more `FolderError`s recorded; partial rebuild succeeded |
+| `78` (`EX_CONFIG`) | vault not initialized |
+
+### `--json` shape
+
+```json
+{
+  "written": ["raw/_index.md", "raw/projects/_index.md"],
+  "unchanged": 4,
+  "policy_errors": [
+    { "path": "raw/broken/_policy.yaml", "reason": "<message>" }
+  ]
+}
+```
+
+---
+
+## Output format — `_index.md`
+
+```markdown
+---
+folder: wiki/entities/people
+kind: folder_index
+updated_at: 2026-04-22T14:02:11Z
+record_count: 42
+subfolder_count: 3
+purpose: "people Cairn knows about"
+---
+# entities/people
+
+## Records (42)
+- [<vault-relative-path>](<vault-relative-path>) — <kind> · updated <date> · <N> backlinks
+- ...
+
+## Subfolders (3)
+- [<name>/](<name>/) — <N> records · last updated <date>
+- ...
+
+## Backlinks into this folder (17)
+- [<source-path>](<source-path>)
+- ...
+```
+
+`purpose` is omitted from the frontmatter when the resolved
+`EffectivePolicy.purpose` is `None`. Each `##` section is omitted when its
+list is empty.
+
+---
+
+## Edge cases
+
+| Case | Behaviour |
+|---|---|
+| No `_policy.yaml` anywhere in chain | `EffectivePolicy::default()` (private, daily, unlimited, 200 tokens) |
+| `_policy.yaml` parse fails | error recorded; that folder + descendants skipped; lint exits `1` |
+| Two records project to same path | unreachable — `MarkdownProjector` uses `<kind>_<id>`; guarded with `debug_assert!` in `materialize_backlinks` |
+| Markdown link to non-existent file | included in backlinks anyway (derivative); `cairn lint`'s drift report is responsible for flagging dangling links — out of scope here |
+| Markdown link is external URL | dropped at `extract_links` |
+| Wiki-style `[[target]]` link | resolved relative to source folder; `.md` appended if missing |
+| Anchor in link (`#section`) | preserved on the `Backlink`, not stripped from target path |
+| Folder rename | next `--fix-folders` rebuilds correctly from store; no migration |
+| Stray `_index.md` for now-empty folder | left alone — lint never deletes files |
+| Pre-existing `_index.md` matches projection | counted as `unchanged`; no write |
+
+---
+
+## Error handling
+
+- `cairn-core::domain::folder` returns `FolderError` (thiserror,
+  `#[non_exhaustive]`). No I/O, no `anyhow`, no `unwrap`/`expect` in core.
+- `cairn-cli::verbs::lint` wraps with `.context("lint --fix-folders: <path>")`
+  at every call site; returns `anyhow::Result<()>` from the verb entry point.
+- A single corrupt file does not abort the rebuild; partial success exits `1`.
+- All file writes go through the existing `write_once` helper —
+  random-named tempfile + `persist`, parent-symlink rejected, target
+  re-validated post-rename.
+
+---
+
+## Testing
+
+### `cairn-core` unit tests (in `folder.rs` `#[cfg(test)]`)
+
+**`parse_policy`**
+- happy round-trip preserves every field
+- unknown key → `PolicyParse` (struct uses `deny_unknown_fields`)
+- malformed YAML → `PolicyParse`
+- empty YAML → `FolderPolicy::default()` (all `None`)
+
+**`resolve_policy` (inheritance — verification criterion)**
+- target with no policies → defaults
+- single policy at root → echoed
+- child overrides parent on one key, inherits others
+- three-deep chain (`a/b/c` → `a/b` → `a`) — deepest wins per key
+- `source_chain` shallowest-first, deepest-last
+
+**`extract_links`**
+- `[label](path.md)` extracted, label discarded
+- `[[target]]` → `target.md`
+- `[[target#anchor]]` → anchor populated
+- relative `../alice.md` resolved against source folder
+- `https://`, `mailto:` dropped
+- code-fenced links ignored
+- escaped `\[not a link\]` ignored
+
+**`materialize_backlinks`**
+- empty record set → empty map
+- record links to existing target → backlink emitted
+- record links to non-existent path → backlink still emitted
+- two records → same target → both appear, sorted by source path
+
+**`aggregate_folders`**
+- single record at `raw/x.md` → one `FolderState` for `raw/`
+- nested records → parents include subfolder aggregates
+- empty folder, empty descendants → no `FolderState`
+- subfolder counts and `last_updated` propagate
+
+**`project_index`**
+- determinism: same `FolderState` → byte-identical output
+- frontmatter contains `folder`, `kind: folder_index`, `updated_at`,
+  `record_count`, `subfolder_count`
+- `purpose` field present iff policy supplied one
+- record / subfolder / backlink sections omitted when empty
+
+### `cairn-cli` integration tests (`crates/cairn-cli/tests/lint_folders.rs`)
+
+Use `FixtureStore` from `cairn-test-fixtures` + `tempfile::tempdir()` vault.
+
+**Folder fixture projection** *(verification criterion)*
+- Bootstrap vault → seed `FixtureStore` with a known set → run
+  `lint --fix-folders` → assert each `_index.md` matches an `insta` snapshot.
+
+**Backlink rebuild from empty markdown tree** *(verification criterion)*
+- Seed store with cross-linking records → vault contains only `.cairn/` and
+  empty `raw/`/`wiki/` → run `lint --fix-folders` → assert backlink sections
+  in every emitted `_index.md` match expected.
+
+**Nested-folder config inheritance** *(verification criterion)*
+- The unit-level `resolve_policy` cases above own this assertion. No CLI
+  debug surface is added at P0.
+
+**`_policy.yaml` parse failure does not abort lint**
+- Two folders, one with valid policy and records, one with garbled
+  `_policy.yaml` → run `lint --fix-folders` → exit `1`, valid folder's
+  `_index.md` still written, error appears in `--json` `policy_errors`.
+
+**Atomic writes**
+- Pre-place `_index.md` with stale content → run lint → final file matches
+  projection; no temp leftovers in the directory.
+
+**`--json` output**
+- Healthy vault → assert valid JSON shape: `{ written, unchanged, policy_errors }`.
+
+### Property tests (`proptest`)
+
+- `parse_policy ∘ serde_yaml::to_string` round-trips for arbitrary
+  `FolderPolicy`.
+- `resolve_policy` is associative under the deepest-wins fold
+  (chunked merges agree with whole-chain merge).
+
+### Skipped (out of scope)
+
+- Live SQLite store tests — `FixtureStore` covers everything; real-store
+  coverage lands with #46.
+- PostToolUse hook tests — sensors issue.
+- `_summary.md` body generation — P1 only.
+
+---
+
+## Invariants touched
+
+- §3.0 DB-is-authority — sidecars are projections, never authoritative.
+- §3.4 sidecar trio — `_index.md` (P0 here), `_summary.md` (schema only),
+  `_policy.yaml` (read-only at P0).
+- §4 invariant 1 harness-agnostic — pure functions in core, no harness dep.
+- §4 invariant 3 CLI-is-ground-truth — `lint --fix-folders` is the verb;
+  the same pure functions back future hook callers.
+- §4 invariant 6 fail-closed — bad policy fails its subtree, not the vault.
+- §4 invariant 7 no-unsafe — no new `unsafe` introduced.
+- §4 invariant 8 no-`unwrap`-in-core — `FolderError` carries every failure.


### PR DESCRIPTION
## Summary

Implements P0 of brief §3.4 ("Folders are first-class") via #44:

- **`_index.md` projection** — `aggregate_folders` + `project_index` produce a deterministic folder index with frontmatter (`folder`, `kind: folder_index`, `updated_at`, counts, optional `purpose`) and Records / Subfolders / Backlinks sections.
- **`_policy.yaml` schema + walk-up** — `FolderPolicy` (deny-unknown-fields), `EffectivePolicy`, deepest-wins `resolve_policy`, fail-closed taint on parse / non-UTF-8 / symlinked / non-regular policy files.
- **Backlinks** — `extract_links` (markdown `[label](path)` + wiki `[[target]]`), `materialize_backlinks` reverse map; standard CommonMark semantics (leading `/` = vault-root, otherwise source-relative); over-root `..` chains drop.
- **`FolderSummary` + `FolderSummaryWriter`** trait stub on the workflow contract for the future summarizer.
- **`cairn lint --fix-folders` handler** — atomic `_index.md` rebuild, byte-comparison for unchanged-detection (recovers from corrupt non-UTF-8 indexes), full-ancestor symlink validation, taint-aware skipping.
- CLI flag wired through `with_fix_folders` decorator; dispatch returns the same Unimplemented envelope as `--fix-markdown` until the SQLite store is threaded into lint (#46).

10 rounds of Codex adversarial review converged: 9 findings fixed across rounds 3-9 (folder-relative hrefs, symlink fast-path bypass, ancestor-symlink walk, symlinked policy taint, bare-link source-relative, `RecordEntry` path threading, chronological timestamp comparison, byte-compare indexes, over-root link drop). Out-of-scope items deferred to follow-up tickets: ingest enforcement (#46-related WAL apply), stale-index cleanup, CLI store wiring (#46), TOCTOU concurrent-swap (workspace-wide fs-safety), `StoredRecord.path` threading (#46), `collect_policies` read-failure isolation (small follow-up).

Invariants touched (CLAUDE.md §4): #6 fail-closed (taint subtree on bad policy), #8 no panics in core, #10 sources/records/schema layering preserved.

## Test plan

- [x] `cargo nextest run --workspace --locked` — 1011 / 1011 pass
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --doc --workspace --locked`
- [x] `./scripts/check-core-boundary.sh`
- [x] Insta snapshot for `raw/_index.md` fixture committed
- [x] Proptest round-trip + `resolve_policy` associativity invariants
- [x] Symlink regressions: parent-symlink, ancestor-symlink, content-matching `_index.md` symlink, symlinked `_policy.yaml`
- [x] Recovery regressions: non-UTF-8 `_policy.yaml`, non-UTF-8 `_index.md`, vault-root policy resolution
- [x] Link semantics: bare-name source-relative, leading-`/` vault-root, nested-folder relative, over-root drop