### PR TITLE
ci(pages): drop enablement flag, document manual Pages setup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,11 @@ name: pages
 
 # Auto-deploy the committed mdBook source to GitHub Pages after `main`
 # advances. Pull requests build the book in docs.yml but never deploy.
+#
+# One-time setup: enable GitHub Pages manually via Settings → Pages →
+# Source: "GitHub Actions". The workflow's GITHUB_TOKEN cannot create the
+# Pages site itself (admin-only API), so `enablement: true` on
+# actions/configure-pages fails with "Resource not accessible by integration".
 
 on:
   push:
@@ -43,8 +48,6 @@ jobs:
         run: mdbook build docs/site --dest-dir target/site
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-        with:
-          enablement: true
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:


### PR DESCRIPTION
## Summary
- `pages / build docs` has been failing on every push to `main` since PR #228 with `Resource not accessible by integration` at the Configure Pages step.
- Root cause: `actions/configure-pages` with `enablement: true` calls the admin-only Create-Pages-Site API, which the workflow's `GITHUB_TOKEN` cannot use regardless of `pages: write`.
- Fix: drop `enablement: true` and document the one-time manual setup (Settings → Pages → Source: GitHub Actions) in the workflow header.

## Test plan
- [ ] Maintainer enables Pages manually in repo Settings (one-time).
- [ ] Merge and confirm next `pages` workflow run succeeds at Configure Pages and Deploy steps.
- [ ] Verify mdBook site is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
