### PR TITLE
feat(core): explain_filter + RecordExclusion for search (#95)

### DIFF
--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -104,7 +104,11 @@ fn search_default_response_omits_excluded_field() {
     // never populates it). Serialized JSON must not contain the
     // "excluded" key — the IDL marks it Option<...> with
     // skip_serializing_if = "Option::is_none".
-    let data = SearchData { excluded: None, hits: Vec::new(), next_cursor: None };
+    let data = SearchData {
+        excluded: None,
+        hits: Vec::new(),
+        next_cursor: None,
+    };
     let json = serde_json::to_string(&data).expect("serializable");
     assert!(
         !json.contains("\"excluded\""),

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -95,3 +95,43 @@ fn status_advertises_policy_trace_capability() {
         "status must advertise cairn.mcp.v1.policy_trace; got {strs:?}"
     );
 }
+
+#[test]
+fn search_default_response_omits_excluded_field() {
+    use cairn_core::generated::verbs::search::SearchData;
+
+    // Construct a SearchData without `excluded` (the explain=false path
+    // never populates it). Serialized JSON must not contain the
+    // "excluded" key — the IDL marks it Option<...> with
+    // skip_serializing_if = "Option::is_none".
+    let data = SearchData { excluded: None, hits: Vec::new(), next_cursor: None };
+    let json = serde_json::to_string(&data).expect("serializable");
+    assert!(
+        !json.contains("\"excluded\""),
+        "default SearchData must not emit excluded field; got {json}"
+    );
+}
+
+#[test]
+fn search_with_excluded_emits_field() {
+    use cairn_core::generated::common::{RecordExclusion, RecordExclusionGate, Ulid};
+    use cairn_core::generated::verbs::search::SearchData;
+
+    // Sanity check the inverse: when explain=true populates excluded,
+    // the JSON does carry the field. This guards against a future
+    // serde annotation accidentally hiding the field permanently.
+    let data = SearchData {
+        excluded: Some(vec![RecordExclusion {
+            target_id: Ulid("01HQZX9F5N0000000000000000".to_owned()),
+            gate: RecordExclusionGate::ReadFilterStaleness,
+            detail: String::new(),
+        }]),
+        hits: Vec::new(),
+        next_cursor: None,
+    };
+    let json = serde_json::to_string(&data).expect("serializable");
+    assert!(
+        json.contains("\"excluded\""),
+        "excluded must appear when set; got {json}"
+    );
+}

--- a/crates/cairn-core/src/generated/common/mod.rs
+++ b/crates/cairn-core/src/generated/common/mod.rs
@@ -140,6 +140,24 @@ impl<'de> ::serde::Deserialize<'de> for Nonce16Base64 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
+pub enum RecordExclusionGate {
+    ReadFilterRelevance,
+    ReadFilterStaleness,
+    ReadFilterDedup,
+}
+
+/// Per-record exclusion entry returned on search responses when args.explain is true. Records the caller cannot otherwise see (Tier-1 visibility) never appear here.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecordExclusion {
+    pub detail: String,
+    pub gate: RecordExclusionGate,
+    pub target_id: crate::generated::common::Ulid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ScopeFilterTier {
     Private,
     Session,

--- a/crates/cairn-core/src/generated/verbs/search.rs
+++ b/crates/cairn-core/src/generated/verbs/search.rs
@@ -226,6 +226,9 @@ pub struct SearchArgs {
     /// Opaque continuation token from a prior search Data.next_cursor.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cursor: Option<crate::generated::common::Cursor>,
+    /// When true, populate policy_trace and data.excluded with per-record exclusions for Tier-2 read filters. Has no effect on the candidate set the caller could see.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub explain: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub filters: Option<SearchArgsFilters>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -245,6 +248,9 @@ struct RawSearchArgs {
     /// Opaque continuation token from a prior search Data.next_cursor.
     #[serde(default)]
     cursor: Option<crate::generated::common::Cursor>,
+    /// When true, populate policy_trace and data.excluded with per-record exclusions for Tier-2 read filters. Has no effect on the candidate set the caller could see.
+    #[serde(default)]
+    explain: Option<bool>,
     #[serde(default)]
     filters: Option<SearchArgsFilters>,
     #[serde(default)]
@@ -266,6 +272,7 @@ impl ::core::convert::TryFrom<RawSearchArgs> for SearchArgs {
         Ok(Self {
             citations: raw.citations,
             cursor: raw.cursor,
+            explain: raw.explain,
             filters: raw.filters,
             limit: raw.limit,
             mode: raw.mode,
@@ -286,6 +293,9 @@ impl<'de> ::serde::Deserialize<'de> for SearchArgs {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SearchData {
+    /// Per-record exclusions; present only when args.explain is true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub excluded: Option<Vec<crate::generated::common::RecordExclusion>>,
     pub hits: Vec<Hit>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<crate::generated::common::Cursor>,

--- a/crates/cairn-core/src/pipeline/explain.rs
+++ b/crates/cairn-core/src/pipeline/explain.rs
@@ -1,0 +1,126 @@
+//! `explain_filter` — pure partition of caller-visible candidates into
+//! kept and excluded subsets (brief §5.1). Tier-1-invisible records
+//! are filtered upstream and must not appear in the input.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use crate::domain::TargetId;
+use crate::policy_trace::{PolicyDetail, PolicyGate, RecordExclusion};
+
+/// One candidate from the store query. Caller-visible by definition;
+/// the store filters Tier-1-invisible records before populating this.
+#[derive(Debug, Clone)]
+pub struct Candidate {
+    /// Lineage key for the record.
+    pub target_id: TargetId,
+    /// How many days old the record is.
+    pub age_days: u32,
+    /// Relevance score from the ranking stage.
+    pub relevance_score: f32,
+    /// Content hash used for deduplication.
+    pub content_hash: String,
+}
+
+/// Pure partition configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct ExplainConfig {
+    /// Candidates older than this are excluded as `ReadFilterStaleness`.
+    pub staleness_threshold_days: u32,
+    /// Number of recent records to consult for dedup-window comparison.
+    /// Reserved for future windowing semantics; dedup is currently global
+    /// across the post-staleness candidate set.
+    pub dedup_window: usize,
+}
+
+/// Reason a candidate was filtered. `as_gate` maps to the producer
+/// `PolicyGate` variant — closed because per-record exclusions are
+/// limited to Tier-2 read filters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReadFilterReason {
+    /// Record was filtered out by relevance ranking.
+    Relevance,
+    /// Record's `age_days` exceeded the threshold.
+    Staleness,
+    /// Record's `content_hash` already seen within the dedup window.
+    Dedup,
+}
+
+impl ReadFilterReason {
+    /// Map to the matching `PolicyGate` variant.
+    #[must_use]
+    pub const fn as_gate(self) -> PolicyGate {
+        match self {
+            Self::Relevance => PolicyGate::ReadFilterRelevance,
+            Self::Staleness => PolicyGate::ReadFilterStaleness,
+            Self::Dedup => PolicyGate::ReadFilterDedup,
+        }
+    }
+}
+
+/// Partition `candidates` into kept and excluded sets. Order:
+///
+/// 1. Staleness — exclude any candidate older than the threshold.
+/// 2. Dedup — within the dedup window, keep the highest-relevance
+///    candidate per `content_hash`; exclude the rest.
+///
+/// Relevance pruning is not applied here — callers that want a
+/// top-N cut compose this with their own ranker.
+#[must_use]
+pub fn explain_filter(
+    candidates: Vec<Candidate>,
+    cfg: &ExplainConfig,
+) -> (Vec<Candidate>, Vec<RecordExclusion>) {
+    let mut excluded: Vec<RecordExclusion> = Vec::new();
+
+    // 1. Staleness pass — preserve original order.
+    let mut after_stale: Vec<Candidate> = Vec::with_capacity(candidates.len());
+    for c in candidates {
+        if c.age_days > cfg.staleness_threshold_days {
+            excluded.push(RecordExclusion::new(
+                c.target_id.clone(),
+                PolicyGate::ReadFilterStaleness,
+                PolicyDetail::None,
+            ));
+        } else {
+            after_stale.push(c);
+        }
+    }
+
+    // 2. Dedup by content_hash — keep highest-relevance per hash,
+    //    preserve the original order of the kept candidates.
+    // `dedup_window` is reserved for future windowing semantics;
+    // the current implementation deduplicates globally across the
+    // post-staleness set.
+    let _ = cfg.dedup_window;
+    let mut best_index_by_hash: HashMap<String, usize> = HashMap::new();
+    for (idx, c) in after_stale.iter().enumerate() {
+        match best_index_by_hash.get(&c.content_hash) {
+            None => {
+                best_index_by_hash.insert(c.content_hash.clone(), idx);
+            }
+            Some(&prev_idx) => {
+                let prev_score = after_stale[prev_idx].relevance_score;
+                if c.relevance_score > prev_score {
+                    best_index_by_hash.insert(c.content_hash.clone(), idx);
+                }
+            }
+        }
+    }
+    let kept_indices: HashSet<usize> = best_index_by_hash.values().copied().collect();
+    let mut kept: Vec<Candidate> = Vec::with_capacity(kept_indices.len());
+    for (idx, c) in after_stale.into_iter().enumerate() {
+        if kept_indices.contains(&idx) {
+            kept.push(c);
+        } else {
+            excluded.push(RecordExclusion::new(
+                c.target_id,
+                PolicyGate::ReadFilterDedup,
+                PolicyDetail::None,
+            ));
+        }
+    }
+
+    (kept, excluded)
+}

--- a/crates/cairn-core/src/pipeline/explain.rs
+++ b/crates/cairn-core/src/pipeline/explain.rs
@@ -16,7 +16,10 @@ pub struct Candidate {
     pub target_id: TargetId,
     /// How many days old the record is.
     pub age_days: u32,
-    /// Relevance score from the ranking stage.
+    /// Relevance score from the ranker; higher wins dedup.
+    /// NaN scores never win — the implementation uses `>` so any
+    /// non-NaN candidate beats a NaN one, and the first non-NaN
+    /// candidate per `content_hash` is preferred.
     pub relevance_score: f32,
     /// Content hash used for deduplication.
     pub content_hash: String,
@@ -28,8 +31,12 @@ pub struct ExplainConfig {
     /// Candidates older than this are excluded as `ReadFilterStaleness`.
     pub staleness_threshold_days: u32,
     /// Number of recent records to consult for dedup-window comparison.
-    /// Reserved for future windowing semantics; dedup is currently global
-    /// across the post-staleness candidate set.
+    ///
+    /// **Reserved.** The current implementation deduplicates globally
+    /// across the post-staleness candidate set and ignores this value.
+    /// A future windowing-aware implementation will respect it. Pass
+    /// any value (e.g. `usize::MAX`) until then; the field exists so
+    /// the wire shape is stable when windowing lands.
     pub dedup_window: usize,
 }
 

--- a/crates/cairn-core/src/pipeline/mod.rs
+++ b/crates/cairn-core/src/pipeline/mod.rs
@@ -23,6 +23,7 @@
 //! - §14 Privacy and Consent (pre-persist redaction, deny-by-default,
 //!   per-sensor opt-in, append-only audit)
 
+pub mod explain;
 pub mod filter;
 pub(crate) mod squash;
 

--- a/crates/cairn-core/src/policy_trace/exclusion.rs
+++ b/crates/cairn-core/src/policy_trace/exclusion.rs
@@ -1,0 +1,42 @@
+//! Per-record exclusion for read verbs in `--explain` mode (brief §5.1).
+//!
+//! Tier-1-invisible records (caller's scope cannot see them) never
+//! appear in this list; the store query filters them before
+//! rank-and-filter runs. Only Tier-2 read-filter gates
+//! (`ReadFilter*`) may construct an exclusion; constructing one with
+//! a Tier-1 gate panics as a fail-closed safety check.
+
+use crate::domain::TargetId;
+
+use super::{PolicyDetail, PolicyGate};
+
+/// Per-record exclusion entry returned on search/retrieve responses
+/// when `args.explain` is true.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordExclusion {
+    /// Target id of the record that was filtered.
+    pub target_id: TargetId,
+    /// The Tier-2 read-filter gate that excluded the record.
+    pub gate: PolicyGate,
+    /// Body-free metadata for the exclusion.
+    pub detail: PolicyDetail,
+}
+
+impl RecordExclusion {
+    /// Construct an exclusion. Panics on a non-`ReadFilter*` gate;
+    /// this is a programmer error and a fail-closed safety check
+    /// against leaking record ids through Tier-1 gates.
+    #[must_use]
+    pub fn new(target_id: TargetId, gate: PolicyGate, detail: PolicyDetail) -> Self {
+        assert!(
+            matches!(
+                gate,
+                PolicyGate::ReadFilterRelevance
+                    | PolicyGate::ReadFilterStaleness
+                    | PolicyGate::ReadFilterDedup
+            ),
+            "RecordExclusion only accepts ReadFilter* gates; got {gate:?}"
+        );
+        Self { target_id, gate, detail }
+    }
+}

--- a/crates/cairn-core/src/policy_trace/exclusion.rs
+++ b/crates/cairn-core/src/policy_trace/exclusion.rs
@@ -26,6 +26,11 @@ impl RecordExclusion {
     /// Construct an exclusion. Panics on a non-`ReadFilter*` gate;
     /// this is a programmer error and a fail-closed safety check
     /// against leaking record ids through Tier-1 gates.
+    ///
+    /// Returns `Self` (not `Result`) by design: a wrong gate is an
+    /// internal bug, not user input, and pushing the panic-or-ignore
+    /// decision up to every caller would defeat the fail-closed
+    /// guarantee.
     #[must_use]
     pub fn new(target_id: TargetId, gate: PolicyGate, detail: PolicyDetail) -> Self {
         assert!(

--- a/crates/cairn-core/src/policy_trace/exclusion.rs
+++ b/crates/cairn-core/src/policy_trace/exclusion.rs
@@ -42,6 +42,10 @@ impl RecordExclusion {
             ),
             "RecordExclusion only accepts ReadFilter* gates; got {gate:?}"
         );
-        Self { target_id, gate, detail }
+        Self {
+            target_id,
+            gate,
+            detail,
+        }
     }
 }

--- a/crates/cairn-core/src/policy_trace/mod.rs
+++ b/crates/cairn-core/src/policy_trace/mod.rs
@@ -12,11 +12,13 @@
 
 mod detail;
 mod entry;
+mod exclusion;
 mod from_pipeline;
 mod gate;
 mod outcome;
 
 pub use detail::PolicyDetail;
 pub use entry::{PolicyTraceEntry, to_wire};
+pub use exclusion::RecordExclusion;
 pub use gate::PolicyGate;
 pub use outcome::PolicyOutcome;

--- a/crates/cairn-core/tests/explain_filter.rs
+++ b/crates/cairn-core/tests/explain_filter.rs
@@ -1,0 +1,82 @@
+//! `explain_filter` partitions visible candidates into kept and
+//! excluded sets, attaching a `RecordExclusion` to each filtered
+//! record. Tier-1-invisible records must already be absent from the
+//! candidate set — this function does not see them.
+
+use cairn_core::domain::TargetId;
+use cairn_core::pipeline::explain::{Candidate, ExplainConfig, ReadFilterReason, explain_filter};
+use cairn_core::policy_trace::{PolicyDetail, PolicyGate};
+
+// Build a valid 26-char ULID-shaped TargetId. Crockford base32 (no I L O U),
+// leading char 0..=7. Trailing char(s) replaced by `suffix` for uniqueness.
+fn id(suffix: char) -> TargetId {
+    let mut s = String::from("01HQZX9F5N0000000000000000");
+    s.pop();
+    s.push(suffix);
+    TargetId::parse(s).expect("valid ULID")
+}
+
+#[test]
+fn empty_candidates_yields_empty_kept_and_excluded() {
+    let cfg = ExplainConfig { staleness_threshold_days: 30, dedup_window: 5 };
+    let (kept, excluded) = explain_filter(Vec::<Candidate>::new(), &cfg);
+    assert!(kept.is_empty());
+    assert!(excluded.is_empty());
+}
+
+#[test]
+fn stale_candidate_is_excluded_with_staleness_gate() {
+    let cfg = ExplainConfig { staleness_threshold_days: 30, dedup_window: 5 };
+    let candidates = vec![Candidate {
+        target_id: id('A'),
+        age_days: 90,
+        relevance_score: 0.8,
+        content_hash: "h1".to_owned(),
+    }];
+    let (kept, excluded) = explain_filter(candidates, &cfg);
+    assert!(kept.is_empty());
+    assert_eq!(excluded.len(), 1);
+    assert_eq!(excluded[0].gate, PolicyGate::ReadFilterStaleness);
+    assert_eq!(excluded[0].detail, PolicyDetail::None);
+}
+
+#[test]
+fn duplicate_content_hash_excluded_by_dedup() {
+    let cfg = ExplainConfig { staleness_threshold_days: 30, dedup_window: 5 };
+    let candidates = vec![
+        Candidate { target_id: id('A'), age_days: 1, relevance_score: 0.9, content_hash: "h".to_owned() },
+        Candidate { target_id: id('B'), age_days: 1, relevance_score: 0.8, content_hash: "h".to_owned() },
+    ];
+    let (kept, excluded) = explain_filter(candidates, &cfg);
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].target_id, id('A'));
+    assert_eq!(excluded.len(), 1);
+    assert_eq!(excluded[0].target_id, id('B'));
+    assert_eq!(excluded[0].gate, PolicyGate::ReadFilterDedup);
+}
+
+#[test]
+fn stale_takes_precedence_over_dedup() {
+    let cfg = ExplainConfig { staleness_threshold_days: 30, dedup_window: 5 };
+    let candidates = vec![
+        Candidate { target_id: id('A'), age_days: 90, relevance_score: 0.9, content_hash: "h".to_owned() },
+        Candidate { target_id: id('B'), age_days: 1,  relevance_score: 0.5, content_hash: "h".to_owned() },
+    ];
+    let (kept, excluded) = explain_filter(candidates, &cfg);
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].target_id, id('B'));
+    assert_eq!(excluded.len(), 1);
+    assert_eq!(excluded[0].gate, PolicyGate::ReadFilterStaleness);
+}
+
+#[test]
+fn read_filter_reason_round_trips() {
+    let cases = [
+        (ReadFilterReason::Staleness, PolicyGate::ReadFilterStaleness),
+        (ReadFilterReason::Dedup, PolicyGate::ReadFilterDedup),
+        (ReadFilterReason::Relevance, PolicyGate::ReadFilterRelevance),
+    ];
+    for (reason, expected_gate) in cases {
+        assert_eq!(reason.as_gate(), expected_gate);
+    }
+}

--- a/crates/cairn-core/tests/explain_filter.rs
+++ b/crates/cairn-core/tests/explain_filter.rs
@@ -18,7 +18,10 @@ fn id(suffix: char) -> TargetId {
 
 #[test]
 fn empty_candidates_yields_empty_kept_and_excluded() {
-    let cfg = ExplainConfig { staleness_threshold_days: 30, dedup_window: 5 };
+    let cfg = ExplainConfig {
+        staleness_threshold_days: 30,
+        dedup_window: 5,
+    };
     let (kept, excluded) = explain_filter(Vec::<Candidate>::new(), &cfg);
     assert!(kept.is_empty());
     assert!(excluded.is_empty());
@@ -26,7 +29,10 @@ fn empty_candidates_yields_empty_kept_and_excluded() {
 
 #[test]
 fn stale_candidate_is_excluded_with_staleness_gate() {
-    let cfg = ExplainConfig { staleness_threshold_days: 30, dedup_window: 5 };
+    let cfg = ExplainConfig {
+        staleness_threshold_days: 30,
+        dedup_window: 5,
+    };
     let candidates = vec![Candidate {
         target_id: id('A'),
         age_days: 90,
@@ -42,10 +48,23 @@ fn stale_candidate_is_excluded_with_staleness_gate() {
 
 #[test]
 fn duplicate_content_hash_excluded_by_dedup() {
-    let cfg = ExplainConfig { staleness_threshold_days: 30, dedup_window: 5 };
+    let cfg = ExplainConfig {
+        staleness_threshold_days: 30,
+        dedup_window: 5,
+    };
     let candidates = vec![
-        Candidate { target_id: id('A'), age_days: 1, relevance_score: 0.9, content_hash: "h".to_owned() },
-        Candidate { target_id: id('B'), age_days: 1, relevance_score: 0.8, content_hash: "h".to_owned() },
+        Candidate {
+            target_id: id('A'),
+            age_days: 1,
+            relevance_score: 0.9,
+            content_hash: "h".to_owned(),
+        },
+        Candidate {
+            target_id: id('B'),
+            age_days: 1,
+            relevance_score: 0.8,
+            content_hash: "h".to_owned(),
+        },
     ];
     let (kept, excluded) = explain_filter(candidates, &cfg);
     assert_eq!(kept.len(), 1);
@@ -57,10 +76,23 @@ fn duplicate_content_hash_excluded_by_dedup() {
 
 #[test]
 fn stale_takes_precedence_over_dedup() {
-    let cfg = ExplainConfig { staleness_threshold_days: 30, dedup_window: 5 };
+    let cfg = ExplainConfig {
+        staleness_threshold_days: 30,
+        dedup_window: 5,
+    };
     let candidates = vec![
-        Candidate { target_id: id('A'), age_days: 90, relevance_score: 0.9, content_hash: "h".to_owned() },
-        Candidate { target_id: id('B'), age_days: 1,  relevance_score: 0.5, content_hash: "h".to_owned() },
+        Candidate {
+            target_id: id('A'),
+            age_days: 90,
+            relevance_score: 0.9,
+            content_hash: "h".to_owned(),
+        },
+        Candidate {
+            target_id: id('B'),
+            age_days: 1,
+            relevance_score: 0.5,
+            content_hash: "h".to_owned(),
+        },
     ];
     let (kept, excluded) = explain_filter(candidates, &cfg);
     assert_eq!(kept.len(), 1);

--- a/crates/cairn-core/tests/policy_trace_exclusion.rs
+++ b/crates/cairn-core/tests/policy_trace_exclusion.rs
@@ -27,7 +27,10 @@ reject_tier1_gate!(
     rejects_prompt_injection_fence,
     PolicyGate::PromptInjectionFence
 );
-reject_tier1_gate!(rejects_filter_should_memorize, PolicyGate::FilterShouldMemorize);
+reject_tier1_gate!(
+    rejects_filter_should_memorize,
+    PolicyGate::FilterShouldMemorize
+);
 reject_tier1_gate!(rejects_visibility_floor, PolicyGate::VisibilityFloor);
 reject_tier1_gate!(rejects_scope_check, PolicyGate::ScopeCheck);
 reject_tier1_gate!(rejects_forget_capability, PolicyGate::ForgetCapability);
@@ -39,7 +42,11 @@ reject_tier1_gate!(
 #[test]
 fn exclusion_holds_target_gate_detail() {
     let id = TargetId::parse(FIXTURE_ID).expect("valid ULID");
-    let e = RecordExclusion::new(id.clone(), PolicyGate::ReadFilterStaleness, PolicyDetail::None);
+    let e = RecordExclusion::new(
+        id.clone(),
+        PolicyGate::ReadFilterStaleness,
+        PolicyDetail::None,
+    );
     assert_eq!(e.target_id, id);
     assert_eq!(e.gate, PolicyGate::ReadFilterStaleness);
     assert_eq!(e.detail, PolicyDetail::None);

--- a/crates/cairn-core/tests/policy_trace_exclusion.rs
+++ b/crates/cairn-core/tests/policy_trace_exclusion.rs
@@ -1,0 +1,47 @@
+//! `RecordExclusion` only accepts `ReadFilter*` gates. Constructing one
+//! with a Tier-1 gate (e.g. `ScopeCheck`) is a programmer error and
+//! a fail-closed safety check against leaking record ids.
+
+use cairn_core::domain::TargetId;
+use cairn_core::policy_trace::{PolicyDetail, PolicyGate, RecordExclusion};
+
+// Valid TargetId: 26-char Crockford base32, leading char 0..=7.
+const FIXTURE_ID: &str = "01HQZX9F5N0000000000000000";
+
+#[test]
+fn exclusion_holds_target_gate_detail() {
+    let id = TargetId::parse(FIXTURE_ID).expect("valid ULID");
+    let e = RecordExclusion::new(id.clone(), PolicyGate::ReadFilterStaleness, PolicyDetail::None);
+    assert_eq!(e.target_id, id);
+    assert_eq!(e.gate, PolicyGate::ReadFilterStaleness);
+    assert_eq!(e.detail, PolicyDetail::None);
+}
+
+#[test]
+fn exclusion_accepts_all_three_read_filter_gates() {
+    let id = TargetId::parse(FIXTURE_ID).expect("valid ULID");
+    for gate in [
+        PolicyGate::ReadFilterRelevance,
+        PolicyGate::ReadFilterStaleness,
+        PolicyGate::ReadFilterDedup,
+    ] {
+        let e = RecordExclusion::new(id.clone(), gate, PolicyDetail::None);
+        assert_eq!(e.gate, gate);
+    }
+}
+
+#[test]
+#[should_panic(expected = "ReadFilter")]
+fn exclusion_rejects_scope_check_gate() {
+    // ScopeCheck is a Tier-1 gate; per design §5.5, a Tier-1 invisible
+    // record's id must never appear in `excluded`.
+    let id = TargetId::parse(FIXTURE_ID).expect("valid ULID");
+    let _ = RecordExclusion::new(id, PolicyGate::ScopeCheck, PolicyDetail::None);
+}
+
+#[test]
+#[should_panic(expected = "ReadFilter")]
+fn exclusion_rejects_filter_should_memorize_gate() {
+    let id = TargetId::parse(FIXTURE_ID).expect("valid ULID");
+    let _ = RecordExclusion::new(id, PolicyGate::FilterShouldMemorize, PolicyDetail::None);
+}

--- a/crates/cairn-core/tests/policy_trace_exclusion.rs
+++ b/crates/cairn-core/tests/policy_trace_exclusion.rs
@@ -8,6 +8,34 @@ use cairn_core::policy_trace::{PolicyDetail, PolicyGate, RecordExclusion};
 // Valid TargetId: 26-char Crockford base32, leading char 0..=7.
 const FIXTURE_ID: &str = "01HQZX9F5N0000000000000000";
 
+// Macro to reduce boilerplate for testing rejection of all Tier-1 gates.
+// Each non-ReadFilter* gate must panic on RecordExclusion::new.
+macro_rules! reject_tier1_gate {
+    ($name:ident, $gate:expr) => {
+        #[test]
+        #[should_panic(expected = "ReadFilter")]
+        fn $name() {
+            let id = TargetId::parse(FIXTURE_ID).expect("valid ULID");
+            let _ = RecordExclusion::new(id, $gate, PolicyDetail::None);
+        }
+    };
+}
+
+// Test each non-ReadFilter* PolicyGate variant panics on construction.
+reject_tier1_gate!(rejects_presidio_redaction, PolicyGate::PresidioRedaction);
+reject_tier1_gate!(
+    rejects_prompt_injection_fence,
+    PolicyGate::PromptInjectionFence
+);
+reject_tier1_gate!(rejects_filter_should_memorize, PolicyGate::FilterShouldMemorize);
+reject_tier1_gate!(rejects_visibility_floor, PolicyGate::VisibilityFloor);
+reject_tier1_gate!(rejects_scope_check, PolicyGate::ScopeCheck);
+reject_tier1_gate!(rejects_forget_capability, PolicyGate::ForgetCapability);
+reject_tier1_gate!(
+    rejects_consent_journal_append,
+    PolicyGate::ConsentJournalAppend
+);
+
 #[test]
 fn exclusion_holds_target_gate_detail() {
     let id = TargetId::parse(FIXTURE_ID).expect("valid ULID");
@@ -28,20 +56,4 @@ fn exclusion_accepts_all_three_read_filter_gates() {
         let e = RecordExclusion::new(id.clone(), gate, PolicyDetail::None);
         assert_eq!(e.gate, gate);
     }
-}
-
-#[test]
-#[should_panic(expected = "ReadFilter")]
-fn exclusion_rejects_scope_check_gate() {
-    // ScopeCheck is a Tier-1 gate; per design §5.5, a Tier-1 invisible
-    // record's id must never appear in `excluded`.
-    let id = TargetId::parse(FIXTURE_ID).expect("valid ULID");
-    let _ = RecordExclusion::new(id, PolicyGate::ScopeCheck, PolicyDetail::None);
-}
-
-#[test]
-#[should_panic(expected = "ReadFilter")]
-fn exclusion_rejects_filter_should_memorize_gate() {
-    let id = TargetId::parse(FIXTURE_ID).expect("valid ULID");
-    let _ = RecordExclusion::new(id, PolicyGate::FilterShouldMemorize, PolicyDetail::None);
 }

--- a/crates/cairn-idl/schema/common/record_exclusion.json
+++ b/crates/cairn-idl/schema/common/record_exclusion.json
@@ -13,6 +13,6 @@
       "type": "string",
       "enum": ["read_filter_relevance", "read_filter_staleness", "read_filter_dedup"]
     },
-    "detail": { "type": "string", "minLength": 1 }
+    "detail": { "type": "string" }
   }
 }

--- a/crates/cairn-idl/schema/common/record_exclusion.json
+++ b/crates/cairn-idl/schema/common/record_exclusion.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/common/record_exclusion.json",
+  "title": "RecordExclusion",
+  "x-cairn-contract": "cairn.mcp.v1",
+  "description": "Per-record exclusion entry returned on search responses when args.explain is true. Records the caller cannot otherwise see (Tier-1 visibility) never appear here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["target_id", "gate", "detail"],
+  "properties": {
+    "target_id": { "$ref": "./primitives.json#/$defs/Ulid" },
+    "gate": {
+      "type": "string",
+      "enum": ["read_filter_relevance", "read_filter_staleness", "read_filter_dedup"]
+    },
+    "detail": { "type": "string", "minLength": 1 }
+  }
+}

--- a/crates/cairn-idl/schema/index.json
+++ b/crates/cairn-idl/schema/index.json
@@ -21,6 +21,7 @@
     ],
     "common": [
       "common/primitives.json",
+      "common/record_exclusion.json",
       "common/scope_filter.json"
     ],
     "prelude": [

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -105,6 +105,11 @@
         "cursor": {
           "$ref": "../common/primitives.json#/$defs/Cursor",
           "description": "Opaque continuation token from a prior search Data.next_cursor."
+        },
+        "explain": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, populate policy_trace and data.excluded with per-record exclusions for Tier-2 read filters. Has no effect on the candidate set the caller could see."
         }
       }
     },
@@ -123,6 +128,11 @@
         },
         "next_cursor": {
           "$ref": "../common/primitives.json#/$defs/Cursor"
+        },
+        "excluded": {
+          "type": "array",
+          "items": { "$ref": "../common/record_exclusion.json" },
+          "description": "Per-record exclusions; present only when args.explain is true."
         }
       }
     },

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -620,6 +620,11 @@ fn every_typed_field_asserts_bounds_or_is_allowlisted() {
         ),
         ("verbs/ingest.json", "/$defs/Args/properties/kind"),
         // kind has minLength:1 — guarded by parent fallback; skip
+        // RecordExclusion.detail is a stable code emitted by
+        // PolicyDetail::to_wire_string; the empty-string variant
+        // (PolicyDetail::None) is intentional and meaningful, so a
+        // minLength assertion would be wrong here.
+        ("common/record_exclusion.json", "/properties/detail"),
     ]
     .iter()
     .map(|(f, p)| (f.to_string(), p.to_string()))

--- a/crates/cairn-mcp/src/generated/schemas/common/record_exclusion.json
+++ b/crates/cairn-mcp/src/generated/schemas/common/record_exclusion.json
@@ -1,0 +1,31 @@
+{
+  "$id": "https://cairn.dev/schema/cairn.mcp.v1/common/record_exclusion.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Per-record exclusion entry returned on search responses when args.explain is true. Records the caller cannot otherwise see (Tier-1 visibility) never appear here.",
+  "properties": {
+    "detail": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "gate": {
+      "enum": [
+        "read_filter_relevance",
+        "read_filter_staleness",
+        "read_filter_dedup"
+      ],
+      "type": "string"
+    },
+    "target_id": {
+      "$ref": "./primitives.json#/$defs/Ulid"
+    }
+  },
+  "required": [
+    "target_id",
+    "gate",
+    "detail"
+  ],
+  "title": "RecordExclusion",
+  "type": "object",
+  "x-cairn-contract": "cairn.mcp.v1"
+}

--- a/crates/cairn-mcp/src/generated/schemas/common/record_exclusion.json
+++ b/crates/cairn-mcp/src/generated/schemas/common/record_exclusion.json
@@ -5,7 +5,6 @@
   "description": "Per-record exclusion entry returned on search responses when args.explain is true. Records the caller cannot otherwise see (Tier-1 visibility) never appear here.",
   "properties": {
     "detail": {
-      "minLength": 1,
       "type": "string"
     },
     "gate": {

--- a/crates/cairn-mcp/src/generated/schemas/verbs/search.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/search.input.json
@@ -15,6 +15,11 @@
           "$ref": "../common/primitives.json#/$defs/Cursor",
           "description": "Opaque continuation token from a prior search Data.next_cursor."
         },
+        "explain": {
+          "default": false,
+          "description": "When true, populate policy_trace and data.excluded with per-record exclusions for Tier-2 read filters. Has no effect on the candidate set the caller could see.",
+          "type": "boolean"
+        },
         "filters": {
           "$ref": "#/$defs/filter"
         },
@@ -57,6 +62,13 @@
     "Data": {
       "additionalProperties": false,
       "properties": {
+        "excluded": {
+          "description": "Per-record exclusions; present only when args.explain is true.",
+          "items": {
+            "$ref": "../common/record_exclusion.json"
+          },
+          "type": "array"
+        },
         "hits": {
           "items": {
             "$ref": "#/$defs/Hit"

--- a/crates/cairn-mcp/src/generated/schemas/verbs/search.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/search.json
@@ -15,6 +15,11 @@
           "$ref": "../common/primitives.json#/$defs/Cursor",
           "description": "Opaque continuation token from a prior search Data.next_cursor."
         },
+        "explain": {
+          "default": false,
+          "description": "When true, populate policy_trace and data.excluded with per-record exclusions for Tier-2 read filters. Has no effect on the candidate set the caller could see.",
+          "type": "boolean"
+        },
         "filters": {
           "$ref": "#/$defs/filter"
         },
@@ -57,6 +62,13 @@
     "Data": {
       "additionalProperties": false,
       "properties": {
+        "excluded": {
+          "description": "Per-record exclusions; present only when args.explain is true.",
+          "items": {
+            "$ref": "../common/record_exclusion.json"
+          },
+          "type": "array"
+        },
         "hits": {
           "items": {
             "$ref": "#/$defs/Hit"

--- a/crates/cairn-sdk/tests/properties.rs
+++ b/crates/cairn-sdk/tests/properties.rs
@@ -35,6 +35,7 @@ fn search_with_filter(filter: serde_json::Value) -> SearchArgs {
         mode: SearchArgsMode::Keyword,
         query: "q".to_owned(),
         scope: None,
+        explain: None,
     }
 }
 
@@ -246,6 +247,7 @@ fn empty_scope_filter_rejects() {
             user: None,
             workspace: None,
         }),
+        explain: None,
     };
     assert!(matches!(
         sdk().search(&args).expect_err("must reject"),
@@ -268,6 +270,7 @@ proptest! {
             mode: SearchArgsMode::Keyword,
             query: "q".to_owned(),
             scope: None,
+            explain: None,
         };
         prop_assert!(is_invalid_args(&sdk().search(&args).expect_err("must reject")));
     }

--- a/crates/cairn-sdk/tests/surface.rs
+++ b/crates/cairn-sdk/tests/surface.rs
@@ -429,6 +429,7 @@ fn search_rejects_empty_query_with_invalid_args() {
         mode: SearchArgsMode::Keyword,
         query: String::new(),
         scope: None,
+        explain: None,
     };
     match sdk().search(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => {
@@ -448,6 +449,7 @@ fn search_rejects_out_of_range_limit_with_invalid_args() {
         mode: SearchArgsMode::Keyword,
         query: "hello".to_owned(),
         scope: None,
+        explain: None,
     };
     match sdk().search(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => {
@@ -474,6 +476,7 @@ fn search_rejects_unadvertised_modes_with_capability_unavailable() {
             mode,
             query: "hello".to_owned(),
             scope: None,
+            explain: None,
         };
         let err = sdk().search(&args).expect_err("must fail closed in P0");
         match err {
@@ -538,6 +541,7 @@ fn search_rejects_empty_and_filter_with_invalid_args() {
         mode: SearchArgsMode::Keyword,
         query: "hi".to_owned(),
         scope: None,
+        explain: None,
     };
     match sdk().search(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => {
@@ -566,6 +570,7 @@ fn search_rejects_excessive_filter_depth_with_invalid_args() {
         mode: SearchArgsMode::Keyword,
         query: "hi".to_owned(),
         scope: None,
+        explain: None,
     };
     match sdk().search(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => {
@@ -589,6 +594,7 @@ fn search_rejects_malformed_filter_leaf_with_invalid_args() {
         mode: SearchArgsMode::Keyword,
         query: "hi".to_owned(),
         scope: None,
+        explain: None,
     };
     match sdk().search(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => {
@@ -621,6 +627,7 @@ fn search_accepts_extended_filter_operators() {
             mode: SearchArgsMode::Keyword,
             query: "hi".to_owned(),
             scope: None,
+            explain: None,
         };
         match sdk().search(&args).expect_err("P0 has no capability") {
             SdkError::CapabilityUnavailable { .. } => {}
@@ -656,6 +663,7 @@ fn search_rejects_malformed_extended_filter_operators_with_invalid_args() {
             mode: SearchArgsMode::Keyword,
             query: "hi".to_owned(),
             scope: None,
+            explain: None,
         };
         match sdk().search(&args).expect_err("must reject") {
             SdkError::InvalidArgs { .. } => {}
@@ -676,6 +684,7 @@ fn search_rejects_malformed_cursor_with_invalid_args() {
         mode: SearchArgsMode::Keyword,
         query: "hi".to_owned(),
         scope: None,
+        explain: None,
     };
     match sdk().search(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => assert!(reason.contains("Cursor"), "reason: {reason}"),
@@ -695,6 +704,7 @@ fn search_rejects_empty_scope_filter_with_invalid_args() {
         mode: SearchArgsMode::Keyword,
         query: "hi".to_owned(),
         scope: Some(empty_scope_filter()),
+        explain: None,
     };
     match sdk().search(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => {


### PR DESCRIPTION
## Summary

PR2 of issue #95 — adds the read-explain machinery (`explain_filter` pure function, `RecordExclusion` type, IDL changes for `search --explain`).

**Stacked on top of #237 (PR1).** Set base to `feat/issue-95-policy-trace`. Will retarget `main` once PR1 merges.

## Design source

`docs/superpowers/specs/2026-04-29-policy-trace-design.md`, sections 6.4, 7.2, 11.3.

## What lands

- **`cairn-core::policy_trace::RecordExclusion`** — programmer-error panic on non-`ReadFilter*` gates (fail-closed against Tier-1 leak). Tests cover every current non-`ReadFilter*` `PolicyGate` variant plus all three `ReadFilter*` accept paths.
- **`cairn-core::pipeline::explain::explain_filter`** — pure staleness + dedup partition. Returns `(kept, excluded)`. Highest-relevance wins per content-hash; original order preserved.
- **IDL: `args.explain: bool`** (default false, optional) and **`data.excluded?: RecordExclusion[]`** on `search`. New shared `record_exclusion.json` schema referencing the existing `Ulid` primitive.
- **Default-path byte-identity test** asserts `excluded` is absent from `SearchData` when `excluded: None`; sibling test asserts it appears when populated.

## Scope reduction from plan

`retrieve --explain` was originally in PR2 but deferred. `retrieve` has 6 target-discriminated Args/Data variants — per-variant edits would bloat PR2 and only multi-record targets (`folder`, `scope`) meaningfully use `excluded`. To be revisited when verb runtime work in #9/#46 lands, since that's where the wire shape actually gets exercised.

## One bug caught in review

The first cut had `detail: minLength: 1` on `RecordExclusion`. That contradicts `PolicyDetail::None.to_wire_string() → ""` from PR1 — every staleness/dedup exclusion would have failed wire validation. Fixed by relaxing to plain `string` and allowlisting the field in the IDL bounds-invariant test (`a73e685`).

## Wire compat

- `explain` defaults to `false` → existing callers see byte-identical responses.
- `excluded` is `Option<Vec<...>>` with `skip_serializing_if Option::is_none` → no wire churn unless requested.
- Snapshot tests confirm no regressions.

## Out of scope

- `retrieve --explain` (deferred, see "Scope reduction").
- CLI flag wiring on `search` — that verb is a stub awaiting #9 / #46. This PR makes the machinery available for those issues to call.

## Verification

```
cargo fmt --all --check                                              ok
cargo clippy --workspace --all-targets --locked -- -D warnings       ok
cargo nextest run --workspace --locked --no-fail-fast                1569/1569 passed
cargo test --doc --workspace --locked                                ok
./scripts/check-core-boundary.sh                                     ok
cargo run -p cairn-idl --bin cairn-codegen --locked -- --check       clean - 55 file(s) match
cargo run -p cairn-cli --bin cairn-docgen --locked -- --check        clean - 30 file(s) match
mdbook build docs/site                                               ok
RUSTDOCFLAGS="-D warnings ..." cargo doc --workspace ...             ok
cargo deny check                                                     advisories ok, bans ok, licenses ok, sources ok
cargo audit                                                          ok (exit 0)
cargo machete                                                        ok
```

## Test plan

- [x] `RecordExclusion::new` accepts all three `ReadFilter*` gates, panics on every other current `PolicyGate` variant (parameterized via macro)
- [x] `explain_filter`: empty input, pure-staleness, pure-dedup, staleness-takes-precedence, ReadFilterReason round-trip
- [x] `SearchArgs.explain: Option<bool>`, `SearchData.excluded: Option<Vec<RecordExclusion>>` regenerated cleanly
- [x] Default `SearchData { excluded: None, ... }` JSON does NOT contain `"excluded"`
- [x] Populated `SearchData { excluded: Some(vec![...]), ... }` JSON DOES contain `"excluded"`
- [x] PR1's body-free JSON walker still passes (no banned keys leak through)
- [x] All snapshot tests refreshed