### PR TITLE
ci(pages): auto-enable GitHub Pages in configure-pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,6 +43,8 @@ jobs:
         run: mdbook build docs/site --dest-dir target/site
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+        with:
+          enablement: true
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:


### PR DESCRIPTION
## Summary
- `pages / build docs` on main fails at `actions/configure-pages` with HTTP 404 because GitHub Pages isn't enabled for the repo.
- Adds `enablement: true` so the action turns Pages on during the first successful build instead of requiring a manual Settings change.

## Test plan
- [ ] Merge and confirm the next `pages` workflow run succeeds at the Configure Pages step.
- [ ] Verify `pages / deploy` publishes the mdBook site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)