### PR TITLE
feat: persist trace records (issue #77)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ name = "cairn-store-sqlite"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "cairn-cli",
  "cairn-core",
  "cairn-embeddings-local",
  "cairn-store-sqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -47,6 +47,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ulid = { workspace = true }
+sha2 = { workspace = true }
 base64 = { workspace = true }
 yaml_serde = { workspace = true }
 toml = { workspace = true }

--- a/crates/cairn-cli/src/generated/verbs.rs
+++ b/crates/cairn-cli/src/generated/verbs.rs
@@ -43,7 +43,7 @@ pub fn retrieve_subcommand() -> clap::Command {
         .arg(clap::Arg::new("rehydrate").long("rehydrate").action(clap::ArgAction::SetTrue))
         .arg(clap::Arg::new("include").long("include").value_name("ENUM").value_parser(["tool_calls", "reasoning"]).action(clap::ArgAction::Append).value_delimiter(','))
         .arg(clap::Arg::new("cursor").long("cursor").value_name("STRING"))
-        .arg(clap::Arg::new("turn_id").long("turn").value_name("U64").value_parser(clap::value_parser!(u64)))
+        .arg(clap::Arg::new("turn_id").long("turn").value_name("STRING"))
         .arg(clap::Arg::new("path").long("folder").value_name("STRING"))
         .arg(clap::Arg::new("depth").long("depth").value_name("U8").value_parser(clap::value_parser!(u8)))
         .arg(clap::Arg::new("scope").long("scope").value_name("JSON"))

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -204,8 +204,13 @@ pub async fn run_handler(
                 had_stop = true;
             }
 
-            // Resolve body from sources/.
-            let text = match resolve_body_text(vault_root, event).await {
+            // Resolve body from sources/, then run the standard pre-persist
+            // PII / secret redactor (CLAUDE.md §4.9 "privacy by construction":
+            // raw record bodies must be redacted before they reach storage).
+            // Trace records flow into both per-event rows and turn summaries
+            // built from those rows, so redacting once at the boundary covers
+            // both surfaces.
+            let raw_text = match resolve_body_text(vault_root, event).await {
                 Ok(t) => t,
                 Err(e) => {
                     failed_turns.push((
@@ -217,6 +222,7 @@ pub async fn run_handler(
                     break;
                 }
             };
+            let text = cairn_core::pipeline::filter::redact(&raw_text).text;
 
             let refs = event
                 .refs

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -1,11 +1,49 @@
 //! `cairn capture_trace` handler.
 
+use std::path::Path;
 use std::process::ExitCode;
 
+use anyhow::Context as _;
+use cairn_core::domain::capture::CaptureEvent;
 use cairn_core::generated::envelope::ResponseVerb;
 use clap::ArgMatches;
+use tokio::fs::File;
+use tokio::io::{AsyncBufReadExt as _, BufReader};
 
 use super::envelope::{emit_json, human_error, unimplemented_response};
+
+/// Read newline-delimited JSON [`CaptureEvent`]s from `path`. Blank lines
+/// are skipped; the first malformed line aborts the read.
+///
+/// # Errors
+///
+/// - File open / read failure (with path context).
+/// - Any line that fails to parse as [`CaptureEvent`].
+pub async fn read_jsonl_events(
+    path: impl AsRef<Path>,
+) -> anyhow::Result<Vec<CaptureEvent>> {
+    let path = path.as_ref();
+    let f = File::open(path)
+        .await
+        .with_context(|| format!("open trace JSONL at {}", path.display()))?;
+    let mut lines = BufReader::new(f).lines();
+    let mut events = Vec::new();
+    let mut line_no = 0_usize;
+    while let Some(line) = lines
+        .next_line()
+        .await
+        .with_context(|| format!("read line from {}", path.display()))?
+    {
+        line_no += 1;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let event: CaptureEvent = serde_json::from_str(&line)
+            .with_context(|| format!("parse CaptureEvent at {}:{line_no}", path.display()))?;
+        events.push(event);
+    }
+    Ok(events)
+}
 
 /// Run `cairn capture_trace`.
 #[must_use]

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -183,12 +183,11 @@ pub async fn run_handler(
         for event in &group {
             // Classify the event. P0 only recognizes the four hook payloads
             // (UserPromptSubmit / PreToolUse / PostToolUse / Stop). Other
-            // event shapes (`AgentMessage`, `ToolOutput`) await sensor
-            // adapters (#84). Skip unrecognized events with a per-event
-            // diagnostic instead of aborting the whole turn — the rest of
-            // the turn's known events still persist correctly, and the
-            // skipped event id surfaces in `failed_turns` so callers can
-            // act on it.
+            // shapes (`AgentMessage`, `ToolOutput`) await sensor adapters
+            // (#84). Fail the whole turn on the first unclassifiable event
+            // rather than persisting a partial set: the summary record
+            // would otherwise be built from incomplete data and become
+            // hard-to-detect data loss.
             let classified = match classify(event) {
                 Ok(c) => c,
                 Err(e) => {
@@ -197,7 +196,8 @@ pub async fn run_handler(
                         turn_str.clone(),
                         format!("classify {}: {e}", event.event_id),
                     ));
-                    continue;
+                    group_failed = true;
+                    break;
                 }
             };
             if classified == TraceEvent::Stop {

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -20,7 +20,7 @@
 //! is reported as failed; the remaining events in the turn are not
 //! persisted.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::process::ExitCode;
 
@@ -132,7 +132,6 @@ pub async fn run_handler(
     // that contains *any* invalid event is poisoned — its valid siblings
     // are dropped too so the store never sees a truncated turn that
     // would summarize against incomplete data.
-    use std::collections::BTreeSet;
     let mut groups: BTreeMap<(String, String), Vec<&CaptureEvent>> = BTreeMap::new();
     let mut failed_turns: Vec<(String, String, String)> = Vec::new();
     let mut poisoned: BTreeSet<(String, String)> = BTreeSet::new();

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -180,6 +180,11 @@ pub async fn run_handler(
         // so post_tool events can resolve their parent_event_id.
         let mut last_pre_tool: BTreeMap<String, CaptureEventId> = BTreeMap::new();
 
+        // Indices into `projected` whose parent_event_id must be resolved
+        // from the store (i.e., the PreTool arrived in a prior batch).
+        // Tuple: (projected_index, tool_call_id).
+        let mut needs_parent_from_store: Vec<(usize, String)> = Vec::new();
+
         for event in &group {
             // Classify the event.
             let classified = match classify(event) {
@@ -220,28 +225,30 @@ pub async fn run_handler(
             // Resolve tool_call_id and parent_event_id.
             let tool_call_id: Option<String> = refs.tool_id.clone();
 
-            // Derive parent_event_id for PostTool/ToolOutput from the
-            // most-recently-seen PreTool with the same tool_call_id.
-            let parent_event_id: Option<CaptureEventId> =
+            // Derive parent_event_id for PostTool/ToolOutput.
+            //
+            // Primary: most-recently-seen PreTool with matching tool_call_id
+            // *in this batch* (fast path, no store round-trip).
+            //
+            // Fallback: if no in-batch PreTool is found, the PreTool may
+            // have arrived in a previous batch.  We project the record with
+            // a placeholder parent (the event's own id) and record it in
+            // `needs_parent_from_store`; the real parent is resolved inside
+            // the transaction after existing rows are loaded.
+            let (parent_event_id, needs_store_lookup) =
                 if matches!(classified, TraceEvent::PostTool | TraceEvent::ToolOutput) {
                     let key = tool_call_id.clone().unwrap_or_default();
-                    let Some(id) = last_pre_tool.get(&key).cloned() else {
-                        failed_turns.push((
-                            session_str.clone(),
-                            turn_str.clone(),
-                            format!(
-                                "PostTool/ToolOutput event {} has no preceding PreTool \
-                                 for tool_call_id={:?}",
-                                event.event_id.as_str(),
-                                tool_call_id,
-                            ),
-                        ));
-                        group_failed = true;
-                        break;
-                    };
-                    Some(id)
+                    if let Some(id) = last_pre_tool.get(&key).cloned() {
+                        (Some(id), false)
+                    } else {
+                        // Use own event id as placeholder so `TraceLink::validate`
+                        // passes (it only requires parent_event_id is Some for
+                        // PostTool/ToolOutput, not that it points at a distinct id).
+                        // The real parent is patched inside `with_tx`.
+                        (Some(event.event_id.clone()), true)
+                    }
                 } else {
-                    None
+                    (None, false)
                 };
 
             let link = TraceLink {
@@ -273,6 +280,11 @@ pub async fn run_handler(
                     break;
                 }
             };
+
+            if needs_store_lookup {
+                let key = tool_call_id.clone().unwrap_or_default();
+                needs_parent_from_store.push((projected.len(), key));
+            }
             projected.push(record);
 
             // Register this PreTool so later PostTool/ToolOutput events can
@@ -292,6 +304,68 @@ pub async fn run_handler(
         let turn_str_tx = turn_str.clone();
         let result = store
             .with_tx(move |tx| {
+                // Resolve any parent_event_ids that could not be satisfied
+                // by the in-batch `last_pre_tool` map.  These are
+                // PostTool/ToolOutput events whose PreTool arrived in a
+                // prior batch.  We query the existing rows for the turn,
+                // locate the pre_tool row with the matching tool_call_id,
+                // and patch `extra_frontmatter.trace.parent_event_id` on
+                // the projected record before `renumber_turn_with` sees it.
+                if !needs_parent_from_store.is_empty() {
+                    let existing = tx.list_trace_events(&session_id_tx, &turn_str_tx)?;
+                    // Build: tool_call_id -> capture_event_id for pre_tool rows.
+                    let pre_tool_by_tcid: BTreeMap<String, String> = existing
+                        .iter()
+                        .filter_map(|r| {
+                            let evt = r
+                                .extra_frontmatter
+                                .get("trace_event")
+                                .and_then(|v| v.as_str())?;
+                            if evt != "pre_tool" {
+                                return None;
+                            }
+                            let trace = r
+                                .extra_frontmatter
+                                .get("trace")
+                                .and_then(|v| v.as_object())?;
+                            let tcid = trace
+                                .get("tool_call_id")
+                                .and_then(|v| v.as_str())?
+                                .to_owned();
+                            let ceid = trace
+                                .get("capture_event_id")
+                                .and_then(|v| v.as_str())?
+                                .to_owned();
+                            Some((tcid, ceid))
+                        })
+                        .collect();
+
+                    for (idx, tool_call_id) in &needs_parent_from_store {
+                        let Some(parent_ceid) = pre_tool_by_tcid.get(tool_call_id) else {
+                            return Err(
+                                cairn_store_sqlite::error::StoreError::Invariant {
+                                    what: format!(
+                                        "PostTool/ToolOutput at projected[{idx}] has no \
+                                         PreTool (in-batch or store) for \
+                                         tool_call_id={tool_call_id:?}"
+                                    ),
+                                },
+                            );
+                        };
+                        // Patch `extra_frontmatter.trace.parent_event_id`.
+                        if let Some(trace_obj) = projected[*idx]
+                            .extra_frontmatter
+                            .get_mut("trace")
+                            .and_then(|v| v.as_object_mut())
+                        {
+                            trace_obj.insert(
+                                "parent_event_id".into(),
+                                serde_json::Value::String(parent_ceid.clone()),
+                            );
+                        }
+                    }
+                }
+
                 tx.renumber_turn_with(&session_id_tx, &turn_str_tx, &projected)?;
                 tx.validate_turn_links(&session_id_tx, &turn_str_tx)?;
 

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -181,17 +181,23 @@ pub async fn run_handler(
         let mut needs_parent_from_store: Vec<(usize, String)> = Vec::new();
 
         for event in &group {
-            // Classify the event.
+            // Classify the event. P0 only recognizes the four hook payloads
+            // (UserPromptSubmit / PreToolUse / PostToolUse / Stop). Other
+            // event shapes (`AgentMessage`, `ToolOutput`) await sensor
+            // adapters (#84). Skip unrecognized events with a per-event
+            // diagnostic instead of aborting the whole turn — the rest of
+            // the turn's known events still persist correctly, and the
+            // skipped event id surfaces in `failed_turns` so callers can
+            // act on it.
             let classified = match classify(event) {
                 Ok(c) => c,
                 Err(e) => {
                     failed_turns.push((
                         session_str.clone(),
                         turn_str.clone(),
-                        format!("classify: {e}"),
+                        format!("classify {}: {e}", event.event_id),
                     ));
-                    group_failed = true;
-                    break;
+                    continue;
                 }
             };
             if classified == TraceEvent::Stop {

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -125,18 +125,30 @@ pub async fn run_handler(
         .context("capture_trace: vault degraded")?;
 
     let events = read_jsonl_events(from).await?;
-    for event in &events {
-        event
-            .validate()
-            .context("CaptureEvent envelope validation")?;
-    }
 
-    // Group by (session_id, turn_id). Events missing either ref are reported
-    // as failed and skipped — there is no turn to persist them into.
+    // Group by (session_id, turn_id). Events missing either ref, or
+    // failing structural validation, are reported as failed and skipped
+    // rather than aborting the whole import — per-turn isolation means
+    // one bad line should not block unrelated turns from being persisted.
     let mut groups: BTreeMap<(String, String), Vec<&CaptureEvent>> = BTreeMap::new();
     let mut failed_turns: Vec<(String, String, String)> = Vec::new();
 
     for event in &events {
+        // Structural envelope validation. Failures land in failed_turns
+        // keyed on whatever session/turn refs the event managed to carry.
+        if let Err(e) = event.validate() {
+            let (s, t) = event
+                .refs
+                .as_ref()
+                .map_or((String::new(), String::new()), |r| {
+                    (
+                        r.session_id.clone().unwrap_or_default(),
+                        r.turn_id.clone().unwrap_or_default(),
+                    )
+                });
+            failed_turns.push((s, t, format!("envelope validate: {e}")));
+            continue;
+        }
         let Some(refs) = event.refs.as_ref() else {
             failed_turns.push((String::new(), String::new(), "event missing refs".into()));
             continue;

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -62,9 +62,7 @@ pub struct CaptureTraceResponse {
 ///
 /// - File open / read failure (with path context).
 /// - Any line that fails to parse as [`CaptureEvent`].
-pub async fn read_jsonl_events(
-    path: impl AsRef<Path>,
-) -> anyhow::Result<Vec<CaptureEvent>> {
+pub async fn read_jsonl_events(path: impl AsRef<Path>) -> anyhow::Result<Vec<CaptureEvent>> {
     let path = path.as_ref();
     let f = File::open(path)
         .await
@@ -128,7 +126,9 @@ pub async fn run_handler(
 
     let events = read_jsonl_events(from).await?;
     for event in &events {
-        event.validate().context("CaptureEvent envelope validation")?;
+        event
+            .validate()
+            .context("CaptureEvent envelope validation")?;
     }
 
     // Group by (session_id, turn_id). Events missing either ref are reported
@@ -138,11 +138,7 @@ pub async fn run_handler(
 
     for event in &events {
         let Some(refs) = event.refs.as_ref() else {
-            failed_turns.push((
-                String::new(),
-                String::new(),
-                "event missing refs".into(),
-            ));
+            failed_turns.push((String::new(), String::new(), "event missing refs".into()));
             continue;
         };
         let (Some(s), Some(t)) = (refs.session_id.as_deref(), refs.turn_id.as_deref()) else {
@@ -171,8 +167,7 @@ pub async fn run_handler(
         // Resolve bodies from sources/ and project records *before* entering
         // the sync tx closure — tokio::fs reads must not run on the DB
         // worker thread.
-        let mut projected: Vec<cairn_core::domain::MemoryRecord> =
-            Vec::with_capacity(group.len());
+        let mut projected: Vec<cairn_core::domain::MemoryRecord> = Vec::with_capacity(group.len());
         let mut had_stop = false;
         let mut group_failed = false;
 
@@ -342,15 +337,13 @@ pub async fn run_handler(
 
                     for (idx, tool_call_id) in &needs_parent_from_store {
                         let Some(parent_ceid) = pre_tool_by_tcid.get(tool_call_id) else {
-                            return Err(
-                                cairn_store_sqlite::error::StoreError::Invariant {
-                                    what: format!(
-                                        "PostTool/ToolOutput at projected[{idx}] has no \
+                            return Err(cairn_store_sqlite::error::StoreError::Invariant {
+                                what: format!(
+                                    "PostTool/ToolOutput at projected[{idx}] has no \
                                          PreTool (in-batch or store) for \
                                          tool_call_id={tool_call_id:?}"
-                                    ),
-                                },
-                            );
+                                ),
+                            });
                         };
                         // Patch `extra_frontmatter.trace.parent_event_id`.
                         if let Some(trace_obj) = projected[*idx]
@@ -371,16 +364,12 @@ pub async fn run_handler(
 
                 // Summarize if Stop landed in this batch OR a summary already
                 // exists (closed-turn re-summarize per spec §4).
-                if had_stop
-                    || tx.turn_summary_exists(&session_id_tx, &turn_str_tx)?
-                {
-                    let final_rows =
-                        tx.list_trace_events(&session_id_tx, &turn_str_tx)?;
-                    let summary =
-                        summarize_turn(&session_id_tx, &turn_str_tx, &final_rows)
-                            .map_err(|e| cairn_store_sqlite::error::StoreError::Invariant {
-                                what: format!("summarize_turn: {e}"),
-                            })?;
+                if had_stop || tx.turn_summary_exists(&session_id_tx, &turn_str_tx)? {
+                    let final_rows = tx.list_trace_events(&session_id_tx, &turn_str_tx)?;
+                    let summary = summarize_turn(&session_id_tx, &turn_str_tx, &final_rows)
+                        .map_err(|e| cairn_store_sqlite::error::StoreError::Invariant {
+                            what: format!("summarize_turn: {e}"),
+                        })?;
                     tx.upsert_trace(&summary)?;
                 }
                 Ok::<(), cairn_store_sqlite::error::StoreError>(())
@@ -410,10 +399,7 @@ pub async fn run_handler(
 /// - I/O error reading the file.
 /// - SHA-256 mismatch between the stored hash and the computed hash.
 /// - Bytes not valid UTF-8.
-async fn resolve_body_text(
-    vault_root: &Path,
-    event: &CaptureEvent,
-) -> anyhow::Result<String> {
+async fn resolve_body_text(vault_root: &Path, event: &CaptureEvent) -> anyhow::Result<String> {
     let path = vault_root.join(&event.payload_ref);
     let bytes = tokio::fs::read(&path)
         .await
@@ -421,9 +407,7 @@ async fn resolve_body_text(
 
     let actual = sha256_hex(&bytes);
     let raw_expected = event.payload_hash.as_str();
-    let expected_hex = raw_expected
-        .strip_prefix("sha256:")
-        .unwrap_or(raw_expected);
+    let expected_hex = raw_expected.strip_prefix("sha256:").unwrap_or(raw_expected);
 
     if actual != expected_hex {
         anyhow::bail!(

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -128,14 +128,19 @@ pub async fn run_handler(
 
     // Group by (session_id, turn_id). Events missing either ref, or
     // failing structural validation, are reported as failed and skipped
-    // rather than aborting the whole import — per-turn isolation means
-    // one bad line should not block unrelated turns from being persisted.
+    // rather than aborting the whole import. Per-turn atomicity: a turn
+    // that contains *any* invalid event is poisoned — its valid siblings
+    // are dropped too so the store never sees a truncated turn that
+    // would summarize against incomplete data.
+    use std::collections::BTreeSet;
     let mut groups: BTreeMap<(String, String), Vec<&CaptureEvent>> = BTreeMap::new();
     let mut failed_turns: Vec<(String, String, String)> = Vec::new();
+    let mut poisoned: BTreeSet<(String, String)> = BTreeSet::new();
 
     for event in &events {
         // Structural envelope validation. Failures land in failed_turns
-        // keyed on whatever session/turn refs the event managed to carry.
+        // keyed on whatever session/turn refs the event managed to carry,
+        // and the (session, turn) pair is poisoned for this import.
         if let Err(e) = event.validate() {
             let (s, t) = event
                 .refs
@@ -146,7 +151,8 @@ pub async fn run_handler(
                         r.turn_id.clone().unwrap_or_default(),
                     )
                 });
-            failed_turns.push((s, t, format!("envelope validate: {e}")));
+            failed_turns.push((s.clone(), t.clone(), format!("envelope validate: {e}")));
+            poisoned.insert((s, t));
             continue;
         }
         let Some(refs) = event.refs.as_ref() else {
@@ -166,6 +172,8 @@ pub async fn run_handler(
             .or_default()
             .push(event);
     }
+    // Drop any group whose turn key was poisoned by an invalid sibling.
+    groups.retain(|key, _| !poisoned.contains(key));
 
     for ((session_str, turn_str), group) in groups {
         let session_id = match SessionId::parse(&session_str) {

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -406,7 +406,33 @@ pub async fn run_handler(
 /// - SHA-256 mismatch between the stored hash and the computed hash.
 /// - Bytes not valid UTF-8.
 async fn resolve_body_text(vault_root: &Path, event: &CaptureEvent) -> anyhow::Result<String> {
-    let path = vault_root.join(&event.payload_ref);
+    // Trust boundary: `payload_ref` is caller-supplied (the JSONL on disk).
+    // A matching `payload_hash` is integrity, not authorization — without a
+    // path containment check, a crafted entry like `../../../etc/passwd`
+    // plus its real SHA-256 would be ingested as a "trace" body. Test
+    // fixtures already supply `payload_ref` rooted at `sources/...`, so we
+    // canonicalize the resolved path and require it to remain under the
+    // canonical `vault_root/sources/` subtree.
+    let raw_path = vault_root.join(&event.payload_ref);
+    let canon_sources = tokio::fs::canonicalize(vault_root.join("sources"))
+        .await
+        .with_context(|| {
+            format!(
+                "canonicalize vault sources root {}",
+                vault_root.join("sources").display()
+            )
+        })?;
+    let canon_path = tokio::fs::canonicalize(&raw_path)
+        .await
+        .with_context(|| format!("canonicalize payload path {}", raw_path.display()))?;
+    if !canon_path.starts_with(&canon_sources) {
+        anyhow::bail!(
+            "payload_ref escapes vault sources/ (resolved {} not under {})",
+            canon_path.display(),
+            canon_sources.display(),
+        );
+    }
+    let path = canon_path;
     let bytes = tokio::fs::read(&path)
         .await
         .with_context(|| format!("read payload at {}", path.display()))?;

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -1,16 +1,59 @@
-//! `cairn capture_trace` handler.
+//! `cairn capture_trace` handler (issue #77, brief §5.0).
+//!
+//! This module owns the async verb handler [`run_handler`] that reads a
+//! JSONL stream of [`CaptureEvent`]s from disk, groups them by
+//! `(session_id, turn_id)`, and persists each turn atomically via
+//! [`SqliteMemoryStore::with_tx`].
+//!
+//! # Parent-event-id convention
+//!
+//! `PostTool` and `ToolOutput` events require a `parent_event_id` pointing
+//! at the `PreTool` event that initiated the same tool call (validated by
+//! `validate_turn_links`). Harnesses emit hook events sequentially, so the
+//! canonical convention implemented here is:
+//!
+//! > *The `parent_event_id` of a `PostTool`/`ToolOutput` event equals the
+//! > `capture_event_id` of the most-recently-seen `PreTool` event with the
+//! > same `tool_call_id` in the same turn group.*
+//!
+//! If no matching `PreTool` is found for a given `tool_call_id`, the event
+//! is reported as failed; the remaining events in the turn are not
+//! persisted.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::ExitCode;
 
 use anyhow::Context as _;
 use cairn_core::domain::capture::CaptureEvent;
+use cairn_core::domain::trace::{TraceEvent, TraceLink};
+use cairn_core::domain::{CaptureEventId, SessionId};
 use cairn_core::generated::envelope::ResponseVerb;
+use cairn_core::pipeline::capture_trace::{classify, project};
+use cairn_core::pipeline::extract::body::ResolvedBody;
+use cairn_core::pipeline::turn::summarize_turn;
+use cairn_store_sqlite::SqliteMemoryStore;
 use clap::ArgMatches;
+use sha2::{Digest as _, Sha256};
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt as _, BufReader};
+use ulid::Ulid;
+
+use crate::identity::{guard::refuse_if_degraded, status::ReconciliationReport};
 
 use super::envelope::{emit_json, human_error, unimplemented_response};
+
+/// Result returned by [`run_handler`] on success.
+#[derive(Debug, serde::Serialize)]
+pub struct CaptureTraceResponse {
+    /// Stable trace-operation id (ULID string). Unique per invocation.
+    pub trace_id: String,
+    /// Per-turn failures: `(session_id, turn_id, error_message)`.
+    ///
+    /// A non-empty list means some turns were not persisted. The turns not
+    /// listed were persisted successfully.
+    pub failed_turns: Vec<(String, String, String)>,
+}
 
 /// Read newline-delimited JSON [`CaptureEvent`]s from `path`. Blank lines
 /// are skipped; the first malformed line aborts the read.
@@ -43,6 +86,287 @@ pub async fn read_jsonl_events(
         events.push(event);
     }
     Ok(events)
+}
+
+/// Persist a JSONL batch of [`CaptureEvent`]s grouped by `(session_id, turn_id)`.
+///
+/// Steps per call:
+/// 1. `refuse_if_degraded` guard.
+/// 2. Read and validate every event in the JSONL file.
+/// 3. Group by `(session_id, turn_id)`; events missing either field are
+///    reported as failures immediately.
+/// 4. For each group: resolve bodies from `sources/`, project records,
+///    resolve `parent_event_id` for `PostTool` events, then atomically
+///    `renumber_turn_with` + `validate_turn_links` + optional `summarize`.
+///    A failure in one turn does **not** abort other turns.
+/// 5. Return a [`CaptureTraceResponse`] with a fresh trace-id and any
+///    per-turn failures.
+///
+/// # Parent-event-id convention
+///
+/// See module-level doc comment.
+///
+/// # Errors
+///
+/// Returns an error only for unrecoverable setup failures (e.g. the JSONL
+/// file cannot be read, or envelope validation fails for all events). Per-turn
+/// failures are reported in [`CaptureTraceResponse::failed_turns`].
+#[allow(
+    clippy::too_many_lines,
+    reason = "CLI verb dispatcher: guard → parse → group → per-turn persist. \
+              Each step is linear; extracting sub-functions would hide the \
+              sequential flow without reducing complexity."
+)]
+pub async fn run_handler(
+    store: &SqliteMemoryStore,
+    vault_root: &Path,
+    from: &Path,
+) -> anyhow::Result<CaptureTraceResponse> {
+    // §3.5 trust-boundary guard.
+    refuse_if_degraded(&ReconciliationReport::default(), vec![])
+        .context("capture_trace: vault degraded")?;
+
+    let events = read_jsonl_events(from).await?;
+    for event in &events {
+        event.validate().context("CaptureEvent envelope validation")?;
+    }
+
+    // Group by (session_id, turn_id). Events missing either ref are reported
+    // as failed and skipped — there is no turn to persist them into.
+    let mut groups: BTreeMap<(String, String), Vec<&CaptureEvent>> = BTreeMap::new();
+    let mut failed_turns: Vec<(String, String, String)> = Vec::new();
+
+    for event in &events {
+        let Some(refs) = event.refs.as_ref() else {
+            failed_turns.push((
+                String::new(),
+                String::new(),
+                "event missing refs".into(),
+            ));
+            continue;
+        };
+        let (Some(s), Some(t)) = (refs.session_id.as_deref(), refs.turn_id.as_deref()) else {
+            failed_turns.push((
+                refs.session_id.clone().unwrap_or_default(),
+                refs.turn_id.clone().unwrap_or_default(),
+                "event missing session_id or turn_id".into(),
+            ));
+            continue;
+        };
+        groups
+            .entry((s.to_owned(), t.to_owned()))
+            .or_default()
+            .push(event);
+    }
+
+    for ((session_str, turn_str), group) in groups {
+        let session_id = match SessionId::parse(&session_str) {
+            Ok(s) => s,
+            Err(e) => {
+                failed_turns.push((session_str, turn_str, e.to_string()));
+                continue;
+            }
+        };
+
+        // Resolve bodies from sources/ and project records *before* entering
+        // the sync tx closure — tokio::fs reads must not run on the DB
+        // worker thread.
+        let mut projected: Vec<cairn_core::domain::MemoryRecord> =
+            Vec::with_capacity(group.len());
+        let mut had_stop = false;
+        let mut group_failed = false;
+
+        // Track most-recently-seen pre_tool capture_event_id per tool_call_id
+        // so post_tool events can resolve their parent_event_id.
+        let mut last_pre_tool: BTreeMap<String, CaptureEventId> = BTreeMap::new();
+
+        for event in &group {
+            // Classify the event.
+            let classified = match classify(event) {
+                Ok(c) => c,
+                Err(e) => {
+                    failed_turns.push((
+                        session_str.clone(),
+                        turn_str.clone(),
+                        format!("classify: {e}"),
+                    ));
+                    group_failed = true;
+                    break;
+                }
+            };
+            if classified == TraceEvent::Stop {
+                had_stop = true;
+            }
+
+            // Resolve body from sources/.
+            let text = match resolve_body_text(vault_root, event).await {
+                Ok(t) => t,
+                Err(e) => {
+                    failed_turns.push((
+                        session_str.clone(),
+                        turn_str.clone(),
+                        format!("resolve_body: {e}"),
+                    ));
+                    group_failed = true;
+                    break;
+                }
+            };
+
+            let refs = event
+                .refs
+                .as_ref()
+                .expect("invariant: filtered to events with refs above");
+
+            // Resolve tool_call_id and parent_event_id.
+            let tool_call_id: Option<String> = refs.tool_id.clone();
+
+            // Derive parent_event_id for PostTool/ToolOutput from the
+            // most-recently-seen PreTool with the same tool_call_id.
+            let parent_event_id: Option<CaptureEventId> =
+                if matches!(classified, TraceEvent::PostTool | TraceEvent::ToolOutput) {
+                    let key = tool_call_id.clone().unwrap_or_default();
+                    let Some(id) = last_pre_tool.get(&key).cloned() else {
+                        failed_turns.push((
+                            session_str.clone(),
+                            turn_str.clone(),
+                            format!(
+                                "PostTool/ToolOutput event {} has no preceding PreTool \
+                                 for tool_call_id={:?}",
+                                event.event_id.as_str(),
+                                tool_call_id,
+                            ),
+                        ));
+                        group_failed = true;
+                        break;
+                    };
+                    Some(id)
+                } else {
+                    None
+                };
+
+            let link = TraceLink {
+                session_id: session_id.clone(),
+                turn_id: turn_str.clone(),
+                sequence: 0, // overridden by renumber_turn_with
+                capture_event_id: event.event_id.clone(),
+                parent_event_id,
+                tool_call_id: tool_call_id.clone(),
+                member_event_ids: Vec::new(),
+            };
+
+            // Build resolved body borrowing from the owned `text` on the stack.
+            // SAFETY: `text` is owned by this block; `resolved` borrows it for
+            // the duration of the `project` call only, which completes before
+            // `text` is dropped. This is safe because both live in the same
+            // `for` iteration scope.
+            let resolved = ResolvedBody::from_trace_hook(&text);
+
+            let record = match project(event, classified, &resolved, &link) {
+                Ok(r) => r,
+                Err(e) => {
+                    failed_turns.push((
+                        session_str.clone(),
+                        turn_str.clone(),
+                        format!("project: {e}"),
+                    ));
+                    group_failed = true;
+                    break;
+                }
+            };
+            projected.push(record);
+
+            // Register this PreTool so later PostTool/ToolOutput events can
+            // find their parent.
+            if classified == TraceEvent::PreTool {
+                let key = tool_call_id.unwrap_or_default();
+                last_pre_tool.insert(key, event.event_id.clone());
+            }
+        }
+
+        if group_failed {
+            continue;
+        }
+
+        // Per-turn atomic transaction.
+        let session_id_tx = session_id.clone();
+        let turn_str_tx = turn_str.clone();
+        let result = store
+            .with_tx(move |tx| {
+                tx.renumber_turn_with(&session_id_tx, &turn_str_tx, &projected)?;
+                tx.validate_turn_links(&session_id_tx, &turn_str_tx)?;
+
+                // Summarize if Stop landed in this batch OR a summary already
+                // exists (closed-turn re-summarize per spec §4).
+                if had_stop
+                    || tx.turn_summary_exists(&session_id_tx, &turn_str_tx)?
+                {
+                    let final_rows =
+                        tx.list_trace_events(&session_id_tx, &turn_str_tx)?;
+                    let summary =
+                        summarize_turn(&session_id_tx, &turn_str_tx, &final_rows)
+                            .map_err(|e| cairn_store_sqlite::error::StoreError::Invariant {
+                                what: format!("summarize_turn: {e}"),
+                            })?;
+                    tx.upsert_trace(&summary)?;
+                }
+                Ok::<(), cairn_store_sqlite::error::StoreError>(())
+            })
+            .await;
+
+        if let Err(e) = result {
+            failed_turns.push((session_str, turn_str, e.to_string()));
+        }
+    }
+
+    Ok(CaptureTraceResponse {
+        trace_id: Ulid::new().to_string(),
+        failed_turns,
+    })
+}
+
+/// Read the payload bytes referenced by `event.payload_ref` from disk
+/// (relative to `vault_root`), verify the SHA-256 hash matches
+/// `event.payload_hash`, and return the body as a UTF-8 `String`.
+///
+/// The `payload_hash` field may be prefixed with `"sha256:"` — this prefix
+/// is stripped before comparison.
+///
+/// # Errors
+///
+/// - I/O error reading the file.
+/// - SHA-256 mismatch between the stored hash and the computed hash.
+/// - Bytes not valid UTF-8.
+async fn resolve_body_text(
+    vault_root: &Path,
+    event: &CaptureEvent,
+) -> anyhow::Result<String> {
+    let path = vault_root.join(&event.payload_ref);
+    let bytes = tokio::fs::read(&path)
+        .await
+        .with_context(|| format!("read payload at {}", path.display()))?;
+
+    let actual = sha256_hex(&bytes);
+    let raw_expected = event.payload_hash.as_str();
+    let expected_hex = raw_expected
+        .strip_prefix("sha256:")
+        .unwrap_or(raw_expected);
+
+    if actual != expected_hex {
+        anyhow::bail!(
+            "payload_hash mismatch at {}: expected sha256:{expected_hex}, got sha256:{actual}",
+            path.display()
+        );
+    }
+
+    String::from_utf8(bytes)
+        .with_context(|| format!("payload at {} is not valid UTF-8", path.display()))
+}
+
+/// Compute the lowercase hex SHA-256 digest of `bytes`.
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    format!("{:x}", h.finalize())
 }
 
 /// Run `cairn capture_trace`.

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -173,7 +173,25 @@ pub async fn run_handler(
 
         // Track most-recently-seen pre_tool capture_event_id per tool_call_id
         // so post_tool events can resolve their parent_event_id.
+        //
+        // Pre-pass: scan the FULL group up-front and index every PreTool by
+        // tool_call_id. This makes parent resolution insensitive to JSONL
+        // file order — a PostTool that appears before its PreTool in the
+        // batch still resolves its parent in-batch instead of falling back
+        // to the cross-batch store-lookup (which only sees rows already
+        // persisted in prior transactions and would mis-fire here).
         let mut last_pre_tool: BTreeMap<String, CaptureEventId> = BTreeMap::new();
+        for event in &group {
+            if !matches!(classify(event), Ok(TraceEvent::PreTool)) {
+                continue;
+            }
+            let Some(refs) = event.refs.as_ref() else {
+                continue;
+            };
+            if let Some(tcid) = refs.tool_id.as_deref() {
+                last_pre_tool.insert(tcid.to_owned(), event.event_id.clone());
+            }
+        }
 
         // Indices into `projected` whose parent_event_id must be resolved
         // from the store (i.e., the PreTool arrived in a prior batch).

--- a/crates/cairn-cli/tests/capture_trace_verb.rs
+++ b/crates/cairn-cli/tests/capture_trace_verb.rs
@@ -62,6 +62,10 @@ const ULID_F: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAF";
 const ULID_G: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAG";
 const ULID_H: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAH";
 
+// ULID for late tool_output event (after the main 4-event turn).
+// Note: Crockford base32 has no I, L, O, U — use K (valid) for the suffix.
+const ULID_LATE: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAK";
+
 #[tokio::test]
 async fn parses_jsonl_into_events() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -677,6 +681,192 @@ async fn capture_trace_single_turn_persists_and_summarizes() {
                 "turn summary should exist after Stop event"
             );
             Ok(())
+        })
+        .await
+        .expect("store query should succeed");
+}
+
+/// Write a single late `PostToolUse` event for the same turn-1 created by
+/// [`write_fixture`].  The event uses the same `tool_call_id` as the
+/// `pre_tool` in that fixture (`"toolu_test_01"`) and a timestamp that falls
+/// between `PreToolUse` and `PostToolUse` — ensuring it interleaves when
+/// `renumber_turn_with` sorts by `captured_at`.
+///
+/// The source file is written under `vault/sources/hook/`.
+fn write_late_tool_output_fixture(vault: &Path, jsonl_path: &Path) {
+    let session = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    let turn = "turn-1";
+    // Same tool_call_id as the pre_tool in write_fixture so the store-lookup
+    // path in run_handler can resolve the parent.
+    let tool_id = "toolu_test_01";
+
+    let late_body = r#"{"tool":"bash","late_output":"extra info"}"#;
+    let late_ref = write_source(vault, &format!("{ULID_LATE}.txt"), late_body);
+
+    let event = make_event(
+        ULID_LATE,
+        // "PostToolUse" maps to TraceEvent::PostTool which requires a parent.
+        // We use PostToolUse here — the store-lookup path will resolve the
+        // parent from the existing pre_tool row already in the store.
+        "PostToolUse",
+        session,
+        turn,
+        // Timestamp between PreToolUse (00:00:02Z) and PostToolUse (00:00:03Z)
+        // so it lands at sequence 2 after renumber, pushing the original
+        // PostToolUse to sequence 3.
+        "2026-05-02T00:00:02.500Z",
+        Some(tool_id.to_owned()),
+        &late_ref,
+        &sha256_hex(late_body),
+    );
+
+    let mut f = std::fs::File::create(jsonl_path).expect("create JSONL file");
+    let line = serde_json::to_string(&event).expect("serialize event");
+    writeln!(f, "{line}").expect("write JSONL line");
+}
+
+// ── Test 1: replay idempotency ────────────────────────────────────────────────
+
+/// Replaying the same JSONL file twice must not create duplicate records.
+///
+/// The `renumber_turn_with` upsert path is idempotent by design: the
+/// `record_id` is derived deterministically from `capture_event_id`, so a
+/// second import of the same event converges to the same row.  The
+/// `UNIQUE INDEX records_trace_summary` on the summary row guarantees at
+/// most one summary per turn; `upsert_trace` performs an INSERT OR REPLACE,
+/// so a second summary write replaces the first rather than inserting a
+/// duplicate.
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn replay_is_idempotent() {
+    let vault = tempfile::tempdir().expect("tempdir");
+    let store = open_test_store_in_memory().await;
+
+    let jsonl_path = vault.path().join("trace.jsonl");
+    write_fixture(vault.path(), &jsonl_path);
+
+    // First import.
+    let resp1 = run_handler(&store, vault.path(), &jsonl_path)
+        .await
+        .expect("first run_handler should succeed");
+    assert!(
+        resp1.failed_turns.is_empty(),
+        "expected no failures on first import, got: {:?}",
+        resp1.failed_turns
+    );
+
+    // Second import of the identical JSONL.
+    let resp2 = run_handler(&store, vault.path(), &jsonl_path)
+        .await
+        .expect("second run_handler should succeed");
+    assert!(
+        resp2.failed_turns.is_empty(),
+        "expected no failures on second import, got: {:?}",
+        resp2.failed_turns
+    );
+
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+
+    store
+        .with_tx({
+            let session_id = session_id.clone();
+            move |tx| {
+                let rows = tx.list_trace_events(&session_id, "turn-1")?;
+                assert_eq!(rows.len(), 4, "no duplicate events from replay: got {}", rows.len());
+
+                // Summary must exist and remain a single row.  The
+                // UNIQUE INDEX on (session_id, turn_id) for turn_summary
+                // combined with `upsert_trace`'s INSERT OR REPLACE semantics
+                // guarantees ≤1 summary; `turn_summary_exists` confirms ≥1.
+                assert!(
+                    tx.turn_summary_exists(&session_id, "turn-1")?,
+                    "summary must exist after replay"
+                );
+                Ok(())
+            }
+        })
+        .await
+        .expect("store query should succeed");
+}
+
+// ── Test 2: late event after a closed turn re-summarizes ──────────────────────
+
+/// A late event arriving after a Stop-closed turn must be ingested and the
+/// summary must be updated to cover all five events.
+///
+/// The late `PostToolUse` event has no `PreTool` in its own JSONL batch.
+/// `run_handler` must fall back to the store-resident rows to resolve the
+/// `parent_event_id` (Option A implementation).
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn late_event_after_close_resummarizes() {
+    let vault = tempfile::tempdir().expect("tempdir");
+    let store = open_test_store_in_memory().await;
+
+    // Import the initial 4-event turn (with Stop → turn is closed).
+    let initial = vault.path().join("initial.jsonl");
+    write_fixture(vault.path(), &initial);
+    let resp = run_handler(&store, vault.path(), &initial)
+        .await
+        .expect("initial run_handler should succeed");
+    assert!(
+        resp.failed_turns.is_empty(),
+        "expected no failures on initial import, got: {:?}",
+        resp.failed_turns
+    );
+
+    // Import a single late PostToolUse for the same turn.  Its PreTool is
+    // only available in the store (not in this JSONL), exercising the
+    // store-lookup fallback in run_handler.
+    let late = vault.path().join("late.jsonl");
+    write_late_tool_output_fixture(vault.path(), &late);
+    let resp = run_handler(&store, vault.path(), &late)
+        .await
+        .expect("late run_handler should succeed");
+    assert!(
+        resp.failed_turns.is_empty(),
+        "late event import should not fail, got: {:?}",
+        resp.failed_turns
+    );
+
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+
+    store
+        .with_tx({
+            let session_id = session_id.clone();
+            move |tx| {
+                let rows = tx.list_trace_events(&session_id, "turn-1")?;
+                assert_eq!(
+                    rows.len(),
+                    5,
+                    "late event must land: expected 5 events, got {}",
+                    rows.len()
+                );
+
+                // Sequences must be 0..4 (renumbered by captured_at order).
+                let seqs: Vec<u64> = rows
+                    .iter()
+                    .map(|r| {
+                        r.extra_frontmatter["trace"]["sequence"]
+                            .as_u64()
+                            .expect("sequence must be u64")
+                    })
+                    .collect();
+                assert_eq!(seqs, vec![0, 1, 2, 3, 4], "sequences must be contiguous 0..4");
+
+                // The summary must have been updated to cover all 5 events.
+                assert!(
+                    tx.turn_summary_exists(&session_id, "turn-1")?,
+                    "summary must exist after late-event re-summarize"
+                );
+                Ok(())
+            }
         })
         .await
         .expect("store query should succeed");

--- a/crates/cairn-cli/tests/capture_trace_verb.rs
+++ b/crates/cairn-cli/tests/capture_trace_verb.rs
@@ -56,6 +56,12 @@ const ULID_A: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAA";
 const ULID_B: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAB";
 const ULID_C: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAC";
 
+// Additional ULIDs for multi-turn tests (turn-2 events).
+const ULID_E: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAE";
+const ULID_F: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAF";
+const ULID_G: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAG";
+const ULID_H: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAH";
+
 #[tokio::test]
 async fn parses_jsonl_into_events() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -283,6 +289,358 @@ fn write_fixture(vault: &Path, jsonl_path: &Path) {
         let line = serde_json::to_string(ev).expect("serialize event");
         writeln!(f, "{line}").expect("write JSONL line");
     }
+}
+
+/// Write eight [`CaptureEvent`]s to `jsonl_path` for two complete turns:
+///
+/// - Turn-1 (`turn-1`): events `FAA`–`FAD`, timestamps `00:00:01..00:00:04Z`
+/// - Turn-2 (`turn-2`): events `FAE`–`FAH`, timestamps `01:00:01..01:00:04Z`
+///
+/// Both turns follow the `UserPromptSubmit → PreToolUse → PostToolUse → Stop`
+/// sequence.  Each turn uses a distinct `tool_id` so the pre/post pairs do not
+/// bleed across turns.
+#[allow(
+    clippy::too_many_lines,
+    reason = "fixture: two full turns × 4 events each; splitting would obscure the symmetry"
+)]
+fn write_multi_turn_fixture(vault: &Path, jsonl_path: &Path) {
+    let session = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+
+    // ── Turn-1 ──────────────────────────────────────────────────────────────
+    let (t1_user, t1_pre, t1_post, t1_stop) = (
+        ULID_A,
+        ULID_B,
+        "01ARZ3NDEKTSV4RRFFQ69G5FAC",
+        "01ARZ3NDEKTSV4RRFFQ69G5FAD",
+    );
+    let t1_tool = "toolu_t1_01";
+    let t1_user_body = "Hello from turn 1";
+    let t1_pre_body = r#"{"tool":"bash","input":{"command":"ls"}}"#;
+    let t1_post_body = r#"{"tool":"bash","output":"file.txt"}"#;
+    let t1_stop_body = "turn 1 ended";
+
+    let t1_user_ref = write_source(vault, &format!("{t1_user}.txt"), t1_user_body);
+    let t1_pre_ref = write_source(vault, &format!("{t1_pre}.txt"), t1_pre_body);
+    let t1_post_ref = write_source(vault, &format!("{t1_post}.txt"), t1_post_body);
+    let t1_stop_ref = write_source(vault, &format!("{t1_stop}.txt"), t1_stop_body);
+
+    // ── Turn-2 ──────────────────────────────────────────────────────────────
+    let t2_tool = "toolu_t2_01";
+    let t2_user_body = "Hello from turn 2";
+    let t2_pre_body = r#"{"tool":"bash","input":{"command":"pwd"}}"#;
+    let t2_post_body = r#"{"tool":"bash","output":"/home/user"}"#;
+    let t2_stop_body = "turn 2 ended";
+
+    let t2_user_ref = write_source(vault, &format!("{ULID_E}.txt"), t2_user_body);
+    let t2_pre_ref = write_source(vault, &format!("{ULID_F}.txt"), t2_pre_body);
+    let t2_post_ref = write_source(vault, &format!("{ULID_G}.txt"), t2_post_body);
+    let t2_stop_ref = write_source(vault, &format!("{ULID_H}.txt"), t2_stop_body);
+
+    let events = vec![
+        // Turn-1
+        make_event(
+            t1_user,
+            "UserPromptSubmit",
+            session,
+            "turn-1",
+            "2026-05-02T00:00:01Z",
+            None,
+            &t1_user_ref,
+            &sha256_hex(t1_user_body),
+        ),
+        make_event(
+            t1_pre,
+            "PreToolUse",
+            session,
+            "turn-1",
+            "2026-05-02T00:00:02Z",
+            Some(t1_tool.to_owned()),
+            &t1_pre_ref,
+            &sha256_hex(t1_pre_body),
+        ),
+        make_event(
+            t1_post,
+            "PostToolUse",
+            session,
+            "turn-1",
+            "2026-05-02T00:00:03Z",
+            Some(t1_tool.to_owned()),
+            &t1_post_ref,
+            &sha256_hex(t1_post_body),
+        ),
+        make_event(
+            t1_stop,
+            "Stop",
+            session,
+            "turn-1",
+            "2026-05-02T00:00:04Z",
+            None,
+            &t1_stop_ref,
+            &sha256_hex(t1_stop_body),
+        ),
+        // Turn-2
+        make_event(
+            ULID_E,
+            "UserPromptSubmit",
+            session,
+            "turn-2",
+            "2026-05-02T01:00:01Z",
+            None,
+            &t2_user_ref,
+            &sha256_hex(t2_user_body),
+        ),
+        make_event(
+            ULID_F,
+            "PreToolUse",
+            session,
+            "turn-2",
+            "2026-05-02T01:00:02Z",
+            Some(t2_tool.to_owned()),
+            &t2_pre_ref,
+            &sha256_hex(t2_pre_body),
+        ),
+        make_event(
+            ULID_G,
+            "PostToolUse",
+            session,
+            "turn-2",
+            "2026-05-02T01:00:03Z",
+            Some(t2_tool.to_owned()),
+            &t2_post_ref,
+            &sha256_hex(t2_post_body),
+        ),
+        make_event(
+            ULID_H,
+            "Stop",
+            session,
+            "turn-2",
+            "2026-05-02T01:00:04Z",
+            None,
+            &t2_stop_ref,
+            &sha256_hex(t2_stop_body),
+        ),
+    ];
+
+    let mut f = std::fs::File::create(jsonl_path).expect("create JSONL file");
+    for ev in &events {
+        let line = serde_json::to_string(ev).expect("serialize event");
+        writeln!(f, "{line}").expect("write JSONL line");
+    }
+}
+
+/// Write five [`CaptureEvent`]s to `jsonl_path`:
+///
+/// - Turn-1 (`turn-1`): complete sequence `UserPromptSubmit → PreToolUse →
+///   PostToolUse → Stop` (events `FAA`–`FAD`).
+/// - Turn-2 (`turn-2`): a single orphaned `PostToolUse` (event `FAE`) whose
+///   `tool_call_id` (`"toolu_orphan"`) has no preceding `PreToolUse` in that
+///   turn.  This triggers the orphan-detection branch inside `run_handler`,
+///   causing turn-2 to fail without touching the store.
+fn write_broken_second_turn_fixture(vault: &Path, jsonl_path: &Path) {
+    let session = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    let t1_tool = "toolu_test_01";
+
+    // ── Turn-1: valid ────────────────────────────────────────────────────────
+    let (id_user, id_pre, id_post, id_stop) = (
+        ULID_A,
+        ULID_B,
+        "01ARZ3NDEKTSV4RRFFQ69G5FAC",
+        "01ARZ3NDEKTSV4RRFFQ69G5FAD",
+    );
+    let user_body = "Hello, please run ls";
+    let pre_body = r#"{"tool":"bash","input":{"command":"ls"}}"#;
+    let post_body = r#"{"tool":"bash","output":"file.txt\ndir/"}"#;
+    let stop_body = "session ended";
+
+    let user_ref = write_source(vault, &format!("{id_user}.txt"), user_body);
+    let pre_ref = write_source(vault, &format!("{id_pre}.txt"), pre_body);
+    let post_ref = write_source(vault, &format!("{id_post}.txt"), post_body);
+    let stop_ref = write_source(vault, &format!("{id_stop}.txt"), stop_body);
+
+    // ── Turn-2: orphaned PostToolUse ─────────────────────────────────────────
+    // The `tool_call_id` is distinct from turn-1's tool so there is no
+    // accidental cross-turn match.  There is intentionally NO PreToolUse
+    // event for "toolu_orphan" in turn-2, which is what triggers the failure.
+    let orphan_body = r#"{"tool":"bash","output":"unexpected"}"#;
+    let orphan_ref = write_source(vault, &format!("{ULID_E}.txt"), orphan_body);
+
+    let events = vec![
+        make_event(
+            id_user,
+            "UserPromptSubmit",
+            session,
+            "turn-1",
+            "2026-05-02T00:00:01Z",
+            None,
+            &user_ref,
+            &sha256_hex(user_body),
+        ),
+        make_event(
+            id_pre,
+            "PreToolUse",
+            session,
+            "turn-1",
+            "2026-05-02T00:00:02Z",
+            Some(t1_tool.to_owned()),
+            &pre_ref,
+            &sha256_hex(pre_body),
+        ),
+        make_event(
+            id_post,
+            "PostToolUse",
+            session,
+            "turn-1",
+            "2026-05-02T00:00:03Z",
+            Some(t1_tool.to_owned()),
+            &post_ref,
+            &sha256_hex(post_body),
+        ),
+        make_event(
+            id_stop,
+            "Stop",
+            session,
+            "turn-1",
+            "2026-05-02T00:00:04Z",
+            None,
+            &stop_ref,
+            &sha256_hex(stop_body),
+        ),
+        // Turn-2: orphaned PostToolUse — no matching PreToolUse in this turn.
+        make_event(
+            ULID_E,
+            "PostToolUse",
+            session,
+            "turn-2",
+            "2026-05-02T01:00:01Z",
+            Some("toolu_orphan".to_owned()),
+            &orphan_ref,
+            &sha256_hex(orphan_body),
+        ),
+    ];
+
+    let mut f = std::fs::File::create(jsonl_path).expect("create JSONL file");
+    for ev in &events {
+        let line = serde_json::to_string(ev).expect("serialize event");
+        writeln!(f, "{line}").expect("write JSONL line");
+    }
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn multi_turn_each_summarized_independently() {
+    let vault = tempfile::tempdir().expect("tempdir");
+    let store = open_test_store_in_memory().await;
+    let jsonl_path = vault.path().join("trace.jsonl");
+
+    write_multi_turn_fixture(vault.path(), &jsonl_path);
+
+    let resp = run_handler(&store, vault.path(), &jsonl_path)
+        .await
+        .expect("run_handler should succeed");
+
+    assert!(
+        resp.failed_turns.is_empty(),
+        "expected no failures, got: {:?}",
+        resp.failed_turns
+    );
+
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+
+    store
+        .with_tx({
+            let session_id = session_id.clone();
+            move |tx| {
+                // Each turn should have exactly 4 non-summary events persisted.
+                let t1_rows = tx.list_trace_events(&session_id, "turn-1")?;
+                assert_eq!(t1_rows.len(), 4, "turn-1 should have 4 events, got {}", t1_rows.len());
+
+                let t2_rows = tx.list_trace_events(&session_id, "turn-2")?;
+                assert_eq!(t2_rows.len(), 4, "turn-2 should have 4 events, got {}", t2_rows.len());
+
+                // Both turns must have a summary (both had a Stop event).
+                assert!(
+                    tx.turn_summary_exists(&session_id, "turn-1")?,
+                    "turn-1 summary should exist"
+                );
+                assert!(
+                    tx.turn_summary_exists(&session_id, "turn-2")?,
+                    "turn-2 summary should exist"
+                );
+                Ok(())
+            }
+        })
+        .await
+        .expect("store query should succeed");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn malformed_second_turn_leaves_first_intact() {
+    let vault = tempfile::tempdir().expect("tempdir");
+    let store = open_test_store_in_memory().await;
+    let jsonl_path = vault.path().join("trace.jsonl");
+
+    write_broken_second_turn_fixture(vault.path(), &jsonl_path);
+
+    let resp = run_handler(&store, vault.path(), &jsonl_path)
+        .await
+        .expect("run_handler should return Ok even when a turn fails");
+
+    // Exactly one turn failure: turn-2.
+    assert_eq!(
+        resp.failed_turns.len(),
+        1,
+        "expected exactly one failed turn (turn-2), got: {:?}",
+        resp.failed_turns
+    );
+    assert_eq!(
+        resp.failed_turns[0].1, "turn-2",
+        "the failing turn should be turn-2, got: {:?}",
+        resp.failed_turns[0]
+    );
+
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+
+    store
+        .with_tx({
+            let session_id = session_id.clone();
+            move |tx| {
+                // Turn-1 must be fully present and summarized.
+                let t1_rows = tx.list_trace_events(&session_id, "turn-1")?;
+                assert_eq!(
+                    t1_rows.len(),
+                    4,
+                    "turn-1 should have 4 events after turn-2 failure, got {}",
+                    t1_rows.len()
+                );
+                assert!(
+                    tx.turn_summary_exists(&session_id, "turn-1")?,
+                    "turn-1 summary must exist after turn-2 failure"
+                );
+
+                // Turn-2 must be completely absent — no partial writes.
+                let t2_rows = tx.list_trace_events(&session_id, "turn-2")?;
+                assert_eq!(
+                    t2_rows.len(),
+                    0,
+                    "turn-2 should have 0 events (atomicity), got {}",
+                    t2_rows.len()
+                );
+                assert!(
+                    !tx.turn_summary_exists(&session_id, "turn-2")?,
+                    "turn-2 summary must NOT exist after failure"
+                );
+                Ok(())
+            }
+        })
+        .await
+        .expect("store query should succeed");
 }
 
 #[tokio::test]

--- a/crates/cairn-cli/tests/capture_trace_verb.rs
+++ b/crates/cairn-cli/tests/capture_trace_verb.rs
@@ -1,11 +1,12 @@
 //! Integration tests for `cairn capture_trace` JSONL parser (issue #77).
 
 use std::io::Write as _;
+use std::path::Path;
 
-use cairn_cli::verbs::capture_trace::read_jsonl_events;
+use cairn_cli::verbs::capture_trace::{read_jsonl_events, run_handler};
 use cairn_core::domain::{
     ActorChainEntry, ChainRole, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload,
-    CaptureRefs, Identity, PayloadHash, Rfc3339Timestamp, SourceFamily,
+    CaptureRefs, Identity, PayloadHash, Rfc3339Timestamp, SessionId, SourceFamily,
 };
 
 /// Build a minimal valid `Hook` [`CaptureEvent`] for use in tests.
@@ -136,4 +137,189 @@ async fn malformed_line_returns_error() {
         msg.contains("parse CaptureEvent"),
         "error should mention parse CaptureEvent, got: {msg}"
     );
+}
+
+// ── run_handler integration tests ─────────────────────────────────────────────
+
+/// Compute the lowercase hex SHA-256 of `text`.
+fn sha256_hex(text: &str) -> String {
+    use sha2::{Digest as _, Sha256};
+    let mut h = Sha256::new();
+    h.update(text.as_bytes());
+    format!("{:x}", h.finalize())
+}
+
+/// Write `content` to `vault/sources/hook/<filename>`, creating the
+/// `sources/hook/` directory if needed, and return the
+/// `vault_root`-relative path (`"sources/hook/<filename>"`).
+fn write_source(vault: &Path, filename: &str, content: &str) -> String {
+    let dir = vault.join("sources").join("hook");
+    std::fs::create_dir_all(&dir).expect("create sources/hook dir");
+    let abs = dir.join(filename);
+    std::fs::write(&abs, content).expect("write source file");
+    format!("sources/hook/{filename}")
+}
+
+/// Build a [`CaptureEvent`] for a `Hook` payload. The `payload_ref` and
+/// `payload_hash` are derived from `body_content` which is written to
+/// `vault/sources/hook/<event_id>.txt` by the caller.
+///
+/// `tool_id` is placed in `refs.tool_id`, satisfying the `tool_call_id`
+/// requirement for `PreTool`/`PostTool`.
+#[allow(clippy::too_many_arguments)]
+fn make_event(
+    event_id: &str,
+    hook_name: &str,
+    session_id: &str,
+    turn_id: &str,
+    timestamp: &str,
+    tool_id: Option<String>,
+    payload_ref: &str,
+    payload_hash_hex: &str,
+) -> CaptureEvent {
+    let sensor =
+        Identity::parse("snr:local:hook:cc-session:v1").expect("invariant: valid sensor id");
+    let hash_str = format!("sha256:{payload_hash_hex}");
+    CaptureEvent {
+        event_id: CaptureEventId::parse(event_id).expect("invariant: valid ULID"),
+        sensor_id: sensor.clone(),
+        // Auto mode with sensor as Author — the natural mode for hook events.
+        // MemoryRecord::validate now allows sensor authors on Trace records
+        // (brief §5.0: sensors are the canonical authors of raw captures).
+        capture_mode: CaptureMode::Auto,
+        actor_chain: vec![ActorChainEntry {
+            role: ChainRole::Author,
+            identity: sensor,
+            at: Rfc3339Timestamp::parse(timestamp).expect("invariant: valid RFC-3339"),
+        }],
+        refs: Some(CaptureRefs {
+            session_id: Some(session_id.to_owned()),
+            turn_id: Some(turn_id.to_owned()),
+            tool_id,
+        }),
+        payload_hash: PayloadHash::parse(&hash_str).expect("invariant: valid sha256 hash"),
+        payload_ref: payload_ref.to_owned(),
+        captured_at: Rfc3339Timestamp::parse(timestamp).expect("invariant: valid RFC-3339"),
+        payload: CapturePayload::Hook {
+            hook_name: hook_name.to_owned(),
+            tool_name: None,
+        },
+        source_family: SourceFamily::Hook,
+    }
+}
+
+/// Open a fresh in-memory [`SqliteMemoryStore`].
+async fn open_test_store_in_memory() -> cairn_store_sqlite::SqliteMemoryStore {
+    cairn_store_sqlite::open_in_memory()
+        .await
+        .expect("open in-memory store")
+}
+
+/// Write four `CaptureEvent`s to `jsonl_path` for a single turn:
+/// `UserPromptSubmit` → `PreToolUse` → `PostToolUse` → `Stop`.
+///
+/// Source files are written under `vault.join("sources/hook/")`.
+///
+/// # Session / turn / event-id constants
+/// - Session: `01ARZ3NDEKTSV4RRFFQ69G5FAV`
+/// - Turn: `turn-1`
+/// - Event ids: `01ARZ3NDEKTSV4RRFFQ69G5FAA` … `FAD`
+/// - Tool call id: `toolu_test_01`
+fn write_fixture(vault: &Path, jsonl_path: &Path) {
+    // ULIDs for each event.
+    let id_user = "01ARZ3NDEKTSV4RRFFQ69G5FAA";
+    let id_pre  = "01ARZ3NDEKTSV4RRFFQ69G5FAB";
+    let id_post = "01ARZ3NDEKTSV4RRFFQ69G5FAC";
+    let id_stop = "01ARZ3NDEKTSV4RRFFQ69G5FAD";
+
+    let session = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    let turn    = "turn-1";
+    let tool_id = "toolu_test_01";
+
+    // Write sources and compute hashes.
+    let user_body  = "Hello, please run ls";
+    let pre_body   = r#"{"tool":"bash","input":{"command":"ls"}}"#;
+    let post_body  = r#"{"tool":"bash","output":"file.txt\ndir/"}"#;
+    let stop_body  = "session ended";
+
+    let user_ref  = write_source(vault, &format!("{id_user}.txt"), user_body);
+    let pre_ref   = write_source(vault, &format!("{id_pre}.txt"),  pre_body);
+    let post_ref  = write_source(vault, &format!("{id_post}.txt"), post_body);
+    let stop_ref  = write_source(vault, &format!("{id_stop}.txt"), stop_body);
+
+    let events = vec![
+        make_event(
+            id_user, "UserPromptSubmit", session, turn,
+            "2026-05-02T00:00:01Z",
+            None,
+            &user_ref,
+            &sha256_hex(user_body),
+        ),
+        make_event(
+            id_pre, "PreToolUse", session, turn,
+            "2026-05-02T00:00:02Z",
+            Some(tool_id.to_owned()),
+            &pre_ref,
+            &sha256_hex(pre_body),
+        ),
+        make_event(
+            id_post, "PostToolUse", session, turn,
+            "2026-05-02T00:00:03Z",
+            Some(tool_id.to_owned()),
+            &post_ref,
+            &sha256_hex(post_body),
+        ),
+        make_event(
+            id_stop, "Stop", session, turn,
+            "2026-05-02T00:00:04Z",
+            None,
+            &stop_ref,
+            &sha256_hex(stop_body),
+        ),
+    ];
+
+    let mut f = std::fs::File::create(jsonl_path).expect("create JSONL file");
+    for ev in &events {
+        let line = serde_json::to_string(ev).expect("serialize event");
+        writeln!(f, "{line}").expect("write JSONL line");
+    }
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn capture_trace_single_turn_persists_and_summarizes() {
+    let vault = tempfile::tempdir().expect("tempdir");
+    let store = open_test_store_in_memory().await;
+    let jsonl_path = vault.path().join("trace.jsonl");
+
+    write_fixture(vault.path(), &jsonl_path);
+
+    let resp = run_handler(&store, vault.path(), &jsonl_path)
+        .await
+        .expect("run_handler should succeed");
+
+    assert!(
+        resp.failed_turns.is_empty(),
+        "expected no failures, got: {:?}",
+        resp.failed_turns
+    );
+
+    // Verify the 4 events were persisted and a summary was written.
+    store
+        .with_tx(|tx| {
+            let session_id =
+                SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+            let rows = tx.list_trace_events(&session_id, "turn-1")?;
+            assert_eq!(rows.len(), 4, "expected 4 trace events, got {}", rows.len());
+            assert!(
+                tx.turn_summary_exists(&session_id, "turn-1")?,
+                "turn summary should exist after Stop event"
+            );
+            Ok(())
+        })
+        .await
+        .expect("store query should succeed");
 }

--- a/crates/cairn-cli/tests/capture_trace_verb.rs
+++ b/crates/cairn-cli/tests/capture_trace_verb.rs
@@ -647,6 +647,37 @@ async fn malformed_second_turn_leaves_first_intact() {
         .expect("store query should succeed");
 }
 
+/// Snapshot test: pin the JSON shape of [`CaptureTraceResponse`].
+///
+/// `trace_id` is a fresh ULID generated server-side per invocation, so the
+/// value is replaced with a stable placeholder before snapshotting.
+/// `failed_turns` is a `Vec<(String, String, String)>` which serde encodes
+/// as JSON arrays — that shape is what we are pinning.
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn capture_trace_response_envelope_snapshot() {
+    let vault = tempfile::tempdir().expect("tempdir");
+    let store = open_test_store_in_memory().await;
+    let jsonl_path = vault.path().join("trace.jsonl");
+
+    write_fixture(vault.path(), &jsonl_path);
+
+    let resp = run_handler(&store, vault.path(), &jsonl_path)
+        .await
+        .expect("run_handler should succeed");
+
+    // `trace_id` is a fresh ULID per invocation — substitute a stable
+    // placeholder before snapshotting so the snapshot pins shape, not value.
+    let mut value =
+        serde_json::to_value(&resp).expect("serialize CaptureTraceResponse");
+    value["trace_id"] = serde_json::Value::String("[trace_id]".into());
+
+    insta::assert_json_snapshot!("capture_trace_response_envelope", value);
+}
+
 #[tokio::test]
 #[allow(
     clippy::expect_used,

--- a/crates/cairn-cli/tests/capture_trace_verb.rs
+++ b/crates/cairn-cli/tests/capture_trace_verb.rs
@@ -307,6 +307,80 @@ fn write_fixture(vault: &Path, jsonl_path: &Path) {
     }
 }
 
+/// Same four events as [`write_fixture`] but emitted in JSONL with the
+/// `PostToolUse` line *before* its matching `PreToolUse`. Used to verify
+/// that in-batch parent resolution is order-insensitive.
+fn write_fixture_post_before_pre(vault: &Path, jsonl_path: &Path) {
+    let id_user = "01ARZ3NDEKTSV4RRFFQ69G5FAA";
+    let id_pre = "01ARZ3NDEKTSV4RRFFQ69G5FAB";
+    let id_post = "01ARZ3NDEKTSV4RRFFQ69G5FAC";
+    let id_stop = "01ARZ3NDEKTSV4RRFFQ69G5FAD";
+
+    let session = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    let turn = "turn-1";
+    let tool_id = "toolu_test_01";
+
+    let user_body = "Hello, please run ls";
+    let pre_body = r#"{"tool":"bash","input":{"command":"ls"}}"#;
+    let post_body = r#"{"tool":"bash","output":"file.txt\ndir/"}"#;
+    let stop_body = "session ended";
+
+    let user_ref = write_source(vault, &format!("{id_user}.txt"), user_body);
+    let pre_ref = write_source(vault, &format!("{id_pre}.txt"), pre_body);
+    let post_ref = write_source(vault, &format!("{id_post}.txt"), post_body);
+    let stop_ref = write_source(vault, &format!("{id_stop}.txt"), stop_body);
+
+    // Emission order: user → POST → PRE → stop. captured_at remains
+    // canonical (PRE@02Z, POST@03Z) so renumber still sorts correctly.
+    let events = vec![
+        make_event(
+            id_user,
+            "UserPromptSubmit",
+            session,
+            turn,
+            "2026-05-02T00:00:01Z",
+            None,
+            &user_ref,
+            &sha256_hex(user_body),
+        ),
+        make_event(
+            id_post,
+            "PostToolUse",
+            session,
+            turn,
+            "2026-05-02T00:00:03Z",
+            Some(tool_id.to_owned()),
+            &post_ref,
+            &sha256_hex(post_body),
+        ),
+        make_event(
+            id_pre,
+            "PreToolUse",
+            session,
+            turn,
+            "2026-05-02T00:00:02Z",
+            Some(tool_id.to_owned()),
+            &pre_ref,
+            &sha256_hex(pre_body),
+        ),
+        make_event(
+            id_stop,
+            "Stop",
+            session,
+            turn,
+            "2026-05-02T00:00:04Z",
+            None,
+            &stop_ref,
+            &sha256_hex(stop_body),
+        ),
+    ];
+    let mut f = std::fs::File::create(jsonl_path).expect("create JSONL file");
+    for ev in &events {
+        let line = serde_json::to_string(ev).expect("serialize event");
+        writeln!(f, "{line}").expect("write JSONL line");
+    }
+}
+
 /// Write eight [`CaptureEvent`]s to `jsonl_path` for two complete turns:
 ///
 /// - Turn-1 (`turn-1`): events `FAA`–`FAD`, timestamps `00:00:01..00:00:04Z`
@@ -732,6 +806,54 @@ async fn capture_trace_single_turn_persists_and_summarizes() {
                 tx.turn_summary_exists(&session_id, "turn-1")?,
                 "turn summary should exist after Stop event"
             );
+            Ok(())
+        })
+        .await
+        .expect("store query should succeed");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn in_batch_post_before_pre_resolves_parent() {
+    let vault = tempfile::tempdir().expect("tempdir");
+    let store = open_test_store_in_memory().await;
+    let jsonl_path = vault.path().join("trace.jsonl");
+
+    write_fixture_post_before_pre(vault.path(), &jsonl_path);
+
+    let resp = run_handler(&store, vault.path(), &jsonl_path)
+        .await
+        .expect("run_handler should succeed");
+    assert!(
+        resp.failed_turns.is_empty(),
+        "expected no failures, got: {:?}",
+        resp.failed_turns
+    );
+
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+    store
+        .with_tx(move |tx| {
+            let rows = tx.list_trace_events(&session_id, "turn-1")?;
+            assert_eq!(rows.len(), 4, "expected 4 events");
+
+            // The post_tool row's parent_event_id must match the pre_tool's
+            // capture_event_id even though post arrived before pre in the JSONL.
+            let post = rows
+                .iter()
+                .find(|r| {
+                    r.extra_frontmatter
+                        .get("trace_event")
+                        .and_then(|v| v.as_str())
+                        == Some("post_tool")
+                })
+                .expect("post_tool row");
+            let parent = post.extra_frontmatter["trace"]["parent_event_id"]
+                .as_str()
+                .expect("parent_event_id present");
+            assert_eq!(parent, "01ARZ3NDEKTSV4RRFFQ69G5FAB");
             Ok(())
         })
         .await

--- a/crates/cairn-cli/tests/capture_trace_verb.rs
+++ b/crates/cairn-cli/tests/capture_trace_verb.rs
@@ -1,0 +1,139 @@
+//! Integration tests for `cairn capture_trace` JSONL parser (issue #77).
+
+use std::io::Write as _;
+
+use cairn_cli::verbs::capture_trace::read_jsonl_events;
+use cairn_core::domain::{
+    ActorChainEntry, ChainRole, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload,
+    CaptureRefs, Identity, PayloadHash, Rfc3339Timestamp, SourceFamily,
+};
+
+/// Build a minimal valid `Hook` [`CaptureEvent`] for use in tests.
+///
+/// Uses `CaptureMode::Auto` + `SourceFamily::Hook` + sensor
+/// `snr:local:hook:cc-session:v1` — the canonical P0 hook sensor whose
+/// label satisfies [`cairn_core::domain::validate_label`].
+fn make_hook_event(
+    event_id: &str,
+    hook_name: &str,
+    session_id: &str,
+    turn_id: &str,
+    timestamp: &str,
+) -> CaptureEvent {
+    let sensor =
+        Identity::parse("snr:local:hook:cc-session:v1").expect("invariant: valid sensor id");
+    CaptureEvent {
+        event_id: CaptureEventId::parse(event_id).expect("invariant: valid ULID"),
+        sensor_id: sensor.clone(),
+        capture_mode: CaptureMode::Auto,
+        actor_chain: vec![ActorChainEntry {
+            role: ChainRole::Author,
+            identity: sensor,
+            at: Rfc3339Timestamp::parse(timestamp).expect("invariant: valid RFC-3339"),
+        }],
+        refs: Some(CaptureRefs {
+            session_id: Some(session_id.to_owned()),
+            turn_id: Some(turn_id.to_owned()),
+            tool_id: None,
+        }),
+        payload_hash: PayloadHash::parse(
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        )
+        .expect("invariant: valid sha256 of empty bytes"),
+        payload_ref: "sources/hook/placeholder.json".into(),
+        captured_at: Rfc3339Timestamp::parse(timestamp).expect("invariant: valid RFC-3339"),
+        payload: CapturePayload::Hook {
+            hook_name: hook_name.to_owned(),
+            tool_name: None,
+        },
+        source_family: SourceFamily::Hook,
+    }
+}
+
+// Three distinct ULIDs for the parametric tests.
+const ULID_A: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAA";
+const ULID_B: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAB";
+const ULID_C: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAC";
+
+#[tokio::test]
+async fn parses_jsonl_into_events() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("trace.jsonl");
+
+    let events_src = [
+        make_hook_event(
+            ULID_A,
+            "UserPromptSubmit",
+            "sess-1",
+            "turn-1",
+            "2026-04-27T00:00:01Z",
+        ),
+        make_hook_event(
+            ULID_B,
+            "PreToolUse",
+            "sess-1",
+            "turn-1",
+            "2026-04-27T00:00:02Z",
+        ),
+        make_hook_event(
+            ULID_C,
+            "PostToolUse",
+            "sess-1",
+            "turn-1",
+            "2026-04-27T00:00:03Z",
+        ),
+    ];
+
+    let mut f = std::fs::File::create(&path).expect("create file");
+    for event in &events_src {
+        let line = serde_json::to_string(event).expect("serialize event");
+        writeln!(f, "{line}").expect("write line");
+    }
+    drop(f);
+
+    let parsed = read_jsonl_events(&path).await.expect("read_jsonl_events");
+    assert_eq!(parsed.len(), 3);
+    assert_eq!(parsed[0].event_id.as_str(), ULID_A);
+    assert_eq!(parsed[1].event_id.as_str(), ULID_B);
+    assert_eq!(parsed[2].event_id.as_str(), ULID_C);
+}
+
+#[tokio::test]
+async fn skips_blank_lines() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("trace.jsonl");
+
+    let event = make_hook_event(
+        ULID_A,
+        "UserPromptSubmit",
+        "sess-1",
+        "turn-1",
+        "2026-04-27T00:00:01Z",
+    );
+    let line = serde_json::to_string(&event).expect("serialize event");
+
+    let mut f = std::fs::File::create(&path).expect("create file");
+    writeln!(f).expect("blank line before");
+    writeln!(f, "{line}").expect("event line");
+    writeln!(f).expect("blank line after");
+    drop(f);
+
+    let parsed = read_jsonl_events(&path).await.expect("read_jsonl_events");
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].event_id.as_str(), ULID_A);
+}
+
+#[tokio::test]
+async fn malformed_line_returns_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("trace.jsonl");
+    std::fs::write(&path, "{not valid json}\n").expect("write file");
+
+    let result = read_jsonl_events(&path).await;
+    assert!(result.is_err(), "expected an error for malformed JSONL");
+    let msg = format!("{:#}", result.unwrap_err());
+    assert!(
+        msg.contains("parse CaptureEvent"),
+        "error should mention parse CaptureEvent, got: {msg}"
+    );
+}

--- a/crates/cairn-cli/tests/capture_trace_verb.rs
+++ b/crates/cairn-cli/tests/capture_trace_verb.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use cairn_cli::verbs::capture_trace::{read_jsonl_events, run_handler};
 use cairn_core::domain::{
-    ActorChainEntry, ChainRole, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload,
-    CaptureRefs, Identity, PayloadHash, Rfc3339Timestamp, SessionId, SourceFamily,
+    ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs,
+    ChainRole, Identity, PayloadHash, Rfc3339Timestamp, SessionId, SourceFamily,
 };
 
 /// Build a minimal valid `Hook` [`CaptureEvent`] for use in tests.
@@ -238,49 +238,61 @@ async fn open_test_store_in_memory() -> cairn_store_sqlite::SqliteMemoryStore {
 fn write_fixture(vault: &Path, jsonl_path: &Path) {
     // ULIDs for each event.
     let id_user = "01ARZ3NDEKTSV4RRFFQ69G5FAA";
-    let id_pre  = "01ARZ3NDEKTSV4RRFFQ69G5FAB";
+    let id_pre = "01ARZ3NDEKTSV4RRFFQ69G5FAB";
     let id_post = "01ARZ3NDEKTSV4RRFFQ69G5FAC";
     let id_stop = "01ARZ3NDEKTSV4RRFFQ69G5FAD";
 
     let session = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
-    let turn    = "turn-1";
+    let turn = "turn-1";
     let tool_id = "toolu_test_01";
 
     // Write sources and compute hashes.
-    let user_body  = "Hello, please run ls";
-    let pre_body   = r#"{"tool":"bash","input":{"command":"ls"}}"#;
-    let post_body  = r#"{"tool":"bash","output":"file.txt\ndir/"}"#;
-    let stop_body  = "session ended";
+    let user_body = "Hello, please run ls";
+    let pre_body = r#"{"tool":"bash","input":{"command":"ls"}}"#;
+    let post_body = r#"{"tool":"bash","output":"file.txt\ndir/"}"#;
+    let stop_body = "session ended";
 
-    let user_ref  = write_source(vault, &format!("{id_user}.txt"), user_body);
-    let pre_ref   = write_source(vault, &format!("{id_pre}.txt"),  pre_body);
-    let post_ref  = write_source(vault, &format!("{id_post}.txt"), post_body);
-    let stop_ref  = write_source(vault, &format!("{id_stop}.txt"), stop_body);
+    let user_ref = write_source(vault, &format!("{id_user}.txt"), user_body);
+    let pre_ref = write_source(vault, &format!("{id_pre}.txt"), pre_body);
+    let post_ref = write_source(vault, &format!("{id_post}.txt"), post_body);
+    let stop_ref = write_source(vault, &format!("{id_stop}.txt"), stop_body);
 
     let events = vec![
         make_event(
-            id_user, "UserPromptSubmit", session, turn,
+            id_user,
+            "UserPromptSubmit",
+            session,
+            turn,
             "2026-05-02T00:00:01Z",
             None,
             &user_ref,
             &sha256_hex(user_body),
         ),
         make_event(
-            id_pre, "PreToolUse", session, turn,
+            id_pre,
+            "PreToolUse",
+            session,
+            turn,
             "2026-05-02T00:00:02Z",
             Some(tool_id.to_owned()),
             &pre_ref,
             &sha256_hex(pre_body),
         ),
         make_event(
-            id_post, "PostToolUse", session, turn,
+            id_post,
+            "PostToolUse",
+            session,
+            turn,
             "2026-05-02T00:00:03Z",
             Some(tool_id.to_owned()),
             &post_ref,
             &sha256_hex(post_body),
         ),
         make_event(
-            id_stop, "Stop", session, turn,
+            id_stop,
+            "Stop",
+            session,
+            turn,
             "2026-05-02T00:00:04Z",
             None,
             &stop_ref,
@@ -559,10 +571,20 @@ async fn multi_turn_each_summarized_independently() {
             move |tx| {
                 // Each turn should have exactly 4 non-summary events persisted.
                 let t1_rows = tx.list_trace_events(&session_id, "turn-1")?;
-                assert_eq!(t1_rows.len(), 4, "turn-1 should have 4 events, got {}", t1_rows.len());
+                assert_eq!(
+                    t1_rows.len(),
+                    4,
+                    "turn-1 should have 4 events, got {}",
+                    t1_rows.len()
+                );
 
                 let t2_rows = tx.list_trace_events(&session_id, "turn-2")?;
-                assert_eq!(t2_rows.len(), 4, "turn-2 should have 4 events, got {}", t2_rows.len());
+                assert_eq!(
+                    t2_rows.len(),
+                    4,
+                    "turn-2 should have 4 events, got {}",
+                    t2_rows.len()
+                );
 
                 // Both turns must have a summary (both had a Stop event).
                 assert!(
@@ -671,8 +693,7 @@ async fn capture_trace_response_envelope_snapshot() {
 
     // `trace_id` is a fresh ULID per invocation — substitute a stable
     // placeholder before snapshotting so the snapshot pins shape, not value.
-    let mut value =
-        serde_json::to_value(&resp).expect("serialize CaptureTraceResponse");
+    let mut value = serde_json::to_value(&resp).expect("serialize CaptureTraceResponse");
     value["trace_id"] = serde_json::Value::String("[trace_id]".into());
 
     insta::assert_json_snapshot!("capture_trace_response_envelope", value);
@@ -806,7 +827,12 @@ async fn replay_is_idempotent() {
             let session_id = session_id.clone();
             move |tx| {
                 let rows = tx.list_trace_events(&session_id, "turn-1")?;
-                assert_eq!(rows.len(), 4, "no duplicate events from replay: got {}", rows.len());
+                assert_eq!(
+                    rows.len(),
+                    4,
+                    "no duplicate events from replay: got {}",
+                    rows.len()
+                );
 
                 // Summary must exist and remain a single row.  The
                 // UNIQUE INDEX on (session_id, turn_id) for turn_summary
@@ -889,7 +915,11 @@ async fn late_event_after_close_resummarizes() {
                             .expect("sequence must be u64")
                     })
                     .collect();
-                assert_eq!(seqs, vec![0, 1, 2, 3, 4], "sequences must be contiguous 0..4");
+                assert_eq!(
+                    seqs,
+                    vec![0, 1, 2, 3, 4],
+                    "sequences must be contiguous 0..4"
+                );
 
                 // The summary must have been updated to cover all 5 events.
                 assert!(

--- a/crates/cairn-cli/tests/snapshots/capture_trace_verb__capture_trace_response_envelope.snap
+++ b/crates/cairn-cli/tests/snapshots/capture_trace_verb__capture_trace_response_envelope.snap
@@ -1,0 +1,8 @@
+---
+source: crates/cairn-cli/tests/capture_trace_verb.rs
+expression: value
+---
+{
+  "failed_turns": [],
+  "trace_id": "[trace_id]"
+}

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -37,8 +37,8 @@ pub mod scope;
 pub mod session;
 pub mod target_id;
 pub mod taxonomy;
-pub mod trace;
 pub mod timestamp;
+pub mod trace;
 
 pub use actor_chain::{ActorChainEntry, ChainRole, validate_chain};
 pub use body_hash::BodyHash;
@@ -66,5 +66,5 @@ pub use session::{
 };
 pub use target_id::TargetId;
 pub use taxonomy::{MemoryClass, MemoryKind, MemoryVisibility};
-pub use trace::{TraceEvent, TraceLink, TraceLinkError};
 pub use timestamp::Rfc3339Timestamp;
+pub use trace::{TraceEvent, TraceLink, TraceLinkError};

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -66,5 +66,5 @@ pub use session::{
 };
 pub use target_id::TargetId;
 pub use taxonomy::{MemoryClass, MemoryKind, MemoryVisibility};
-pub use trace::TraceEvent;
+pub use trace::{TraceEvent, TraceLink, TraceLinkError};
 pub use timestamp::Rfc3339Timestamp;

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -37,6 +37,7 @@ pub mod scope;
 pub mod session;
 pub mod target_id;
 pub mod taxonomy;
+pub mod trace;
 pub mod timestamp;
 
 pub use actor_chain::{ActorChainEntry, ChainRole, validate_chain};
@@ -65,4 +66,5 @@ pub use session::{
 };
 pub use target_id::TargetId;
 pub use taxonomy::{MemoryClass, MemoryKind, MemoryVisibility};
+pub use trace::TraceEvent;
 pub use timestamp::Rfc3339Timestamp;

--- a/crates/cairn-core/src/domain/record.rs
+++ b/crates/cairn-core/src/domain/record.rs
@@ -288,10 +288,19 @@ impl MemoryRecord {
         //     to `provenance.source_sensor` (otherwise the signature does
         //     not prove sensor participation; unsigned `Sensor` chain
         //     entries are claims, not proof, until P2 countersignatures).
-        //   - Sensor authors are *only* legal for `SensorObservation`. A
-        //     sensor key has narrow trust (raw event capture); allowing it
-        //     to author derived kinds like `Rule`, `Fact`, or `Reasoning`
-        //     would let a low-trust signer mint high-trust memories.
+        //   - Sensor authors are *only* legal for `SensorObservation` and
+        //     `Trace` records. A sensor key has narrow trust (raw event
+        //     capture); allowing it to author derived kinds like `Rule`,
+        //     `Fact`, or `Reasoning` would let a low-trust signer mint
+        //     high-trust memories.
+        //   - `Trace` records are raw-event captures produced by sensors in
+        //     `Auto` mode (brief §5.0, §9.3). `Auto` mode binds the chain
+        //     Author to the sensor_id (`bind_auto_author`), so a sensor
+        //     author on a Trace record is expected and legitimate — the
+        //     sensor captured the agent's activity verbatim. `Trace` records
+        //     can also carry non-sensor authors (e.g. `Proactive` / `Explicit`
+        //     mode events), so the rule is permissive rather than requiring
+        //     `author == source_sensor`.
         let author_is_sensor =
             matches!(author, Some(a) if a.identity.kind() == IdentityKind::Sensor);
         match self.kind {
@@ -307,10 +316,14 @@ impl MemoryRecord {
                     });
                 }
             }
+            // Trace records are raw-event captures: a sensor author is
+            // legitimate (Auto-mode hook events) alongside non-sensor authors
+            // (Proactive/Explicit-mode events). No additional constraint here.
+            MemoryKind::Trace => {}
             other if author_is_sensor => {
                 return Err(DomainError::InvalidIdentity {
                     message: format!(
-                        "sensor identities may only author `sensor_observation` records, not `{}` (derived kinds need a human or agent author)",
+                        "sensor identities may only author `sensor_observation` or `trace` records, not `{}` (derived kinds need a human or agent author)",
                         other.as_str()
                     ),
                 });

--- a/crates/cairn-core/src/domain/trace.rs
+++ b/crates/cairn-core/src/domain/trace.rs
@@ -1,7 +1,7 @@
 //! Trace-record domain types (issue #77, brief §5.0, §9.3).
 
-use sha2::{Digest, Sha256};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use ulid::Ulid;
 
@@ -144,9 +144,8 @@ pub fn summary_record_id(session_id: &SessionId, turn_id: &str) -> RecordId {
     let ulid = Ulid::from_bytes(bytes);
     // invariant: Ulid::to_string() always produces 26 valid Crockford-base32
     // characters by construction; RecordId::parse cannot fail on this input.
-    RecordId::parse(ulid.to_string()).unwrap_or_else(|_| {
-        unreachable!("ulid::to_string always yields valid RecordId")
-    })
+    RecordId::parse(ulid.to_string())
+        .unwrap_or_else(|_| unreachable!("ulid::to_string always yields valid RecordId"))
 }
 
 #[cfg(test)]
@@ -187,7 +186,9 @@ mod tests {
 
     #[test]
     fn user_message_link_is_valid() {
-        link_template().validate(TraceEvent::UserMessage).expect("valid");
+        link_template()
+            .validate(TraceEvent::UserMessage)
+            .expect("valid");
     }
 
     #[test]

--- a/crates/cairn-core/src/domain/trace.rs
+++ b/crates/cairn-core/src/domain/trace.rs
@@ -1,6 +1,9 @@
 //! Trace-record domain types (issue #77, brief §5.0, §9.3).
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::domain::{CaptureEventId, SessionId};
 
 /// Classifies the kind of event captured in a trace record.
 ///
@@ -28,6 +31,98 @@ pub enum TraceEvent {
     TurnSummary,
 }
 
+/// Linkage metadata attached to every trace record. Stored under
+/// `extra_frontmatter.trace` on the `MemoryRecord`. The single canonical
+/// location for all trace fields (spec §6.1, §8.1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TraceLink {
+    /// Owning session.
+    pub session_id: SessionId,
+    /// Opaque harness-supplied turn id (matches `CaptureRefs.turn_id`).
+    pub turn_id: String,
+    /// Monotonic position within `(session_id, turn_id)`.
+    pub sequence: u64,
+    /// Stable identity of the originating `CaptureEvent`.
+    pub capture_event_id: CaptureEventId,
+    /// Set on `PostTool` and `ToolOutput`; points at the `PreTool` that
+    /// initiated the tool call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_event_id: Option<CaptureEventId>,
+    /// Set on `PreTool`, `PostTool`, and `ToolOutput`. Groups events
+    /// belonging to the same tool invocation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    /// Set on `TurnSummary` only. The exact set of capture-event ids the
+    /// summary covers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub member_event_ids: Vec<CaptureEventId>,
+}
+
+/// Field-level validation failures for [`TraceLink::validate`].
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TraceLinkError {
+    /// `turn_id` was empty or whitespace-only.
+    #[error("turn_id must not be empty or whitespace")]
+    EmptyTurnId,
+    /// A tool-bearing event lacked `tool_call_id`.
+    #[error("tool_call_id required for this event type")]
+    MissingToolCallId,
+    /// A `PostTool` / `ToolOutput` lacked `parent_event_id`.
+    #[error("parent_event_id required for this event type")]
+    MissingParent,
+    /// `parent_event_id` was set on an event type that does not allow it.
+    #[error("parent_event_id only valid on PostTool/ToolOutput")]
+    UnexpectedParent,
+    /// `tool_call_id` was set on an event type that does not allow it.
+    #[error("tool_call_id only valid on PreTool/PostTool/ToolOutput")]
+    UnexpectedToolCallId,
+    /// `member_event_ids` was non-empty on a non-`TurnSummary` event.
+    #[error("member_event_ids only valid on TurnSummary")]
+    UnexpectedMemberIds,
+    /// A `TurnSummary` had an empty `member_event_ids`.
+    #[error("turn_summary requires non-empty member_event_ids")]
+    EmptyMemberIds,
+}
+
+impl TraceLink {
+    /// Validate field-level invariants given the event type the link is
+    /// attached to. Referential checks (parent existence, summary membership)
+    /// are enforced separately in the store transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first violated invariant.
+    pub fn validate(&self, event: TraceEvent) -> Result<(), TraceLinkError> {
+        if self.turn_id.trim().is_empty() {
+            return Err(TraceLinkError::EmptyTurnId);
+        }
+        let needs_tool_call = matches!(
+            event,
+            TraceEvent::PreTool | TraceEvent::PostTool | TraceEvent::ToolOutput
+        );
+        match (needs_tool_call, self.tool_call_id.as_ref()) {
+            (true, None) => return Err(TraceLinkError::MissingToolCallId),
+            (false, Some(_)) => return Err(TraceLinkError::UnexpectedToolCallId),
+            _ => {}
+        }
+        let needs_parent = matches!(event, TraceEvent::PostTool | TraceEvent::ToolOutput);
+        match (needs_parent, self.parent_event_id.as_ref()) {
+            (true, None) => return Err(TraceLinkError::MissingParent),
+            (false, Some(_)) => return Err(TraceLinkError::UnexpectedParent),
+            _ => {}
+        }
+        let is_summary = event == TraceEvent::TurnSummary;
+        match (is_summary, self.member_event_ids.is_empty()) {
+            (true, true) => return Err(TraceLinkError::EmptyMemberIds),
+            (false, false) => return Err(TraceLinkError::UnexpectedMemberIds),
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -42,5 +137,102 @@ mod tests {
             serde_json::from_str::<TraceEvent>("\"turn_summary\"").unwrap(),
             TraceEvent::TurnSummary
         );
+    }
+
+    fn cap(id: &str) -> CaptureEventId {
+        CaptureEventId::parse(id).expect("valid ulid")
+    }
+
+    fn sess() -> SessionId {
+        SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid")
+    }
+
+    fn link_template() -> TraceLink {
+        TraceLink {
+            session_id: sess(),
+            turn_id: "turn-4".into(),
+            sequence: 0,
+            capture_event_id: cap("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+            parent_event_id: None,
+            tool_call_id: None,
+            member_event_ids: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn user_message_link_is_valid() {
+        link_template().validate(TraceEvent::UserMessage).expect("valid");
+    }
+
+    #[test]
+    fn pre_tool_requires_tool_call_id() {
+        let err = link_template().validate(TraceEvent::PreTool).unwrap_err();
+        assert!(matches!(err, TraceLinkError::MissingToolCallId));
+    }
+
+    #[test]
+    fn pre_tool_with_tool_call_id_is_valid() {
+        let mut l = link_template();
+        l.tool_call_id = Some("call_abc".into());
+        l.validate(TraceEvent::PreTool).expect("valid");
+    }
+
+    #[test]
+    fn post_tool_requires_parent() {
+        let mut l = link_template();
+        l.tool_call_id = Some("call".into());
+        let err = l.validate(TraceEvent::PostTool).unwrap_err();
+        assert!(matches!(err, TraceLinkError::MissingParent));
+        l.parent_event_id = Some(cap("01ARZ3NDEKTSV4RRFFQ69G5FBW"));
+        l.validate(TraceEvent::PostTool).expect("valid");
+    }
+
+    #[test]
+    fn user_message_rejects_parent() {
+        let mut l = link_template();
+        l.parent_event_id = Some(cap("01ARZ3NDEKTSV4RRFFQ69G5FBW"));
+        assert!(matches!(
+            l.validate(TraceEvent::UserMessage).unwrap_err(),
+            TraceLinkError::UnexpectedParent
+        ));
+    }
+
+    #[test]
+    fn user_message_rejects_tool_call_id() {
+        let mut l = link_template();
+        l.tool_call_id = Some("call".into());
+        assert!(matches!(
+            l.validate(TraceEvent::UserMessage).unwrap_err(),
+            TraceLinkError::UnexpectedToolCallId
+        ));
+    }
+
+    #[test]
+    fn member_ids_only_on_summary() {
+        let mut l = link_template();
+        l.member_event_ids = vec![cap("01ARZ3NDEKTSV4RRFFQ69G5FBW")];
+        assert!(matches!(
+            l.validate(TraceEvent::UserMessage).unwrap_err(),
+            TraceLinkError::UnexpectedMemberIds
+        ));
+    }
+
+    #[test]
+    fn summary_requires_member_ids() {
+        let l = link_template();
+        assert!(matches!(
+            l.validate(TraceEvent::TurnSummary).unwrap_err(),
+            TraceLinkError::EmptyMemberIds
+        ));
+    }
+
+    #[test]
+    fn empty_turn_id_rejected() {
+        let mut l = link_template();
+        l.turn_id = "  ".into();
+        assert!(matches!(
+            l.validate(TraceEvent::UserMessage).unwrap_err(),
+            TraceLinkError::EmptyTurnId
+        ));
     }
 }

--- a/crates/cairn-core/src/domain/trace.rs
+++ b/crates/cairn-core/src/domain/trace.rs
@@ -1,0 +1,46 @@
+//! Trace-record domain types (issue #77, brief §5.0, §9.3).
+
+use serde::{Deserialize, Serialize};
+
+/// Classifies the kind of event captured in a trace record.
+///
+/// Each variant maps to a distinct moment in an agent turn:
+/// the human message, agent reply, tool lifecycle steps, and
+/// session bookends. `#[non_exhaustive]` allows new variants
+/// to be added without a semver break.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TraceEvent {
+    /// A message sent by the human / user turn.
+    UserMessage,
+    /// A message produced by the agent.
+    AgentMessage,
+    /// Captured immediately before a tool call is dispatched.
+    PreTool,
+    /// Captured immediately after a tool call returns.
+    PostTool,
+    /// The raw output returned by a tool invocation.
+    ToolOutput,
+    /// The agent stop / end-of-turn event.
+    Stop,
+    /// A summarising record written at the end of a turn.
+    TurnSummary,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&TraceEvent::UserMessage).unwrap(),
+            "\"user_message\""
+        );
+        assert_eq!(
+            serde_json::from_str::<TraceEvent>("\"turn_summary\"").unwrap(),
+            TraceEvent::TurnSummary
+        );
+    }
+}

--- a/crates/cairn-core/src/domain/trace.rs
+++ b/crates/cairn-core/src/domain/trace.rs
@@ -1,9 +1,11 @@
 //! Trace-record domain types (issue #77, brief §5.0, §9.3).
 
+use sha2::{Digest, Sha256};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use ulid::Ulid;
 
-use crate::domain::{CaptureEventId, SessionId};
+use crate::domain::{CaptureEventId, RecordId, SessionId};
 
 /// Classifies the kind of event captured in a trace record.
 ///
@@ -123,6 +125,30 @@ impl TraceLink {
     }
 }
 
+/// Deterministic, ULID-shaped record id for a `turn_summary` (spec §5.2).
+///
+/// Same `(session_id, turn_id)` always maps to the same id, so summary
+/// upserts are idempotent across replays. The result is a legal
+/// [`RecordId`] (26-char Crockford ULID) so it round-trips through every
+/// store/IDL path that already accepts `RecordId`.
+#[must_use]
+pub fn summary_record_id(session_id: &SessionId, turn_id: &str) -> RecordId {
+    let mut h = Sha256::new();
+    h.update(b"cairn:trace:turnsum\0");
+    h.update(session_id.as_str().as_bytes());
+    h.update(b"\0");
+    h.update(turn_id.as_bytes());
+    let digest = h.finalize();
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    let ulid = Ulid::from_bytes(bytes);
+    // invariant: Ulid::to_string() always produces 26 valid Crockford-base32
+    // characters by construction; RecordId::parse cannot fail on this input.
+    RecordId::parse(ulid.to_string()).unwrap_or_else(|_| {
+        unreachable!("ulid::to_string always yields valid RecordId")
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,5 +260,30 @@ mod tests {
             l.validate(TraceEvent::UserMessage).unwrap_err(),
             TraceLinkError::EmptyTurnId
         ));
+    }
+
+    #[test]
+    fn summary_id_is_deterministic() {
+        let s1 = summary_record_id(&sess(), "turn-4");
+        let s2 = summary_record_id(&sess(), "turn-4");
+        assert_eq!(s1, s2);
+        assert_ne!(s1, summary_record_id(&sess(), "turn-5"));
+    }
+
+    #[test]
+    fn summary_id_is_valid_record_id() {
+        let id = summary_record_id(&sess(), "turn-4");
+        let reparsed = crate::domain::RecordId::parse(id.as_str())
+            .expect("ulid-shaped record id must round-trip through RecordId::parse");
+        assert_eq!(id, reparsed);
+    }
+
+    #[test]
+    fn summary_id_distinguishes_session() {
+        let other = SessionId::parse("01BX5ZZKBKACTAV9WEVGEMMVRZ").expect("valid");
+        assert_ne!(
+            summary_record_id(&sess(), "turn-4"),
+            summary_record_id(&other, "turn-4")
+        );
     }
 }

--- a/crates/cairn-core/src/generated/verbs/retrieve.rs
+++ b/crates/cairn-core/src/generated/verbs/retrieve.rs
@@ -185,16 +185,18 @@ impl<'de> ::serde::Deserialize<'de> for DataSession {
 #[serde(deny_unknown_fields)]
 pub struct DataTurn {
     pub session_id: String,
-    pub turn: TurnItem,
-    pub turn_id: u64,
+    /// Ordered TurnItems for the turn — one per trace event (user/agent message, pre/post tool, tool output, stop, summary). Sorted by (captured_at, capture_event_id).
+    pub turn: Vec<TurnItem>,
+    pub turn_id: String,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawDataTurn {
     session_id: String,
-    turn: TurnItem,
-    turn_id: u64,
+    /// Ordered TurnItems for the turn — one per trace event (user/agent message, pre/post tool, tool output, stop, summary). Sorted by (captured_at, capture_event_id).
+    turn: Vec<TurnItem>,
+    turn_id: String,
 }
 
 impl ::core::convert::TryFrom<RawDataTurn> for DataTurn {
@@ -275,7 +277,7 @@ pub struct TurnItem {
     pub role: TurnItemRole,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<serde_json::Value>>,
-    pub turn_id: u64,
+    pub turn_id: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -327,7 +329,7 @@ pub enum RetrieveArgs {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         include: Option<Vec<RetrieveArgsTurnInclude>>,
         session_id: String,
-        turn_id: u64,
+        turn_id: String,
     },
     Folder {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -380,7 +382,7 @@ struct RawRetrieveArgsTurn {
     #[serde(default)]
     include: Option<Vec<RetrieveArgsTurnInclude>>,
     session_id: String,
-    turn_id: u64,
+    turn_id: String,
 }
 
 #[derive(Deserialize)]

--- a/crates/cairn-core/src/pipeline/capture_trace.rs
+++ b/crates/cairn-core/src/pipeline/capture_trace.rs
@@ -97,10 +97,7 @@ pub fn project(
         Json::String(link.session_id.as_str().to_owned()),
     );
     trace_obj.insert("turn_id".into(), Json::String(link.turn_id.clone()));
-    trace_obj.insert(
-        "sequence".into(),
-        Json::Number(link.sequence.into()),
-    );
+    trace_obj.insert("sequence".into(), Json::Number(link.sequence.into()));
     trace_obj.insert(
         "capture_event_id".into(),
         Json::String(link.capture_event_id.to_string()),
@@ -211,8 +208,9 @@ fn provenance_from_event(event: &CaptureEvent) -> Provenance {
 /// all-`a`s for a *test record*; we use all-`0`s here to distinguish
 /// a *pending-signature* record from a *test fixture* record).
 fn placeholder_signature() -> Ed25519Signature {
-    Ed25519Signature::parse(format!("ed25519:{}", "0".repeat(128)))
-        .unwrap_or_else(|_| unreachable!("'0'.repeat(128) always satisfies Ed25519Signature::parse"))
+    Ed25519Signature::parse(format!("ed25519:{}", "0".repeat(128))).unwrap_or_else(|_| {
+        unreachable!("'0'.repeat(128) always satisfies Ed25519Signature::parse")
+    })
 }
 
 /// Render the textual body for a given event type. Pure; no I/O.
@@ -239,11 +237,11 @@ fn truncate(s: &str, max_bytes: usize) -> String {
 mod tests {
     use super::*;
     use crate::domain::{
+        ActorChainEntry, ChainRole, Identity, Rfc3339Timestamp, SessionId,
         capture::{
             CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs, PayloadHash,
             SourceFamily,
         },
-        ActorChainEntry, ChainRole, Identity, Rfc3339Timestamp, SessionId,
     };
     use crate::pipeline::extract::body;
 
@@ -335,10 +333,7 @@ mod tests {
 
     #[test]
     fn classifies_stop() {
-        assert_eq!(
-            classify(&mk_hook_event("Stop")).unwrap(),
-            TraceEvent::Stop
-        );
+        assert_eq!(classify(&mk_hook_event("Stop")).unwrap(), TraceEvent::Stop);
     }
 
     #[test]

--- a/crates/cairn-core/src/pipeline/capture_trace.rs
+++ b/crates/cairn-core/src/pipeline/capture_trace.rs
@@ -1,0 +1,75 @@
+//! Trace-event projector (issue #77, brief §5.0).
+//!
+//! Pure helpers that turn a `CaptureEvent` plus a hash-verified
+//! `ResolvedBody` into a `MemoryRecord` (Task 6) for any of the seven
+//! [`TraceEvent`] variants. This module owns body shaping and the cap that
+//! keeps trace records bounded; full bytes stay in `sources/` referenced
+//! by `payload_hash`.
+
+use crate::domain::trace::{TraceEvent, TraceLinkError};
+
+/// Maximum size of a stored trace-record body, in bytes. Anything larger
+/// is truncated at a UTF-8 char boundary; the full bytes remain in
+/// `sources/` referenced by `payload_hash`.
+pub const TRACE_BODY_CAP: usize = 4 * 1024;
+
+/// Failure modes for the trace projector.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TraceProjectError {
+    /// The provided [`crate::domain::trace::TraceLink`] failed field-level
+    /// validation.
+    #[error("trace link: {0}")]
+    Link(#[from] TraceLinkError),
+}
+
+/// Render the textual body for a given event type. Pure; no I/O.
+///
+/// Caller is responsible for passing already-privacy-filtered text. The
+/// body is truncated at [`TRACE_BODY_CAP`] on a UTF-8 char boundary.
+#[must_use]
+// Task 6 wires the dispatch; allow dead_code until then.
+#[allow(dead_code)]
+pub(crate) fn shape_body(_event: TraceEvent, filtered_text: &str) -> String {
+    truncate(filtered_text, TRACE_BODY_CAP)
+}
+
+// Called only from shape_body; allow until Task 6 wires usage.
+#[allow(dead_code)]
+fn truncate(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_owned();
+    }
+    let mut end = max_bytes;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_truncates_at_cap() {
+        let big = "x".repeat(TRACE_BODY_CAP + 100);
+        let body = shape_body(TraceEvent::ToolOutput, &big);
+        assert!(body.len() <= TRACE_BODY_CAP);
+    }
+
+    #[test]
+    fn body_below_cap_unchanged() {
+        let body = shape_body(TraceEvent::UserMessage, "hello world");
+        assert_eq!(body, "hello world");
+    }
+
+    #[test]
+    fn truncate_respects_char_boundary() {
+        // Build a string whose byte length crosses the cap mid multi-byte char.
+        let mut s = "x".repeat(TRACE_BODY_CAP - 2);
+        s.push('𝄞'); // 4 bytes (U+1D11E)
+        let body = shape_body(TraceEvent::UserMessage, &s);
+        assert!(body.is_char_boundary(body.len()));
+    }
+}

--- a/crates/cairn-core/src/pipeline/capture_trace.rs
+++ b/crates/cairn-core/src/pipeline/capture_trace.rs
@@ -6,7 +6,10 @@
 //! keeps trace records bounded; full bytes stay in `sources/` referenced
 //! by `payload_hash`.
 
-use crate::domain::trace::{TraceEvent, TraceLinkError};
+use crate::domain::{
+    capture::{CaptureEvent, CapturePayload},
+    trace::{TraceEvent, TraceLinkError},
+};
 
 /// Maximum size of a stored trace-record body, in bytes. Anything larger
 /// is truncated at a UTF-8 char boundary; the full bytes remain in
@@ -21,6 +24,31 @@ pub enum TraceProjectError {
     /// validation.
     #[error("trace link: {0}")]
     Link(#[from] TraceLinkError),
+    /// The capture event does not map to any known trace-event type.
+    #[error("cannot classify capture event into a trace event type")]
+    Unclassifiable,
+}
+
+/// Map a [`CaptureEvent`] to a [`TraceEvent`]. Static rules; no LLM.
+///
+/// Hook payloads route by hook name (brief §9.3). Non-hook payloads are
+/// rejected with [`TraceProjectError::Unclassifiable`] in P0.
+///
+/// # Errors
+///
+/// Returns [`TraceProjectError::Unclassifiable`] when the event does not
+/// match any known mapping.
+pub fn classify(event: &CaptureEvent) -> Result<TraceEvent, TraceProjectError> {
+    match &event.payload {
+        CapturePayload::Hook { hook_name, .. } => match hook_name.as_str() {
+            "UserPromptSubmit" => Ok(TraceEvent::UserMessage),
+            "PreToolUse" => Ok(TraceEvent::PreTool),
+            "PostToolUse" => Ok(TraceEvent::PostTool),
+            "Stop" => Ok(TraceEvent::Stop),
+            _ => Err(TraceProjectError::Unclassifiable),
+        },
+        _ => Err(TraceProjectError::Unclassifiable),
+    }
 }
 
 /// Render the textual body for a given event type. Pure; no I/O.
@@ -50,6 +78,53 @@ fn truncate(s: &str, max_bytes: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::{
+        capture::{
+            CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs, PayloadHash,
+            SourceFamily,
+        },
+        ActorChainEntry, ChainRole, Identity, Rfc3339Timestamp,
+    };
+
+    fn ts() -> Rfc3339Timestamp {
+        Rfc3339Timestamp::parse("2026-04-27T00:00:00Z").expect("invariant: valid timestamp")
+    }
+
+    /// Build a minimal hook `CaptureEvent` for classification tests.
+    ///
+    /// Copied from `pipeline::squash::tests::hook_event` (squash.rs ~line 503),
+    /// parameterised on `hook_name` instead of a fixed `"PostToolUse"`.
+    fn mk_hook_event(hook_name: &str) -> CaptureEvent {
+        CaptureEvent {
+            event_id: CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+                .expect("invariant: fixed ULID is valid"),
+            sensor_id: Identity::parse("snr:local:hook:cc-session:v1")
+                .expect("invariant: fixed sensor identity is valid"),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: Identity::parse("snr:local:hook:cc-session:v1")
+                    .expect("invariant: fixed sensor identity is valid"),
+                at: ts(),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some("sess".into()),
+                turn_id: Some("turn".into()),
+                tool_id: None,
+            }),
+            payload_hash: PayloadHash::parse(
+                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+            .expect("invariant: well-formed sha256 hash"),
+            payload_ref: "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.txt".into(),
+            captured_at: ts(),
+            payload: CapturePayload::Hook {
+                hook_name: hook_name.into(),
+                tool_name: None,
+            },
+            source_family: SourceFamily::Hook,
+        }
+    }
 
     #[test]
     fn body_truncates_at_cap() {
@@ -71,5 +146,53 @@ mod tests {
         s.push('𝄞'); // 4 bytes (U+1D11E)
         let body = shape_body(TraceEvent::UserMessage, &s);
         assert!(body.is_char_boundary(body.len()));
+    }
+
+    #[test]
+    fn classifies_user_prompt_submit() {
+        assert_eq!(
+            classify(&mk_hook_event("UserPromptSubmit")).unwrap(),
+            TraceEvent::UserMessage
+        );
+    }
+
+    #[test]
+    fn classifies_pre_tool_use() {
+        assert_eq!(
+            classify(&mk_hook_event("PreToolUse")).unwrap(),
+            TraceEvent::PreTool
+        );
+    }
+
+    #[test]
+    fn classifies_post_tool_use() {
+        assert_eq!(
+            classify(&mk_hook_event("PostToolUse")).unwrap(),
+            TraceEvent::PostTool
+        );
+    }
+
+    #[test]
+    fn classifies_stop() {
+        assert_eq!(
+            classify(&mk_hook_event("Stop")).unwrap(),
+            TraceEvent::Stop
+        );
+    }
+
+    #[test]
+    fn unknown_hook_rejected() {
+        assert!(matches!(
+            classify(&mk_hook_event("UnknownHook")).unwrap_err(),
+            TraceProjectError::Unclassifiable
+        ));
+    }
+
+    #[test]
+    fn session_start_rejected() {
+        assert!(matches!(
+            classify(&mk_hook_event("SessionStart")).unwrap_err(),
+            TraceProjectError::Unclassifiable
+        ));
     }
 }

--- a/crates/cairn-core/src/pipeline/capture_trace.rs
+++ b/crates/cairn-core/src/pipeline/capture_trace.rs
@@ -6,10 +6,18 @@
 //! keeps trace records bounded; full bytes stay in `sources/` referenced
 //! by `payload_hash`.
 
+use std::collections::BTreeMap;
+
+use serde_json::{Map as JsonMap, Value as Json};
+
 use crate::domain::{
+    ChainRole, DomainError, EvidenceVector, Provenance, ScopeTuple, TargetId,
     capture::{CaptureEvent, CapturePayload},
-    trace::{TraceEvent, TraceLinkError},
+    record::{Ed25519Signature, MemoryRecord, RecordId},
+    taxonomy::{MemoryClass, MemoryKind, MemoryVisibility},
+    trace::{TraceEvent, TraceLink, TraceLinkError, summary_record_id},
 };
+use crate::pipeline::extract::body::ResolvedBody;
 
 /// Maximum size of a stored trace-record body, in bytes. Anything larger
 /// is truncated at a UTF-8 char boundary; the full bytes remain in
@@ -27,6 +35,12 @@ pub enum TraceProjectError {
     /// The capture event does not map to any known trace-event type.
     #[error("cannot classify capture event into a trace event type")]
     Unclassifiable,
+    /// `RecordId::parse` rejected the derived id.
+    #[error("record id derivation: {0}")]
+    RecordId(#[from] DomainError),
+    /// JSON serialization failed (e.g., serializing `TraceEvent`).
+    #[error("serde: {0}")]
+    Serde(#[from] serde_json::Error),
 }
 
 /// Map a [`CaptureEvent`] to a [`TraceEvent`]. Static rules; no LLM.
@@ -51,19 +65,165 @@ pub fn classify(event: &CaptureEvent) -> Result<TraceEvent, TraceProjectError> {
     }
 }
 
+/// Project a [`CaptureEvent`] + verified [`ResolvedBody`] + [`TraceLink`]
+/// into a [`MemoryRecord`] of [`MemoryKind::Trace`].
+///
+/// Pure: no I/O, no signing key required. The returned record carries a
+/// zeroed placeholder signature (`ed25519:000…`); a later signing stage
+/// must finalize it before the store accepts it. This mirrors the pattern
+/// used by the sample-record factory in
+/// `crate::domain::record::tests_export::sample_record`, which also
+/// constructs a syntactically-valid-but-content-free signature.
+///
+/// # Errors
+///
+/// - [`TraceProjectError::Link`] if [`TraceLink::validate`] fails.
+/// - [`TraceProjectError::RecordId`] if the derived record-id ULID is
+///   somehow malformed (should not happen in practice — ULIDs from
+///   `CaptureEventId` are already validated).
+/// - [`TraceProjectError::Serde`] if serializing `classified` to JSON fails.
+pub fn project(
+    event: &CaptureEvent,
+    classified: TraceEvent,
+    resolved_body: &ResolvedBody<'_>,
+    link: &TraceLink,
+) -> Result<MemoryRecord, TraceProjectError> {
+    link.validate(classified)?;
+
+    // Build extra_frontmatter["trace"]: the canonical linkage blob (spec §6.1, §8.1).
+    let mut trace_obj = JsonMap::new();
+    trace_obj.insert(
+        "session_id".into(),
+        Json::String(link.session_id.as_str().to_owned()),
+    );
+    trace_obj.insert("turn_id".into(), Json::String(link.turn_id.clone()));
+    trace_obj.insert(
+        "sequence".into(),
+        Json::Number(link.sequence.into()),
+    );
+    trace_obj.insert(
+        "capture_event_id".into(),
+        Json::String(link.capture_event_id.to_string()),
+    );
+    trace_obj.insert(
+        "payload_hash".into(),
+        Json::String(event.payload_hash.as_str().to_owned()),
+    );
+    trace_obj.insert(
+        "payload_ref".into(),
+        Json::String(event.payload_ref.clone()),
+    );
+    if let Some(parent) = &link.parent_event_id {
+        trace_obj.insert("parent_event_id".into(), Json::String(parent.to_string()));
+    }
+    if let Some(call) = &link.tool_call_id {
+        trace_obj.insert("tool_call_id".into(), Json::String(call.clone()));
+    }
+    if !link.member_event_ids.is_empty() {
+        let arr: Vec<Json> = link
+            .member_event_ids
+            .iter()
+            .map(|id| Json::String(id.to_string()))
+            .collect();
+        trace_obj.insert("member_event_ids".into(), Json::Array(arr));
+    }
+
+    let mut extra: BTreeMap<String, Json> = BTreeMap::new();
+    extra.insert("trace_event".into(), serde_json::to_value(classified)?);
+    extra.insert("trace".into(), Json::Object(trace_obj));
+
+    let body = shape_body(classified, resolved_body.text());
+
+    let scope = ScopeTuple {
+        session_id: Some(link.session_id.as_str().to_owned()),
+        ..ScopeTuple::default()
+    };
+
+    // Record id: deterministic for TurnSummary (idempotent across replays),
+    // derived from capture_event_id otherwise (ULID by construction).
+    let id: RecordId = if classified == TraceEvent::TurnSummary {
+        summary_record_id(&link.session_id, &link.turn_id)
+    } else {
+        RecordId::parse(link.capture_event_id.as_str())?
+    };
+
+    let target_id = TargetId::parse(id.as_str())?;
+
+    Ok(MemoryRecord {
+        id,
+        target_id,
+        kind: MemoryKind::Trace,
+        class: MemoryClass::Episodic,
+        visibility: MemoryVisibility::Private,
+        scope,
+        body,
+        provenance: provenance_from_event(event),
+        updated_at: event.captured_at.clone(),
+        evidence: EvidenceVector::default(),
+        salience: 0.5,
+        confidence: 1.0,
+        actor_chain: event.actor_chain.clone(),
+        signature: placeholder_signature(),
+        tags: Vec::new(),
+        extra_frontmatter: extra,
+    })
+}
+
+/// Build a [`Provenance`] from a [`CaptureEvent`].
+///
+/// - `source_sensor` = `event.sensor_id` (always a `snr:` identity on a
+///   valid capture event).
+/// - `created_at` / `updated_at` = `event.captured_at`.
+/// - `originating_agent_id` = the `Author` chain entry's identity; falls
+///   back to `sensor_id` if the chain is somehow empty (should not occur
+///   on a validated event).
+/// - `source_hash` = `event.payload_hash.as_str()` — the cryptographic
+///   hash of the raw payload bytes stored in `sources/`.
+/// - `consent_ref` = `"consent:pending"` — a P0 placeholder; the
+///   consent journal integration lands in a later task.
+/// - `llm_id_if_any` = `None` — trace records are captured verbatim,
+///   not produced by an LLM.
+fn provenance_from_event(event: &CaptureEvent) -> Provenance {
+    let originating_agent_id = event
+        .actor_chain
+        .iter()
+        .find(|e| e.role == ChainRole::Author)
+        .map_or_else(|| event.sensor_id.clone(), |e| e.identity.clone());
+
+    Provenance {
+        source_sensor: event.sensor_id.clone(),
+        created_at: event.captured_at.clone(),
+        originating_agent_id,
+        source_hash: event.payload_hash.as_str().to_owned(),
+        consent_ref: "consent:pending".to_owned(),
+        llm_id_if_any: None,
+    }
+}
+
+/// Return a syntactically valid but content-free Ed25519 signature
+/// placeholder. The returned value passes `Ed25519Signature::parse`
+/// (correct prefix + 128 hex chars) but carries no key material.
+/// A later signing stage replaces this before the record is accepted
+/// by the store.
+///
+/// Pattern: all-zeros hex, matching the "unsigned" sentinel used in
+/// `crate::domain::record::tests_export::sample_record` (which uses
+/// all-`a`s for a *test record*; we use all-`0`s here to distinguish
+/// a *pending-signature* record from a *test fixture* record).
+fn placeholder_signature() -> Ed25519Signature {
+    Ed25519Signature::parse(format!("ed25519:{}", "0".repeat(128)))
+        .unwrap_or_else(|_| unreachable!("'0'.repeat(128) always satisfies Ed25519Signature::parse"))
+}
+
 /// Render the textual body for a given event type. Pure; no I/O.
 ///
 /// Caller is responsible for passing already-privacy-filtered text. The
 /// body is truncated at [`TRACE_BODY_CAP`] on a UTF-8 char boundary.
 #[must_use]
-// Task 6 wires the dispatch; allow dead_code until then.
-#[allow(dead_code)]
 pub(crate) fn shape_body(_event: TraceEvent, filtered_text: &str) -> String {
     truncate(filtered_text, TRACE_BODY_CAP)
 }
 
-// Called only from shape_body; allow until Task 6 wires usage.
-#[allow(dead_code)]
 fn truncate(s: &str, max_bytes: usize) -> String {
     if s.len() <= max_bytes {
         return s.to_owned();
@@ -83,8 +243,9 @@ mod tests {
             CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs, PayloadHash,
             SourceFamily,
         },
-        ActorChainEntry, ChainRole, Identity, Rfc3339Timestamp,
+        ActorChainEntry, ChainRole, Identity, Rfc3339Timestamp, SessionId,
     };
+    use crate::pipeline::extract::body;
 
     fn ts() -> Rfc3339Timestamp {
         Rfc3339Timestamp::parse("2026-04-27T00:00:00Z").expect("invariant: valid timestamp")
@@ -194,5 +355,59 @@ mod tests {
             classify(&mk_hook_event("SessionStart")).unwrap_err(),
             TraceProjectError::Unclassifiable
         ));
+    }
+
+    #[test]
+    fn projects_user_message_record() {
+        let event = mk_hook_event("UserPromptSubmit");
+        let resolved = body::for_test("hello world");
+        let link = TraceLink {
+            session_id: SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+                .expect("invariant: valid ULID"),
+            turn_id: "turn-1".into(),
+            sequence: 0,
+            capture_event_id: event.event_id.clone(),
+            parent_event_id: None,
+            tool_call_id: None,
+            member_event_ids: Vec::new(),
+        };
+        let record = project(&event, TraceEvent::UserMessage, &resolved, &link).unwrap();
+        assert_eq!(record.kind, MemoryKind::Trace);
+        assert_eq!(record.class, MemoryClass::Episodic);
+        assert_eq!(record.visibility, MemoryVisibility::Private);
+        assert_eq!(
+            record.scope.session_id.as_deref(),
+            Some("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+        );
+        assert!(record.body.contains("hello world"));
+        let trace_meta = record.extra_frontmatter.get("trace").unwrap();
+        assert_eq!(trace_meta["turn_id"], "turn-1");
+        assert_eq!(trace_meta["sequence"], 0);
+        assert_eq!(
+            record.extra_frontmatter.get("trace_event").unwrap(),
+            "user_message"
+        );
+    }
+
+    #[test]
+    fn project_validates_link() {
+        // PreTool without tool_call_id → Link error.
+        let event = mk_hook_event("PreToolUse");
+        let resolved = body::for_test("some tool input");
+        let link = TraceLink {
+            session_id: SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+                .expect("invariant: valid ULID"),
+            turn_id: "t".into(),
+            sequence: 0,
+            capture_event_id: event.event_id.clone(),
+            parent_event_id: None,
+            tool_call_id: None, // missing — required for PreTool
+            member_event_ids: Vec::new(),
+        };
+        let err = project(&event, TraceEvent::PreTool, &resolved, &link).unwrap_err();
+        assert!(
+            matches!(err, TraceProjectError::Link(_)),
+            "expected Link error, got {err:?}"
+        );
     }
 }

--- a/crates/cairn-core/src/pipeline/capture_trace.rs
+++ b/crates/cairn-core/src/pipeline/capture_trace.rs
@@ -45,8 +45,15 @@ pub enum TraceProjectError {
 
 /// Map a [`CaptureEvent`] to a [`TraceEvent`]. Static rules; no LLM.
 ///
-/// Hook payloads route by hook name (brief §9.3). Non-hook payloads are
-/// rejected with [`TraceProjectError::Unclassifiable`] in P0.
+/// **P0 supports only the four hook payloads** routed by hook name
+/// (brief §9.3): `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`.
+/// The remaining `TraceEvent` variants — `AgentMessage`, `ToolOutput`,
+/// `TurnSummary` — are produced by other paths: `AgentMessage` and
+/// `ToolOutput` await sensor adapters (issue #84); `TurnSummary` is
+/// generated post-hoc by [`crate::pipeline::turn::summarize_turn`] and
+/// never reaches `classify`. Until those land, JSONL streams that
+/// include them will fail their entire turn at the importer (the
+/// importer fails closed rather than persisting a partial set).
 ///
 /// # Errors
 ///

--- a/crates/cairn-core/src/pipeline/extract/body.rs
+++ b/crates/cairn-core/src/pipeline/extract/body.rs
@@ -171,6 +171,29 @@ impl<'a> ResolvedBody<'a> {
         })
     }
 
+    /// Construct from hash-verified bytes read from `sources/` by the
+    /// trace-capture pipeline (brief §5.0). The caller must have already
+    /// verified `sha256(bytes) == event.payload_hash` before calling this
+    /// constructor. Intended for hook events that are **not** user-utterance
+    /// hooks (e.g. `PreToolUse`, `PostToolUse`, `Stop`) — those hooks carry
+    /// tool/agent content rather than direct user text, so `HookUtterance`
+    /// is not an appropriate source tag. The source is recorded as
+    /// `HookUtterance` because that is the closest match for
+    /// harness-captured hook payload bytes; a future task will introduce a
+    /// dedicated `HookCapture` or `TracePayload` variant.
+    ///
+    /// **Do not use outside the `capture_trace` verb pipeline.** Every other
+    /// body resolution path should go through the typed constructors
+    /// (`from_user_ingest`, `from_hook_utterance`) which enforce
+    /// payload-variant invariants.
+    #[must_use]
+    pub fn from_trace_hook(text: &'a str) -> Self {
+        Self {
+            text,
+            source: BodySource::HookUtterance,
+        }
+    }
+
     /// The resolved body text.
     #[must_use]
     pub fn text(&self) -> &str {

--- a/crates/cairn-core/src/pipeline/extract/body.rs
+++ b/crates/cairn-core/src/pipeline/extract/body.rs
@@ -184,6 +184,18 @@ impl<'a> ResolvedBody<'a> {
     }
 }
 
+/// Construct a `ResolvedBody` for **unit tests only**, bypassing the
+/// payload-variant checks. This is `pub(crate)` so `pipeline::capture_trace`
+/// tests can build a body for non-user-utterance hooks (e.g. `PreTool`)
+/// without duplicating its fields into a `CapturePayload::Hook`.
+#[cfg(test)]
+pub(crate) fn for_test(text: &str) -> ResolvedBody<'_> {
+    ResolvedBody {
+        text,
+        source: BodySource::HookUtterance,
+    }
+}
+
 /// Hook names whose payload body canonically carries direct user
 /// utterance text. Adding a new entry is a trust-boundary change —
 /// the hook must be one whose payload contains text the user actually

--- a/crates/cairn-core/src/pipeline/mod.rs
+++ b/crates/cairn-core/src/pipeline/mod.rs
@@ -29,6 +29,7 @@ pub mod extract;
 pub mod filter;
 pub mod lint;
 pub(crate) mod squash;
+pub mod turn;
 
 /// Fuzz-only re-export of the squash module's public surface. Gated
 /// behind the `fuzz` crate feature so production builds keep the

--- a/crates/cairn-core/src/pipeline/mod.rs
+++ b/crates/cairn-core/src/pipeline/mod.rs
@@ -23,6 +23,7 @@
 //! - §14 Privacy and Consent (pre-persist redaction, deny-by-default,
 //!   per-sensor opt-in, append-only audit)
 
+pub mod capture_trace;
 pub mod explain;
 pub mod extract;
 pub mod filter;

--- a/crates/cairn-core/src/pipeline/turn.rs
+++ b/crates/cairn-core/src/pipeline/turn.rs
@@ -428,8 +428,8 @@ mod tests {
             _ => TE::UserMessage,
         };
 
-        let ts = Rfc3339Timestamp::parse("2026-05-02T00:00:00Z")
-            .expect("invariant: fixed timestamp");
+        let ts =
+            Rfc3339Timestamp::parse("2026-05-02T00:00:00Z").expect("invariant: fixed timestamp");
         let event = CaptureEvent {
             event_id: CaptureEventId::parse(capture_event_id_str)
                 .expect("invariant: test capture_event_id must be valid ULID"),

--- a/crates/cairn-core/src/pipeline/turn.rs
+++ b/crates/cairn-core/src/pipeline/turn.rs
@@ -1,0 +1,184 @@
+//! Turn-level pure helpers for trace persistence (issue #77, spec §4 Ordering).
+//!
+//! `cairn-core` is store-agnostic. These helpers operate on lightweight
+//! references that the CLI verb (or tests) supplies; the actual `SQLite`
+//! reads happen elsewhere.
+
+use crate::domain::capture::CaptureEvent;
+use crate::domain::trace::TraceEvent;
+
+/// One entry in a turn's ordered event sequence.
+#[derive(Debug, Clone, Copy)]
+pub struct OrderedEntry<'a> {
+    /// The originating capture envelope.
+    pub event: &'a CaptureEvent,
+    /// The trace-event classification produced by `classify`.
+    pub classified: TraceEvent,
+}
+
+/// Sort the union of `persisted` and `incoming` events by
+/// `(captured_at, capture_event_id)`. Stable across replays — identical
+/// inputs always produce the same ordering.
+///
+/// `persisted` represents events that already live in the store for this
+/// turn (decoded back into their original `CaptureEvent`s by the caller).
+/// `incoming` represents the new events being imported.
+///
+/// Chronological ordering uses [`crate::domain::Rfc3339Timestamp::cmp_chronological`]
+/// which accounts for timezone offsets, rather than lexical string comparison.
+/// Ties in timestamp are broken by `capture_event_id` ascending (lexical on
+/// the ULID string, which also sorts chronologically for ULIDs generated in
+/// the same millisecond).
+#[must_use]
+pub fn order_by_captured_at<'a>(
+    persisted: &'a [OrderedEntry<'a>],
+    incoming: &'a [OrderedEntry<'a>],
+) -> Vec<OrderedEntry<'a>> {
+    let mut all: Vec<OrderedEntry<'a>> = Vec::with_capacity(persisted.len() + incoming.len());
+    all.extend_from_slice(persisted);
+    all.extend_from_slice(incoming);
+    all.sort_by(|x, y| {
+        x.event
+            .captured_at
+            .cmp_chronological(&y.event.captured_at)
+            .then_with(|| x.event.event_id.as_str().cmp(y.event.event_id.as_str()))
+    });
+    all
+}
+
+/// Assign sequences `0..N` over an already-ordered slice. Returned
+/// `(sequence, entry)` pairs preserve the input order.
+#[must_use]
+pub fn assign_sequences<'a>(ordered: &'a [OrderedEntry<'a>]) -> Vec<(u64, OrderedEntry<'a>)> {
+    ordered
+        .iter()
+        .enumerate()
+        // `i` is a `usize`; on all supported targets `usize` fits in `u64`
+        // (both 32-bit and 64-bit platforms), so the fallback is unreachable
+        // in practice. `unwrap_or` avoids a bare `unwrap`.
+        .map(|(i, entry)| (u64::try_from(i).unwrap_or(u64::MAX), *entry))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        ActorChainEntry, ChainRole, Identity, Rfc3339Timestamp,
+        capture::{
+            CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs, PayloadHash,
+            SourceFamily,
+        },
+    };
+
+    /// Build a minimal hook `CaptureEvent` with the given `event_id` and
+    /// `captured_at`. Mirrors `pipeline::capture_trace::tests::mk_hook_event`
+    /// but parameterised on both fields so ordering tests can vary them
+    /// independently.
+    fn mk_at(event_id: &str, captured_at: &str) -> CaptureEvent {
+        let ts = Rfc3339Timestamp::parse(captured_at)
+            .expect("invariant: test timestamp must be valid RFC3339");
+        CaptureEvent {
+            event_id: CaptureEventId::parse(event_id)
+                .expect("invariant: test event_id must be a valid ULID"),
+            sensor_id: Identity::parse("snr:local:hook:cc-session:v1")
+                .expect("invariant: fixed sensor identity is valid"),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: Identity::parse("snr:local:hook:cc-session:v1")
+                    .expect("invariant: fixed sensor identity is valid"),
+                at: ts.clone(),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some("sess".into()),
+                turn_id: Some("turn".into()),
+                tool_id: None,
+            }),
+            payload_hash: PayloadHash::parse(
+                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+            .expect("invariant: well-formed sha256 hash"),
+            payload_ref: format!("sources/hook/{event_id}.txt"),
+            captured_at: ts,
+            payload: CapturePayload::Hook {
+                hook_name: "UserPromptSubmit".into(),
+                tool_name: None,
+            },
+            source_family: SourceFamily::Hook,
+        }
+    }
+
+    #[test]
+    fn orders_by_captured_at_then_event_id() {
+        let a = mk_at("01ARZ3NDEKTSV4RRFFQ69G5FAA", "2026-05-02T00:00:01Z");
+        let b = mk_at("01ARZ3NDEKTSV4RRFFQ69G5FAB", "2026-05-02T00:00:00Z");
+        let c = mk_at("01ARZ3NDEKTSV4RRFFQ69G5FAC", "2026-05-02T00:00:00Z");
+        let entries: Vec<OrderedEntry<'_>> = [&a, &b, &c]
+            .into_iter()
+            .map(|e| OrderedEntry {
+                event: e,
+                classified: TraceEvent::UserMessage,
+            })
+            .collect();
+        let ordered = order_by_captured_at(&[], &entries);
+        // Earlier timestamp first; ties broken by capture_event_id ascending.
+        assert_eq!(
+            ordered[0].event.event_id.as_str(),
+            "01ARZ3NDEKTSV4RRFFQ69G5FAB"
+        );
+        assert_eq!(
+            ordered[1].event.event_id.as_str(),
+            "01ARZ3NDEKTSV4RRFFQ69G5FAC"
+        );
+        assert_eq!(
+            ordered[2].event.event_id.as_str(),
+            "01ARZ3NDEKTSV4RRFFQ69G5FAA"
+        );
+    }
+
+    #[test]
+    fn assigns_sequences_zero_indexed() {
+        let a = mk_at("01ARZ3NDEKTSV4RRFFQ69G5FAA", "2026-05-02T00:00:00Z");
+        let b = mk_at("01ARZ3NDEKTSV4RRFFQ69G5FAB", "2026-05-02T00:00:01Z");
+        let entries: Vec<OrderedEntry<'_>> = [&a, &b]
+            .into_iter()
+            .map(|e| OrderedEntry {
+                event: e,
+                classified: TraceEvent::UserMessage,
+            })
+            .collect();
+        let ordered = order_by_captured_at(&[], &entries);
+        let with_seq = assign_sequences(&ordered);
+        assert_eq!(with_seq[0].0, 0);
+        assert_eq!(with_seq[1].0, 1);
+        assert_eq!(
+            with_seq[0].1.event.event_id.as_str(),
+            "01ARZ3NDEKTSV4RRFFQ69G5FAA"
+        );
+    }
+
+    #[test]
+    fn merges_persisted_and_incoming() {
+        let p = mk_at("01ARZ3NDEKTSV4RRFFQ69G5FAA", "2026-05-02T00:00:01Z");
+        let i = mk_at("01ARZ3NDEKTSV4RRFFQ69G5FAB", "2026-05-02T00:00:00Z");
+        let persisted = [OrderedEntry {
+            event: &p,
+            classified: TraceEvent::UserMessage,
+        }];
+        let incoming = [OrderedEntry {
+            event: &i,
+            classified: TraceEvent::PreTool,
+        }];
+        let ordered = order_by_captured_at(&persisted, &incoming);
+        // Incoming has earlier timestamp; should sort first.
+        assert_eq!(
+            ordered[0].event.event_id.as_str(),
+            "01ARZ3NDEKTSV4RRFFQ69G5FAB"
+        );
+        assert_eq!(
+            ordered[1].event.event_id.as_str(),
+            "01ARZ3NDEKTSV4RRFFQ69G5FAA"
+        );
+    }
+}

--- a/crates/cairn-core/src/pipeline/turn.rs
+++ b/crates/cairn-core/src/pipeline/turn.rs
@@ -4,8 +4,17 @@
 //! references that the CLI verb (or tests) supplies; the actual `SQLite`
 //! reads happen elsewhere.
 
+use std::collections::BTreeMap;
+use std::fmt::Write;
+
+use serde_json::{Map as JsonMap, Value as Json};
+
 use crate::domain::capture::CaptureEvent;
-use crate::domain::trace::TraceEvent;
+use crate::domain::record::{Ed25519Signature, MemoryRecord};
+use crate::domain::taxonomy::{MemoryClass, MemoryKind, MemoryVisibility};
+use crate::domain::trace::{TraceEvent, summary_record_id};
+use crate::domain::{EvidenceVector, Provenance, ScopeTuple, SessionId, TargetId};
+use crate::pipeline::capture_trace::TRACE_BODY_CAP;
 
 /// One entry in a turn's ordered event sequence.
 #[derive(Debug, Clone, Copy)]
@@ -58,6 +67,208 @@ pub fn assign_sequences<'a>(ordered: &'a [OrderedEntry<'a>]) -> Vec<(u64, Ordere
         // in practice. `unwrap_or` avoids a bare `unwrap`.
         .map(|(i, entry)| (u64::try_from(i).unwrap_or(u64::MAX), *entry))
         .collect()
+}
+
+/// Failure modes for [`summarize_turn`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TurnSummaryError {
+    /// At least one event is required to summarize.
+    #[error("turn must contain at least one event")]
+    EmptyTurn,
+    /// Events span more than one `(session_id, turn_id)`.
+    #[error("events span more than one (session_id, turn_id)")]
+    CrossTurn,
+    /// Sequence numbers must be strictly increasing.
+    #[error("sequences must be strictly increasing")]
+    OutOfOrderSequences,
+    /// A record lacked the required `extra_frontmatter.trace.*` field.
+    #[error("record is missing extra_frontmatter.trace.{0}")]
+    MissingTrace(&'static str),
+}
+
+/// Build a deterministic `turn_summary` [`MemoryRecord`] from an ordered
+/// slice of trace records belonging to one `(session_id, turn_id)`.
+///
+/// Pure: no LLM, no I/O. Same input always produces the same output.
+///
+/// The returned record carries a zeroed placeholder signature
+/// (`ed25519:000…`); a later signing stage must finalize it before the
+/// store accepts it. This mirrors the pattern used by
+/// [`crate::pipeline::capture_trace::project`].
+///
+/// # Errors
+///
+/// See [`TurnSummaryError`].
+pub fn summarize_turn(
+    session_id: &SessionId,
+    turn_id: &str,
+    events: &[MemoryRecord],
+) -> Result<MemoryRecord, TurnSummaryError> {
+    if events.is_empty() {
+        return Err(TurnSummaryError::EmptyTurn);
+    }
+    let member_ids = validate_and_collect_members(session_id, turn_id, events)?;
+    let body = build_summary_body(session_id, turn_id, events)?;
+    let id = summary_record_id(session_id, turn_id);
+    let extra = build_summary_frontmatter(session_id, turn_id, &id, member_ids);
+    let first = &events[0];
+    // Safety: non-empty checked above; last index cannot fail.
+    let last = &events[events.len() - 1];
+    let provenance = Provenance {
+        source_sensor: first.provenance.source_sensor.clone(),
+        created_at: first.provenance.created_at.clone(),
+        originating_agent_id: first.provenance.originating_agent_id.clone(),
+        // Summary has no raw source bytes — zeroed SHA256 sentinel mirrors
+        // the all-zeros pattern used for the placeholder signature below.
+        source_hash: format!("sha256:{}", "0".repeat(64)),
+        consent_ref: "consent:pending".to_owned(),
+        llm_id_if_any: None,
+    };
+    let scope = ScopeTuple {
+        session_id: Some(session_id.as_str().to_owned()),
+        ..ScopeTuple::default()
+    };
+    let target_id = TargetId::parse(id.as_str())
+        .unwrap_or_else(|_| unreachable!("summary_record_id always yields a valid ULID"));
+    // Placeholder signature: all-zeros hex, matching
+    // `capture_trace::placeholder_signature`. A later signing stage
+    // replaces this before the store accepts the record.
+    let signature = Ed25519Signature::parse(format!("ed25519:{}", "0".repeat(128)))
+        .unwrap_or_else(|_| unreachable!("128 '0' chars always satisfies Ed25519Signature::parse"));
+    Ok(MemoryRecord {
+        id,
+        target_id,
+        kind: MemoryKind::Trace,
+        class: MemoryClass::Episodic,
+        visibility: MemoryVisibility::Private,
+        scope,
+        body,
+        provenance,
+        updated_at: last.updated_at.clone(),
+        evidence: EvidenceVector::default(),
+        salience: 0.5,
+        confidence: 1.0,
+        actor_chain: first.actor_chain.clone(),
+        signature,
+        tags: Vec::new(),
+        extra_frontmatter: extra,
+    })
+}
+
+/// Validate that all events belong to `(session_id, turn_id)` with
+/// strictly increasing sequences, and collect the `capture_event_id` of
+/// each in order.
+fn validate_and_collect_members(
+    session_id: &SessionId,
+    turn_id: &str,
+    events: &[MemoryRecord],
+) -> Result<Vec<String>, TurnSummaryError> {
+    let mut last_seq: Option<u64> = None;
+    let mut member_ids: Vec<String> = Vec::with_capacity(events.len());
+    for r in events {
+        let trace = r
+            .extra_frontmatter
+            .get("trace")
+            .and_then(Json::as_object)
+            .ok_or(TurnSummaryError::MissingTrace("(root)"))?;
+        let s = trace
+            .get("session_id")
+            .and_then(Json::as_str)
+            .ok_or(TurnSummaryError::MissingTrace("session_id"))?;
+        let t = trace
+            .get("turn_id")
+            .and_then(Json::as_str)
+            .ok_or(TurnSummaryError::MissingTrace("turn_id"))?;
+        if s != session_id.as_str() || t != turn_id {
+            return Err(TurnSummaryError::CrossTurn);
+        }
+        let seq = trace
+            .get("sequence")
+            .and_then(Json::as_u64)
+            .ok_or(TurnSummaryError::MissingTrace("sequence"))?;
+        if last_seq.is_some_and(|prev| seq <= prev) {
+            return Err(TurnSummaryError::OutOfOrderSequences);
+        }
+        last_seq = Some(seq);
+        let cap_id = trace
+            .get("capture_event_id")
+            .and_then(Json::as_str)
+            .ok_or(TurnSummaryError::MissingTrace("capture_event_id"))?;
+        member_ids.push(cap_id.to_owned());
+    }
+    Ok(member_ids)
+}
+
+/// Build the deterministic body: header + one line per event, capped at
+/// [`TRACE_BODY_CAP`]. Same truncation logic as `capture_trace::truncate`.
+fn build_summary_body(
+    session_id: &SessionId,
+    turn_id: &str,
+    events: &[MemoryRecord],
+) -> Result<String, TurnSummaryError> {
+    let mut body = format!("## Turn {} (session {})\n", turn_id, session_id.as_str());
+    for r in events {
+        let trace = r
+            .extra_frontmatter
+            .get("trace")
+            .and_then(Json::as_object)
+            .ok_or(TurnSummaryError::MissingTrace("(root)"))?;
+        let seq = trace.get("sequence").and_then(Json::as_u64).unwrap_or(0);
+        let evt = r
+            .extra_frontmatter
+            .get("trace_event")
+            .and_then(Json::as_str)
+            .unwrap_or("");
+        let excerpt: String = r.body.chars().take(80).collect();
+        // writeln! on String is infallible (String's fmt::Write never errors).
+        let _ = writeln!(body, "- [seq {seq}] {evt}: {excerpt}");
+        if body.len() >= TRACE_BODY_CAP {
+            let mut end = TRACE_BODY_CAP;
+            while !body.is_char_boundary(end) {
+                end -= 1;
+            }
+            body.truncate(end);
+            break;
+        }
+    }
+    Ok(body)
+}
+
+/// Build the `extra_frontmatter` map for a turn-summary record.
+fn build_summary_frontmatter(
+    session_id: &SessionId,
+    turn_id: &str,
+    id: &crate::domain::record::RecordId,
+    member_ids: Vec<String>,
+) -> BTreeMap<String, Json> {
+    let mut trace_obj = JsonMap::new();
+    trace_obj.insert(
+        "session_id".into(),
+        Json::String(session_id.as_str().to_owned()),
+    );
+    trace_obj.insert("turn_id".into(), Json::String(turn_id.to_owned()));
+    // sequence = 0: summaries are out-of-band from the monotonic event
+    // sequence. The unique-seq SQLite index excludes summary records, so
+    // 0 is the designated sentinel and easy to filter on.
+    trace_obj.insert("sequence".into(), Json::Number(0_u64.into()));
+    // capture_event_id for the summary equals its own deterministic record
+    // id — synthetic, no underlying CaptureEvent.
+    trace_obj.insert(
+        "capture_event_id".into(),
+        Json::String(id.as_str().to_owned()),
+    );
+    trace_obj.insert(
+        "member_event_ids".into(),
+        Json::Array(member_ids.into_iter().map(Json::String).collect()),
+    );
+    let mut extra: BTreeMap<String, Json> = BTreeMap::new();
+    extra.insert(
+        "trace_event".into(),
+        Json::String("turn_summary".to_owned()),
+    );
+    extra.insert("trace".into(), Json::Object(trace_obj));
+    extra
 }
 
 #[cfg(test)]
@@ -180,5 +391,188 @@ mod tests {
             ordered[1].event.event_id.as_str(),
             "01ARZ3NDEKTSV4RRFFQ69G5FAA"
         );
+    }
+
+    // ── summarize_turn tests ──────────────────────────────────────────────
+
+    /// Build a minimal trace `MemoryRecord` by calling
+    /// `capture_trace::project` with synthesized inputs. Uses
+    /// `UserMessage` for all events; adjust `hook_name` / `classified`
+    /// if variant-specific tests are needed.
+    #[allow(
+        clippy::expect_used,
+        reason = "test helper: bad inputs mean the test data itself is broken"
+    )]
+    fn mk_trace_record(
+        session_id_str: &str,
+        turn_id: &str,
+        sequence: u64,
+        capture_event_id_str: &str,
+        trace_event: &str,
+        body_text: &str,
+    ) -> MemoryRecord {
+        use crate::domain::trace::{TraceEvent as TE, TraceLink};
+        use crate::pipeline::capture_trace::project;
+        use crate::pipeline::extract::body;
+
+        // Map trace_event string to a hook name and classified variant.
+        let hook_name = match trace_event {
+            "stop" => "Stop",
+            "pre_tool" => "PreToolUse",
+            "post_tool" => "PostToolUse",
+            // user_message, agent_message, and unknown — use UserPromptSubmit
+            _ => "UserPromptSubmit",
+        };
+        let classified = match trace_event {
+            "stop" => TE::Stop,
+            _ => TE::UserMessage,
+        };
+
+        let ts = Rfc3339Timestamp::parse("2026-05-02T00:00:00Z")
+            .expect("invariant: fixed timestamp");
+        let event = CaptureEvent {
+            event_id: CaptureEventId::parse(capture_event_id_str)
+                .expect("invariant: test capture_event_id must be valid ULID"),
+            sensor_id: Identity::parse("snr:local:hook:cc-session:v1")
+                .expect("invariant: fixed sensor identity"),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: Identity::parse("snr:local:hook:cc-session:v1")
+                    .expect("invariant: fixed sensor identity"),
+                at: ts.clone(),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some(session_id_str.into()),
+                turn_id: Some(turn_id.into()),
+                tool_id: None,
+            }),
+            payload_hash: PayloadHash::parse(
+                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+            .expect("invariant: well-formed sha256 hash"),
+            payload_ref: format!("sources/hook/{capture_event_id_str}.txt"),
+            captured_at: ts,
+            payload: CapturePayload::Hook {
+                hook_name: hook_name.into(),
+                tool_name: None,
+            },
+            source_family: SourceFamily::Hook,
+        };
+
+        let sess = SessionId::parse(session_id_str).expect("invariant: valid session_id ULID");
+        let cap_id = CaptureEventId::parse(capture_event_id_str)
+            .expect("invariant: valid capture_event_id ULID");
+        let link = TraceLink {
+            session_id: sess,
+            turn_id: turn_id.to_owned(),
+            sequence,
+            capture_event_id: cap_id,
+            parent_event_id: None,
+            tool_call_id: None,
+            member_event_ids: Vec::new(),
+        };
+
+        let resolved = body::for_test(body_text);
+        project(&event, classified, &resolved, &link)
+            .expect("invariant: test inputs must produce a valid trace record")
+    }
+
+    #[test]
+    fn summarize_orders_and_collects_member_ids() {
+        let s = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+        let events = vec![
+            mk_trace_record(
+                "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                "turn-1",
+                0,
+                "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+                "user_message",
+                "hi",
+            ),
+            mk_trace_record(
+                "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                "turn-1",
+                1,
+                "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+                "agent_message",
+                "hello",
+            ),
+        ];
+        let summary = summarize_turn(&s, "turn-1", &events).unwrap();
+        assert_eq!(summary.kind, MemoryKind::Trace);
+        assert_eq!(
+            summary.extra_frontmatter.get("trace_event").unwrap(),
+            "turn_summary"
+        );
+        let trace = summary.extra_frontmatter.get("trace").unwrap();
+        let members = trace["member_event_ids"].as_array().unwrap();
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0], "01ARZ3NDEKTSV4RRFFQ69G5FAA");
+        assert_eq!(members[1], "01ARZ3NDEKTSV4RRFFQ69G5FAB");
+        assert_eq!(summary.id, summary_record_id(&s, "turn-1"));
+    }
+
+    #[test]
+    fn summarize_rejects_empty() {
+        let s = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+        assert_eq!(
+            summarize_turn(&s, "turn-1", &[]).unwrap_err(),
+            TurnSummaryError::EmptyTurn
+        );
+    }
+
+    #[test]
+    fn summarize_rejects_cross_turn() {
+        let s = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+        let events = vec![
+            mk_trace_record(
+                "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                "turn-1",
+                0,
+                "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+                "user_message",
+                "a",
+            ),
+            mk_trace_record(
+                "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                "turn-2",
+                0,
+                "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+                "user_message",
+                "b",
+            ),
+        ];
+        assert!(matches!(
+            summarize_turn(&s, "turn-1", &events).unwrap_err(),
+            TurnSummaryError::CrossTurn
+        ));
+    }
+
+    #[test]
+    fn summarize_rejects_out_of_order_sequence() {
+        let s = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+        let events = vec![
+            mk_trace_record(
+                "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                "turn-1",
+                1,
+                "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+                "user_message",
+                "a",
+            ),
+            mk_trace_record(
+                "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                "turn-1",
+                0,
+                "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+                "agent_message",
+                "b",
+            ),
+        ];
+        assert!(matches!(
+            summarize_turn(&s, "turn-1", &events).unwrap_err(),
+            TurnSummaryError::OutOfOrderSequences
+        ));
     }
 }

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -90,14 +90,14 @@
         "command": "retrieve",
         "flags": [
           { "name": "session_id", "long": "session", "value_source": "string" },
-          { "name": "turn_id",    "long": "turn",    "value_source": "u64" },
+          { "name": "turn_id",    "long": "turn",    "value_source": "string" },
           { "name": "include",    "long": "include", "value_source": "list<enum(tool_calls,reasoning)>" }
         ]
       },
       "properties": {
         "target":     { "const": "turn" },
         "session_id": { "type": "string", "minLength": 1 },
-        "turn_id":    { "type": "integer", "minimum": 0 },
+        "turn_id":    { "type": "string", "minLength": 1 },
         "include": {
           "type": "array",
           "minItems": 1,
@@ -234,8 +234,12 @@
       "required": ["session_id", "turn_id", "turn"],
       "properties": {
         "session_id": { "type": "string", "minLength": 1 },
-        "turn_id":    { "type": "integer", "minimum": 0 },
-        "turn":       { "$ref": "#/$defs/TurnItem" }
+        "turn_id":    { "type": "string", "minLength": 1 },
+        "turn": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TurnItem" },
+          "description": "Ordered TurnItems for the turn — one per trace event (user/agent message, pre/post tool, tool output, stop, summary). Sorted by (captured_at, capture_event_id)."
+        }
       }
     },
     "DataFolder": {
@@ -269,7 +273,7 @@
       "additionalProperties": false,
       "required": ["turn_id", "role"],
       "properties": {
-        "turn_id": { "type": "integer", "minimum": 0 },
+        "turn_id": { "type": "string", "minLength": 1 },
         "role":    { "type": "string", "enum": ["user", "assistant", "tool", "system"] },
         "content": { "type": "string" },
         "tool_calls": { "type": "array", "items": { "type": "object" } },

--- a/crates/cairn-idl/tests/snapshots/codegen_snapshot__snapshot_skill_md.snap
+++ b/crates/cairn-idl/tests/snapshots/codegen_snapshot__snapshot_skill_md.snap
@@ -148,11 +148,11 @@ cairn retrieve --session SESSION_ID --cursor CURSOR
 ```
 
 ```bash
-cairn retrieve --session SESSION_ID --turn 0
+cairn retrieve --session SESSION_ID --turn TURN_ID
 ```
 
 ```bash
-cairn retrieve --session SESSION_ID --turn 0 --include tool_calls
+cairn retrieve --session SESSION_ID --turn TURN_ID --include tool_calls
 ```
 
 ```bash

--- a/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.input.json
@@ -284,8 +284,8 @@
           "const": "turn"
         },
         "turn_id": {
-          "minimum": 0,
-          "type": "integer"
+          "minLength": 1,
+          "type": "string"
         }
       },
       "required": [
@@ -306,7 +306,7 @@
           {
             "long": "turn",
             "name": "turn_id",
-            "value_source": "u64"
+            "value_source": "string"
           },
           {
             "long": "include",
@@ -480,11 +480,15 @@
           "type": "string"
         },
         "turn": {
-          "$ref": "#/$defs/TurnItem"
+          "description": "Ordered TurnItems for the turn — one per trace event (user/agent message, pre/post tool, tool output, stop, summary). Sorted by (captured_at, capture_event_id).",
+          "items": {
+            "$ref": "#/$defs/TurnItem"
+          },
+          "type": "array"
         },
         "turn_id": {
-          "minimum": 0,
-          "type": "integer"
+          "minLength": 1,
+          "type": "string"
         }
       },
       "required": [
@@ -539,8 +543,8 @@
           "type": "array"
         },
         "turn_id": {
-          "minimum": 0,
-          "type": "integer"
+          "minLength": 1,
+          "type": "string"
         }
       },
       "required": [

--- a/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.json
@@ -284,8 +284,8 @@
           "const": "turn"
         },
         "turn_id": {
-          "minimum": 0,
-          "type": "integer"
+          "minLength": 1,
+          "type": "string"
         }
       },
       "required": [
@@ -306,7 +306,7 @@
           {
             "long": "turn",
             "name": "turn_id",
-            "value_source": "u64"
+            "value_source": "string"
           },
           {
             "long": "include",
@@ -480,11 +480,15 @@
           "type": "string"
         },
         "turn": {
-          "$ref": "#/$defs/TurnItem"
+          "description": "Ordered TurnItems for the turn — one per trace event (user/agent message, pre/post tool, tool output, stop, summary). Sorted by (captured_at, capture_event_id).",
+          "items": {
+            "$ref": "#/$defs/TurnItem"
+          },
+          "type": "array"
         },
         "turn_id": {
-          "minimum": 0,
-          "type": "integer"
+          "minLength": 1,
+          "type": "string"
         }
       },
       "required": [
@@ -539,8 +543,8 @@
           "type": "array"
         },
         "turn_id": {
-          "minimum": 0,
-          "type": "integer"
+          "minLength": 1,
+          "type": "string"
         }
       },
       "required": [

--- a/crates/cairn-store-sqlite/Cargo.toml
+++ b/crates/cairn-store-sqlite/Cargo.toml
@@ -39,6 +39,7 @@ test-helpers = []
 
 [dev-dependencies]
 cairn-core = { workspace = true, features = ["test-fixtures", "test-helpers"] }
+cairn-cli = { path = "../cairn-cli" }
 cairn-store-sqlite = { path = ".", features = ["test-helpers"] }
 cairn-test-fixtures = { workspace = true }
 proptest = { workspace = true }

--- a/crates/cairn-store-sqlite/src/error.rs
+++ b/crates/cairn-store-sqlite/src/error.rs
@@ -155,6 +155,20 @@ pub enum StoreError {
         sequence: u64,
     },
 
+    /// A `post_tool` or `tool_output` record has a `parent_event_id` that
+    /// either doesn't resolve to a `pre_tool` in the same turn or has a
+    /// mismatched `tool_call_id`.
+    #[error("trace link orphan: child={child_id} parent={parent_id}: {reason}")]
+    TraceLinkOrphan {
+        /// The `capture_event_id` of the child record with the broken link.
+        child_id: String,
+        /// The `parent_event_id` referenced by the child (may be empty string
+        /// if the field was missing entirely).
+        parent_id: String,
+        /// Human-readable description of the violated invariant.
+        reason: String,
+    },
+
     /// Two distinct record ids share the same `trace.capture_event_id`.
     /// This should not happen under the documented projector contract
     /// (Task 6 derives `record_id` deterministically from

--- a/crates/cairn-store-sqlite/src/error.rs
+++ b/crates/cairn-store-sqlite/src/error.rs
@@ -140,6 +140,31 @@ pub enum StoreError {
         /// The trait-method name that was invoked.
         method: &'static str,
     },
+
+    /// Two distinct events tried to land at the same trace `sequence`.
+    /// The `records_trace_seq` unique index enforces `(session_id,
+    /// turn_id, sequence)` uniqueness; this variant surfaces when two
+    /// different `capture_event_id`s collide on the same slot.
+    #[error("trace sequence conflict at session={session_id} turn={turn_id} seq={sequence}")]
+    TraceSequenceConflict {
+        /// The session id of the conflicting trace record.
+        session_id: String,
+        /// The turn id of the conflicting trace record.
+        turn_id: String,
+        /// The sequence number that was already claimed.
+        sequence: u64,
+    },
+
+    /// Two distinct record ids share the same `trace.capture_event_id`.
+    /// This should not happen under the documented projector contract
+    /// (Task 6 derives `record_id` deterministically from
+    /// `capture_event_id`), so this variant indicates a projector
+    /// contract violation.
+    #[error("trace capture_event_id collision: {capture_event_id}")]
+    TraceCaptureEventIdConflict {
+        /// The `capture_event_id` shared by two distinct record ids.
+        capture_event_id: String,
+    },
 }
 
 // Note: the plan specifies an explicit

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -37,6 +37,9 @@ const M0021_CONSENT_KIND_NOT_NULL: &str = include_str!("sql/0021_consent_kind_no
 // branch-local 0020 will recognise the renamed row by its sql_hash on
 // the next open and stamp the new name.
 const M0022_RECORD_VECTORS: &str = include_str!("sql/0022_record_vectors.sql");
+// Renumbered 0022 → 0023 on rebase since main shipped 0022_record_vectors
+// first. SQL body unchanged.
+const M0023_TRACE_LINKS: &str = include_str!("sql/0023_trace_links.sql");
 const M0030_RECORDS_FTS_WEIGHTED: &str = include_str!("sql/0030_records_fts_weighted.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
@@ -104,6 +107,7 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
         M0021_CONSENT_KIND_NOT_NULL,
     ),
     (22, "0022_record_vectors", M0022_RECORD_VECTORS),
+    (23, "0023_trace_links", M0023_TRACE_LINKS),
     (30, "0030_records_fts_weighted", M0030_RECORDS_FTS_WEIGHTED),
 ];
 
@@ -134,6 +138,7 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0020_WORKFLOW_JOBS),
         M::up(M0021_CONSENT_KIND_NOT_NULL),
         M::up(M0022_RECORD_VECTORS),
+        M::up(M0023_TRACE_LINKS),
         M::up(M0030_RECORDS_FTS_WEIGHTED),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/sql/0023_trace_links.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0023_trace_links.sql
@@ -1,0 +1,43 @@
+-- 0023_trace_links — generated columns + unique indices for trace records
+-- (issue #77, spec §6.1).
+
+ALTER TABLE records ADD COLUMN trace_event TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace_event')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_session_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.session_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_turn_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.turn_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_sequence INTEGER
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.sequence')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_capture_event_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.capture_event_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_parent_event_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.parent_event_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_payload_hash TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.payload_hash')) VIRTUAL;
+
+-- Idempotency: same CaptureEvent may not produce two rows.
+CREATE UNIQUE INDEX records_trace_event_id
+  ON records(trace_capture_event_id)
+  WHERE trace_capture_event_id IS NOT NULL;
+
+-- Exactly one summary per (session_id, turn_id).
+CREATE UNIQUE INDEX records_trace_summary
+  ON records(trace_session_id, trace_turn_id)
+  WHERE trace_event = 'turn_summary';
+
+-- Sequence monotonicity within a turn (excluding summary rows).
+CREATE UNIQUE INDEX records_trace_seq
+  ON records(trace_session_id, trace_turn_id, trace_sequence)
+  WHERE trace_event IS NOT NULL AND trace_event != 'turn_summary';
+
+CREATE INDEX records_trace_parent
+  ON records(trace_parent_event_id)
+  WHERE trace_parent_event_id IS NOT NULL;
+
+CREATE INDEX records_trace_payload_hash
+  ON records(trace_payload_hash)
+  WHERE trace_payload_hash IS NOT NULL;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (23, '0023_trace_links', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -98,9 +98,9 @@ impl StoreTx<'_> {
     /// Read every non-tombstoned, non-summary trace record for a turn,
     /// ordered by `trace_sequence` ASC.
     ///
-    /// Uses the canonical [`record_from_json`] decoder from
-    /// [`crate::store::projection`], so the hydration path is identical
-    /// to all other read paths in this adapter.
+    /// Uses the canonical `record_from_json` decoder from the projection
+    /// module, so the hydration path is identical to all other read
+    /// paths in this adapter.
     ///
     /// Rows with `trace_event = 'turn_summary'` are excluded — they are
     /// aggregated records, not individual events. Tombstoned rows are

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -22,7 +22,7 @@
 
 use cairn_core::contract::memory_store::{Edge, EdgeKey, TombstoneReason, UpsertOutcome};
 use cairn_core::domain::{MemoryRecord, RecordId, SessionId};
-use rusqlite::{Transaction, params};
+use rusqlite::{OptionalExtension as _, Transaction, params};
 use tracing::instrument;
 
 use crate::error::StoreError;
@@ -135,6 +135,96 @@ impl StoreTx<'_> {
             record_from_json(&json)
         })
         .collect()
+    }
+
+    /// Returns `true` iff a non-tombstoned `turn_summary` row exists for
+    /// the given session + turn.
+    ///
+    /// Used by the `capture_trace` pipeline to decide whether a summary
+    /// has already been written for a turn before attempting to insert a
+    /// new one (brief §8.1).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Sqlite`] for SQL failures.
+    pub fn turn_summary_exists(
+        &self,
+        session_id: &SessionId,
+        turn_id: &str,
+    ) -> Result<bool, StoreError> {
+        let mut stmt = self.tx.prepare(
+            "SELECT 1 FROM records \
+              WHERE trace_event = 'turn_summary' \
+                AND trace_session_id = ?1 \
+                AND trace_turn_id = ?2 \
+                AND tombstoned = 0 \
+              LIMIT 1",
+        )?;
+        let exists = stmt
+            .query_row(params![session_id.as_str(), turn_id], |_| Ok(()))
+            .optional()?
+            .is_some();
+        Ok(exists)
+    }
+
+    /// Count non-tombstoned trace records whose `trace_payload_hash`
+    /// matches `payload_hash` AND whose scope `(tenant, user, agent)`
+    /// matches the given dimensions, excluding the listed `record_id`s.
+    ///
+    /// `NULL` matches `NULL` for each scope dimension via
+    /// `coalesce(json_extract(scope, '$.X'), '') = coalesce(?N, '')`.
+    ///
+    /// Used by the dedup gate in `capture_trace` to determine whether an
+    /// identical payload already exists in the same scope before inserting
+    /// a new trace record (brief §8.1).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Sqlite`] for SQL failures.
+    pub fn payload_hash_count_in_scope(
+        &self,
+        payload_hash: &str,
+        tenant: Option<&str>,
+        user: Option<&str>,
+        agent: Option<&str>,
+        exclude: &[&str],
+    ) -> Result<u64, StoreError> {
+        let where_exclude = if exclude.is_empty() {
+            String::new()
+        } else {
+            let placeholders = (0..exclude.len())
+                .map(|i| format!("?{}", i + 5)) // first 4 params: hash + 3 scopes
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(" AND record_id NOT IN ({placeholders})")
+        };
+        let sql = format!(
+            "SELECT COUNT(*) FROM records \
+              WHERE trace_payload_hash = ?1 \
+                AND coalesce(json_extract(scope, '$.tenant'), '') = coalesce(?2, '') \
+                AND coalesce(json_extract(scope, '$.user'),   '') = coalesce(?3, '') \
+                AND coalesce(json_extract(scope, '$.agent'),  '') = coalesce(?4, '') \
+                AND tombstoned = 0{where_exclude}"
+        );
+        let mut params: Vec<rusqlite::types::Value> = vec![
+            rusqlite::types::Value::Text(payload_hash.to_owned()),
+            tenant.map_or(rusqlite::types::Value::Null, |s| {
+                rusqlite::types::Value::Text(s.to_owned())
+            }),
+            user.map_or(rusqlite::types::Value::Null, |s| {
+                rusqlite::types::Value::Text(s.to_owned())
+            }),
+            agent.map_or(rusqlite::types::Value::Null, |s| {
+                rusqlite::types::Value::Text(s.to_owned())
+            }),
+        ];
+        for id in exclude {
+            params.push(rusqlite::types::Value::Text((*id).to_owned()));
+        }
+        let mut stmt = self.tx.prepare(&sql)?;
+        let n: i64 =
+            stmt.query_row(rusqlite::params_from_iter(params), |row| row.get(0))?;
+        Ok(u64::try_from(n).unwrap_or(0))
     }
 
     /// Synchronous edge removal. Returns `true` if a row was deleted,

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -352,6 +352,50 @@ impl StoreTx<'_> {
     ///   happen under the documented projector contract).
     /// - Any other [`StoreError`] from the underlying upsert path.
     pub fn upsert_trace(&mut self, record: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
+        // `turn_summary` records use a deterministic `record_id` derived from
+        // `(session_id, turn_id)`.  The `records_trace_summary` UNIQUE index
+        // covers all rows (active *and* inactive) whose `trace_event` is
+        // `'turn_summary'`, so the standard `upsert_in_tx` flow
+        // (deactivate-old + insert-new) would leave an inactive summary row
+        // in the index and cause a UNIQUE constraint violation on the next
+        // re-summarize.  We avoid this by doing an in-place JSON UPDATE on
+        // the existing active summary row instead of the deactivate+insert
+        // pattern.
+        let is_summary = record
+            .extra_frontmatter
+            .get("trace_event")
+            .and_then(|v| v.as_str())
+            == Some("turn_summary");
+
+        if is_summary {
+            let new_json = serde_json::to_string(record).map_err(|e| {
+                StoreError::Invariant {
+                    what: format!("serialize summary record: {e}"),
+                }
+            })?;
+            let target_id = record.target_id.as_str();
+            let n = self.tx.execute(
+                "UPDATE records SET record_json = ?1 \
+                  WHERE target_id = ?2 AND active = 1",
+                rusqlite::params![new_json, target_id],
+            )?;
+            if n == 0 {
+                // No existing row: fall through to standard insert.
+                return match upsert_in_tx(&mut self.tx, record) {
+                    Ok(out) => Ok(out),
+                    Err(other) => Err(other),
+                };
+            }
+            // Updated in place: return an outcome consistent with UpsertOutcome.
+            return Ok(UpsertOutcome {
+                record_id: record.id.clone(),
+                target_id: record.target_id.clone(),
+                version: 1, // version is not bumped on in-place updates
+                content_changed: true,
+                prior_hash: None,
+            });
+        }
+
         match upsert_in_tx(&mut self.tx, record) {
             Ok(out) => Ok(out),
             // `records_trace_seq` index columns: trace_session_id,
@@ -436,14 +480,28 @@ impl StoreTx<'_> {
         // Existing rows are updated in-place (same direct SQL UPDATE pattern).
         // Incoming rows are brand-new records — `upsert_in_tx` inserts them
         // directly with the final sequence.
+        //
+        // Deduplication: if an incoming record carries the same `record_id`
+        // as an existing row (i.e., a replay of an already-persisted event),
+        // it is excluded from `all`.  The existing row already covers it and
+        // will be updated to its final sequence in the loop below.  Including
+        // the duplicate would inflate the total count, assign wrong sequences
+        // (0..2N instead of 0..N), and hit the UNIQUE index on
+        // `(session_id, turn_id, sequence)` on the second write to the same
+        // record_id.
+        let existing_ids: std::collections::HashSet<&str> =
+            existing.iter().map(|r| r.id.as_str()).collect();
+
         let mut all: Vec<MemoryRecord> =
             Vec::with_capacity(existing.len() + incoming.len());
         all.extend(existing.iter().cloned());
-        all.extend(incoming.iter().cloned());
+        all.extend(
+            incoming
+                .iter()
+                .filter(|r| !existing_ids.contains(r.id.as_str()))
+                .cloned(),
+        );
         all.sort_by(compare_by_captured_at_and_event_id);
-
-        let existing_ids: std::collections::HashSet<&str> =
-            existing.iter().map(|r| r.id.as_str()).collect();
 
         for (i, row) in all.iter().enumerate() {
             let final_seq = i64::try_from(i).unwrap_or(i64::MAX);

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -137,6 +137,111 @@ impl StoreTx<'_> {
         .collect()
     }
 
+    /// Verify referential invariants among trace records for a turn (spec
+    /// §4 "Referential"). Call after writing all events for the turn,
+    /// before committing.
+    ///
+    /// Reads all non-tombstoned, non-summary trace records for the turn via
+    /// [`Self::list_trace_events`], then checks that every `post_tool` and
+    /// `tool_output` record:
+    ///
+    /// 1. Has a non-empty `parent_event_id`.
+    /// 2. References a parent that exists in the same turn.
+    /// 3. The parent's `trace_event` is `pre_tool`.
+    /// 4. The parent's `tool_call_id` matches the child's `tool_call_id`.
+    ///
+    /// # Errors
+    ///
+    /// - [`StoreError::TraceLinkOrphan`] if a `post_tool`/`tool_output`
+    ///   parent is missing, cross-turn, the wrong event type, or has a
+    ///   mismatched `tool_call_id`.
+    /// - Other [`StoreError`] from the underlying read.
+    pub fn validate_turn_links(
+        &self,
+        session_id: &SessionId,
+        turn_id: &str,
+    ) -> Result<(), StoreError> {
+        use std::collections::HashMap;
+
+        let rows = self.list_trace_events(session_id, turn_id)?;
+
+        // Index by capture_event_id for O(1) parent lookup.
+        // Value: (trace_event, tool_call_id).
+        let by_id: HashMap<String, (&str, Option<&str>)> = rows
+            .iter()
+            .filter_map(|r| {
+                let trace = r.extra_frontmatter.get("trace")?.as_object()?;
+                let id = trace.get("capture_event_id")?.as_str()?.to_owned();
+                let evt = r.extra_frontmatter.get("trace_event")?.as_str()?;
+                let tcid = trace.get("tool_call_id").and_then(|v| v.as_str());
+                Some((id, (evt, tcid)))
+            })
+            .collect();
+
+        for r in &rows {
+            let trace = r
+                .extra_frontmatter
+                .get("trace")
+                .and_then(|v| v.as_object())
+                .ok_or_else(|| StoreError::Invariant {
+                    what: "trace record missing extra_frontmatter.trace".into(),
+                })?;
+            let event = r
+                .extra_frontmatter
+                .get("trace_event")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if !matches!(event, "post_tool" | "tool_output") {
+                continue;
+            }
+
+            let child_id = trace
+                .get("capture_event_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let child_tcid = trace
+                .get("tool_call_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let parent_id = trace
+                .get("parent_event_id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| StoreError::TraceLinkOrphan {
+                    child_id: child_id.to_owned(),
+                    parent_id: String::new(),
+                    reason: "missing parent_event_id".into(),
+                })?;
+
+            let Some((parent_evt, parent_tcid)) = by_id.get(parent_id) else {
+                return Err(StoreError::TraceLinkOrphan {
+                    child_id: child_id.to_owned(),
+                    parent_id: parent_id.to_owned(),
+                    reason: "parent not found in turn".into(),
+                });
+            };
+            if *parent_evt != "pre_tool" {
+                return Err(StoreError::TraceLinkOrphan {
+                    child_id: child_id.to_owned(),
+                    parent_id: parent_id.to_owned(),
+                    reason: format!(
+                        "parent has trace_event={parent_evt}, expected pre_tool"
+                    ),
+                });
+            }
+            let parent_tcid = parent_tcid.unwrap_or("");
+            if child_tcid != parent_tcid {
+                return Err(StoreError::TraceLinkOrphan {
+                    child_id: child_id.to_owned(),
+                    parent_id: parent_id.to_owned(),
+                    reason: format!(
+                        "tool_call_id mismatch: child={child_tcid}, parent={parent_tcid}"
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// Returns `true` iff a non-tombstoned `turn_summary` row exists for
     /// the given session + turn.
     ///

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -21,12 +21,12 @@
 //! [`MemoryStore`]: cairn_core::contract::memory_store::MemoryStore
 
 use cairn_core::contract::memory_store::{Edge, EdgeKey, TombstoneReason, UpsertOutcome};
-use cairn_core::domain::{MemoryRecord, RecordId, SessionId};
+use cairn_core::domain::{BodyHash, MemoryRecord, RecordId, SessionId};
 use rusqlite::{OptionalExtension as _, Transaction, params};
 use tracing::instrument;
 
 use crate::error::StoreError;
-use crate::store::projection::record_from_json;
+use crate::store::projection::{ProjectedRow, record_from_json};
 use crate::store::upsert::upsert_in_tx;
 use crate::store::{SqliteMemoryStore, current_unix_ms};
 
@@ -364,29 +364,97 @@ impl StoreTx<'_> {
             == Some("turn_summary");
 
         if is_summary {
-            let new_json = serde_json::to_string(record).map_err(|e| StoreError::Invariant {
-                what: format!("serialize summary record: {e}"),
-            })?;
+            // Re-summarize must keep `record_json` and the denormalized
+            // columns (body, body_hash, scope, kind/class/visibility,
+            // confidence, salience, tags, updated_at) in lock-step. The
+            // standard `upsert_in_tx` deactivate+insert path can't be used
+            // here: `records_trace_summary` is a UNIQUE index over
+            // `(trace_session_id, trace_turn_id) WHERE trace_event =
+            // 'turn_summary'` covering both active and inactive rows, so an
+            // inactive prior summary would collide with the new insert.
+            // Build a `ProjectedRow` and update every column from it.
+            let body_hash = BodyHash::compute(&record.body);
+            let now_ms = current_unix_ms();
             let target_id = record.target_id.as_str();
-            let n = self.tx.execute(
-                "UPDATE records SET record_json = ?1 \
-                  WHERE target_id = ?2 AND active = 1",
-                rusqlite::params![new_json, target_id],
+
+            // Look up the existing active row to preserve its created_at
+            // and version (in-place rewrite, not a new version row).
+            let prior: Option<(String, i64, i64)> = self
+                .tx
+                .query_row(
+                    "SELECT record_id, version, created_at FROM records \
+                       WHERE target_id = ?1 AND active = 1 LIMIT 1",
+                    params![target_id],
+                    |r| {
+                        Ok((
+                            r.get::<_, String>(0)?,
+                            r.get::<_, i64>(1)?,
+                            r.get::<_, i64>(2)?,
+                        ))
+                    },
+                )
+                .optional()?;
+
+            let Some((prior_id, prior_version, created_at)) = prior else {
+                // No existing row: standard insert path is fine — there's no
+                // inactive summary row to collide with the partial UNIQUE.
+                return upsert_in_tx(&mut self.tx, record);
+            };
+
+            let version_u32 = u32::try_from(prior_version).map_err(|_| StoreError::Invariant {
+                what: format!("prior summary version overflows u32: {prior_version}"),
+            })?;
+            let row = ProjectedRow::from_record(
+                record,
+                version_u32,
+                created_at,
+                now_ms,
+                &body_hash,
+                true,
+                false,
             )?;
-            if n == 0 {
-                // No existing row: fall through to standard insert.
-                return match upsert_in_tx(&mut self.tx, record) {
-                    Ok(out) => Ok(out),
-                    Err(other) => Err(other),
-                };
-            }
-            // Updated in place: return an outcome consistent with UpsertOutcome.
+
+            let n = self.tx.execute(
+                "UPDATE records SET \
+                    record_json = ?1, \
+                    body = ?2, \
+                    body_hash = ?3, \
+                    updated_at = ?4, \
+                    scope = ?5, \
+                    actor_chain = ?6, \
+                    kind = ?7, \
+                    class = ?8, \
+                    visibility = ?9, \
+                    confidence = ?10, \
+                    salience = ?11, \
+                    tags_json = ?12, \
+                    path = ?13 \
+                  WHERE record_id = ?14",
+                params![
+                    row.record_json,
+                    row.body,
+                    row.body_hash,
+                    row.updated_at,
+                    row.scope,
+                    row.actor_chain,
+                    row.kind,
+                    row.class,
+                    row.visibility,
+                    row.confidence,
+                    row.salience,
+                    row.tags_json,
+                    row.path,
+                    prior_id,
+                ],
+            )?;
+            debug_assert_eq!(n, 1, "summary in-place UPDATE matched 0 rows");
+
             return Ok(UpsertOutcome {
                 record_id: record.id.clone(),
                 target_id: record.target_id.clone(),
-                version: 1, // version is not bumped on in-place updates
+                version: version_u32,
                 content_changed: true,
-                prior_hash: None,
+                prior_hash: Some(body_hash),
             });
         }
 

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -116,6 +116,12 @@ impl StoreTx<'_> {
         session_id: &SessionId,
         turn_id: &str,
     ) -> Result<Vec<MemoryRecord>, StoreError> {
+        // `active = 1` excludes superseded version rows; without it,
+        // any future re-upsert of the same target_id would let
+        // turn-reconstruction read both the live and the superseded
+        // copies (defence-in-depth — the trace_capture_event_id UNIQUE
+        // index makes this hard to trigger today, but the read should
+        // not depend on that).
         let mut stmt = self.tx.prepare(
             "SELECT record_json \
                FROM records \
@@ -123,6 +129,7 @@ impl StoreTx<'_> {
                 AND trace_turn_id = ?2 \
                 AND trace_event IS NOT NULL \
                 AND trace_event != 'turn_summary' \
+                AND active = 1 \
                 AND tombstoned = 0 \
               ORDER BY trace_sequence ASC",
         )?;

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -126,10 +126,9 @@ impl StoreTx<'_> {
                 AND tombstoned = 0 \
               ORDER BY trace_sequence ASC",
         )?;
-        let rows = stmt.query_map(
-            params![session_id.as_str(), turn_id],
-            |row| row.get::<_, String>(0),
-        )?;
+        let rows = stmt.query_map(params![session_id.as_str(), turn_id], |row| {
+            row.get::<_, String>(0)
+        })?;
         rows.map(|r| {
             let json = r?;
             record_from_json(&json)
@@ -223,9 +222,7 @@ impl StoreTx<'_> {
                 return Err(StoreError::TraceLinkOrphan {
                     child_id: child_id.to_owned(),
                     parent_id: parent_id.to_owned(),
-                    reason: format!(
-                        "parent has trace_event={parent_evt}, expected pre_tool"
-                    ),
+                    reason: format!("parent has trace_event={parent_evt}, expected pre_tool"),
                 });
             }
             let parent_tcid = parent_tcid.unwrap_or("");
@@ -327,8 +324,7 @@ impl StoreTx<'_> {
             params.push(rusqlite::types::Value::Text((*id).to_owned()));
         }
         let mut stmt = self.tx.prepare(&sql)?;
-        let n: i64 =
-            stmt.query_row(rusqlite::params_from_iter(params), |row| row.get(0))?;
+        let n: i64 = stmt.query_row(rusqlite::params_from_iter(params), |row| row.get(0))?;
         Ok(u64::try_from(n).unwrap_or(0))
     }
 
@@ -368,10 +364,8 @@ impl StoreTx<'_> {
             == Some("turn_summary");
 
         if is_summary {
-            let new_json = serde_json::to_string(record).map_err(|e| {
-                StoreError::Invariant {
-                    what: format!("serialize summary record: {e}"),
-                }
+            let new_json = serde_json::to_string(record).map_err(|e| StoreError::Invariant {
+                what: format!("serialize summary record: {e}"),
             })?;
             let target_id = record.target_id.as_str();
             let n = self.tx.execute(
@@ -402,9 +396,7 @@ impl StoreTx<'_> {
             // trace_turn_id, trace_sequence.  SQLite error message:
             // "UNIQUE constraint failed: records.trace_session_id,
             //  records.trace_turn_id, records.trace_sequence"
-            Err(StoreError::Sqlite(ref e))
-                if is_unique_constraint(e, "records.trace_sequence") =>
-            {
+            Err(StoreError::Sqlite(ref e)) if is_unique_constraint(e, "records.trace_sequence") => {
                 Err(extract_seq_conflict(record))
             }
             // `records_trace_event_id` index column: trace_capture_event_id.
@@ -467,9 +459,7 @@ impl StoreTx<'_> {
             )?;
             if n == 0 {
                 return Err(StoreError::Invariant {
-                    what: format!(
-                        "renumber park: no active row found for record_id `{record_id}`"
-                    ),
+                    what: format!("renumber park: no active row found for record_id `{record_id}`"),
                 });
             }
         }
@@ -492,8 +482,7 @@ impl StoreTx<'_> {
         let existing_ids: std::collections::HashSet<&str> =
             existing.iter().map(|r| r.id.as_str()).collect();
 
-        let mut all: Vec<MemoryRecord> =
-            Vec::with_capacity(existing.len() + incoming.len());
+        let mut all: Vec<MemoryRecord> = Vec::with_capacity(existing.len() + incoming.len());
         all.extend(existing.iter().cloned());
         all.extend(
             incoming
@@ -567,10 +556,7 @@ fn with_sequence(row: &MemoryRecord, sequence: i64) -> Result<MemoryRecord, Stor
 /// Uses [`cairn_core::domain::Rfc3339Timestamp::cmp_chronological`] for the
 /// timestamp comparison, which accounts for timezone offsets correctly — lexical
 /// `as_str()` comparison is wrong once offsets are involved.
-fn compare_by_captured_at_and_event_id(
-    a: &MemoryRecord,
-    b: &MemoryRecord,
-) -> std::cmp::Ordering {
+fn compare_by_captured_at_and_event_id(a: &MemoryRecord, b: &MemoryRecord) -> std::cmp::Ordering {
     let cap_id = |r: &MemoryRecord| -> String {
         r.extra_frontmatter
             .get("trace")
@@ -605,10 +591,7 @@ fn is_unique_constraint(e: &rusqlite::Error, column_signature: &str) -> bool {
 /// and return a [`StoreError::TraceSequenceConflict`]. Falls back to empty
 /// strings / 0 if the keys are absent (caller-side bug; still typed).
 fn extract_seq_conflict(r: &MemoryRecord) -> StoreError {
-    let trace = r
-        .extra_frontmatter
-        .get("trace")
-        .and_then(|v| v.as_object());
+    let trace = r.extra_frontmatter.get("trace").and_then(|v| v.as_object());
     let session_id = trace
         .and_then(|t| t.get("session_id"))
         .and_then(|v| v.as_str())

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -21,11 +21,12 @@
 //! [`MemoryStore`]: cairn_core::contract::memory_store::MemoryStore
 
 use cairn_core::contract::memory_store::{Edge, EdgeKey, TombstoneReason, UpsertOutcome};
-use cairn_core::domain::{MemoryRecord, RecordId};
+use cairn_core::domain::{MemoryRecord, RecordId, SessionId};
 use rusqlite::{Transaction, params};
 use tracing::instrument;
 
 use crate::error::StoreError;
+use crate::store::projection::record_from_json;
 use crate::store::upsert::upsert_in_tx;
 use crate::store::{SqliteMemoryStore, current_unix_ms};
 
@@ -92,6 +93,48 @@ impl StoreTx<'_> {
             ],
         )?;
         Ok(())
+    }
+
+    /// Read every non-tombstoned, non-summary trace record for a turn,
+    /// ordered by `trace_sequence` ASC.
+    ///
+    /// Uses the canonical [`record_from_json`] decoder from
+    /// [`crate::store::projection`], so the hydration path is identical
+    /// to all other read paths in this adapter.
+    ///
+    /// Rows with `trace_event = 'turn_summary'` are excluded — they are
+    /// aggregated records, not individual events. Tombstoned rows are
+    /// excluded via `tombstoned = 0`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Sqlite`] for SQL failures or
+    /// [`StoreError::Codec`] if a stored `record_json` cannot be
+    /// deserialized.
+    pub fn list_trace_events(
+        &self,
+        session_id: &SessionId,
+        turn_id: &str,
+    ) -> Result<Vec<MemoryRecord>, StoreError> {
+        let mut stmt = self.tx.prepare(
+            "SELECT record_json \
+               FROM records \
+              WHERE trace_session_id = ?1 \
+                AND trace_turn_id = ?2 \
+                AND trace_event IS NOT NULL \
+                AND trace_event != 'turn_summary' \
+                AND tombstoned = 0 \
+              ORDER BY trace_sequence ASC",
+        )?;
+        let rows = stmt.query_map(
+            params![session_id.as_str(), turn_id],
+            |row| row.get::<_, String>(0),
+        )?;
+        rows.map(|r| {
+            let json = r?;
+            record_from_json(&json)
+        })
+        .collect()
     }
 
     /// Synchronous edge removal. Returns `true` if a row was deleted,

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -227,6 +227,51 @@ impl StoreTx<'_> {
         Ok(u64::try_from(n).unwrap_or(0))
     }
 
+    /// Idempotent trace-record upsert. Replays of the same
+    /// `capture_event_id` converge on the same `record_id` (the
+    /// projector derives one from the other, Task 6) and become no-op
+    /// upserts via the primary-key idempotency in `upsert_in_tx`.
+    ///
+    /// Unique-constraint violations on the `records_trace_seq` and
+    /// `records_trace_event_id` indices are translated to typed errors
+    /// so callers can distinguish a sequence collision (two different
+    /// events competing for the same turn slot) from an
+    /// `capture_event_id` collision (projector contract violation).
+    ///
+    /// # Errors
+    ///
+    /// - [`StoreError::TraceSequenceConflict`] if two distinct events
+    ///   tried to claim the same `(session_id, turn_id, sequence)`.
+    /// - [`StoreError::TraceCaptureEventIdConflict`] if two distinct
+    ///   record ids carry the same `trace.capture_event_id` (should not
+    ///   happen under the documented projector contract).
+    /// - Any other [`StoreError`] from the underlying upsert path.
+    pub fn upsert_trace(&mut self, record: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
+        match upsert_in_tx(&mut self.tx, record) {
+            Ok(out) => Ok(out),
+            // `records_trace_seq` index columns: trace_session_id,
+            // trace_turn_id, trace_sequence.  SQLite error message:
+            // "UNIQUE constraint failed: records.trace_session_id,
+            //  records.trace_turn_id, records.trace_sequence"
+            Err(StoreError::Sqlite(ref e))
+                if is_unique_constraint(e, "records.trace_sequence") =>
+            {
+                Err(extract_seq_conflict(record))
+            }
+            // `records_trace_event_id` index column: trace_capture_event_id.
+            // SQLite error message:
+            // "UNIQUE constraint failed: records.trace_capture_event_id"
+            Err(StoreError::Sqlite(ref e))
+                if is_unique_constraint(e, "records.trace_capture_event_id") =>
+            {
+                Err(StoreError::TraceCaptureEventIdConflict {
+                    capture_event_id: extract_capture_event_id(record),
+                })
+            }
+            Err(other) => Err(other),
+        }
+    }
+
     /// Synchronous edge removal. Returns `true` if a row was deleted,
     /// `false` if no row matched the key.
     ///
@@ -240,6 +285,63 @@ impl StoreTx<'_> {
         )?;
         Ok(n > 0)
     }
+}
+
+/// Returns `true` when `e` is a `UNIQUE` constraint failure whose error
+/// message contains `column_signature`. `SQLite` formats the message as
+/// `"UNIQUE constraint failed: TABLE.COL, …"` using the indexed
+/// column names, not the index name, so we match on the column signature
+/// (`column_signature`) that uniquely identifies each index.
+///
+/// | Index                    | Column signature                  |
+/// |---|---|
+/// | `records_trace_seq`      | `"records.trace_sequence"`        |
+/// | `records_trace_event_id` | `"records.trace_capture_event_id"` |
+fn is_unique_constraint(e: &rusqlite::Error, column_signature: &str) -> bool {
+    matches!(
+        e,
+        rusqlite::Error::SqliteFailure(_, Some(msg)) if msg.contains(column_signature)
+    )
+}
+
+/// Extract `(session_id, turn_id, sequence)` from `extra_frontmatter["trace"]`
+/// and return a [`StoreError::TraceSequenceConflict`]. Falls back to empty
+/// strings / 0 if the keys are absent (caller-side bug; still typed).
+fn extract_seq_conflict(r: &MemoryRecord) -> StoreError {
+    let trace = r
+        .extra_frontmatter
+        .get("trace")
+        .and_then(|v| v.as_object());
+    let session_id = trace
+        .and_then(|t| t.get("session_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_owned();
+    let turn_id = trace
+        .and_then(|t| t.get("turn_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_owned();
+    let sequence = trace
+        .and_then(|t| t.get("sequence"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    StoreError::TraceSequenceConflict {
+        session_id,
+        turn_id,
+        sequence,
+    }
+}
+
+/// Extract `trace.capture_event_id` from `extra_frontmatter`. Falls back
+/// to an empty string if absent.
+fn extract_capture_event_id(r: &MemoryRecord) -> String {
+    r.extra_frontmatter
+        .get("trace")
+        .and_then(|v| v.get("capture_event_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_owned()
 }
 
 impl SqliteMemoryStore {

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -272,6 +272,95 @@ impl StoreTx<'_> {
         }
     }
 
+    /// Two-phase renumber of a turn's trace events when out-of-order
+    /// backfill arrives (spec §4 "Ordering").
+    ///
+    /// Phase 1: park existing rows on unique negative sentinels so the
+    ///          `UNIQUE` sequence index never sees a transient collision.
+    /// Phase 2: reassign `0..N` sorted by `(captured_at, capture_event_id)`
+    ///          across the union of existing and incoming records.
+    ///
+    /// All writes happen inside `self.tx`. A crash mid-renumber rolls
+    /// back to pre-renumber state.
+    ///
+    /// `incoming` records have their `extra_frontmatter.trace.sequence`
+    /// overridden by this call; caller-supplied sequence values are
+    /// ignored.
+    ///
+    /// # Errors
+    ///
+    /// Any [`StoreError`] from the underlying upserts, or
+    /// [`StoreError::Invariant`] if a record is missing the expected
+    /// `extra_frontmatter.trace` object.
+    pub fn renumber_turn_with(
+        &mut self,
+        session_id: &SessionId,
+        turn_id: &str,
+        incoming: &[MemoryRecord],
+    ) -> Result<(), StoreError> {
+        let existing = self.list_trace_events(session_id, turn_id)?;
+
+        // Phase 1: park each existing row at a distinct negative sentinel by
+        // directly patching `record_json` in the DB. Direct SQL UPDATE (rather
+        // than `upsert_in_tx`) is required because `upsert_in_tx` creates a new
+        // version row and leaves an inactive row still holding the old sequence
+        // value; since `records_trace_seq` covers ALL rows (not just active),
+        // that inactive row would hold onto the slot and block Phase 2.
+        for (i, row) in existing.iter().enumerate() {
+            let park_seq = -(i64::try_from(i).unwrap_or(i64::MAX) + 1);
+            let record_id = row.id.as_str();
+            let n = self.tx.execute(
+                "UPDATE records \
+                    SET record_json = json_set(record_json, \
+                        '$.extra_frontmatter.trace.sequence', ?1) \
+                  WHERE record_id = ?2 AND active = 1",
+                params![park_seq, record_id],
+            )?;
+            if n == 0 {
+                return Err(StoreError::Invariant {
+                    what: format!(
+                        "renumber park: no active row found for record_id `{record_id}`"
+                    ),
+                });
+            }
+        }
+
+        // Phase 2: union existing + incoming and sort by (captured_at,
+        // capture_event_id), then assign monotonic 0..N sequences.
+        //
+        // Existing rows are updated in-place (same direct SQL UPDATE pattern).
+        // Incoming rows are brand-new records — `upsert_in_tx` inserts them
+        // directly with the final sequence.
+        let mut all: Vec<MemoryRecord> =
+            Vec::with_capacity(existing.len() + incoming.len());
+        all.extend(existing.iter().cloned());
+        all.extend(incoming.iter().cloned());
+        all.sort_by(compare_by_captured_at_and_event_id);
+
+        let existing_ids: std::collections::HashSet<&str> =
+            existing.iter().map(|r| r.id.as_str()).collect();
+
+        for (i, row) in all.iter().enumerate() {
+            let final_seq = i64::try_from(i).unwrap_or(i64::MAX);
+            if existing_ids.contains(row.id.as_str()) {
+                // Existing row: update in-place.
+                let record_id = row.id.as_str();
+                self.tx.execute(
+                    "UPDATE records \
+                        SET record_json = json_set(record_json, \
+                            '$.extra_frontmatter.trace.sequence', ?1) \
+                      WHERE record_id = ?2 AND active = 1",
+                    params![final_seq, record_id],
+                )?;
+            } else {
+                // Incoming new record: set its final sequence and insert.
+                let final_row = with_sequence(row, final_seq)?;
+                upsert_in_tx(&mut self.tx, &final_row)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Synchronous edge removal. Returns `true` if a row was deleted,
     /// `false` if no row matched the key.
     ///
@@ -285,6 +374,51 @@ impl StoreTx<'_> {
         )?;
         Ok(n > 0)
     }
+}
+
+/// Clone `row` with `extra_frontmatter.trace.sequence` set to `sequence`.
+///
+/// Returns [`StoreError::Invariant`] if the record lacks the expected
+/// `extra_frontmatter.trace` object (structural invariant of a trace record).
+fn with_sequence(row: &MemoryRecord, sequence: i64) -> Result<MemoryRecord, StoreError> {
+    let mut next = row.clone();
+    let trace = next
+        .extra_frontmatter
+        .get_mut("trace")
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| StoreError::Invariant {
+            what: "trace record missing extra_frontmatter.trace".into(),
+        })?;
+    trace.insert(
+        "sequence".into(),
+        serde_json::Value::Number(sequence.into()),
+    );
+    Ok(next)
+}
+
+/// Comparator for the two-phase renumber sort: primary key is chronological
+/// order of `updated_at` (which mirrors `captured_at` from the originating
+/// `CaptureEvent`); secondary key is `capture_event_id` for deterministic
+/// tie-breaking.
+///
+/// Uses [`cairn_core::domain::Rfc3339Timestamp::cmp_chronological`] for the
+/// timestamp comparison, which accounts for timezone offsets correctly — lexical
+/// `as_str()` comparison is wrong once offsets are involved.
+fn compare_by_captured_at_and_event_id(
+    a: &MemoryRecord,
+    b: &MemoryRecord,
+) -> std::cmp::Ordering {
+    let cap_id = |r: &MemoryRecord| -> String {
+        r.extra_frontmatter
+            .get("trace")
+            .and_then(|t| t.get("capture_event_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_owned()
+    };
+    a.updated_at
+        .cmp_chronological(&b.updated_at)
+        .then_with(|| cap_id(a).cmp(&cap_id(b)))
 }
 
 /// Returns `true` when `e` is a `UNIQUE` constraint failure whose error

--- a/crates/cairn-store-sqlite/src/verify.rs
+++ b/crates/cairn-store-sqlite/src/verify.rs
@@ -174,6 +174,13 @@ const EXPECTED_OBJECTS: &[(&str, &str)] = &[
     ("table", "pending_embeddings"),
     ("index", "pending_embeddings_enqueued_idx"),
     ("trigger", "records_vector_cleanup"),
+    // 0023_trace_links (issue #77, spec §6.1; renumbered from 0022 on
+    // rebase since main shipped 0022_record_vectors first).
+    ("index", "records_trace_event_id"),
+    ("index", "records_trace_summary"),
+    ("index", "records_trace_seq"),
+    ("index", "records_trace_parent"),
+    ("index", "records_trace_payload_hash"),
 ];
 
 fn hash_hex(content: &str) -> String {

--- a/crates/cairn-store-sqlite/tests/migration_smoke.rs
+++ b/crates/cairn-store-sqlite/tests/migration_smoke.rs
@@ -7,3 +7,59 @@ fn migration_0002_applies_cleanly() {
     let r = cairn_store_sqlite::SqliteIdentityRegistry::open_in_memory();
     assert!(r.is_ok(), "{:?}", r.err());
 }
+
+/// Verify that migration 0022 adds the expected generated columns and indices
+/// for trace records (issue #77, spec §6.1).
+#[test]
+fn migration_0022_trace_links_applies() {
+    let conn = cairn_store_sqlite::open_in_memory_sync()
+        .expect("open_in_memory_sync: migrations should apply cleanly");
+
+    // Verify generated columns exist on `records`. Use `table_xinfo` (extended)
+    // rather than `table_info` because SQLite omits generated/virtual columns
+    // from the non-extended PRAGMA output.
+    let mut stmt = conn
+        .prepare("PRAGMA table_xinfo(records)")
+        .expect("prepare PRAGMA table_xinfo");
+    let cols: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .expect("query_map table_xinfo")
+        .filter_map(Result::ok)
+        .collect();
+    for expected in [
+        "trace_event",
+        "trace_session_id",
+        "trace_turn_id",
+        "trace_sequence",
+        "trace_capture_event_id",
+        "trace_parent_event_id",
+        "trace_payload_hash",
+    ] {
+        assert!(
+            cols.contains(&expected.to_string()),
+            "missing column {expected}"
+        );
+    }
+
+    // Verify expected indices exist.
+    let mut idx = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='records'")
+        .expect("prepare sqlite_master index query");
+    let names: Vec<String> = idx
+        .query_map([], |r| r.get(0))
+        .expect("query_map index names")
+        .filter_map(Result::ok)
+        .collect();
+    for expected in [
+        "records_trace_event_id",
+        "records_trace_summary",
+        "records_trace_seq",
+        "records_trace_parent",
+        "records_trace_payload_hash",
+    ] {
+        assert!(
+            names.contains(&expected.to_string()),
+            "missing index {expected}"
+        );
+    }
+}

--- a/crates/cairn-store-sqlite/tests/trace_reconstruction_proptest.rs
+++ b/crates/cairn-store-sqlite/tests/trace_reconstruction_proptest.rs
@@ -1,0 +1,302 @@
+//! Property test: a single turn's trace events round-trip through the
+//! `capture_trace` verb path and come back ordered by
+//! `(captured_at, capture_event_id)`, with the summary's
+//! `member_event_ids` covering every persisted event in canonical order
+//! (issue #77, brief §5.6).
+//!
+//! Generation strategy
+//! -------------------
+//! For each case we synthesize 1..=8 events for a single
+//! `(session_id, turn_id)` pair:
+//!
+//! - Index 0 is always a `UserPromptSubmit` (the turn opener).
+//! - The last event is always a `Stop` so the verb path emits a summary.
+//! - Intermediate events are additional `UserPromptSubmit` hooks with
+//!   varied `captured_at` so we exercise non-trivial sort orders.
+//!
+//! Using only hooks that classify as parent-less trace events keeps the
+//! property focused on ordering + summary membership, without dragging the
+//! pre/post-tool linkage rules into the generator.
+
+use std::io::Write as _;
+use std::path::Path;
+
+use cairn_cli::verbs::capture_trace::run_handler;
+use cairn_core::contract::MemoryStore as _;
+use cairn_core::domain::{
+    ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs,
+    ChainRole, Identity, PayloadHash, Rfc3339Timestamp, SessionId, SourceFamily,
+    trace::summary_record_id,
+};
+use proptest::prelude::*;
+use sha2::{Digest as _, Sha256};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn sha256_hex(text: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(text.as_bytes());
+    format!("{:x}", h.finalize())
+}
+
+fn write_source(vault: &Path, filename: &str, content: &str) -> String {
+    let dir = vault.join("sources").join("hook");
+    std::fs::create_dir_all(&dir).expect("create sources/hook dir");
+    let abs = dir.join(filename);
+    std::fs::write(&abs, content).expect("write source file");
+    format!("sources/hook/{filename}")
+}
+
+/// Encode `index` (`0..16_777_216`) as a 26-char Crockford base32 ULID
+/// string. The high 80 bits are zero-padded; the low bits encode `index`.
+/// Crockford base32 alphabet (no `I`, `L`, `O`, `U`).
+fn ulid_for(index: u32) -> String {
+    const ALPHABET: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    let mut out = [b'0'; 26];
+    let mut n = u128::from(index);
+    let mut pos = 25_usize;
+    while n > 0 && pos < 26 {
+        let d = (n & 0x1F) as usize;
+        out[pos] = ALPHABET[d];
+        n >>= 5;
+        if pos == 0 {
+            break;
+        }
+        pos -= 1;
+    }
+    String::from_utf8(out.to_vec()).expect("invariant: ascii alphabet")
+}
+
+fn rfc3339_at(base_offset_secs: u32) -> String {
+    // 2026-05-02T00:00:00Z + offset seconds, capped well within a single day.
+    let total = u64::from(base_offset_secs);
+    let h = (total / 3600) % 24;
+    let m = (total / 60) % 60;
+    let s = total % 60;
+    format!("2026-05-02T{h:02}:{m:02}:{s:02}Z")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn make_event(
+    event_id: &str,
+    hook_name: &str,
+    session_id: &str,
+    turn_id: &str,
+    timestamp: &str,
+    payload_ref: &str,
+    payload_hash_hex: &str,
+) -> CaptureEvent {
+    let sensor =
+        Identity::parse("snr:local:hook:cc-session:v1").expect("invariant: valid sensor id");
+    let hash_str = format!("sha256:{payload_hash_hex}");
+    CaptureEvent {
+        event_id: CaptureEventId::parse(event_id).expect("invariant: valid ULID"),
+        sensor_id: sensor.clone(),
+        capture_mode: CaptureMode::Auto,
+        actor_chain: vec![ActorChainEntry {
+            role: ChainRole::Author,
+            identity: sensor,
+            at: Rfc3339Timestamp::parse(timestamp).expect("invariant: valid RFC-3339"),
+        }],
+        refs: Some(CaptureRefs {
+            session_id: Some(session_id.to_owned()),
+            turn_id: Some(turn_id.to_owned()),
+            tool_id: None,
+        }),
+        payload_hash: PayloadHash::parse(&hash_str).expect("invariant: valid sha256 hash"),
+        payload_ref: payload_ref.to_owned(),
+        captured_at: Rfc3339Timestamp::parse(timestamp).expect("invariant: valid RFC-3339"),
+        payload: CapturePayload::Hook {
+            hook_name: hook_name.to_owned(),
+            tool_name: None,
+        },
+        source_family: SourceFamily::Hook,
+    }
+}
+
+/// Build a vector of `(event_id, captured_at)` pairs for a turn of `n`
+/// events. Index 0 is a `UserPromptSubmit`, last is a `Stop`, intermediate
+/// rows are additional `UserPromptSubmit`s.
+struct GeneratedEvent {
+    event_id: String,
+    hook_name: &'static str,
+    captured_at: String,
+}
+
+fn build_events(n: usize, offsets: &[u32], seed: u32) -> Vec<GeneratedEvent> {
+    debug_assert_eq!(n, offsets.len(), "offsets length must match n");
+    (0..n)
+        .map(|i| {
+            // ULIDs use a high-byte derived from seed so different cases get
+            // distinct ids; low-byte tracks index. `i` is bounded by 8.
+            let id_index = (u32::try_from(i).unwrap_or(0)).wrapping_add(seed.wrapping_mul(1024));
+            GeneratedEvent {
+                event_id: ulid_for(id_index),
+                hook_name: if i + 1 == n {
+                    "Stop"
+                } else {
+                    "UserPromptSubmit"
+                },
+                captured_at: rfc3339_at(offsets[i]),
+            }
+        })
+        .collect()
+}
+
+fn write_jsonl(
+    vault: &Path,
+    jsonl_path: &Path,
+    session: &str,
+    turn: &str,
+    events: &[GeneratedEvent],
+) {
+    let mut f = std::fs::File::create(jsonl_path).expect("create JSONL file");
+    for ev in events {
+        let body = format!("body:{}:{}", ev.event_id, ev.captured_at);
+        let payload_ref = write_source(vault, &format!("{}.txt", ev.event_id), &body);
+        let hash = sha256_hex(&body);
+        let event = make_event(
+            &ev.event_id,
+            ev.hook_name,
+            session,
+            turn,
+            &ev.captured_at,
+            &payload_ref,
+            &hash,
+        );
+        let line = serde_json::to_string(&event).expect("serialize event");
+        writeln!(f, "{line}").expect("write JSONL line");
+    }
+}
+
+/// Canonical ordering rule: `(captured_at, capture_event_id)`, both lexical
+/// on RFC-3339 strings (matches `Rfc3339Timestamp::cmp_chronological` for
+/// our generator since every timestamp uses the same `Z` offset and same
+/// fixed-width `HH:MM:SS` form).
+fn canonical_order(events: &[GeneratedEvent]) -> Vec<&GeneratedEvent> {
+    let mut v: Vec<&GeneratedEvent> = events.iter().collect();
+    v.sort_by(|a, b| {
+        a.captured_at
+            .cmp(&b.captured_at)
+            .then_with(|| a.event_id.cmp(&b.event_id))
+    });
+    v
+}
+
+// ── property ──────────────────────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        .. ProptestConfig::default()
+    })]
+    #[test]
+    fn turn_round_trip_reconstructs_canonical_order(
+        n in 1_usize..=8,
+        seed in 0_u32..1024,
+        // We over-generate offsets and truncate to `n` inside the body —
+        // proptest can't easily make a vector whose length is a previously
+        // generated value. Range chosen wide enough to allow ties.
+        offsets_raw in proptest::collection::vec(0_u32..3600, 8),
+    ) {
+        let mut offsets = offsets_raw.clone();
+        offsets.truncate(n);
+        // n==1: lone event must be a Stop (no UserPromptSubmit before it,
+        // but the turn-summary path requires the closer). Skip n==1 cases
+        // that would have only a Stop with no opener — actually a single
+        // Stop is acceptable to the verb (it summarizes the lone event).
+        let events = build_events(n, &offsets, seed);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
+
+        rt.block_on(async {
+            let vault = tempfile::tempdir().expect("tempdir");
+            let store = cairn_store_sqlite::open_in_memory()
+                .await
+                .expect("open in-memory store");
+            let jsonl_path = vault.path().join("trace.jsonl");
+
+            let session = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+            let turn = "turn-prop";
+
+            write_jsonl(vault.path(), &jsonl_path, session, turn, &events);
+
+            let resp = run_handler(&store, vault.path(), &jsonl_path)
+                .await
+                .expect("run_handler should succeed");
+            prop_assert!(
+                resp.failed_turns.is_empty(),
+                "expected no failures, got: {:?}",
+                resp.failed_turns
+            );
+
+            // Read back all non-summary events and verify the order matches
+            // the canonical sort of the generated events.
+            let session_id = SessionId::parse(session).expect("valid session_id");
+            let expected_order: Vec<String> = canonical_order(&events)
+                .iter()
+                .map(|e| e.event_id.clone())
+                .collect();
+
+            let observed_order: Vec<String> = store
+                .with_tx({
+                    let session_id = session_id.clone();
+                    let turn = turn.to_owned();
+                    move |tx| {
+                        let rows = tx.list_trace_events(&session_id, &turn)?;
+                        let ids: Vec<String> = rows
+                            .iter()
+                            .map(|r| {
+                                r.extra_frontmatter["trace"]["capture_event_id"]
+                                    .as_str()
+                                    .expect("trace.capture_event_id is a string")
+                                    .to_owned()
+                            })
+                            .collect();
+                        Ok(ids)
+                    }
+                })
+                .await
+                .expect("with_tx read should succeed");
+
+            prop_assert_eq!(
+                observed_order.clone(),
+                expected_order.clone(),
+                "trace events must be persisted in canonical (captured_at, capture_event_id) order"
+            );
+
+            // The turn always ends with Stop, so a summary must exist with
+            // member_event_ids equal to the canonical order of all event ids.
+            let summary_id = summary_record_id(&session_id, turn);
+            let summary = store
+                .get(&summary_id)
+                .await
+                .expect("get summary record")
+                .expect("summary record must exist after Stop");
+            let members = summary
+                .extra_frontmatter
+                .get("trace")
+                .and_then(|t| t.get("member_event_ids"))
+                .and_then(|m| m.as_array())
+                .expect("summary must carry trace.member_event_ids array")
+                .iter()
+                .map(|v| {
+                    v.as_str()
+                        .expect("member_event_ids entries are strings")
+                        .to_owned()
+                })
+                .collect::<Vec<String>>();
+
+            prop_assert_eq!(
+                members,
+                expected_order,
+                "summary.member_event_ids must equal the canonical order of all turn events"
+            );
+
+            Ok(())
+        })?;
+    }
+}

--- a/crates/cairn-store-sqlite/tests/trace_store.rs
+++ b/crates/cairn-store-sqlite/tests/trace_store.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeMap;
 use cairn_core::contract::memory_store::TombstoneReason;
 use cairn_core::domain::{MemoryRecord, RecordId, SessionId, TargetId};
 use cairn_core::domain::record::tests_export::sample_record;
+use cairn_store_sqlite::error::StoreError;
 use cairn_store_sqlite::open_in_memory;
 use serde_json::{Map as JsonMap, Value as Json};
 
@@ -313,4 +314,102 @@ async fn payload_hash_count_in_scope_basic() {
         })
         .await
         .expect("with_tx");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn upsert_trace_is_idempotent_on_capture_event_id() {
+    let store = open_in_memory().await.expect("open store");
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    let event_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    let record = mk_trace_record(&session_id, "turn-1", 0, event_id);
+
+    store
+        .with_tx({
+            let r = record.clone();
+            move |tx| {
+                tx.upsert_trace(&r)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    store
+        .with_tx({
+            let r = record.clone();
+            move |tx| {
+                tx.upsert_trace(&r)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    store
+        .with_tx(move |tx| {
+            let rows = tx.list_trace_events(&session_id, "turn-1")?;
+            assert_eq!(
+                rows.len(),
+                1,
+                "duplicate capture_event_id must not produce two rows"
+            );
+            Ok(())
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn upsert_trace_rejects_duplicate_sequence() {
+    let store = open_in_memory().await.expect("open store");
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    let r1 = mk_trace_record(&session_id, "turn-1", 0, "01ARZ3NDEKTSV4RRFFQ69G5FAA");
+    let r2 = mk_trace_record(&session_id, "turn-1", 0, "01ARZ3NDEKTSV4RRFFQ69G5FAB");
+
+    let result = store
+        .with_tx({
+            let r1 = r1.clone();
+            let r2 = r2.clone();
+            move |tx| {
+                tx.upsert_trace(&r1)?;
+                tx.upsert_trace(&r2)?;
+                Ok(())
+            }
+        })
+        .await;
+    let err = result.expect_err("duplicate sequence should error");
+    assert!(
+        matches!(err, StoreError::TraceSequenceConflict { .. }),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn upsert_trace_allows_same_sequence_after_first_record_replayed() {
+    // Replaying r1 then upserting it again should still succeed (idempotent).
+    let store = open_in_memory().await.expect("open store");
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    let r1 = mk_trace_record(&session_id, "turn-1", 0, "01ARZ3NDEKTSV4RRFFQ69G5FAA");
+    store
+        .with_tx({
+            let r = r1.clone();
+            move |tx| {
+                tx.upsert_trace(&r)?;
+                tx.upsert_trace(&r)?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
 }

--- a/crates/cairn-store-sqlite/tests/trace_store.rs
+++ b/crates/cairn-store-sqlite/tests/trace_store.rs
@@ -124,6 +124,34 @@ fn mk_summary_record(session_id: &SessionId, turn_id: &str, member_event_ids: &[
     r
 }
 
+/// Like [`mk_trace_record`] but also sets `updated_at` on the record to
+/// `captured_at`, mirroring the projector contract where `updated_at` is
+/// derived from the originating `CaptureEvent`'s timestamp.
+///
+/// Used by renumber tests that need precise chronological ordering.
+#[allow(
+    clippy::expect_used,
+    reason = "fixture helpers: panic on invalid input is intentional"
+)]
+fn mk_trace_record_at(
+    session_id: &SessionId,
+    turn_id: &str,
+    sequence: u64,
+    capture_event_id: &str,
+    captured_at: &str,
+) -> MemoryRecord {
+    use cairn_core::domain::Rfc3339Timestamp;
+    let mut r = mk_trace_record(session_id, turn_id, sequence, capture_event_id);
+    r.updated_at = Rfc3339Timestamp::parse(captured_at)
+        .expect("test: captured_at must be a valid RFC3339 timestamp");
+    r
+}
+
+/// Convenience alias used by tests that need an in-memory store.
+async fn test_store_in_memory() -> cairn_store_sqlite::SqliteMemoryStore {
+    open_in_memory().await.expect("open in-memory store")
+}
+
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -412,4 +440,86 @@ async fn upsert_trace_allows_same_sequence_after_first_record_replayed() {
         })
         .await
         .unwrap();
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn out_of_order_backfill_renumbers() {
+    let store = test_store_in_memory().await;
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+
+    // Construct three records: a (t=2), b (t=3), c (t=1).
+    let a = mk_trace_record_at(
+        &session_id,
+        "turn-1",
+        999,
+        "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+        "2026-05-02T00:00:02Z",
+    );
+    let b = mk_trace_record_at(
+        &session_id,
+        "turn-1",
+        999,
+        "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+        "2026-05-02T00:00:03Z",
+    );
+    let c = mk_trace_record_at(
+        &session_id,
+        "turn-1",
+        999,
+        "01ARZ3NDEKTSV4RRFFQ69G5FAC",
+        "2026-05-02T00:00:01Z",
+    );
+
+    store
+        .with_tx({
+            let a = a.clone();
+            let b = b.clone();
+            let c = c.clone();
+            let session_id = session_id.clone();
+            move |tx| {
+                // First two events arrive in order and are renumbered.
+                tx.renumber_turn_with(&session_id, "turn-1", &[a, b])?;
+                // Late arrival of c (earliest captured_at) triggers a full renumber.
+                tx.renumber_turn_with(&session_id, "turn-1", &[c])?;
+
+                let rows = tx.list_trace_events(&session_id, "turn-1")?;
+
+                // Final order must be c (t=1), a (t=2), b (t=3).
+                let order: Vec<&str> = rows
+                    .iter()
+                    .map(|r| {
+                        r.extra_frontmatter["trace"]["capture_event_id"]
+                            .as_str()
+                            .expect("capture_event_id present")
+                    })
+                    .collect();
+                assert_eq!(
+                    order,
+                    vec![
+                        "01ARZ3NDEKTSV4RRFFQ69G5FAC", // captured_at = t1
+                        "01ARZ3NDEKTSV4RRFFQ69G5FAA", // captured_at = t2
+                        "01ARZ3NDEKTSV4RRFFQ69G5FAB", // captured_at = t3
+                    ],
+                    "rows must be ordered by captured_at after renumber"
+                );
+
+                let seqs: Vec<u64> = rows
+                    .iter()
+                    .map(|r| {
+                        r.extra_frontmatter["trace"]["sequence"]
+                            .as_u64()
+                            .expect("sequence present")
+                    })
+                    .collect();
+                assert_eq!(seqs, vec![0, 1, 2], "sequences must be 0..N after renumber");
+
+                Ok(())
+            }
+        })
+        .await
+        .expect("with_tx");
 }

--- a/crates/cairn-store-sqlite/tests/trace_store.rs
+++ b/crates/cairn-store-sqlite/tests/trace_store.rs
@@ -6,8 +6,8 @@
 use std::collections::BTreeMap;
 
 use cairn_core::contract::memory_store::TombstoneReason;
-use cairn_core::domain::{MemoryRecord, RecordId, SessionId, TargetId};
 use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::{MemoryRecord, RecordId, SessionId, TargetId};
 use cairn_store_sqlite::error::StoreError;
 use cairn_store_sqlite::open_in_memory;
 use serde_json::{Map as JsonMap, Value as Json};
@@ -28,7 +28,12 @@ use serde_json::{Map as JsonMap, Value as Json};
     clippy::expect_used,
     reason = "fixture helpers: panic on invalid input is intentional"
 )]
-fn mk_trace_record(session_id: &SessionId, turn_id: &str, sequence: u64, capture_event_id: &str) -> MemoryRecord {
+fn mk_trace_record(
+    session_id: &SessionId,
+    turn_id: &str,
+    sequence: u64,
+    capture_event_id: &str,
+) -> MemoryRecord {
     let mut r = sample_record();
     // Use the capture_event_id as both record_id and target_id so every
     // inserted row has a distinct identity.
@@ -37,20 +42,32 @@ fn mk_trace_record(session_id: &SessionId, turn_id: &str, sequence: u64, capture
 
     // Build the trace linkage object.
     let mut trace_obj = JsonMap::new();
-    trace_obj.insert("session_id".into(), Json::String(session_id.as_str().to_owned()));
+    trace_obj.insert(
+        "session_id".into(),
+        Json::String(session_id.as_str().to_owned()),
+    );
     trace_obj.insert("turn_id".into(), Json::String(turn_id.to_owned()));
     trace_obj.insert("sequence".into(), Json::Number(sequence.into()));
-    trace_obj.insert("capture_event_id".into(), Json::String(capture_event_id.to_owned()));
+    trace_obj.insert(
+        "capture_event_id".into(),
+        Json::String(capture_event_id.to_owned()),
+    );
     trace_obj.insert(
         "payload_hash".into(),
         Json::String(
             "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         ),
     );
-    trace_obj.insert("payload_ref".into(), Json::String(format!("sources/hook/{capture_event_id}.txt")));
+    trace_obj.insert(
+        "payload_ref".into(),
+        Json::String(format!("sources/hook/{capture_event_id}.txt")),
+    );
 
     let mut extra: BTreeMap<String, Json> = BTreeMap::new();
-    extra.insert("trace_event".into(), Json::String("user_message".to_owned()));
+    extra.insert(
+        "trace_event".into(),
+        Json::String("user_message".to_owned()),
+    );
     extra.insert("trace".into(), Json::Object(trace_obj));
     r.extra_frontmatter = extra;
 
@@ -89,7 +106,11 @@ fn mk_trace_record_with_hash(
     clippy::expect_used,
     reason = "fixture helpers: panic on invalid input is intentional"
 )]
-fn mk_summary_record(session_id: &SessionId, turn_id: &str, member_event_ids: &[&str]) -> MemoryRecord {
+fn mk_summary_record(
+    session_id: &SessionId,
+    turn_id: &str,
+    member_event_ids: &[&str],
+) -> MemoryRecord {
     // Derive the deterministic summary id exactly as the real pipeline does.
     let summary_id = cairn_core::domain::trace::summary_record_id(session_id, turn_id);
     let summary_id_str = summary_id.as_str().to_owned();
@@ -99,10 +120,16 @@ fn mk_summary_record(session_id: &SessionId, turn_id: &str, member_event_ids: &[
     r.target_id = TargetId::parse(summary_id_str.clone()).expect("test: summary_id is valid ULID");
 
     let mut trace_obj = JsonMap::new();
-    trace_obj.insert("session_id".into(), Json::String(session_id.as_str().to_owned()));
+    trace_obj.insert(
+        "session_id".into(),
+        Json::String(session_id.as_str().to_owned()),
+    );
     trace_obj.insert("turn_id".into(), Json::String(turn_id.to_owned()));
     // Summary rows have no sequence; sequence column will be NULL.
-    trace_obj.insert("capture_event_id".into(), Json::String(summary_id_str.clone()));
+    trace_obj.insert(
+        "capture_event_id".into(),
+        Json::String(summary_id_str.clone()),
+    );
     let members: Vec<Json> = member_event_ids
         .iter()
         .map(|s| Json::String((*s).to_owned()))
@@ -114,10 +141,16 @@ fn mk_summary_record(session_id: &SessionId, turn_id: &str, member_event_ids: &[
             "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
         ),
     );
-    trace_obj.insert("payload_ref".into(), Json::String(format!("sources/hook/{summary_id_str}.txt")));
+    trace_obj.insert(
+        "payload_ref".into(),
+        Json::String(format!("sources/hook/{summary_id_str}.txt")),
+    );
 
     let mut extra: BTreeMap<String, Json> = BTreeMap::new();
-    extra.insert("trace_event".into(), Json::String("turn_summary".to_owned()));
+    extra.insert(
+        "trace_event".into(),
+        Json::String("turn_summary".to_owned()),
+    );
     extra.insert("trace".into(), Json::Object(trace_obj));
     r.extra_frontmatter = extra;
 
@@ -210,7 +243,12 @@ async fn list_trace_events_orders_by_sequence() {
                 ("01ARZ3NDEKTSV4RRFFQ69G5FAB", 0),
                 ("01ARZ3NDEKTSV4RRFFQ69G5FAC", 1),
             ] {
-                tx.upsert(&mk_trace_record(&session_id, "turn-1", seq, capture_event_id))?;
+                tx.upsert(&mk_trace_record(
+                    &session_id,
+                    "turn-1",
+                    seq,
+                    capture_event_id,
+                ))?;
             }
             let rows = tx.list_trace_events(&session_id, "turn-1")?;
             let seqs: Vec<u64> = rows
@@ -221,7 +259,11 @@ async fn list_trace_events_orders_by_sequence() {
                         .expect("sequence present")
                 })
                 .collect();
-            assert_eq!(seqs, vec![0, 1, 2], "records must be ordered by trace_sequence ASC");
+            assert_eq!(
+                seqs,
+                vec![0, 1, 2],
+                "records must be ordered by trace_sequence ASC"
+            );
             Ok(())
         })
         .await
@@ -369,13 +411,17 @@ async fn payload_hash_count_in_scope_basic() {
             assert_eq!(n, 1, "expected 1 after excluding r1");
 
             // Wrong scope → 0.
-            let n =
-                tx.payload_hash_count_in_scope(hash, Some("other-tenant"), None, None, &[])?;
+            let n = tx.payload_hash_count_in_scope(hash, Some("other-tenant"), None, None, &[])?;
             assert_eq!(n, 0, "wrong tenant scope should match 0");
 
             // Different hash → 0.
-            let n =
-                tx.payload_hash_count_in_scope("sha256:other", None, Some("hmn:tafeng"), None, &[])?;
+            let n = tx.payload_hash_count_in_scope(
+                "sha256:other",
+                None,
+                Some("hmn:tafeng"),
+                None,
+                &[],
+            )?;
             assert_eq!(n, 0, "different hash should match 0");
             Ok(())
         })

--- a/crates/cairn-store-sqlite/tests/trace_store.rs
+++ b/crates/cairn-store-sqlite/tests/trace_store.rs
@@ -124,6 +124,45 @@ fn mk_summary_record(session_id: &SessionId, turn_id: &str, member_event_ids: &[
     r
 }
 
+/// Build a trace record where `trace_event`, `tool_call_id`, and
+/// `parent_event_id` are all caller-controlled.
+///
+/// This is the full-featured builder used by link-validation tests.
+/// Pass `None` for `tool_call_id` / `parent_event_id` to omit those
+/// fields from `extra_frontmatter.trace`.
+#[allow(
+    clippy::expect_used,
+    reason = "fixture helpers: panic on invalid input is intentional"
+)]
+fn mk_trace_record_with_event(
+    session_id: &SessionId,
+    turn_id: &str,
+    sequence: u64,
+    capture_event_id: &str,
+    trace_event: &str,
+    tool_call_id: Option<&str>,
+    parent_event_id: Option<&str>,
+) -> MemoryRecord {
+    let mut r = mk_trace_record(session_id, turn_id, sequence, capture_event_id);
+    // Override trace_event.
+    r.extra_frontmatter
+        .insert("trace_event".into(), Json::String(trace_event.to_owned()));
+    // Patch optional trace sub-fields.
+    let trace = r
+        .extra_frontmatter
+        .get_mut("trace")
+        .expect("trace key set by mk_trace_record")
+        .as_object_mut()
+        .expect("trace is an object");
+    if let Some(tcid) = tool_call_id {
+        trace.insert("tool_call_id".into(), Json::String(tcid.to_owned()));
+    }
+    if let Some(pid) = parent_event_id {
+        trace.insert("parent_event_id".into(), Json::String(pid.to_owned()));
+    }
+    r
+}
+
 /// Like [`mk_trace_record`] but also sets `updated_at` on the record to
 /// `captured_at`, mirroring the projector contract where `updated_at` is
 /// derived from the originating `CaptureEvent`'s timestamp.
@@ -522,4 +561,125 @@ async fn out_of_order_backfill_renumbers() {
         })
         .await
         .expect("with_tx");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn link_validation_passes_when_parent_in_turn() {
+    let store = test_store_in_memory().await;
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    store
+        .with_tx({
+            let session_id = session_id.clone();
+            move |tx| {
+                // pre_tool with tool_call_id="call_abc"
+                let pre = mk_trace_record_with_event(
+                    &session_id,
+                    "turn-1",
+                    0,
+                    "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+                    "pre_tool",
+                    Some("call_abc"),
+                    None,
+                );
+                // post_tool referencing the pre by capture_event_id
+                let post = mk_trace_record_with_event(
+                    &session_id,
+                    "turn-1",
+                    1,
+                    "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+                    "post_tool",
+                    Some("call_abc"),
+                    Some("01ARZ3NDEKTSV4RRFFQ69G5FAA"),
+                );
+                tx.upsert_trace(&pre)?;
+                tx.upsert_trace(&post)?;
+                tx.validate_turn_links(&session_id, "turn-1")?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn link_validation_rejects_missing_parent() {
+    let store = test_store_in_memory().await;
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    let result = store
+        .with_tx({
+            let session_id = session_id.clone();
+            move |tx| {
+                // post_tool whose parent_event_id never landed.
+                let post = mk_trace_record_with_event(
+                    &session_id,
+                    "turn-1",
+                    0,
+                    "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+                    "post_tool",
+                    Some("call_abc"),
+                    Some("01ARZ3NDEKTSV4RRFFQ69G5FFF"), // does not exist
+                );
+                tx.upsert_trace(&post)?;
+                tx.validate_turn_links(&session_id, "turn-1")?;
+                Ok(())
+            }
+        })
+        .await;
+    let err = result.expect_err("missing parent should fail");
+    assert!(
+        matches!(err, StoreError::TraceLinkOrphan { .. }),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn link_validation_rejects_tool_call_id_mismatch() {
+    let store = test_store_in_memory().await;
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    let result = store
+        .with_tx({
+            let session_id = session_id.clone();
+            move |tx| {
+                let pre = mk_trace_record_with_event(
+                    &session_id,
+                    "turn-1",
+                    0,
+                    "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+                    "pre_tool",
+                    Some("call_abc"),
+                    None,
+                );
+                let post = mk_trace_record_with_event(
+                    &session_id,
+                    "turn-1",
+                    1,
+                    "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+                    "post_tool",
+                    Some("call_other"), // mismatch
+                    Some("01ARZ3NDEKTSV4RRFFQ69G5FAA"),
+                );
+                tx.upsert_trace(&pre)?;
+                tx.upsert_trace(&post)?;
+                tx.validate_turn_links(&session_id, "turn-1")?;
+                Ok(())
+            }
+        })
+        .await;
+    let err = result.expect_err("tool_call_id mismatch should fail");
+    assert!(
+        matches!(err, StoreError::TraceLinkOrphan { ref reason, .. } if reason.contains("tool_call_id")),
+        "got {err:?}"
+    );
 }

--- a/crates/cairn-store-sqlite/tests/trace_store.rs
+++ b/crates/cairn-store-sqlite/tests/trace_store.rs
@@ -56,6 +56,29 @@ fn mk_trace_record(session_id: &SessionId, turn_id: &str, sequence: u64, capture
     r
 }
 
+/// Wrapper around [`mk_trace_record`] that overrides the `payload_hash`
+/// field in the trace object.
+#[allow(
+    clippy::expect_used,
+    reason = "fixture helpers: panic on invalid input is intentional"
+)]
+fn mk_trace_record_with_hash(
+    session_id: &SessionId,
+    turn_id: &str,
+    sequence: u64,
+    capture_event_id: &str,
+    payload_hash: &str,
+) -> MemoryRecord {
+    let mut r = mk_trace_record(session_id, turn_id, sequence, capture_event_id);
+    r.extra_frontmatter
+        .get_mut("trace")
+        .expect("trace key set by mk_trace_record")
+        .as_object_mut()
+        .expect("trace is an object")
+        .insert("payload_hash".into(), Json::String(payload_hash.to_owned()));
+    r
+}
+
 /// Build a `turn_summary` record for the given session/turn.
 ///
 /// The `trace_event` column is gated to `'turn_summary'`; this helper
@@ -65,7 +88,7 @@ fn mk_trace_record(session_id: &SessionId, turn_id: &str, sequence: u64, capture
     clippy::expect_used,
     reason = "fixture helpers: panic on invalid input is intentional"
 )]
-fn mk_summary_record(session_id: &SessionId, turn_id: &str) -> MemoryRecord {
+fn mk_summary_record(session_id: &SessionId, turn_id: &str, member_event_ids: &[&str]) -> MemoryRecord {
     // Derive the deterministic summary id exactly as the real pipeline does.
     let summary_id = cairn_core::domain::trace::summary_record_id(session_id, turn_id);
     let summary_id_str = summary_id.as_str().to_owned();
@@ -79,7 +102,11 @@ fn mk_summary_record(session_id: &SessionId, turn_id: &str) -> MemoryRecord {
     trace_obj.insert("turn_id".into(), Json::String(turn_id.to_owned()));
     // Summary rows have no sequence; sequence column will be NULL.
     trace_obj.insert("capture_event_id".into(), Json::String(summary_id_str.clone()));
-    trace_obj.insert("member_event_ids".into(), Json::Array(Vec::new()));
+    let members: Vec<Json> = member_event_ids
+        .iter()
+        .map(|s| Json::String((*s).to_owned()))
+        .collect();
+    trace_obj.insert("member_event_ids".into(), Json::Array(members));
     trace_obj.insert(
         "payload_hash".into(),
         Json::String(
@@ -150,7 +177,7 @@ async fn list_trace_events_excludes_summary() {
                 0,
                 "01ARZ3NDEKTSV4RRFFQ69G5FAA",
             ))?;
-            tx.upsert(&mk_summary_record(&session_id, "turn-1"))?;
+            tx.upsert(&mk_summary_record(&session_id, "turn-1", &[]))?;
 
             let rows = tx.list_trace_events(&session_id, "turn-1")?;
             assert_eq!(rows.len(), 1, "summary row must be excluded");
@@ -185,6 +212,103 @@ async fn list_trace_events_excludes_tombstoned() {
 
             let rows = tx.list_trace_events(&session_id, "turn-1")?;
             assert!(rows.is_empty(), "tombstoned row must be excluded");
+            Ok(())
+        })
+        .await
+        .expect("with_tx");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn turn_summary_exists_after_write() {
+    let store = open_in_memory().await.expect("open store");
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    store
+        .with_tx(move |tx| {
+            assert!(!tx.turn_summary_exists(&session_id, "turn-1")?);
+            let s = mk_summary_record(&session_id, "turn-1", &["01ARZ3NDEKTSV4RRFFQ69G5FAA"]);
+            tx.upsert(&s)?;
+            assert!(tx.turn_summary_exists(&session_id, "turn-1")?);
+            Ok(())
+        })
+        .await
+        .expect("with_tx");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn turn_summary_exists_false_for_other_turn() {
+    let store = open_in_memory().await.expect("open store");
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    store
+        .with_tx(move |tx| {
+            let s = mk_summary_record(&session_id, "turn-1", &["01ARZ3NDEKTSV4RRFFQ69G5FAA"]);
+            tx.upsert(&s)?;
+            assert!(!tx.turn_summary_exists(&session_id, "turn-2")?);
+            Ok(())
+        })
+        .await
+        .expect("with_tx");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn payload_hash_count_in_scope_basic() {
+    let store = open_in_memory().await.expect("open store");
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid");
+    let hash = "sha256:deadbeef";
+    store
+        .with_tx(move |tx| {
+            // Two records with the same hash under the same scope (scope.user = "hmn:tafeng").
+            let r1 = mk_trace_record_with_hash(
+                &session_id,
+                "turn-1",
+                0,
+                "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+                hash,
+            );
+            let r2 = mk_trace_record_with_hash(
+                &session_id,
+                "turn-1",
+                1,
+                "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+                hash,
+            );
+            tx.upsert(&r1)?;
+            tx.upsert(&r2)?;
+
+            // No exclusion → 2.
+            let n = tx.payload_hash_count_in_scope(hash, None, Some("hmn:tafeng"), None, &[])?;
+            assert_eq!(n, 2, "expected 2 matching records");
+
+            // Exclude r1 → 1.
+            let n = tx.payload_hash_count_in_scope(
+                hash,
+                None,
+                Some("hmn:tafeng"),
+                None,
+                &[r1.id.as_str()],
+            )?;
+            assert_eq!(n, 1, "expected 1 after excluding r1");
+
+            // Wrong scope → 0.
+            let n =
+                tx.payload_hash_count_in_scope(hash, Some("other-tenant"), None, None, &[])?;
+            assert_eq!(n, 0, "wrong tenant scope should match 0");
+
+            // Different hash → 0.
+            let n =
+                tx.payload_hash_count_in_scope("sha256:other", None, Some("hmn:tafeng"), None, &[])?;
+            assert_eq!(n, 0, "different hash should match 0");
             Ok(())
         })
         .await

--- a/crates/cairn-store-sqlite/tests/trace_store.rs
+++ b/crates/cairn-store-sqlite/tests/trace_store.rs
@@ -1,0 +1,192 @@
+//! Integration tests for trace-record store methods (issue #77).
+//!
+//! Covers `StoreTx::list_trace_events`: ordering by `trace_sequence`,
+//! exclusion of `turn_summary` rows, and exclusion of tombstoned rows.
+
+use std::collections::BTreeMap;
+
+use cairn_core::contract::memory_store::TombstoneReason;
+use cairn_core::domain::{MemoryRecord, RecordId, SessionId, TargetId};
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_store_sqlite::open_in_memory;
+use serde_json::{Map as JsonMap, Value as Json};
+
+// ── test helpers ──────────────────────────────────────────────────────────────
+
+/// Build a minimal trace `MemoryRecord` for a given session/turn/sequence.
+///
+/// Uses `sample_record()` as a skeleton, then patches the fields the
+/// migration-generated columns key on:
+/// - `extra_frontmatter["trace_event"]`  → `"user_message"`
+/// - `extra_frontmatter["trace"]`        → `{ session_id, turn_id, sequence,
+///                                           capture_event_id, payload_hash,
+///                                           payload_ref }`
+/// - `id` / `target_id`                 → derived from `capture_event_id`
+///   (unique per call site via the `capture_event_id` parameter)
+#[allow(
+    clippy::expect_used,
+    reason = "fixture helpers: panic on invalid input is intentional"
+)]
+fn mk_trace_record(session_id: &SessionId, turn_id: &str, sequence: u64, capture_event_id: &str) -> MemoryRecord {
+    let mut r = sample_record();
+    // Use the capture_event_id as both record_id and target_id so every
+    // inserted row has a distinct identity.
+    r.id = RecordId::parse(capture_event_id).expect("test: valid ULID capture_event_id");
+    r.target_id = TargetId::parse(capture_event_id).expect("test: valid ULID capture_event_id");
+
+    // Build the trace linkage object.
+    let mut trace_obj = JsonMap::new();
+    trace_obj.insert("session_id".into(), Json::String(session_id.as_str().to_owned()));
+    trace_obj.insert("turn_id".into(), Json::String(turn_id.to_owned()));
+    trace_obj.insert("sequence".into(), Json::Number(sequence.into()));
+    trace_obj.insert("capture_event_id".into(), Json::String(capture_event_id.to_owned()));
+    trace_obj.insert(
+        "payload_hash".into(),
+        Json::String(
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+        ),
+    );
+    trace_obj.insert("payload_ref".into(), Json::String(format!("sources/hook/{capture_event_id}.txt")));
+
+    let mut extra: BTreeMap<String, Json> = BTreeMap::new();
+    extra.insert("trace_event".into(), Json::String("user_message".to_owned()));
+    extra.insert("trace".into(), Json::Object(trace_obj));
+    r.extra_frontmatter = extra;
+
+    r
+}
+
+/// Build a `turn_summary` record for the given session/turn.
+///
+/// The `trace_event` column is gated to `'turn_summary'`; this helper
+/// sets that and gives the record a unique id derived from
+/// `cairn_core::domain::trace::summary_record_id`.
+#[allow(
+    clippy::expect_used,
+    reason = "fixture helpers: panic on invalid input is intentional"
+)]
+fn mk_summary_record(session_id: &SessionId, turn_id: &str) -> MemoryRecord {
+    // Derive the deterministic summary id exactly as the real pipeline does.
+    let summary_id = cairn_core::domain::trace::summary_record_id(session_id, turn_id);
+    let summary_id_str = summary_id.as_str().to_owned();
+
+    let mut r = sample_record();
+    r.id = summary_id;
+    r.target_id = TargetId::parse(summary_id_str.clone()).expect("test: summary_id is valid ULID");
+
+    let mut trace_obj = JsonMap::new();
+    trace_obj.insert("session_id".into(), Json::String(session_id.as_str().to_owned()));
+    trace_obj.insert("turn_id".into(), Json::String(turn_id.to_owned()));
+    // Summary rows have no sequence; sequence column will be NULL.
+    trace_obj.insert("capture_event_id".into(), Json::String(summary_id_str.clone()));
+    trace_obj.insert("member_event_ids".into(), Json::Array(Vec::new()));
+    trace_obj.insert(
+        "payload_hash".into(),
+        Json::String(
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_owned(),
+        ),
+    );
+    trace_obj.insert("payload_ref".into(), Json::String(format!("sources/hook/{summary_id_str}.txt")));
+
+    let mut extra: BTreeMap<String, Json> = BTreeMap::new();
+    extra.insert("trace_event".into(), Json::String("turn_summary".to_owned()));
+    extra.insert("trace".into(), Json::Object(trace_obj));
+    r.extra_frontmatter = extra;
+
+    r
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn list_trace_events_orders_by_sequence() {
+    let store = open_in_memory().await.expect("open store");
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+
+    // Insert three trace records with sequences 2, 0, 1 (out of order).
+    store
+        .with_tx(move |tx| {
+            for (capture_event_id, seq) in [
+                ("01ARZ3NDEKTSV4RRFFQ69G5FAA", 2_u64),
+                ("01ARZ3NDEKTSV4RRFFQ69G5FAB", 0),
+                ("01ARZ3NDEKTSV4RRFFQ69G5FAC", 1),
+            ] {
+                tx.upsert(&mk_trace_record(&session_id, "turn-1", seq, capture_event_id))?;
+            }
+            let rows = tx.list_trace_events(&session_id, "turn-1")?;
+            let seqs: Vec<u64> = rows
+                .iter()
+                .map(|r| {
+                    r.extra_frontmatter["trace"]["sequence"]
+                        .as_u64()
+                        .expect("sequence present")
+                })
+                .collect();
+            assert_eq!(seqs, vec![0, 1, 2], "records must be ordered by trace_sequence ASC");
+            Ok(())
+        })
+        .await
+        .expect("with_tx");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn list_trace_events_excludes_summary() {
+    let store = open_in_memory().await.expect("open store");
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+
+    store
+        .with_tx(move |tx| {
+            tx.upsert(&mk_trace_record(
+                &session_id,
+                "turn-1",
+                0,
+                "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+            ))?;
+            tx.upsert(&mk_summary_record(&session_id, "turn-1"))?;
+
+            let rows = tx.list_trace_events(&session_id, "turn-1")?;
+            assert_eq!(rows.len(), 1, "summary row must be excluded");
+            assert_ne!(
+                rows[0]
+                    .extra_frontmatter
+                    .get("trace_event")
+                    .and_then(Json::as_str),
+                Some("turn_summary"),
+                "returned row must not be a summary"
+            );
+            Ok(())
+        })
+        .await
+        .expect("with_tx");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn list_trace_events_excludes_tombstoned() {
+    let store = open_in_memory().await.expect("open store");
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+
+    store
+        .with_tx(move |tx| {
+            let r = mk_trace_record(&session_id, "turn-1", 0, "01ARZ3NDEKTSV4RRFFQ69G5FAA");
+            tx.upsert(&r)?;
+            tx.tombstone(&r.id, TombstoneReason::Forget)?;
+
+            let rows = tx.list_trace_events(&session_id, "turn-1")?;
+            assert!(rows.is_empty(), "tombstoned row must be excluded");
+            Ok(())
+        })
+        .await
+        .expect("with_tx");
+}

--- a/docs/design/traceability.md
+++ b/docs/design/traceability.md
@@ -72,13 +72,13 @@ until automated enforcement is added.
 | §4 Contracts / plugins / identity | #3, #7, #10, #23, #27, #50–#53, #113, #124, #143 | — | Plugin registry and conformance covered. |
 | §4.1 Plugin architecture | #177 | — | `XxxPlugin` companion traits with `NAME` and `SUPPORTED_VERSIONS` static pre-construction checks; `register_plugin_with!` factory variant. |
 | §4.2 Actor-chain / identity provisioning | #50 | — | Ed25519 identity domain (`hmn:`/`agt:`/`snr:` prefixes), `IdentityRegistry` contract, vault-binding protocol, two-phase key rotation, revoke, purge, `IdentityService`, default-identity provisioning, keystore integration, status sweep, and `usr:` → `hmn:` rename. Privacy-by-construction invariant (no plaintext key bytes on disk) verified in E2 acceptance suite. |
-| §5 Pipeline / WAL / sessions | #8, #12, #13, #16, #54–#58, #71–#79, #89–#92 | #146 (resolved) | Capture, extract, filter, classify, plan/apply, WAL, hooks, and session capture covered. |
+| §5 Pipeline / WAL / sessions | #8, #12, #13, #16, #54–#58, #71–#79, #89–#92 | #146 (resolved) | Capture, extract, filter, classify, plan/apply, WAL, hooks, and session capture covered. #77 persists the seven trace event types as `MemoryKind::Trace` records (per-turn transactional, idempotent on `capture_event_id`, two-phase renumber on out-of-order backfill, closed-turn resummarize); see `crates/cairn-core/src/pipeline/capture_trace.rs` and migration `0023_trace_links.sql`. |
 | §5.2.a `LLMExtractor` + `ExtractChain` | #73, #74 | — | Region+text-excerpt-derived spans, role-aware fail-closed chain, structured discard candidates. |
 | §6 Taxonomy / provenance | #4, #37–#40 | — | Canonical kinds, classes, visibility, and provenance owned by core schema. |
 | §6.a Multi-modal memory | #15, #29, #84–#88, #130–#132 | — | P0 local sensors plus P2 connectors and aggregate memory. |
 | §7 Hot memory / profile | #14, #80–#83 | — | Budgeted hot prefix, profile, cache, and lint coverage. |
 | §8 CLI / MCP / SDK / skill contract | #9, #10, #11, #59–#70 | — | IDL-generated surfaces and parity checks covered. |
-| §8.1 Session lifecycle | #13, #76–#79 | — | Auto-discovery, trace storage, retrieve variants, and hooks. |
+| §8.1 Session lifecycle | #13, #76–#79 | — | Auto-discovery, trace storage, retrieve variants, and hooks. #77 lands the persistence half (records + linkage + summaries); public `retrieve(target=Turn\|Session)` IDL evolution to expose them is tracked as a follow-up. |
 | §9 Sensors | #15, #84–#88 | #150 (resolved) | Local hooks, IDE, terminal, clipboard, voice, screen, recording. |
 | §10 Continuous learning | #16, #22, #24, #27, #28, #89–#92, #110–#112, #124–#127 | — | P0 rolling workflows, P1 reflection and dreaming, P2 agent and evolution. |
 | §11 Evolution | #28, #127–#129 | — | EvolutionWorkflow, Skillify, and skill graph covered. |

--- a/docs/site/src/reference/generated/commands/retrieve.md
+++ b/docs/site/src/reference/generated/commands/retrieve.md
@@ -34,7 +34,7 @@ Options:
       --cursor <STRING>
 
 
-      --turn <U64>
+      --turn <STRING>
 
 
       --folder <STRING>

--- a/docs/superpowers/plans/2026-05-02-issue-77-trace-records.md
+++ b/docs/superpowers/plans/2026-05-02-issue-77-trace-records.md
@@ -1,0 +1,2310 @@
+# Trace-Record Persistence Implementation Plan (issue #77)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist the seven trace event types (user/agent message, pre/post tool, tool output, stop, turn summary) as linked, ordered, idempotent records that round-trip through reconstruction tests and survive forget.
+
+**Architecture:** All seven event types map to one `MemoryKind::Trace` with structured linkage in `extra_frontmatter.trace`. A pure projector in `cairn-core` builds records from `CaptureEvent` + `ResolvedBody`. A SQLite migration adds generated columns + unique indices for idempotent replay, sequence monotonicity, and one summary per turn. The `capture_trace` CLI verb reads JSONL, groups by turn, and writes each turn inside `SqliteMemoryStore::with_tx` so partial imports never strand a turn. Sequences derive from `captured_at`, with two-phase parking when out-of-order events arrive.
+
+**Tech Stack:** Rust 2024 / 1.95.0, `tokio`, `rusqlite` via `tokio_rusqlite`, `clap` 4.5, `thiserror`, `rstest`, `proptest`, `insta`, `cargo nextest`.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md`. Read it first.
+
+---
+
+## File Structure
+
+| Path | Role |
+|---|---|
+| `crates/cairn-core/src/domain/trace.rs` | NEW. `TraceEvent` enum, `TraceLink` struct, `TraceLinkError`, `summary_record_id()`, validation. |
+| `crates/cairn-core/src/domain/mod.rs` | Add `pub mod trace;` + re-exports. |
+| `crates/cairn-core/src/pipeline/capture_trace.rs` | NEW. Pure `project()`, `classify()`, body-shape helpers. |
+| `crates/cairn-core/src/pipeline/turn.rs` | NEW. Pure `summarize_turn()` + `order_by_captured_at()` + `assign_sequences()`. |
+| `crates/cairn-core/src/pipeline/mod.rs` | Add `pub mod capture_trace; pub mod turn;`. |
+| `crates/cairn-store-sqlite/src/migrations/sql/0022_trace_links.sql` | NEW. Generated columns + unique indices. |
+| `crates/cairn-store-sqlite/src/migrations/mod.rs` | Register migration `0022`. |
+| `crates/cairn-store-sqlite/src/store/tx.rs` | Add `upsert_trace`, `list_trace_events`, `turn_summary_exists`, `payload_hash_count_in_scope` to `StoreTx`. |
+| `crates/cairn-cli/src/verbs/capture_trace.rs` | Replace stub with full impl: JSONL parser → group-by-turn → renumber + summary inside `with_tx`. |
+| `crates/cairn-cli/src/verbs/forget.rs` | Extend forget to delete `payload_ref` files for trace records when in-scope refcount is zero. |
+| `crates/cairn-test-fixtures/src/...` | Add JSONL trace fixtures (single-turn, multi-turn, malformed). |
+
+---
+
+## Conventions for Every Task
+
+- **TDD always.** Failing test first, smallest code to pass, refactor.
+- **`cargo nextest run -p <crate> <pattern>`** for fast loops; `--workspace` only on commit.
+- **No `unwrap()`/`expect()` in `cairn-core`** — workspace lints deny it. Use `?` and typed errors.
+- **`#[cfg(test)] mod tests`** next to code in unit tests.
+- **`rstest` fixtures** for table-driven cases, `insta` for snapshots, `proptest` for round-trip invariants.
+- **Commit per step 5.** Imperative subject ≤72 chars referencing brief section numbers when relevant.
+
+---
+
+## Task 1: TraceEvent enum + module skeleton
+
+**Files:**
+- Create: `crates/cairn-core/src/domain/trace.rs`
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/cairn-core/src/domain/trace.rs`:
+
+```rust
+//! Trace-record domain types (issue #77, brief §5.0, §9.3).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TraceEvent {
+    UserMessage,
+    AgentMessage,
+    PreTool,
+    PostTool,
+    ToolOutput,
+    Stop,
+    TurnSummary,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&TraceEvent::UserMessage).unwrap(),
+            "\"user_message\""
+        );
+        assert_eq!(
+            serde_json::from_str::<TraceEvent>("\"turn_summary\"").unwrap(),
+            TraceEvent::TurnSummary
+        );
+    }
+}
+```
+
+Wire the module by adding to `crates/cairn-core/src/domain/mod.rs` (find the `pub mod` block, alphabetical):
+
+```rust
+pub mod trace;
+pub use trace::TraceEvent;
+```
+
+- [ ] **Step 2: Run test to verify it fails / compiles**
+
+```bash
+cargo nextest run -p cairn-core trace::tests
+```
+
+Expected: PASS (this task only adds the enum). If lints fire on the empty
+module, address them inline — the enum is enough.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/trace.rs crates/cairn-core/src/domain/mod.rs
+git commit -m "feat(core): add TraceEvent enum (issue #77, brief §5.0)"
+```
+
+---
+
+## Task 2: TraceLink struct + field-level validation
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/trace.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/cairn-core/src/domain/trace.rs` `mod tests`:
+
+```rust
+use crate::domain::{CaptureEventId, SessionId};
+
+fn cap(id: &str) -> CaptureEventId {
+    CaptureEventId::parse(id).expect("valid ulid")
+}
+fn sess() -> SessionId {
+    SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid")
+}
+
+#[test]
+fn valid_pre_tool_link() {
+    let link = TraceLink {
+        session_id: sess(),
+        turn_id: "turn-4".into(),
+        sequence: 2,
+        capture_event_id: cap("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        parent_event_id: None,
+        tool_call_id: Some("call_abc".into()),
+        member_event_ids: Vec::new(),
+    };
+    link.validate(TraceEvent::PreTool).expect("valid");
+}
+
+#[test]
+fn pre_tool_requires_tool_call_id() {
+    let link = TraceLink {
+        session_id: sess(),
+        turn_id: "turn-4".into(),
+        sequence: 0,
+        capture_event_id: cap("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        parent_event_id: None,
+        tool_call_id: None,
+        member_event_ids: Vec::new(),
+    };
+    let err = link.validate(TraceEvent::PreTool).unwrap_err();
+    assert!(matches!(err, TraceLinkError::MissingToolCallId));
+}
+
+#[test]
+fn post_tool_requires_parent() {
+    let mut link = TraceLink {
+        session_id: sess(),
+        turn_id: "t".into(),
+        sequence: 0,
+        capture_event_id: cap("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        parent_event_id: None,
+        tool_call_id: Some("call".into()),
+        member_event_ids: Vec::new(),
+    };
+    assert!(matches!(
+        link.validate(TraceEvent::PostTool).unwrap_err(),
+        TraceLinkError::MissingParent
+    ));
+    link.parent_event_id = Some(cap("01ARZ3NDEKTSV4RRFFQ69G5FBW"));
+    link.validate(TraceEvent::PostTool).expect("valid");
+}
+
+#[test]
+fn member_ids_only_on_summary() {
+    let link = TraceLink {
+        session_id: sess(),
+        turn_id: "t".into(),
+        sequence: 0,
+        capture_event_id: cap("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        parent_event_id: None,
+        tool_call_id: None,
+        member_event_ids: vec![cap("01ARZ3NDEKTSV4RRFFQ69G5FBW")],
+    };
+    assert!(matches!(
+        link.validate(TraceEvent::UserMessage).unwrap_err(),
+        TraceLinkError::UnexpectedMemberIds
+    ));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo nextest run -p cairn-core trace::tests
+```
+
+Expected: FAIL — `TraceLink` and `TraceLinkError` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `crates/cairn-core/src/domain/trace.rs`:
+
+```rust
+use crate::domain::{CaptureEventId, SessionId};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TraceLink {
+    pub session_id: SessionId,
+    pub turn_id: String,
+    pub sequence: u64,
+    pub capture_event_id: CaptureEventId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_event_id: Option<CaptureEventId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub member_event_ids: Vec<CaptureEventId>,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TraceLinkError {
+    #[error("turn_id must not be empty or whitespace")]
+    EmptyTurnId,
+    #[error("tool_call_id required for {0:?}")]
+    MissingToolCallId,
+    #[error("parent_event_id required for {0:?}")]
+    MissingParent,
+    #[error("parent_event_id only valid on PostTool/ToolOutput")]
+    UnexpectedParent,
+    #[error("tool_call_id only valid on PreTool/PostTool/ToolOutput")]
+    UnexpectedToolCallId,
+    #[error("member_event_ids only valid on TurnSummary")]
+    UnexpectedMemberIds,
+    #[error("turn_summary requires non-empty member_event_ids")]
+    EmptyMemberIds,
+}
+
+impl TraceLink {
+    pub fn validate(&self, event: TraceEvent) -> Result<(), TraceLinkError> {
+        if self.turn_id.trim().is_empty() {
+            return Err(TraceLinkError::EmptyTurnId);
+        }
+        let needs_tool_call = matches!(
+            event,
+            TraceEvent::PreTool | TraceEvent::PostTool | TraceEvent::ToolOutput
+        );
+        match (needs_tool_call, self.tool_call_id.as_ref()) {
+            (true, None) => return Err(TraceLinkError::MissingToolCallId),
+            (false, Some(_)) => return Err(TraceLinkError::UnexpectedToolCallId),
+            _ => {}
+        }
+        let needs_parent = matches!(event, TraceEvent::PostTool | TraceEvent::ToolOutput);
+        match (needs_parent, self.parent_event_id.as_ref()) {
+            (true, None) => return Err(TraceLinkError::MissingParent),
+            (false, Some(_)) => return Err(TraceLinkError::UnexpectedParent),
+            _ => {}
+        }
+        let is_summary = event == TraceEvent::TurnSummary;
+        match (is_summary, self.member_event_ids.is_empty()) {
+            (true, true) => return Err(TraceLinkError::EmptyMemberIds),
+            (false, false) => return Err(TraceLinkError::UnexpectedMemberIds),
+            _ => {}
+        }
+        Ok(())
+    }
+}
+```
+
+The two error variants `UnexpectedParent` and `UnexpectedToolCallId` are
+declared but not asserted in the tests above; add a test for each:
+
+```rust
+#[test]
+fn user_message_rejects_parent() {
+    let link = TraceLink {
+        session_id: sess(), turn_id: "t".into(), sequence: 0,
+        capture_event_id: cap("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        parent_event_id: Some(cap("01ARZ3NDEKTSV4RRFFQ69G5FBW")),
+        tool_call_id: None, member_event_ids: Vec::new(),
+    };
+    assert!(matches!(
+        link.validate(TraceEvent::UserMessage).unwrap_err(),
+        TraceLinkError::UnexpectedParent
+    ));
+}
+
+#[test]
+fn user_message_rejects_tool_call_id() {
+    let link = TraceLink {
+        session_id: sess(), turn_id: "t".into(), sequence: 0,
+        capture_event_id: cap("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        parent_event_id: None, tool_call_id: Some("c".into()),
+        member_event_ids: Vec::new(),
+    };
+    assert!(matches!(
+        link.validate(TraceEvent::UserMessage).unwrap_err(),
+        TraceLinkError::UnexpectedToolCallId
+    ));
+}
+
+#[test]
+fn empty_turn_id_rejected() {
+    let link = TraceLink {
+        session_id: sess(), turn_id: "  ".into(), sequence: 0,
+        capture_event_id: cap("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        parent_event_id: None, tool_call_id: None,
+        member_event_ids: Vec::new(),
+    };
+    assert!(matches!(
+        link.validate(TraceEvent::UserMessage).unwrap_err(),
+        TraceLinkError::EmptyTurnId
+    ));
+}
+```
+
+- [ ] **Step 4: Run all tests pass**
+
+```bash
+cargo nextest run -p cairn-core trace::tests
+```
+
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/trace.rs
+git commit -m "feat(core): TraceLink + field-level validation (#77)"
+```
+
+---
+
+## Task 3: Deterministic summary record id
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/trace.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn summary_id_is_deterministic() {
+    let s1 = summary_record_id(&sess(), "turn-4");
+    let s2 = summary_record_id(&sess(), "turn-4");
+    assert_eq!(s1, s2);
+    assert_ne!(s1, summary_record_id(&sess(), "turn-5"));
+}
+
+#[test]
+fn summary_id_is_valid_record_id() {
+    let id = summary_record_id(&sess(), "turn-4");
+    // RecordId::parse re-validates ULID shape — must round-trip.
+    let reparsed = crate::domain::RecordId::parse(id.as_str()).expect("valid record id");
+    assert_eq!(id, reparsed);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo nextest run -p cairn-core summary_id
+```
+
+Expected: FAIL — `summary_record_id` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `crates/cairn-core/src/domain/trace.rs`:
+
+```rust
+use crate::domain::RecordId;
+use sha2::{Digest, Sha256};
+use ulid::Ulid;
+
+/// Deterministic, ULID-shaped record id for a `turn_summary`. Same
+/// `(session_id, turn_id)` always maps to the same id, so summary upserts
+/// are idempotent under replay.
+#[must_use]
+pub fn summary_record_id(session_id: &SessionId, turn_id: &str) -> RecordId {
+    let mut h = Sha256::new();
+    h.update(b"cairn:trace:turnsum\0");
+    h.update(session_id.as_str().as_bytes());
+    h.update(b"\0");
+    h.update(turn_id.as_bytes());
+    let digest = h.finalize();
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    let ulid = Ulid::from_bytes(bytes);
+    RecordId::parse(ulid.to_string()).unwrap_or_else(|_| {
+        // Unreachable: a 16-byte ULID always serializes to 26 valid chars.
+        // This branch exists to keep no-unwrap lints happy without an expect.
+        unreachable!("ulid::to_string always produces valid RecordId")
+    })
+}
+```
+
+If `sha2` and `ulid` are not already in `cairn-core`'s `Cargo.toml`, add
+them as workspace deps. Check first:
+
+```bash
+grep -E "^sha2|^ulid" crates/cairn-core/Cargo.toml
+```
+
+If missing, add `sha2 = { workspace = true }` and `ulid = { workspace = true }`
+to `[dependencies]`. If they aren't workspace deps yet, add them to
+`[workspace.dependencies]` in the root `Cargo.toml` (`sha2 = "0.10"`,
+`ulid = "1"` — match versions used elsewhere if present).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo nextest run -p cairn-core summary_id
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/trace.rs crates/cairn-core/Cargo.toml Cargo.toml
+git commit -m "feat(core): deterministic summary_record_id (#77)"
+```
+
+---
+
+## Task 4: ResolvedBody review + body-shape helper
+
+**Files:**
+- Read: `crates/cairn-core/src/pipeline/extract/body.rs` (no edits)
+- Create: `crates/cairn-core/src/pipeline/capture_trace.rs`
+- Modify: `crates/cairn-core/src/pipeline/mod.rs`
+
+- [ ] **Step 1: Read the existing `ResolvedBody`**
+
+```bash
+grep -n "pub struct ResolvedBody\|impl ResolvedBody\|pub fn from_" crates/cairn-core/src/pipeline/extract/body.rs | head -20
+```
+
+Note the constructors and what `text()` / `payload_hash()` accessors exist.
+The trace projector reuses this type — do not redefine it.
+
+- [ ] **Step 2: Write the failing test for body shaping**
+
+Create `crates/cairn-core/src/pipeline/capture_trace.rs`:
+
+```rust
+//! Trace-event projector (issue #77).
+
+use crate::domain::trace::{TraceEvent, TraceLink, TraceLinkError};
+
+/// Maximum size of a stored trace-record body, in bytes. Anything larger is
+/// truncated; the full bytes remain in `sources/` referenced by
+/// `payload_hash`.
+pub const TRACE_BODY_CAP: usize = 4 * 1024;
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TraceProjectError {
+    #[error("trace link: {0}")]
+    Link(#[from] TraceLinkError),
+}
+
+/// Render the textual body for a given event type. Pure; no I/O.
+pub(crate) fn shape_body(event: TraceEvent, filtered_text: &str) -> String {
+    let truncated = truncate(filtered_text, TRACE_BODY_CAP);
+    match event {
+        TraceEvent::UserMessage | TraceEvent::AgentMessage | TraceEvent::ToolOutput => truncated,
+        TraceEvent::PreTool | TraceEvent::PostTool | TraceEvent::Stop => truncated,
+        TraceEvent::TurnSummary => truncated,
+    }
+}
+
+fn truncate(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes { return s.to_owned(); }
+    // Truncate on a char boundary.
+    let mut end = max_bytes;
+    while !s.is_char_boundary(end) { end -= 1; }
+    s[..end].to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_truncates_at_cap() {
+        let big = "x".repeat(TRACE_BODY_CAP + 100);
+        let body = shape_body(TraceEvent::ToolOutput, &big);
+        assert!(body.len() <= TRACE_BODY_CAP);
+    }
+
+    #[test]
+    fn truncate_respects_char_boundary() {
+        // 4-byte char at the cap boundary
+        let mut s = "x".repeat(TRACE_BODY_CAP - 2);
+        s.push('𝄞'); // 4 bytes
+        let body = shape_body(TraceEvent::UserMessage, &s);
+        assert!(body.is_char_boundary(body.len()));
+    }
+}
+```
+
+Add to `crates/cairn-core/src/pipeline/mod.rs`:
+
+```rust
+pub mod capture_trace;
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo nextest run -p cairn-core pipeline::capture_trace
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/pipeline/capture_trace.rs crates/cairn-core/src/pipeline/mod.rs
+git commit -m "feat(core): trace-projector body shaping + cap (#77)"
+```
+
+---
+
+## Task 5: Classifier — CaptureEvent → TraceEvent
+
+**Files:**
+- Modify: `crates/cairn-core/src/pipeline/capture_trace.rs`
+
+- [ ] **Step 1: Survey the existing `CapturePayload` variants**
+
+```bash
+grep -n "pub enum CapturePayload\|^    Hook\|hook_name\|HookEvent" crates/cairn-core/src/domain/capture.rs | head -20
+```
+
+Note which payload variant carries `hook_name` and what its values are
+(`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`,
+`PreCompact`, `Stop`). The classifier maps those plus non-hook payloads
+to `TraceEvent`.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `pipeline::capture_trace::tests`:
+
+```rust
+use crate::domain::capture::{CaptureEvent, CapturePayload, /* whatever the hook variant is */};
+
+// Use the existing test helpers from pipeline::squash::tests (look there
+// for a `terminal_event` / `hook_event` builder you can copy locally —
+// don't depend on test-only code from another module).
+
+#[test]
+fn classifies_user_prompt_submit() {
+    let event = mk_hook_event("UserPromptSubmit");
+    assert_eq!(classify(&event).unwrap(), TraceEvent::UserMessage);
+}
+
+#[test]
+fn classifies_pre_tool_use() {
+    assert_eq!(classify(&mk_hook_event("PreToolUse")).unwrap(), TraceEvent::PreTool);
+}
+
+#[test]
+fn classifies_post_tool_use() {
+    assert_eq!(classify(&mk_hook_event("PostToolUse")).unwrap(), TraceEvent::PostTool);
+}
+
+#[test]
+fn classifies_stop() {
+    assert_eq!(classify(&mk_hook_event("Stop")).unwrap(), TraceEvent::Stop);
+}
+
+#[test]
+fn unknown_hook_rejected() {
+    assert!(matches!(
+        classify(&mk_hook_event("UnknownHook")).unwrap_err(),
+        TraceProjectError::Unclassifiable
+    ));
+}
+```
+
+`mk_hook_event` should mirror the `hook_event(payload_bytes)` helper in
+`pipeline::squash::tests` — copy its body into this `mod tests`. Refer
+back to that module if signatures change.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cargo nextest run -p cairn-core pipeline::capture_trace::tests::classifies
+```
+
+Expected: FAIL — `classify` undefined.
+
+- [ ] **Step 4: Implement classifier**
+
+Add to `crates/cairn-core/src/pipeline/capture_trace.rs`:
+
+```rust
+use crate::domain::capture::{CaptureEvent, CapturePayload};
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TraceProjectError {
+    #[error("trace link: {0}")]
+    Link(#[from] TraceLinkError),
+    #[error("cannot classify capture event into a trace event type")]
+    Unclassifiable,
+    #[error("agent_message events must come from a non-hook payload")]
+    AgentMessageFromHook,
+    #[error("tool_output events require a tool_call_id")]
+    ToolOutputMissingCallId,
+}
+
+/// Map a `CaptureEvent` to a `TraceEvent`. Static rules:
+/// - Hook payloads route by `hook_name`.
+/// - Non-hook payloads (CLI/MCP message capture) route to UserMessage or
+///   AgentMessage based on payload tag (the existing source_family /
+///   payload variant — adjust the match arm to whatever the codebase
+///   uses today).
+pub fn classify(event: &CaptureEvent) -> Result<TraceEvent, TraceProjectError> {
+    match &event.payload {
+        CapturePayload::Hook { hook_name, .. } => match hook_name.as_str() {
+            "UserPromptSubmit" => Ok(TraceEvent::UserMessage),
+            "PreToolUse"       => Ok(TraceEvent::PreTool),
+            "PostToolUse"      => Ok(TraceEvent::PostTool),
+            "Stop"             => Ok(TraceEvent::Stop),
+            // SessionStart / PreCompact do not map to trace records in P0.
+            _ => Err(TraceProjectError::Unclassifiable),
+        },
+        // Adjust this arm to whatever non-hook payload variant carries
+        // agent text + tool output. Look at the existing CapturePayload
+        // definition to see the right discriminator.
+        _ => Err(TraceProjectError::Unclassifiable),
+    }
+}
+```
+
+**Important:** the `match &event.payload` arms must match the actual
+variants on `CapturePayload`. Open `crates/cairn-core/src/domain/capture.rs`
+around line 400 and adapt — do not invent variants. If the codebase uses
+a different field name than `hook_name`, follow the actual one.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo nextest run -p cairn-core pipeline::capture_trace::tests::classifies
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-core/src/pipeline/capture_trace.rs
+git commit -m "feat(core): classify CaptureEvent → TraceEvent (#77, brief §9.3)"
+```
+
+---
+
+## Task 6: Projector — `project()` builds MemoryRecord
+
+**Files:**
+- Modify: `crates/cairn-core/src/pipeline/capture_trace.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```rust
+#[test]
+fn projects_user_message_record() {
+    let event = mk_hook_event("UserPromptSubmit");
+    let resolved = ResolvedBody::from_text("hello world", &event.payload_hash);
+    let link = TraceLink {
+        session_id: sess(),
+        turn_id: "turn-1".into(),
+        sequence: 0,
+        capture_event_id: event.event_id.clone(),
+        parent_event_id: None,
+        tool_call_id: None,
+        member_event_ids: Vec::new(),
+    };
+    let record = project(&event, TraceEvent::UserMessage, &resolved, link).unwrap();
+    assert_eq!(record.kind, MemoryKind::Trace);
+    assert_eq!(record.class, MemoryClass::Episodic);
+    assert_eq!(record.visibility, MemoryVisibility::Private);
+    assert_eq!(record.scope.session_id.as_deref(), Some(sess().as_str()));
+    assert!(record.body.contains("hello world"));
+    let trace_meta = record.extra_frontmatter.get("trace").unwrap();
+    assert_eq!(trace_meta["turn_id"], "turn-1");
+    assert_eq!(trace_meta["sequence"], 0);
+    assert_eq!(record.extra_frontmatter.get("trace_event").unwrap(), "user_message");
+}
+
+#[test]
+fn project_validates_link_against_event() {
+    let event = mk_hook_event("PreToolUse");
+    let resolved = ResolvedBody::from_text("Read", &event.payload_hash);
+    let link_bad = TraceLink { /* missing tool_call_id */ };
+    assert!(project(&event, TraceEvent::PreTool, &resolved, link_bad).is_err());
+}
+```
+
+(`ResolvedBody::from_text` in the test — if no constructor exists yet, use
+whatever public constructor `body.rs` exposes. If none does and the type
+is private, route through the existing extractor pipeline's test-only
+helpers in `body.rs`'s `mod tests`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo nextest run -p cairn-core pipeline::capture_trace::tests::projects
+```
+
+Expected: FAIL — `project` undefined.
+
+- [ ] **Step 3: Implement `project`**
+
+```rust
+use crate::domain::record::MemoryRecord;
+use crate::domain::scope::ScopeTuple;
+use crate::domain::taxonomy::{MemoryClass, MemoryKind, MemoryVisibility};
+use crate::domain::EvidenceVector;
+use crate::pipeline::extract::body::ResolvedBody;
+use serde_json::{Map as JsonMap, Value as Json};
+
+pub fn project(
+    event: &CaptureEvent,
+    classified: TraceEvent,
+    resolved_body: &ResolvedBody,
+    link: TraceLink,
+) -> Result<MemoryRecord, TraceProjectError> {
+    link.validate(classified)?;
+
+    // Trace fields go entirely under extra_frontmatter.trace (the single
+    // canonical path; see spec §6.1 / §8.1).
+    let mut trace = JsonMap::new();
+    trace.insert("session_id".into(), Json::String(link.session_id.as_str().to_owned()));
+    trace.insert("turn_id".into(), Json::String(link.turn_id.clone()));
+    trace.insert("sequence".into(), Json::Number(link.sequence.into()));
+    trace.insert("capture_event_id".into(), Json::String(link.capture_event_id.to_string()));
+    trace.insert("payload_hash".into(), Json::String(event.payload_hash.to_string()));
+    trace.insert("payload_ref".into(), Json::String(event.payload_ref.clone()));
+    if let Some(parent) = &link.parent_event_id {
+        trace.insert("parent_event_id".into(), Json::String(parent.to_string()));
+    }
+    if let Some(call) = &link.tool_call_id {
+        trace.insert("tool_call_id".into(), Json::String(call.clone()));
+    }
+    if !link.member_event_ids.is_empty() {
+        let arr = link.member_event_ids.iter()
+            .map(|id| Json::String(id.to_string()))
+            .collect();
+        trace.insert("member_event_ids".into(), Json::Array(arr));
+    }
+
+    let mut extra = std::collections::BTreeMap::new();
+    extra.insert("trace_event".into(), Json::String(serde_json::to_value(classified)?
+        .as_str().unwrap_or("").to_owned()));
+    extra.insert("trace".into(), Json::Object(trace));
+
+    let body = shape_body(classified, resolved_body.text());
+    let scope = ScopeTuple {
+        session_id: Some(link.session_id.as_str().to_owned()),
+        // Other dimensions copied from the event's actor chain — match
+        // whatever the existing squash projector does for ScopeTuple.
+        ..ScopeTuple::default()
+    };
+
+    let id = if classified == TraceEvent::TurnSummary {
+        crate::domain::trace::summary_record_id(&link.session_id, &link.turn_id)
+    } else {
+        // For non-summary events, derive RecordId from capture_event_id
+        // (same shape, ULID).
+        crate::domain::RecordId::parse(link.capture_event_id.as_str())?
+    };
+
+    Ok(MemoryRecord {
+        id: id.clone(),
+        target_id: id.into(), // fresh record, target_id == id (record.rs §3)
+        kind: MemoryKind::Trace,
+        class: MemoryClass::Episodic,
+        visibility: MemoryVisibility::Private,
+        scope,
+        body,
+        provenance: provenance_from_event(event), // small helper, see below
+        updated_at: event.captured_at.clone(),
+        evidence: EvidenceVector::default(),
+        salience: 0.5,
+        confidence: 1.0,
+        actor_chain: event.actor_chain.clone(),
+        signature: /* see note */ ,
+        tags: Vec::new(),
+        extra_frontmatter: extra,
+    })
+}
+```
+
+**Signature note:** `MemoryRecord` carries an Ed25519 signature over the
+canonical record bytes (`record.rs:170`). The squash pipeline already has
+a sign-after-build path; mirror it. If signing requires a key handle, the
+projector takes a signing closure as an extra parameter. Look at how
+`pipeline::squash` resolves this in the codebase before forcing a shape;
+if signing is deferred to a separate stage in squash (likely), do the
+same here — leave `signature` as a placeholder until a follow-up signing
+stage. Update the test to construct an unsigned record if the codebase
+already has that pattern.
+
+`provenance_from_event` is a small helper that copies sensor + capture_mode
++ captured_at into the existing `Provenance` struct. Look at the squash
+projector's equivalent and replicate.
+
+Add `#[derive(thiserror::Error)] enum` variants for any new errors used:
+
+```rust
+#[error("invalid record id derivation: {0}")]
+RecordId(#[from] crate::domain::DomainError),
+#[error("serde: {0}")]
+Serde(#[from] serde_json::Error),
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo nextest run -p cairn-core pipeline::capture_trace::tests::projects
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/pipeline/capture_trace.rs
+git commit -m "feat(core): project CaptureEvent → trace MemoryRecord (#77, brief §5.0)"
+```
+
+---
+
+## Task 7: Sequence ordering — `order_by_captured_at` + `assign_sequences`
+
+**Files:**
+- Create: `crates/cairn-core/src/pipeline/turn.rs`
+- Modify: `crates/cairn-core/src/pipeline/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/cairn-core/src/pipeline/turn.rs`:
+
+```rust
+//! Turn-level pure helpers for trace persistence (issue #77).
+
+use crate::domain::capture::CaptureEvent;
+use crate::domain::record::MemoryRecord;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(id: &str, captured_at: &str) -> CaptureEvent {
+        // Builder — copy from pipeline::squash::tests if available.
+        todo!("use the existing test builder")
+    }
+
+    #[test]
+    fn orders_by_captured_at_then_event_id() {
+        let a = mk("01ARZ3NDEKTSV4RRFFQ69G5FAA", "2026-05-02T00:00:01Z");
+        let b = mk("01ARZ3NDEKTSV4RRFFQ69G5FAB", "2026-05-02T00:00:00Z");
+        let c = mk("01ARZ3NDEKTSV4RRFFQ69G5FAC", "2026-05-02T00:00:00Z");
+        let ordered = order_by_captured_at(&[], &[(&a, ()), (&b, ()), (&c, ())]);
+        // Earlier timestamp first; ties broken by capture_event_id.
+        assert_eq!(ordered[0].event.event_id.as_str(), "01ARZ3NDEKTSV4RRFFQ69G5FAB");
+        assert_eq!(ordered[1].event.event_id.as_str(), "01ARZ3NDEKTSV4RRFFQ69G5FAC");
+        assert_eq!(ordered[2].event.event_id.as_str(), "01ARZ3NDEKTSV4RRFFQ69G5FAA");
+    }
+
+    #[test]
+    fn assigns_sequences_zero_indexed() {
+        // Three sorted events → sequences 0,1,2.
+        // Test details after order_by_captured_at lands.
+    }
+}
+```
+
+(Note: the `(&a, ())` pattern shows the function takes pairs of (event,
+classified). Pick the actual signature when implementing — `()` is a
+placeholder for whatever metadata travels with each event; in practice
+it'll be `TraceEvent`.)
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+cargo nextest run -p cairn-core pipeline::turn::tests::orders
+```
+
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::domain::trace::{TraceEvent, TraceLink};
+
+pub struct OrderedEntry<'a> {
+    pub event: &'a CaptureEvent,
+    pub classified: TraceEvent,
+}
+
+/// Merge already-persisted records (decoded from the store) with newly
+/// arriving events, sorted by `(captured_at, capture_event_id)`. Stable
+/// across replays.
+pub fn order_by_captured_at<'a>(
+    persisted: &'a [(MemoryRecord, &'a CaptureEvent, TraceEvent)],
+    incoming: &'a [(&'a CaptureEvent, TraceEvent)],
+) -> Vec<OrderedEntry<'a>> {
+    let mut all: Vec<OrderedEntry<'a>> = persisted.iter()
+        .map(|(_, ev, cls)| OrderedEntry { event: ev, classified: *cls })
+        .chain(incoming.iter().map(|(ev, cls)| OrderedEntry { event: *ev, classified: *cls }))
+        .collect();
+    all.sort_by(|x, y| {
+        x.event.captured_at.cmp(&y.event.captured_at)
+            .then_with(|| x.event.event_id.as_str().cmp(y.event.event_id.as_str()))
+    });
+    all
+}
+
+/// Assign sequences 0..N over an already-ordered slice. Returns Vec<TraceLink>
+/// with the resolved `sequence`. Caller fills the rest of `TraceLink`.
+pub fn assign_sequences(
+    session_id: &crate::domain::SessionId,
+    turn_id: &str,
+    ordered: &[OrderedEntry<'_>],
+) -> Vec<TraceLink> {
+    ordered.iter().enumerate().map(|(i, entry)| {
+        let mut link = TraceLink {
+            session_id: session_id.clone(),
+            turn_id: turn_id.to_owned(),
+            sequence: i as u64,
+            capture_event_id: entry.event.event_id.clone(),
+            parent_event_id: None,
+            tool_call_id: None,
+            member_event_ids: Vec::new(),
+        };
+        // Caller (CLI verb) fills parent/tool_call_id from the event's
+        // refs after this returns. Keep this fn pure-data, no side effects.
+        link
+    }).collect()
+}
+```
+
+Note: real signatures may differ — adapt the persisted-slice tuple to
+whatever the store actually returns. The point is: reading a turn's rows
+gives you back enough to reconstruct an `OrderedEntry`.
+
+Add to `crates/cairn-core/src/pipeline/mod.rs`:
+
+```rust
+pub mod turn;
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo nextest run -p cairn-core pipeline::turn
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/pipeline/turn.rs crates/cairn-core/src/pipeline/mod.rs
+git commit -m "feat(core): captured_at sequence ordering helpers (#77)"
+```
+
+---
+
+## Task 8: `summarize_turn` — pure roll-up
+
+**Files:**
+- Modify: `crates/cairn-core/src/pipeline/turn.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pipeline::turn::tests`:
+
+```rust
+#[test]
+fn summarize_orders_and_collects_member_ids() {
+    let events: Vec<MemoryRecord> = vec![
+        // build three trace records with sequence 0,1,2 and three different
+        // capture_event_ids in extra_frontmatter.trace
+        // ...
+    ];
+    let summary = summarize_turn(&sess(), "turn-1", &events).unwrap();
+    let trace = summary.extra_frontmatter.get("trace").unwrap();
+    let members = trace["member_event_ids"].as_array().unwrap();
+    assert_eq!(members.len(), 3);
+    assert_eq!(summary.kind, MemoryKind::Trace);
+    assert_eq!(
+        summary.extra_frontmatter.get("trace_event").unwrap(),
+        "turn_summary"
+    );
+    // Deterministic id matches what summary_record_id produces.
+    assert_eq!(
+        summary.id,
+        crate::domain::trace::summary_record_id(&sess(), "turn-1")
+    );
+}
+
+#[test]
+fn summarize_rejects_cross_turn_events() {
+    let mixed = vec![/* records from two different turns */];
+    assert!(matches!(
+        summarize_turn(&sess(), "turn-1", &mixed).unwrap_err(),
+        TurnSummaryError::CrossTurn
+    ));
+}
+
+#[test]
+fn summarize_rejects_empty() {
+    assert!(matches!(
+        summarize_turn(&sess(), "turn-1", &[]).unwrap_err(),
+        TurnSummaryError::EmptyTurn
+    ));
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+cargo nextest run -p cairn-core pipeline::turn::tests::summarize
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```rust
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TurnSummaryError {
+    #[error("turn must contain at least one event")]
+    EmptyTurn,
+    #[error("events span more than one (session_id, turn_id)")]
+    CrossTurn,
+    #[error("sequences must be strictly increasing")]
+    OutOfOrderSequences,
+    #[error("record is missing extra_frontmatter.trace")]
+    MissingTrace,
+}
+
+pub fn summarize_turn(
+    session_id: &crate::domain::SessionId,
+    turn_id: &str,
+    events: &[MemoryRecord],
+) -> Result<MemoryRecord, TurnSummaryError> {
+    if events.is_empty() {
+        return Err(TurnSummaryError::EmptyTurn);
+    }
+    // Validate all events share (session_id, turn_id) and sequences strict-inc.
+    let mut last_seq: Option<u64> = None;
+    let mut member_ids = Vec::with_capacity(events.len());
+    for r in events {
+        let trace = r.extra_frontmatter.get("trace")
+            .and_then(|v| v.as_object())
+            .ok_or(TurnSummaryError::MissingTrace)?;
+        let s = trace.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
+        let t = trace.get("turn_id").and_then(|v| v.as_str()).unwrap_or("");
+        if s != session_id.as_str() || t != turn_id {
+            return Err(TurnSummaryError::CrossTurn);
+        }
+        let seq = trace.get("sequence").and_then(|v| v.as_u64())
+            .ok_or(TurnSummaryError::MissingTrace)?;
+        if let Some(prev) = last_seq {
+            if seq <= prev { return Err(TurnSummaryError::OutOfOrderSequences); }
+        }
+        last_seq = Some(seq);
+        let cap_id = trace.get("capture_event_id").and_then(|v| v.as_str())
+            .ok_or(TurnSummaryError::MissingTrace)?;
+        member_ids.push(cap_id.to_owned());
+    }
+
+    // Body: deterministic concat (one line per event). Cap at TRACE_BODY_CAP.
+    let mut body = format!("## Turn {} (session {})\n", turn_id, session_id.as_str());
+    for r in events {
+        let trace = r.extra_frontmatter.get("trace").and_then(|v| v.as_object()).unwrap();
+        let seq = trace.get("sequence").and_then(|v| v.as_u64()).unwrap_or(0);
+        let evt = r.extra_frontmatter.get("trace_event").and_then(|v| v.as_str()).unwrap_or("");
+        let excerpt: String = r.body.chars().take(80).collect();
+        body.push_str(&format!("- [seq {}] {}: {}\n", seq, evt, excerpt));
+    }
+
+    // Build the summary record using the same projector path: synthesize a
+    // TraceLink with member_event_ids set, then construct directly (we don't
+    // have a CaptureEvent for synthetic summaries).
+    let id = crate::domain::trace::summary_record_id(session_id, turn_id);
+    // ... fill in MemoryRecord fields, mirroring project() but without
+    // payload_hash/payload_ref (no underlying CaptureEvent).
+
+    todo!("assemble MemoryRecord — see project() for the field set")
+}
+```
+
+(The `todo!()` marker is for *you, the engineer* — fill in by mirroring
+`project()`. Do not commit a `todo!`.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo nextest run -p cairn-core pipeline::turn::tests::summarize
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/pipeline/turn.rs
+git commit -m "feat(core): summarize_turn pure roll-up (#77, brief §5.0)"
+```
+
+---
+
+## Task 9: SQLite migration `0022_trace_links.sql`
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/migrations/sql/0022_trace_links.sql`
+- Modify: `crates/cairn-store-sqlite/src/migrations/mod.rs`
+
+- [ ] **Step 1: Inspect migration registration**
+
+```bash
+grep -n "0021\|register_migrations\|MIGRATIONS\|migrations\\\!" crates/cairn-store-sqlite/src/migrations/mod.rs
+```
+
+Note the registration shape (likely a `&[(&str, &str)]` or `migrations!`
+macro). Match the existing pattern.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `crates/cairn-store-sqlite/tests/migration_smoke.rs`:
+
+```rust
+#[tokio::test]
+async fn migration_0022_trace_links_applies() {
+    let store = test_store_in_memory().await;
+    let conn = store.require_conn("test").unwrap();
+    conn.call(|c| {
+        // Verify the generated columns exist.
+        let mut stmt = c.prepare("PRAGMA table_info(records)").unwrap();
+        let cols: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert!(cols.contains(&"trace_event".to_owned()));
+        assert!(cols.contains(&"trace_session_id".to_owned()));
+        assert!(cols.contains(&"trace_turn_id".to_owned()));
+        assert!(cols.contains(&"trace_sequence".to_owned()));
+        assert!(cols.contains(&"trace_capture_event_id".to_owned()));
+        assert!(cols.contains(&"trace_parent_event_id".to_owned()));
+        assert!(cols.contains(&"trace_payload_hash".to_owned()));
+
+        // Verify indices.
+        let mut idx = c.prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='records'").unwrap();
+        let names: Vec<String> = idx.query_map([], |r| r.get(0)).unwrap().filter_map(Result::ok).collect();
+        assert!(names.contains(&"records_trace_event_id".to_owned()));
+        assert!(names.contains(&"records_trace_summary".to_owned()));
+        assert!(names.contains(&"records_trace_seq".to_owned()));
+        assert!(names.contains(&"records_trace_parent".to_owned()));
+        assert!(names.contains(&"records_trace_payload_hash".to_owned()));
+        Ok::<_, tokio_rusqlite::Error>(())
+    }).await.unwrap();
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cargo nextest run -p cairn-store-sqlite migration_0022
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Write the migration**
+
+`crates/cairn-store-sqlite/src/migrations/sql/0022_trace_links.sql`:
+
+```sql
+-- 0022_trace_links — generated columns + unique indices for trace records
+-- (issue #77, spec §6.1).
+
+ALTER TABLE records ADD COLUMN trace_event TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace_event')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_session_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.session_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_turn_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.turn_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_sequence INTEGER
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.sequence')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_capture_event_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.capture_event_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_parent_event_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.parent_event_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_payload_hash TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.payload_hash')) VIRTUAL;
+
+CREATE UNIQUE INDEX records_trace_event_id
+  ON records(trace_capture_event_id)
+  WHERE trace_capture_event_id IS NOT NULL;
+
+CREATE UNIQUE INDEX records_trace_summary
+  ON records(trace_session_id, trace_turn_id)
+  WHERE trace_event = 'turn_summary';
+
+CREATE UNIQUE INDEX records_trace_seq
+  ON records(trace_session_id, trace_turn_id, trace_sequence)
+  WHERE trace_event IS NOT NULL AND trace_event != 'turn_summary';
+
+CREATE INDEX records_trace_parent
+  ON records(trace_parent_event_id)
+  WHERE trace_parent_event_id IS NOT NULL;
+
+CREATE INDEX records_trace_payload_hash
+  ON records(trace_payload_hash)
+  WHERE trace_payload_hash IS NOT NULL;
+```
+
+Register in `crates/cairn-store-sqlite/src/migrations/mod.rs` matching the
+existing 0021 entry's pattern.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo nextest run -p cairn-store-sqlite migration_0022
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/migrations/
+git commit -m "feat(store): trace-link generated cols + indices (#77, spec §6.1)"
+```
+
+---
+
+## Task 10: `StoreTx::list_trace_events`
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/store/tx.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/cairn-store-sqlite/tests/trace_store.rs` (new file):
+
+```rust
+//! Integration tests for trace-record store methods.
+
+use cairn_test_fixtures::*;
+use cairn_core::domain::SessionId;
+
+#[tokio::test]
+async fn list_trace_events_orders_by_sequence() {
+    let store = test_store_in_memory().await;
+    // Insert three trace records with sequences 2, 0, 1 (deliberately scrambled).
+    insert_trace_record(&store, /* session, turn, sequence */).await;
+    // ...
+    store.with_tx(|tx| {
+        let rows = tx.list_trace_events(&sess(), "turn-1")?;
+        let seqs: Vec<u64> = rows.iter()
+            .map(|r| r.extra_frontmatter["trace"]["sequence"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![0, 1, 2]);
+        Ok(())
+    }).await.unwrap();
+}
+
+#[tokio::test]
+async fn list_trace_events_excludes_summary() {
+    // Insert summary + two events, expect only the two events back.
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo nextest run -p cairn-store-sqlite trace_store
+```
+
+Expected: FAIL — `list_trace_events` undefined.
+
+- [ ] **Step 3: Implement**
+
+Add to `crates/cairn-store-sqlite/src/store/tx.rs` `impl StoreTx`:
+
+```rust
+use cairn_core::domain::SessionId;
+use cairn_core::domain::record::MemoryRecord;
+
+pub fn list_trace_events(
+    &self,
+    session_id: &SessionId,
+    turn_id: &str,
+) -> Result<Vec<MemoryRecord>, StoreError> {
+    let mut stmt = self.tx.prepare(
+        "SELECT <full record-row columns> FROM records \
+            WHERE trace_session_id = ?1 \
+              AND trace_turn_id = ?2 \
+              AND trace_event IS NOT NULL \
+              AND trace_event != 'turn_summary' \
+              AND tombstoned = 0 \
+            ORDER BY trace_sequence ASC"
+    )?;
+    let rows = stmt.query_map(
+        rusqlite::params![session_id.as_str(), turn_id],
+        |row| { /* re-use existing row→MemoryRecord decoder */ Ok(decode_row(row)) },
+    )?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(StoreError::from)
+}
+```
+
+The `<full record-row columns>` and `decode_row` should reuse the same
+helpers as `read.rs`'s existing record loaders. Look there:
+
+```bash
+grep -n "fn decode_row\|fn record_from_row\|SELECT.*records" crates/cairn-store-sqlite/src/store/read.rs | head
+```
+
+Reuse — do not duplicate the column list.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo nextest run -p cairn-store-sqlite trace_store::list_trace_events
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/store/tx.rs crates/cairn-store-sqlite/tests/trace_store.rs
+git commit -m "feat(store): list_trace_events ordered read (#77)"
+```
+
+---
+
+## Task 11: `StoreTx::turn_summary_exists` + `payload_hash_count_in_scope`
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/store/tx.rs`
+
+- [ ] **Step 1: Failing tests**
+
+Append to `tests/trace_store.rs`:
+
+```rust
+#[tokio::test]
+async fn turn_summary_exists_after_write() {
+    let store = test_store_in_memory().await;
+    store.with_tx(|tx| {
+        assert!(!tx.turn_summary_exists(&sess(), "turn-1")?);
+        // Write a summary record (raw upsert with trace_event='turn_summary').
+        insert_summary(tx, &sess(), "turn-1");
+        assert!(tx.turn_summary_exists(&sess(), "turn-1")?);
+        Ok(())
+    }).await.unwrap();
+}
+
+#[tokio::test]
+async fn payload_hash_count_excludes_target_set() {
+    // Two records sharing the same payload_hash under the same scope.
+    // count_in_scope(hash, scope, exclude=[id1]) should return 1.
+}
+```
+
+- [ ] **Step 2: Run failing**
+
+```bash
+cargo nextest run -p cairn-store-sqlite turn_summary_exists payload_hash_count
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```rust
+pub fn turn_summary_exists(
+    &self,
+    session_id: &SessionId,
+    turn_id: &str,
+) -> Result<bool, StoreError> {
+    let mut stmt = self.tx.prepare(
+        "SELECT 1 FROM records \
+          WHERE trace_event = 'turn_summary' \
+            AND trace_session_id = ?1 \
+            AND trace_turn_id = ?2 \
+            AND tombstoned = 0 \
+          LIMIT 1"
+    )?;
+    let exists = stmt
+        .query_row(rusqlite::params![session_id.as_str(), turn_id], |_| Ok(()))
+        .optional()?
+        .is_some();
+    Ok(exists)
+}
+
+pub fn payload_hash_count_in_scope(
+    &self,
+    payload_hash: &str,
+    tenant: Option<&str>,
+    user: Option<&str>,
+    agent: Option<&str>,
+    exclude: &[&str],   // record_ids being forgotten
+) -> Result<u64, StoreError> {
+    // Build the IN-clause dynamically; or use a temp table for large excludes.
+    // Look at existing `forget` or `tombstone` queries for the established
+    // pattern.
+    todo!("see read.rs / consent.rs for in-scope query templates")
+}
+```
+
+- [ ] **Step 4: Run passing**
+
+```bash
+cargo nextest run -p cairn-store-sqlite turn_summary_exists payload_hash_count
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/store/tx.rs crates/cairn-store-sqlite/tests/trace_store.rs
+git commit -m "feat(store): summary-exists + scoped payload_hash refcount (#77)"
+```
+
+---
+
+## Task 12: `StoreTx::upsert_trace`
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/store/tx.rs`
+
+- [ ] **Step 1: Failing test — idempotency**
+
+Append to `tests/trace_store.rs`:
+
+```rust
+#[tokio::test]
+async fn upsert_trace_is_idempotent_on_capture_event_id() {
+    let store = test_store_in_memory().await;
+    let event_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    let record = mk_trace_record(event_id, /* seq */ 0);
+    store.with_tx(|tx| { tx.upsert_trace(&record)?; Ok(()) }).await.unwrap();
+    store.with_tx(|tx| { tx.upsert_trace(&record)?; Ok(()) }).await.unwrap();
+
+    store.with_tx(|tx| {
+        let rows = tx.list_trace_events(&sess(), "turn-1")?;
+        assert_eq!(rows.len(), 1, "duplicate capture_event_id must not produce two rows");
+        Ok(())
+    }).await.unwrap();
+}
+
+#[tokio::test]
+async fn upsert_trace_rejects_duplicate_sequence() {
+    let store = test_store_in_memory().await;
+    let r1 = mk_trace_record("01ARZ3NDEKTSV4RRFFQ69G5FAA", 0);
+    let r2 = mk_trace_record("01ARZ3NDEKTSV4RRFFQ69G5FBB", 0); // same seq, different event id
+    let result: Result<_, _> = store.with_tx(|tx| {
+        tx.upsert_trace(&r1)?;
+        tx.upsert_trace(&r2)?;
+        Ok(())
+    }).await;
+    let err = result.unwrap_err();
+    // Map UNIQUE-constraint failure to a typed TraceSequenceConflict.
+    assert!(matches!(err, StoreError::TraceSequenceConflict { .. }));
+}
+```
+
+- [ ] **Step 2: Run failing**
+
+```bash
+cargo nextest run -p cairn-store-sqlite upsert_trace
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```rust
+pub fn upsert_trace(
+    &mut self,
+    record: &MemoryRecord,
+) -> Result<UpsertOutcome, StoreError> {
+    // Reuse upsert_in_tx — the unique indices on trace_capture_event_id and
+    // (trace_session_id, trace_turn_id, trace_sequence) handle idempotency
+    // and conflicts respectively.
+    match upsert_in_tx(&mut self.tx, record) {
+        Ok(out) => Ok(out),
+        Err(StoreError::Sqlite(e)) if is_unique_constraint(&e, "records_trace_seq") => {
+            Err(StoreError::TraceSequenceConflict {
+                session_id: extract_session(record),
+                turn_id:    extract_turn(record),
+                sequence:   extract_seq(record),
+            })
+        }
+        Err(other) => Err(other),
+    }
+}
+```
+
+Add `TraceSequenceConflict { session_id, turn_id, sequence }` to
+`crates/cairn-store-sqlite/src/error.rs`. The `is_unique_constraint`
+helper checks the SQLite error string for the index name.
+
+- [ ] **Step 4: Run passing**
+
+```bash
+cargo nextest run -p cairn-store-sqlite upsert_trace
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/store/tx.rs crates/cairn-store-sqlite/src/error.rs crates/cairn-store-sqlite/tests/trace_store.rs
+git commit -m "feat(store): upsert_trace + TraceSequenceConflict (#77)"
+```
+
+---
+
+## Task 13: Two-phase renumber on backfill
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/store/tx.rs`
+
+- [ ] **Step 1: Failing test**
+
+Append to `tests/trace_store.rs`:
+
+```rust
+#[tokio::test]
+async fn out_of_order_backfill_renumbers() {
+    let store = test_store_in_memory().await;
+    // Insert two events at captured_at t=2 (seq 0) and t=3 (seq 1).
+    // Then backfill an event at captured_at t=1 — expect final order
+    // [t1=seq0, t2=seq1, t3=seq2].
+    let a = mk_trace_record_at("01ARZ3NDEKTSV4RRFFQ69G5FAA", "2026-05-02T00:00:02Z", 0);
+    let b = mk_trace_record_at("01ARZ3NDEKTSV4RRFFQ69G5FAB", "2026-05-02T00:00:03Z", 1);
+    store.with_tx(|tx| { tx.upsert_trace(&a)?; tx.upsert_trace(&b)?; Ok(()) }).await.unwrap();
+
+    let c = mk_trace_record_at("01ARZ3NDEKTSV4RRFFQ69G5FAC", "2026-05-02T00:00:01Z", 0);
+    // The CLI verb's renumber path will assign c=0, a=1, b=2. Drive it via
+    // a helper: `renumber_turn_with(tx, &sess(), "turn-1", &[c])`.
+    store.with_tx(|tx| {
+        renumber_turn_with(tx, &sess(), "turn-1", &[c])?;
+        let seqs: Vec<u64> = tx.list_trace_events(&sess(), "turn-1")?.iter()
+            .map(|r| r.extra_frontmatter["trace"]["sequence"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![0, 1, 2]);
+        Ok(())
+    }).await.unwrap();
+}
+```
+
+- [ ] **Step 2: Run failing**
+
+Expected: FAIL — `renumber_turn_with` undefined.
+
+- [ ] **Step 3: Implement two-phase renumber**
+
+In `tx.rs`:
+
+```rust
+/// Two-phase renumber of all trace events for a turn (issue #77, spec §4
+/// "Ordering"). Park existing rows on negative sentinels first, reassign
+/// `0..N` sorted by (captured_at, capture_event_id), then write the
+/// final values. Runs entirely inside the open transaction.
+pub fn renumber_turn_with(
+    &mut self,
+    session_id: &SessionId,
+    turn_id: &str,
+    incoming: &[MemoryRecord],
+) -> Result<(), StoreError> {
+    // 1. Read existing rows.
+    let existing = self.list_trace_events(session_id, turn_id)?;
+    // 2. Park: rewrite each existing row's trace.sequence to -1-i.
+    for (i, row) in existing.iter().enumerate() {
+        let parked = with_sequence(row, -1 - i as i64)?;
+        upsert_in_tx(&mut self.tx, &parked)?;
+    }
+    // 3. Order all (existing + incoming) by captured_at + event_id, assign 0..N.
+    let mut all: Vec<MemoryRecord> = existing;
+    all.extend(incoming.iter().cloned());
+    all.sort_by(|a, b| compare_by_captured_at_and_event_id(a, b));
+    // 4. Final assignment.
+    for (i, row) in all.iter().enumerate() {
+        let final_row = with_sequence(row, i as i64)?;
+        upsert_in_tx(&mut self.tx, &final_row)?;
+    }
+    Ok(())
+}
+```
+
+`with_sequence` rebuilds `extra_frontmatter.trace.sequence` and re-signs
+the record (signature note in Task 6 applies). `compare_by_captured_at_and_event_id`
+walks `extra_frontmatter.trace.capture_event_id` plus the record's
+`updated_at` (or a stored `captured_at` you carry through projection).
+
+**Sequence column type:** if `trace_sequence` is INTEGER, negative
+sentinels work natively. If you defined it as a TEXT-storing JSON
+representation, the comparison still works but verify with
+`PRAGMA table_info`.
+
+- [ ] **Step 4: Run passing**
+
+```bash
+cargo nextest run -p cairn-store-sqlite trace_store::out_of_order_backfill
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/store/tx.rs crates/cairn-store-sqlite/tests/trace_store.rs
+git commit -m "feat(store): two-phase renumber on out-of-order backfill (#77)"
+```
+
+---
+
+## Task 14: Referential validation in transaction
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/store/tx.rs`
+
+- [ ] **Step 1: Failing tests**
+
+```rust
+#[tokio::test]
+async fn orphan_parent_rejected() {
+    let store = test_store_in_memory().await;
+    let post_tool = mk_post_tool_record(
+        "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+        /* parent */ "01ARZ3NDEKTSV4RRFFQ69G5FBB",  // never inserted
+        /* tool_call_id */ "call_abc",
+    );
+    let result: Result<_, _> = store.with_tx(|tx| {
+        tx.upsert_trace(&post_tool)?;
+        tx.validate_turn_links(&sess(), "turn-1")?;
+        Ok(())
+    }).await;
+    assert!(matches!(
+        result.unwrap_err(),
+        StoreError::TraceLinkOrphan { .. }
+    ));
+}
+
+#[tokio::test]
+async fn tool_call_id_mismatch_rejected() {
+    // pre_tool with call_abc, post_tool referencing pre_tool but with
+    // tool_call_id="other" — rejected.
+}
+```
+
+- [ ] **Step 2: Run failing**
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```rust
+pub fn validate_turn_links(
+    &self,
+    session_id: &SessionId,
+    turn_id: &str,
+) -> Result<(), StoreError> {
+    let rows = self.list_trace_events(session_id, turn_id)?;
+    // Build map: capture_event_id → (trace_event, tool_call_id).
+    let by_id: std::collections::HashMap<String, (String, Option<String>)> = rows.iter()
+        .map(|r| {
+            let trace = &r.extra_frontmatter["trace"];
+            let id = trace["capture_event_id"].as_str().unwrap_or("").to_owned();
+            let evt = r.extra_frontmatter["trace_event"].as_str().unwrap_or("").to_owned();
+            let tcid = trace.get("tool_call_id").and_then(|v| v.as_str()).map(str::to_owned);
+            (id, (evt, tcid))
+        })
+        .collect();
+    for r in &rows {
+        let trace = &r.extra_frontmatter["trace"];
+        let event = r.extra_frontmatter["trace_event"].as_str().unwrap_or("");
+        if !matches!(event, "post_tool" | "tool_output") { continue; }
+        let parent = trace.get("parent_event_id").and_then(|v| v.as_str())
+            .ok_or_else(|| StoreError::Invariant("missing parent_event_id".into()))?;
+        let (parent_evt, parent_tcid) = by_id.get(parent)
+            .ok_or_else(|| StoreError::TraceLinkOrphan {
+                child_id: trace["capture_event_id"].as_str().unwrap().to_owned(),
+                parent_id: parent.to_owned(),
+                reason: "parent not in turn".into(),
+            })?;
+        if parent_evt != "pre_tool" {
+            return Err(StoreError::TraceLinkOrphan { /* ... */ });
+        }
+        let child_tcid = trace.get("tool_call_id").and_then(|v| v.as_str()).unwrap_or("");
+        let parent_tcid = parent_tcid.as_deref().unwrap_or("");
+        if child_tcid != parent_tcid {
+            return Err(StoreError::TraceLinkOrphan { /* mismatch */ });
+        }
+    }
+    Ok(())
+}
+```
+
+Add `TraceLinkOrphan { child_id, parent_id, reason }` to `StoreError`.
+
+- [ ] **Step 4: Run passing**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/store/tx.rs crates/cairn-store-sqlite/src/error.rs
+git commit -m "feat(store): in-transaction trace-link integrity check (#77)"
+```
+
+---
+
+## Task 15: CLI verb — JSONL parser
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/capture_trace.rs`
+
+- [ ] **Step 1: Failing test**
+
+```bash
+mkdir -p crates/cairn-cli/tests/fixtures/trace
+```
+
+Create `crates/cairn-cli/tests/fixtures/trace/single-turn.jsonl` with three
+hand-written `CaptureEvent` JSON lines (UserPromptSubmit + PreToolUse +
+PostToolUse for a single `(session, turn-1)`).
+
+Add `crates/cairn-cli/tests/capture_trace_verb.rs`:
+
+```rust
+#[tokio::test]
+async fn parses_jsonl_into_events() {
+    let path = "tests/fixtures/trace/single-turn.jsonl";
+    let events = read_jsonl_events(path).await.unwrap();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].refs.as_ref().unwrap().turn_id.as_deref(), Some("turn-1"));
+}
+```
+
+- [ ] **Step 2: Failing**
+
+Expected: FAIL — `read_jsonl_events` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `capture_trace.rs`:
+
+```rust
+use cairn_core::domain::capture::CaptureEvent;
+use std::path::Path;
+use tokio::fs::File;
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+pub async fn read_jsonl_events(path: impl AsRef<Path>) -> anyhow::Result<Vec<CaptureEvent>> {
+    let f = File::open(path).await.context("open trace JSONL")?;
+    let mut lines = BufReader::new(f).lines();
+    let mut events = Vec::new();
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() { continue; }
+        let event: CaptureEvent = serde_json::from_str(&line)
+            .context("parse CaptureEvent line")?;
+        events.push(event);
+    }
+    Ok(events)
+}
+```
+
+- [ ] **Step 4: Passing**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/capture_trace.rs crates/cairn-cli/tests/
+git commit -m "feat(cli): capture_trace JSONL parser (#77)"
+```
+
+---
+
+## Task 16: CLI verb — group by turn + per-turn transaction
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/capture_trace.rs`
+
+- [ ] **Step 1: Failing test — single-turn end-to-end**
+
+```rust
+#[tokio::test]
+async fn capture_trace_single_turn_persists_and_summarizes() {
+    let store = test_sqlite_store().await;
+    capture_trace::run_handler(&store, "tests/fixtures/trace/single-turn.jsonl")
+        .await.unwrap();
+
+    store.with_tx(|tx| {
+        let rows = tx.list_trace_events(&sess(), "turn-1")?;
+        assert_eq!(rows.len(), 3);
+        assert!(tx.turn_summary_exists(&sess(), "turn-1")?);
+        Ok(())
+    }).await.unwrap();
+}
+```
+
+- [ ] **Step 2: Failing**
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** (replace stub)
+
+```rust
+pub async fn run_handler(
+    store: &SqliteMemoryStore,
+    from: &Path,
+) -> anyhow::Result<CaptureTraceResponse> {
+    refuse_if_degraded(store).await?;
+    let events = read_jsonl_events(from).await?;
+
+    let groups = group_by_turn(&events);  // Vec<(SessionId, String, Vec<&CaptureEvent>)>
+    let mut failed = Vec::new();
+    for (session_id, turn_id, raw_group) in groups {
+        let result = store.with_tx(move |tx| {
+            // Project + classify each event.
+            let mut to_write = Vec::with_capacity(raw_group.len());
+            for event in &raw_group {
+                event.validate()?;
+                let classified = classify(event)?;
+                to_write.push((event, classified));
+            }
+            // Pull existing turn rows for renumber.
+            let existing = tx.list_trace_events(&session_id, &turn_id)?;
+            // Compose merged TraceLink list ordered by captured_at.
+            let merged = order_and_assign(&existing, &to_write, &session_id, &turn_id);
+            // Park existing → write merged (Task 13 helper).
+            for parked in park_existing(&existing) {
+                tx.upsert_trace(&parked)?;
+            }
+            for (event, classified, link) in &merged {
+                let resolved = resolve_body(tx, event)?;
+                let record = pipeline::capture_trace::project(
+                    event, *classified, &resolved, link.clone()
+                )?;
+                tx.upsert_trace(&record)?;
+            }
+            tx.validate_turn_links(&session_id, &turn_id)?;
+
+            // Decide whether to summarize.
+            let close_event_in_batch = raw_group.iter()
+                .any(|e| matches!(classify(e), Ok(TraceEvent::Stop)));
+            if close_event_in_batch || tx.turn_summary_exists(&session_id, &turn_id)? {
+                let final_rows = tx.list_trace_events(&session_id, &turn_id)?;
+                let summary = pipeline::turn::summarize_turn(
+                    &session_id, &turn_id, &final_rows,
+                )?;
+                tx.upsert_trace(&summary)?;
+            }
+            Ok::<(), StoreError>(())
+        }).await;
+        if let Err(e) = result {
+            failed.push((session_id, turn_id, e.to_string()));
+        }
+    }
+    Ok(CaptureTraceResponse { trace_id: ulid::Ulid::new().to_string(), failed })
+}
+```
+
+`group_by_turn`, `order_and_assign`, `park_existing`, `resolve_body` are
+small helpers — implement them in this same file. `resolve_body` reads
+`sources/<event.payload_ref>` and verifies `sha256 == event.payload_hash`,
+returning a `ResolvedBody` (use the existing extractor pipeline's helper if
+exposed; otherwise add it next to read_jsonl_events).
+
+- [ ] **Step 4: Passing**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/capture_trace.rs
+git commit -m "feat(cli): capture_trace persists turn + summary (#77, brief §5.0)"
+```
+
+---
+
+## Task 17: CLI verb — multi-turn fixture + atomicity test
+
+**Files:**
+- Create: `crates/cairn-cli/tests/fixtures/trace/multi-turn.jsonl`
+- Create: `crates/cairn-cli/tests/fixtures/trace/multi-turn-second-broken.jsonl`
+- Modify: `crates/cairn-cli/tests/capture_trace_verb.rs`
+
+- [ ] **Step 1: Failing tests**
+
+```rust
+#[tokio::test]
+async fn multi_turn_each_summarized_independently() {
+    let store = test_sqlite_store().await;
+    capture_trace::run_handler(&store, "tests/fixtures/trace/multi-turn.jsonl")
+        .await.unwrap();
+    store.with_tx(|tx| {
+        assert!(tx.turn_summary_exists(&sess(), "turn-1")?);
+        assert!(tx.turn_summary_exists(&sess(), "turn-2")?);
+        // Member ids in turn-1 summary do NOT include turn-2 events.
+        // ...
+        Ok(())
+    }).await.unwrap();
+}
+
+#[tokio::test]
+async fn malformed_second_turn_leaves_first_intact() {
+    let store = test_sqlite_store().await;
+    let result = capture_trace::run_handler(
+        &store, "tests/fixtures/trace/multi-turn-second-broken.jsonl"
+    ).await.unwrap();
+    assert_eq!(result.failed.len(), 1);
+
+    store.with_tx(|tx| {
+        // Turn 1 fully present + summarized.
+        assert!(tx.turn_summary_exists(&sess(), "turn-1")?);
+        // Turn 2 unwritten.
+        let t2 = tx.list_trace_events(&sess(), "turn-2")?;
+        assert!(t2.is_empty());
+        Ok(())
+    }).await.unwrap();
+}
+```
+
+Build the fixtures: `multi-turn.jsonl` is two complete turns; the broken
+variant has a structurally invalid second turn (e.g., `post_tool` whose
+`parent_event_id` does not appear in its own turn).
+
+- [ ] **Step 2: Failing → Passing**
+
+```bash
+cargo nextest run -p cairn-cli capture_trace_verb::multi_turn capture_trace_verb::malformed_second_turn
+```
+
+Expected: PASS (if Task 16's per-turn-transaction logic is correct).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-cli/tests/
+git commit -m "test(cli): multi-turn + per-turn atomicity for capture_trace (#77)"
+```
+
+---
+
+## Task 18: Replay idempotency test + closed-turn resummarize
+
+**Files:**
+- Modify: `crates/cairn-cli/tests/capture_trace_verb.rs`
+
+- [ ] **Step 1: Tests**
+
+```rust
+#[tokio::test]
+async fn replay_is_idempotent() {
+    let store = test_sqlite_store().await;
+    let path = "tests/fixtures/trace/single-turn.jsonl";
+    capture_trace::run_handler(&store, path).await.unwrap();
+    capture_trace::run_handler(&store, path).await.unwrap();
+
+    store.with_tx(|tx| {
+        let rows = tx.list_trace_events(&sess(), "turn-1")?;
+        assert_eq!(rows.len(), 3, "no dupes from replay");
+        assert!(tx.turn_summary_exists(&sess(), "turn-1")?);
+        // Exactly one summary.
+        let n: u32 = tx.tx.query_row(
+            "SELECT COUNT(*) FROM records WHERE trace_event='turn_summary' \
+              AND trace_session_id=?1 AND trace_turn_id=?2",
+            params![sess().as_str(), "turn-1"],
+            |r| r.get(0),
+        ).unwrap();
+        assert_eq!(n, 1);
+        Ok(())
+    }).await.unwrap();
+}
+
+#[tokio::test]
+async fn late_event_after_close_resummarizes() {
+    let store = test_sqlite_store().await;
+    capture_trace::run_handler(&store, "tests/fixtures/trace/single-turn.jsonl")
+        .await.unwrap();
+    // Now import a late tool_output for turn-1 that arrives after Stop.
+    capture_trace::run_handler(
+        &store, "tests/fixtures/trace/single-turn-late.jsonl"
+    ).await.unwrap();
+    store.with_tx(|tx| {
+        let rows = tx.list_trace_events(&sess(), "turn-1")?;
+        assert_eq!(rows.len(), 4);
+        // Summary's member_event_ids must now include the late event.
+        let summary = load_summary(tx, &sess(), "turn-1")?;
+        let members = summary.extra_frontmatter["trace"]["member_event_ids"].as_array().unwrap();
+        assert_eq!(members.len(), 4);
+        Ok(())
+    }).await.unwrap();
+}
+```
+
+Add the `single-turn-late.jsonl` fixture: one `tool_output` event with
+`captured_at` between two existing events.
+
+- [ ] **Step 2: Run**
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-cli/tests/
+git commit -m "test(cli): replay idempotency + closed-turn resummarize (#77)"
+```
+
+---
+
+## Task 19: Forget extension — per-principal hash refcount + payload_ref delete
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/forget.rs`
+- Modify: `crates/cairn-cli/tests/forget_trace.rs` (new)
+
+- [ ] **Step 1: Read existing forget**
+
+```bash
+sed -n '1,80p' crates/cairn-cli/src/verbs/forget.rs
+```
+
+Note where the verb dispatches per record and what state it has access to.
+
+- [ ] **Step 2: Failing test — privacy boundary**
+
+```rust
+#[tokio::test]
+async fn forget_session_deletes_sources_only_when_unreferenced_in_scope() {
+    let store = test_sqlite_store().await;
+    // Insert two trace records under the same scope sharing the same
+    // payload_hash but different payload_refs.
+    let hash = "sha256:deadbeef";
+    insert_trace(&store, /* event_id */ "01A...AA", hash, "sources/a.bin").await;
+    insert_trace(&store, /* event_id */ "01A...BB", hash, "sources/b.bin").await;
+
+    write_blob("sources/a.bin", b"x");
+    write_blob("sources/b.bin", b"x");
+
+    // Forget only the first record.
+    forget::run_record(&store, "01A...AA").await.unwrap();
+    assert!(Path::new("sources/a.bin").exists() == false || /* deleted */ true);
+    // The second record still references the hash → file may stay.
+    assert!(Path::new("sources/b.bin").exists());
+    // Consent journal entry is "retained-self" (not "retained-shared").
+    let entries = read_consent_journal();
+    assert!(entries.iter().any(|e| e.contains("retained-self")));
+}
+```
+
+- [ ] **Step 3: Failing**
+
+Expected: FAIL.
+
+- [ ] **Step 4: Implement**
+
+In `forget.rs`, when iterating forgotten records, branch on
+`record.kind == MemoryKind::Trace`:
+
+```rust
+if record.kind == MemoryKind::Trace {
+    let trace = &record.extra_frontmatter["trace"];
+    let payload_hash = trace["payload_hash"].as_str().unwrap_or("");
+    let payload_ref  = trace["payload_ref"].as_str().unwrap_or("");
+
+    // In-scope refcount. exclude = the record being forgotten.
+    let count = store.with_tx(|tx| tx.payload_hash_count_in_scope(
+        payload_hash,
+        record.scope.tenant.as_deref(),
+        record.scope.user.as_deref(),
+        record.scope.agent.as_deref(),
+        &[record.id.as_str()],
+    )).await?;
+
+    let action = if count == 0 {
+        let path = vault_root.join(payload_ref);
+        if path.exists() {
+            tokio::fs::remove_file(&path).await
+                .context("remove sources/ blob")?;
+        }
+        "deleted"
+    } else {
+        "retained-self"
+    };
+    consent_journal.append(record.id.as_str(), payload_hash, action).await?;
+}
+```
+
+Then redact the record body (existing forget code).
+
+- [ ] **Step 5: Passing**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/forget.rs crates/cairn-cli/tests/
+git commit -m "feat(cli): forget deletes trace sources/ by hash (#77, spec §8.1)"
+```
+
+---
+
+## Task 20: Reconstruction property test
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/tests/trace_reconstruction_proptest.rs`
+
+- [ ] **Step 1: Test**
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn turn_round_trips_through_store(
+        n_events in 1usize..=8,
+        seed in any::<u64>(),
+    ) {
+        // Generate n events with random captured_at timestamps for one turn.
+        // Persist via run_handler (writing them to a tmp JSONL).
+        // list_trace_events back → assert ordering matches sort(captured_at, event_id)
+        // and member_event_ids on the summary equals the full set.
+        // Use tokio::runtime::Runtime::new() inside the proptest body.
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo nextest run -p cairn-store-sqlite trace_reconstruction
+```
+
+Expected: PASS (after enough iterations).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/tests/trace_reconstruction_proptest.rs
+git commit -m "test(store): proptest turn round-trip reconstruction (#77)"
+```
+
+---
+
+## Task 21: CLI snapshot test
+
+**Files:**
+- Modify: `crates/cairn-cli/tests/capture_trace_verb.rs`
+
+- [ ] **Step 1: Test**
+
+```rust
+#[tokio::test]
+async fn capture_trace_response_snapshot() {
+    let store = test_sqlite_store().await;
+    let resp = capture_trace::run_handler(&store, "tests/fixtures/trace/single-turn.jsonl")
+        .await.unwrap();
+    // Stable trace_id for snapshot — override with a fixed ULID in tests.
+    insta::assert_json_snapshot!(resp);
+}
+```
+
+Snapshot file lives at `crates/cairn-cli/tests/snapshots/...`.
+
+- [ ] **Step 2: Run + accept**
+
+```bash
+cargo nextest run -p cairn-cli capture_trace_response_snapshot
+cargo insta review
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-cli/tests/snapshots/ crates/cairn-cli/tests/capture_trace_verb.rs
+git commit -m "test(cli): capture_trace response snapshot (#77)"
+```
+
+---
+
+## Task 22: Verification + traceability
+
+**Files:**
+- Modify: `docs/design/traceability.md`
+
+- [ ] **Step 1: Run full verification checklist**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo nextest run --workspace --locked --no-fail-fast
+cargo test --doc --workspace --locked
+./scripts/check-core-boundary.sh
+cargo run -p cairn-idl --bin cairn-codegen --locked -- --check
+cargo run -p cairn-cli --bin cairn-docgen --locked -- --check
+```
+
+Fix anything that fires. Common issues:
+- Missing rustdoc on new public items → `warn(missing_docs)` is on.
+- `clippy::pedantic` complaints → resolve, don't `#[allow]` without a one-line reason comment.
+- `cargo machete` flags an unused dep you added in Task 3 → delete.
+
+- [ ] **Step 2: Update traceability**
+
+Add to `docs/design/traceability.md` under §5.0 / §9.3 entries:
+
+```
+| §5.0 turn journey | issue #77 | persisted as MemoryKind::Trace records, see crates/cairn-core/src/pipeline/capture_trace.rs |
+```
+
+- [ ] **Step 3: File the follow-up issue locally**
+
+Capture (don't open yet — let the user do that on PR open):
+
+```bash
+cat > /tmp/followup-77.md <<'EOF'
+[P0] Evolve retrieve(target=Turn|Session) IDL to carry an ordered event array
+
+- DataTurn.turn_id should be string (matches CaptureRefs.turn_id).
+- DataTurn.turn should become an array of TurnItems.
+- TurnItem.turn_id should be string.
+
+Trace records persist with the linkage needed (issue #77). This issue
+exposes them through the public retrieve verb so first-party CLI/MCP/SDK
+clients can read trace data back.
+EOF
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/design/traceability.md
+git commit -m "docs: traceability for #77 trace-record persistence"
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --title "feat: persist trace records (issue #77)" --body "$(cat <<'EOF'
+## Summary
+
+- Persists the seven trace event types (user/agent message, pre/post tool, tool output, stop, turn summary) as linked, idempotent records (brief §5.0).
+- Migration 0022 adds generated columns + unique indices: idempotency on capture_event_id, one summary per turn, sequence monotonicity, parent index, payload_hash index.
+- CLI verb `cairn capture_trace --from <jsonl>` runs each turn inside its own transaction; out-of-order backfills renumber via two-phase parking; closed-turn writes resummarize.
+- Forget extended for trace records: in-scope payload_hash refcount + concrete payload_ref deletion.
+- Hook handlers (#79), sensor adapters (#84), Claude Code hook map (#102), and public retrieve(target=Turn) IDL evolution all explicitly out of scope.
+
+## Test plan
+- [ ] `cargo nextest run --workspace`
+- [ ] proptest turn round-trip: 256+ iterations
+- [ ] manual: import single-turn.jsonl, multi-turn.jsonl, late-event.jsonl
+- [ ] forget --session deletes sources/ blobs
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+After the PR opens, post a comment with the captured follow-up text and
+file it as a separate GitHub issue.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §4 domain types → Tasks 1–3; §5 pipeline → Tasks 4–8; §6.1 migration → Task 9; §6.2 store ops → Tasks 10–14; §7 CLI verb → Tasks 15–18; §8.1 forget → Task 19; §9.x tests → Tasks 17, 18, 20, 21; §12 verification → Task 22.
+- **Type consistency:** `TraceLink.turn_id: String` end-to-end; `summary_record_id` returns `RecordId`; CLI verb takes `&SqliteMemoryStore`. Match the actual member name on `CaptureRefs` (`turn_id`, `tool_id`) when reading capture envelopes — do not invent fields.
+- **Open todo's:** Tasks 6 and 8 contain `todo!("...")` placeholders for the engineer to fill in from existing patterns (signature handling, MemoryRecord assembly). They are documentation, not code — do not commit `todo!()`.
+- **Persistent gap (intentional):** public `retrieve(target=Turn)` evolution. Captured in Task 22 follow-up.

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -1,0 +1,314 @@
+# Issue #77 — Persist Trace Records
+
+**Status:** Draft
+**Date:** 2026-05-02
+**Branch:** `feat/issue-77-trace-records`
+**Brief sections:** §5.0 (turn journey), §6.1 (taxonomy), §9.3 (five-hook lifecycle), §10.0 (lifecycle)
+**Issue:** [#77](https://github.com/windoliver/cairn/issues/77)
+**Dependencies (closed):** #71 (CaptureEvent), #76 (session lifecycle)
+**Out of scope:** #79 (hook handlers), #84 (sensor adapters), #102 (Claude Code hook map)
+
+## 1. Goal
+
+Persist seven trace event types — `user_message`, `agent_message`, `pre_tool`,
+`post_tool`, `tool_output`, `stop`, `turn_summary` — as linked, ordered,
+attribution-bearing records that participate in retention, redaction, search,
+and forget. A full agent turn must be reconstructable from these records.
+
+## 2. Non-goals
+
+- Hook command handlers (`cairn hook PreToolUse` etc. — #79).
+- Sensor adapters that translate harness payloads into `CaptureEvent`s (#84).
+- LLM-synthesized turn summaries (P1+).
+- P2 tree-structured sessions beyond simple parent/child turn links.
+
+## 3. Approach
+
+One MemoryKind (`MemoryKind::Trace`, already in §6.1) with a structured
+`trace_event` discriminator and `trace` linkage object stored in
+`MemoryRecord.extra_frontmatter`. Reuses the existing
+`CaptureEvent → squash → WAL` pipeline; the only new pipeline functions are
+the trace classifier and the turn-summary roll-up. No new MemoryKinds — the
+19-kind taxonomy stays pinned.
+
+`scope.session_id` mirrors `trace.session_id` so existing IDL `ScopeFilter`
+queries find trace records without new predicates.
+
+## 4. Domain (`cairn-core`)
+
+New module `crates/cairn-core/src/domain/trace.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TraceEvent {
+    UserMessage,
+    AgentMessage,
+    PreTool,
+    PostTool,
+    ToolOutput,
+    Stop,
+    TurnSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TraceLink {
+    pub session_id: SessionId,
+    pub turn_id: u64,
+    pub sequence: u64,                          // monotonic within turn
+    pub capture_event_id: CaptureEventId,       // back-ref to raw envelope
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_event_id: Option<CaptureEventId>, // post_tool/tool_output → pre_tool
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub member_event_ids: Vec<CaptureEventId>,   // turn_summary only
+}
+```
+
+Serialization into `extra_frontmatter`:
+
+```yaml
+trace_event: pre_tool
+trace:
+  session_id: 01ARZ3...
+  turn_id: 4
+  sequence: 2
+  capture_event_id: 01HQ...
+  tool_call_id: call_abc
+```
+
+Validation invariants (all in `TraceLink::validate`):
+
+- `member_event_ids` is empty unless `trace_event == TurnSummary`.
+- `parent_event_id` is set iff `trace_event ∈ {PostTool, ToolOutput}`.
+- `tool_call_id` is set iff `trace_event ∈ {PreTool, PostTool, ToolOutput}`.
+- `sequence` strictly monotonic within `(session_id, turn_id)` — enforced at
+  the store layer (UNIQUE index), surfaced as a typed error.
+
+## 5. Pipeline (`cairn-core/src/pipeline/`)
+
+Two pure modules.
+
+### 5.1 `pipeline/capture_trace.rs`
+
+```rust
+pub fn project(
+    event: &CaptureEvent,
+    classified: TraceEvent,
+    link: TraceLink,
+) -> Result<MemoryRecord, TraceProjectError>
+```
+
+Builds a `MemoryRecord` with:
+
+- `kind = MemoryKind::Trace`
+- `class = MemoryClass::Episodic`
+- `visibility = MemoryVisibility::Private`
+- `scope = ScopeTuple { session_id: Some(link.session_id), .. }`
+- `body` = privacy-filtered text per event type (see §5.3)
+- `extra_frontmatter` = `{trace_event, trace}` plus carry-through of
+  `payload_hash` and `capture_event_id` from the envelope
+- `actor_chain` cloned from the `CaptureEvent` — preserves sensor/author
+  attribution
+- `provenance` filled from `CaptureEvent` metadata (sensor, mode, captured_at)
+
+### 5.2 `pipeline/turn.rs`
+
+```rust
+pub fn summarize_turn(
+    session_id: &SessionId,
+    turn_id: u64,
+    events: &[MemoryRecord],
+) -> Result<MemoryRecord, TurnSummaryError>
+```
+
+Concatenates ordered events into a single `TurnSummary` record. No LLM —
+deterministic format:
+
+```
+## Turn N (session <id>)
+- [seq 0] user_message: <body excerpt>
+- [seq 1] agent_message: <body excerpt>
+- [seq 2] pre_tool: <tool>(<arg digest>)
+- [seq 3] post_tool: <tool> ok=true
+- [seq 4] tool_output: <output excerpt>
+```
+
+Member ids stored in `TraceLink.member_event_ids`. Pre-conditions: `events`
+all have matching `(session_id, turn_id)`, `sequence` strictly increasing,
+and at least one user or agent message. Otherwise typed error.
+
+### 5.3 Body content per event type
+
+Each body is the **already privacy-filtered** text. Filtering reuses the
+existing `filter` pipeline stage (Presidio pre-persist). The raw bytes live
+under `sources/` per the existing capture flow; record bodies hold redacted
+projections.
+
+| Event           | Body                                                 |
+| --------------- | ---------------------------------------------------- |
+| `user_message`  | Filtered user prompt text                            |
+| `agent_message` | Filtered assistant message text + reasoning excerpt  |
+| `pre_tool`      | `<tool_name>(<arg digest>)` — args summarized        |
+| `post_tool`     | `<tool_name> ok=<bool> duration=<ms>`                |
+| `tool_output`   | Filtered output excerpt (capped at N bytes)          |
+| `stop`          | One line: stop reason + total turn duration          |
+| `turn_summary`  | Roll-up text from §5.2                               |
+
+Bodies cap at 4 KiB each; full content stays in `sources/` referenced by
+`payload_ref` on the originating `CaptureEvent`.
+
+## 6. Store (`cairn-store-sqlite`)
+
+### 6.1 Migration `0003_trace_links.sql`
+
+Generated columns over the existing records table extracting trace fields
+from `extra_frontmatter` JSON (SQLite supports `GENERATED ALWAYS AS ... VIRTUAL`
+with `json_extract`):
+
+```sql
+ALTER TABLE records ADD COLUMN trace_event TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace_event')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_session_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.session_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_turn_id INTEGER
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.turn_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_sequence INTEGER
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.sequence')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_parent_event_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.parent_event_id')) VIRTUAL;
+
+CREATE UNIQUE INDEX records_trace_seq
+  ON records(trace_session_id, trace_turn_id, trace_sequence)
+  WHERE trace_event IS NOT NULL AND trace_event != 'turn_summary';
+
+CREATE INDEX records_trace_parent
+  ON records(trace_parent_event_id)
+  WHERE trace_parent_event_id IS NOT NULL;
+```
+
+The unique index enforces sequence monotonicity at the database boundary,
+turning a duplicate `sequence` into a typed `TraceSequenceConflict` error
+instead of silent corruption.
+
+### 6.2 Retrieve targets
+
+`retrieve(target=Turn)` and `retrieve(target=Session)` already exist in the
+IDL with `DataTurn` / `TurnItem` wire shape. Implement them in the SQLite
+store:
+
+- `Turn`: `SELECT ... WHERE trace_session_id=? AND trace_turn_id=? ORDER BY trace_sequence`,
+  fold into `TurnItem` per role mapping (user_message → User,
+  agent_message → Assistant, pre_tool/post_tool/tool_output → Tool with
+  `tool_calls` array).
+- `Session`: paged across turns using the cursor field already in the IDL.
+
+## 7. CLI verb (`cairn-cli/src/verbs/capture_trace.rs`)
+
+Replace the current stub. Pseudocode:
+
+```rust
+async fn run(args: CaptureTraceArgs, store: &dyn MemoryStore) -> Result<...> {
+    refuse_if_degraded(...)?;
+    for event in args.events {
+        let classified = classify(&event)?;          // hook_name + payload tag
+        let link = next_link_for(&store, &event).await?;
+        let record = pipeline::capture_trace::project(&event, classified, link)?;
+        store.write(record).await?;                  // WAL two-phase, §5.6
+    }
+    if args.is_stop {
+        let turn = store.list_turn(session, turn_id).await?;
+        let summary = pipeline::turn::summarize_turn(...)?;
+        store.write(summary).await?;
+    }
+    Ok(success_response(...))
+}
+```
+
+Classification rule: `(CaptureEvent.refs.hook_name, payload tag) → TraceEvent`.
+Static table — no LLM.
+
+## 8. Privacy, forget, search — no new code paths
+
+| Concern   | Mechanism                                                              |
+| --------- | ---------------------------------------------------------------------- |
+| Privacy   | Bodies pass through existing `filter` (Presidio pre-persist). Raw bytes stay in `sources/` referenced by `payload_hash`. |
+| Forget    | `forget --record` / `forget --session` operates on `MemoryRecord` regardless of kind — trace records get embeddings zeroed, bodies dropped, `payload_hash` retained for audit. |
+| Search    | FTS5 already gates by visibility. Trace records default to `private`; `search` with the right scope predicate finds them. |
+| Retention | `ExpirationWorkflow` already operates on `MemoryRecord` — trace records inherit the same decay/salience rules. |
+
+Tests confirm these paths work — no implementation changes expected here. If
+a path *does* need adjustment, that's a finding, not planned work.
+
+## 9. Testing
+
+### 9.1 Unit (`cairn-core`)
+
+- `pipeline::capture_trace::project` — table-driven via `rstest`, one case per
+  `TraceEvent` variant. Asserts kind, class, visibility, scope, body shape,
+  actor_chain, extra_frontmatter.
+- `pipeline::turn::summarize_turn` — ordering, member-id capture, error on
+  cross-turn events, error on missing user/agent message.
+- `domain::trace::TraceLink::validate` — every invariant in §4 has both a
+  passing and a failing case.
+
+### 9.2 Property (`proptest`)
+
+- Round-trip: generate N ordered trace events for a turn → project →
+  `summarize_turn` → reconstruction equals input ordering and parent/child
+  edges.
+
+### 9.3 Integration (`cairn-store-sqlite/tests/`)
+
+- End-to-end `capture_trace` → store → `retrieve(target=Turn)` returns the
+  expected `DataTurn` with `tool_calls` populated, ordering preserved.
+- Duplicate-`sequence` write returns `TraceSequenceConflict`, store state
+  unchanged.
+- `forget --session <id>` zeros bodies of all trace records, leaves
+  `payload_hash` and the consent journal entry intact.
+- Privacy: a trace event whose payload contains a synthetic PII token is
+  redacted in the body but the `payload_hash` matches the un-redacted source.
+
+### 9.4 CLI snapshot
+
+- `cairn capture_trace --json` for a fixture turn produces a stable
+  `insta`-snapshot of the response envelope.
+
+## 10. File map
+
+```
+crates/cairn-core/src/domain/trace.rs                # NEW
+crates/cairn-core/src/domain/mod.rs                  # +pub mod trace
+crates/cairn-core/src/pipeline/capture_trace.rs      # NEW
+crates/cairn-core/src/pipeline/turn.rs               # NEW
+crates/cairn-core/src/pipeline/mod.rs                # +pub mod
+crates/cairn-store-sqlite/migrations/0003_trace_links.sql  # NEW
+crates/cairn-store-sqlite/src/...                    # retrieve(Turn|Session) impl
+crates/cairn-cli/src/verbs/capture_trace.rs          # replace stub
+crates/cairn-test-fixtures/src/...                   # trace fixtures
+```
+
+## 11. Risks
+
+- **Generated-column migration cost.** SQLite virtual generated columns are
+  free at write time but rebuild on read. If retrieve perf suffers, fall back
+  to a denormalized `trace_links` side table populated via trigger. Defer
+  until benchmarks show a problem.
+- **Sequence assignment under crash.** `next_link_for` reads max sequence
+  then writes — a crash between commits could leave a gap. Acceptable
+  (gaps are not corruption); the unique index prevents duplicates.
+- **Body cap of 4 KiB.** Could truncate useful context for long tool outputs.
+  Mitigated by `payload_ref` pointing at full bytes in `sources/`. Tunable
+  via config; default conservative.
+
+## 12. Verification checklist
+
+Standard CLAUDE.md §8 checklist plus:
+
+- `cargo run -p cairn-idl --bin cairn-codegen -- --check` (no IDL changes
+  expected, but verify).
+- `cargo run -p cairn-cli --bin cairn-docgen -- --write` if any CLI flag
+  changes; otherwise skip.

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -86,13 +86,31 @@ trace:
   tool_call_id: call_abc
 ```
 
-Validation invariants (all in `TraceLink::validate`):
+Validation invariants. **Field-level** (`TraceLink::validate`, pure):
 
 - `member_event_ids` is empty unless `trace_event == TurnSummary`.
 - `parent_event_id` is set iff `trace_event ∈ {PostTool, ToolOutput}`.
 - `tool_call_id` is set iff `trace_event ∈ {PreTool, PostTool, ToolOutput}`.
-- `sequence` strictly monotonic within `(session_id, turn_id)` — enforced at
-  the store layer (UNIQUE index), surfaced as a typed error.
+
+**Referential** (enforced inside `transaction(...)` before commit;
+violations roll back the entire turn):
+
+- For every `PostTool` / `ToolOutput` record, `parent_event_id` MUST
+  resolve to an existing `PreTool` record in the same
+  `(session_id, turn_id)` whose `tool_call_id` matches. Cross-turn,
+  cross-session, or cross-tool-call links are rejected with a typed
+  `TraceLinkOrphan` error.
+- `member_event_ids` on a `TurnSummary` MUST be exactly the set of
+  non-summary trace records persisted under the same
+  `(session_id, turn_id)`. Drift surfaces as `TraceSummaryMembership`.
+- `sequence` strictly monotonic within `(session_id, turn_id)` —
+  enforced at the store layer (UNIQUE index), surfaced as
+  `TraceSequenceConflict`.
+
+The referential checks run inside the transaction so a malformed parent
+reference cannot land partially. Field-level checks run earlier in the CLI
+verb's pre-write validation pass (see §7) so invalid input fails fast
+without acquiring write locks.
 
 ## 5. Pipeline (`cairn-core/src/pipeline/`)
 
@@ -437,13 +455,47 @@ separate scoped change with `cairn-docgen --write` re-run.
 
 | Concern   | Mechanism                                                              |
 | --------- | ---------------------------------------------------------------------- |
-| Privacy   | Bodies pass through existing `filter` (Presidio pre-persist). Raw bytes stay in `sources/` referenced by `payload_hash`. |
-| Forget    | `forget --record` / `forget --session` operates on `MemoryRecord` regardless of kind — trace records get embeddings zeroed, bodies dropped, `payload_hash` retained for audit. |
+| Privacy   | Bodies pass through existing `filter` (Presidio pre-persist). Raw bytes live in `sources/` referenced by `payload_hash`; deleted on `forget` (see below). |
 | Search    | FTS5 already gates by visibility. Trace records default to `private`; `search` with the right scope predicate finds them. |
 | Retention | `ExpirationWorkflow` already operates on `MemoryRecord` — trace records inherit the same decay/salience rules. |
 
-Tests confirm these paths work — no implementation changes expected here. If
-a path *does* need adjustment, that's a finding, not planned work.
+### 8.1 Forget for trace records — sources deletion is part of #77
+
+The brief's existing forget semantics for `MemoryRecord` (zero bodies + zero
+embeddings + retain `payload_hash` for audit) is insufficient for trace
+records: the *most sensitive* trace content — raw prompts, tool I/O,
+reasoning — lives in `sources/<payload_hash>` referenced by every trace
+record's envelope. Leaving those bytes on disk after `forget --session`
+defeats the privacy story.
+
+This PR therefore extends `forget` for trace-backed records:
+
+1. `forget --record <id>` and `forget --session <id>` collect the set of
+   `payload_ref` values from every targeted trace record.
+2. For each `payload_ref`:
+   - If no other (non-forgotten) record still references the same
+     `payload_hash`, the file at `sources/<payload_ref>` is **deleted**.
+   - If another record still references it (e.g., the same prompt was
+     captured twice with different attribution), the file is retained
+     and the consent journal logs the retention reason.
+3. The consent journal records, per forgotten record:
+   `{record_id, payload_hash, sources_action: "deleted" | "retained-shared"}`
+   so an auditor can verify after the fact whether raw bytes were erased.
+4. `payload_hash` is still retained on the (now redacted) record itself
+   as the audit anchor — the hash alone is not user-recoverable PII; the
+   bytes it pointed to are gone.
+
+Refcount tracking lives in the existing `sources/` index already maintained
+by the capture pipeline (it must be — `payload_ref` deduplication across
+events is brief §3 behavior). This PR only consults it on forget; if the
+existing implementation lacks a refcount, surfacing that gap as a separate
+issue is acceptable, but #77 cannot ship until *some* sources-deletion
+path lands or the issue's privacy acceptance is downgraded.
+
+### 8.2 Other concerns
+
+Tests confirm the search and retention paths work without code changes — if
+adjustment is needed, that's a finding, not planned work.
 
 ## 9. Testing
 
@@ -481,6 +533,15 @@ a path *does* need adjustment, that's a finding, not planned work.
   event leaves the *first* turn fully persisted (events + summary) and
   the *second* turn unwritten — no partial prefix. Re-running with the
   fixed file completes the second turn idempotently.
+- **Orphan parent rejected**: a `post_tool` whose `parent_event_id`
+  points at a non-existent or cross-turn `pre_tool` returns
+  `TraceLinkOrphan`; the entire turn rolls back.
+- **Tool-call-id mismatch rejected**: a `tool_output` whose
+  `tool_call_id` differs from its parent's returns `TraceLinkOrphan`.
+- **Forget deletes sources**: `forget --session <id>` removes
+  `sources/<payload_ref>` for every trace record where no other live
+  record references the same `payload_hash`. Asserts file removal +
+  consent journal entries `{deleted, retained-shared}`.
 - Duplicate-`sequence` write returns `TraceSequenceConflict`, store state
   unchanged.
 - `forget --session <id>` zeros bodies of all trace records, leaves

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -104,9 +104,24 @@ Two pure modules.
 pub fn project(
     event: &CaptureEvent,
     classified: TraceEvent,
+    resolved_body: &ResolvedBody,    // hash-verified text from sources/
     link: TraceLink,
 ) -> Result<MemoryRecord, TraceProjectError>
 ```
+
+`ResolvedBody` is the existing extractor-pipeline type
+(`crates/cairn-core/src/pipeline/extract/body.rs`) that pairs raw text with
+its `payload_hash` after verification. Same construction as the extractor
+path: callers (the CLI verb) resolve the body from `sources/` referenced by
+`event.payload_ref`, verify `sha256(bytes) == event.payload_hash`, then
+pass the verified body in. The projector itself stays pure — it does no
+I/O, never opens a file, and never receives raw bytes — so the privacy
+boundary stays the same as for ingest.
+
+The privacy filter (Presidio pre-persist) runs on the verified text *before*
+construction so the body stored on the record is the redacted form;
+`payload_hash` continues to bind the record to the un-redacted source for
+audit.
 
 Builds a `MemoryRecord` with:
 
@@ -131,12 +146,31 @@ pub fn summarize_turn(
 ) -> Result<MemoryRecord, TurnSummaryError>
 ```
 
-The summary record uses a **deterministic record id** derived from
-`(session_id, turn_id)` — `RecordId(format!("turnsum:{session_id}:{turn_id}"))`,
-ULID-like prefix or a hash, picked to fit the existing `RecordId` newtype.
-That id is what `upsert_trace` keys on for summary rows: a replay of the
-same turn produces the same id, so the second write is a no-op upsert into
-the existing row instead of a duplicate.
+The summary record uses a **deterministic, ULID-shaped record id** derived
+from `(session_id, turn_id)`. The current `RecordId` newtype validates
+26-char Crockford-base32 ULIDs, so the id must satisfy that lexer:
+
+```rust
+fn summary_record_id(session_id: &SessionId, turn_id: &str) -> RecordId {
+    // SHA-256 over the canonical pair, first 80 bits → ULID timestamp,
+    // next 80 bits → ULID randomness.
+    let mut h = Sha256::new();
+    h.update(b"cairn:trace:turnsum\0");
+    h.update(session_id.as_str().as_bytes());
+    h.update(b"\0");
+    h.update(turn_id.as_bytes());
+    let digest = h.finalize();
+    let ulid = Ulid::from_bytes(digest[..16].try_into().unwrap());
+    RecordId::parse(ulid.to_string()).expect("ULID-shaped by construction")
+}
+```
+
+The result is a stable ULID — same input always maps to the same id — but
+also a *legal* `RecordId` that the rest of the store, IDL serialization,
+and sort logic accept without special-casing. The unique
+`records_trace_summary` index in §6.1 is the second line of defense if a
+deterministic id ever collides with an existing record id (probability
+~2⁻¹²⁸; treated as unreachable but the index still rejects it).
 
 Concatenates ordered events into a single `TurnSummary` record. No LLM —
 deterministic format:
@@ -232,7 +266,67 @@ The unique indices enforce three invariants at the database boundary:
   non-summary events share a `sequence`. Surfaced as a typed
   `TraceSequenceConflict`.
 
-### 6.2 Reconstruction surface and `retrieve` IDL gap
+### 6.2 `MemoryStore` contract additions
+
+Per CLAUDE.md §5/invariant 4 ("implement behind an existing trait"), the
+trace path needs three new method on `MemoryStore`. None alter existing
+methods; all are additive:
+
+```rust
+trait MemoryStore {
+    // ... existing methods ...
+
+    /// Idempotent write keyed on the stable identity in
+    /// `record.extra_frontmatter.trace.capture_event_id` (for raw events)
+    /// or on `record.id` (for `turn_summary`). The store SHALL NOT allocate
+    /// a new row when a matching identity already exists; it MAY no-op or
+    /// update mutable columns (body, salience, redaction state).
+    async fn upsert_trace(&self, record: MemoryRecord) -> Result<(), StoreError>;
+
+    /// Returns trace records for a turn ordered by
+    /// `extra_frontmatter.trace.sequence`. Excludes `turn_summary`.
+    async fn list_trace_events(
+        &self,
+        session_id: &SessionId,
+        turn_id: &str,
+    ) -> Result<Vec<MemoryRecord>, StoreError>;
+
+    /// Run `f` inside a single store-level transaction. Implementations on
+    /// SQLite use `BEGIN IMMEDIATE` so concurrent `capture_trace` invocations
+    /// serialize at the file-lock boundary rather than racing on
+    /// `build_link`'s read-max-then-write. The closure receives a
+    /// `&dyn MemoryStoreTx` — the same trait surface the closure needs
+    /// (`upsert_trace`, `list_trace_events`) bound to the open transaction.
+    async fn transaction<'a, F, T>(
+        &'a self,
+        f: F,
+    ) -> Result<T, StoreError>
+    where
+        F: for<'tx> FnOnce(&'tx dyn MemoryStoreTx) -> BoxFuture<'tx, Result<T, StoreError>>
+            + Send
+            + 'a,
+        T: Send + 'a;
+}
+
+trait MemoryStoreTx: Send + Sync {
+    async fn upsert_trace(&self, record: MemoryRecord) -> Result<(), StoreError>;
+    async fn list_trace_events(
+        &self,
+        session_id: &SessionId,
+        turn_id: &str,
+    ) -> Result<Vec<MemoryRecord>, StoreError>;
+}
+```
+
+The exact callback shape (BoxFuture vs RPITIT, `MemoryStoreTx` as a sealed
+trait) is an implementation detail; the contract is: there exists a way to
+submit a closure that runs atomically against the store, with access to
+the trace methods. Test doubles in `cairn-test-fixtures` implement the
+same trait pair so that pure-core unit tests do not need a real SQLite
+file. WAL §5.6 guarantees still apply — `transaction(...)` is the
+verb-level wrapper *around* the WAL state machine, not a replacement for it.
+
+### 6.3 Reconstruction surface and `retrieve` IDL gap
 
 Issue #77's acceptance reads **"A full agent turn can be reconstructed from
 trace records and links"** and its verification step is **"Run turn
@@ -408,8 +502,9 @@ crates/cairn-core/src/pipeline/capture_trace.rs      # NEW
 crates/cairn-core/src/pipeline/turn.rs               # NEW
 crates/cairn-core/src/pipeline/mod.rs                # +pub mod
 crates/cairn-store-sqlite/migrations/0003_trace_links.sql  # NEW
-crates/cairn-store-sqlite/src/...                    # +list_trace_events impl
-crates/cairn-core/src/contract/memory_store.rs       # +list_trace_events trait method
+crates/cairn-store-sqlite/src/...                    # +upsert_trace, +list_trace_events, +transaction impl (BEGIN IMMEDIATE)
+crates/cairn-core/src/contract/memory_store.rs       # +upsert_trace, +list_trace_events, +transaction (additive — see §6.2)
+crates/cairn-test-fixtures/src/memory_store.rs       # extend in-memory double for new methods
 crates/cairn-cli/src/verbs/capture_trace.rs          # replace stub (uses existing IDL `from` flag)
 crates/cairn-test-fixtures/src/...                   # trace fixtures (JSONL inputs)
 ```
@@ -427,6 +522,14 @@ crates/cairn-test-fixtures/src/...                   # trace fixtures (JSONL inp
 - **Body cap of 4 KiB.** Could truncate useful context for long tool outputs.
   Mitigated by `payload_ref` pointing at full bytes in `sources/`. Tunable
   via config; default conservative.
+- **Public read surface for trace records is a known gap.** Adversarial
+  review surfaced this in three consecutive rounds. The decision (Choice X
+  in §6.3) is to ship persistence first and evolve `retrieve(target=Turn)`
+  in a follow-up. Risk: first-party CLI/MCP/SDK clients see records they
+  cannot read back through the supported public verb until the follow-up
+  lands. Accepted because the user explicitly scoped #77 to persistence-only
+  and the issue's reconstruction acceptance is satisfied at the store
+  boundary by `list_trace_events`.
 
 ## 12. Verification checklist
 

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -563,16 +563,22 @@ shared with another principal.
 
 Concretely:
 
-1. `forget --record <id>` and `forget --session <id>` collect the set of
-   `payload_hash` values from every targeted trace record, **paired
-   with the record's scope** (`scope.tenant`, `scope.user`,
-   `scope.agent`).
-2. For each `(payload_hash, scope)`:
-   - Query the records table for any other live record sharing the same
-     `payload_hash` **AND** matching scope dimensions
-     (same tenant, same user, same agent). If the count is zero in
-     this scope, the corresponding `sources/<payload_hash>.<ext>`
-     entries the principal owns are **deleted**.
+1. `forget --record <id>` and `forget --session <id>` collect, from each
+   targeted trace record's envelope:
+   - `payload_hash` (used for the in-scope refcount query),
+   - **the concrete `payload_ref`** (the actual on-disk path under
+     `sources/`, used for deletion),
+   - the record's scope dimensions (`scope.tenant`, `scope.user`,
+     `scope.agent`).
+2. For each forgotten record:
+   - Query the records table for any *other* live record under the
+     **same** `(tenant, user, agent)` whose `trace_payload_hash` matches
+     this record's hash. If the count is zero in scope, every
+     `payload_ref` collected in step 1 for this hash is **deleted from
+     disk** by its concrete path. This guarantees every on-disk file the
+     forgotten records actually referenced is removed, even if the
+     storage layout is not yet canonicalized to a single hash-derived
+     path.
    - If the count is non-zero (the principal has another live record
      referencing the same blob — same prompt captured twice in their
      own session), the file is retained.
@@ -662,12 +668,14 @@ adjustment is needed, that's a finding, not planned work.
   `TraceLinkOrphan`; the entire turn rolls back.
 - **Tool-call-id mismatch rejected**: a `tool_output` whose
   `tool_call_id` differs from its parent's returns `TraceLinkOrphan`.
-- **Forget deletes sources by hash, scoped to principal**:
-  `forget --session <id>` deletes every `sources/<payload_hash>.<ext>`
-  whose hash has no other live record under the **same**
-  `(tenant, user, agent)`. Asserts file removal when the originating
-  `payload_ref` paths differ but the hash is the same. Consent journal
-  records `{deleted, retained-self}` only — no cross-principal leak.
+- **Forget deletes by concrete payload_ref, scoped refcount by hash**:
+  `forget --session <id>` removes every `payload_ref` path persisted
+  on the forgotten records, gated by an in-scope hash refcount that
+  decides "no other live record references this hash for the same
+  principal." Asserts file removal at the actual paths even when the
+  storage layout uses non-canonical `payload_ref` values. Consent
+  journal records `{deleted, retained-self}` only — no cross-principal
+  leak.
 - **Forget privacy boundary**: a record under principal A and another
   under principal B share the same `payload_hash`. Forgetting A's
   record proceeds as if B's reference does not exist; the consent

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -404,28 +404,38 @@ async fn run(args: CaptureTraceArgs, store: &dyn MemoryStore) -> Result<...> {
     refuse_if_degraded(...)?;
     let events = read_jsonl::<CaptureEvent>(&args.from).await?;  // streaming, bounded buffer
 
-    // Validate the full file *before* writing anything. A malformed event
-    // anywhere in the file aborts the import with no rows persisted.
-    let projected: Vec<(_, _, _)> = events.iter()
-        .map(|event| {
-            event.validate()?;
-            let classified = classify(event)?;
-            Ok((event, classified))
-        })
-        .collect::<Result<_, _>>()?;
-
-    // Group by (session_id, turn_id). Each turn group is one transaction:
-    // either all of its events plus the summary land, or none do. A
-    // mid-import failure for turn N never strands a partial prefix of
-    // turn N's events committed.
-    for (session_id, turn_id, group) in group_by_turn(&projected) {
-        store.transaction(|tx| async move {
+    // Group by (session_id, turn_id). Each turn group is validated and
+    // committed independently — a malformed event in turn 2 does NOT
+    // abort already-validated, committed turn 1. Reasons:
+    //   - large trace batches stay resilient to one bad event;
+    //   - replay with a fixed file finishes the missing turn idempotently;
+    //   - cross-turn coupling is undesirable (the brief treats turns as
+    //     independent units of memory).
+    for (session_id, turn_id, raw_group) in group_by_turn(&events) {
+        // Per-turn validation. Failure leaves earlier turns intact and
+        // surfaces in the response's `failed_turns` list (see below);
+        // it does not poison later turns either.
+        let projected: Result<Vec<_>, _> = raw_group.iter()
+            .map(|event| {
+                event.validate()?;
+                Ok((event, classify(event)?))
+            })
+            .collect();
+        let projected = match projected {
+            Ok(p) => p,
+            Err(e) => { failed_turns.push((session_id, turn_id, e)); continue; }
+        };
+        let group = projected;
+        let result = store.transaction(|tx| async move {
             for (event, classified) in &group {
                 // Inside the tx, build_link's read-max-then-write is
                 // serialized by the WAL state machine (§5.6) — concurrent
                 // writers are sequenced, not racing.
                 let link = build_link(tx, event, *classified).await?;
-                let record = pipeline::capture_trace::project(event, *classified, link)?;
+                let resolved = resolve_body(tx, event).await?; // hash-verified text
+                let record = pipeline::capture_trace::project(
+                    event, *classified, &resolved, link,
+                )?;
                 tx.upsert_trace(record).await?;
             }
             if turn_is_closed(&group) {
@@ -436,9 +446,15 @@ async fn run(args: CaptureTraceArgs, store: &dyn MemoryStore) -> Result<...> {
                 tx.upsert_trace(summary).await?;
             }
             Ok::<_, TraceError>(())
-        }).await?;
+        }).await;
+        if let Err(e) = result {
+            // Transaction rolled back — entire turn is unwritten.
+            // Continue to the next turn; partial earlier turns stay
+            // committed.
+            failed_turns.push((session_id, turn_id, e));
+        }
     }
-    Ok(success_response(trace_id))
+    Ok(success_response(trace_id, failed_turns))
 }
 ```
 
@@ -468,29 +484,44 @@ reasoning — lives in `sources/<payload_hash>` referenced by every trace
 record's envelope. Leaving those bytes on disk after `forget --session`
 defeats the privacy story.
 
-This PR therefore extends `forget` for trace-backed records:
+**One canonical identity for source blobs: `payload_hash`.** The existing
+`CaptureEvent` carries both `payload_hash` (sha256 of bytes) and
+`payload_ref` (vault-relative path under `sources/`). Refcounting and
+deletion both key on `payload_hash` — never on `payload_ref` — to avoid
+the failure mode where two refs point at the same content and only one
+gets cleaned up.
+
+Concretely:
 
 1. `forget --record <id>` and `forget --session <id>` collect the set of
-   `payload_ref` values from every targeted trace record.
-2. For each `payload_ref`:
-   - If no other (non-forgotten) record still references the same
-     `payload_hash`, the file at `sources/<payload_ref>` is **deleted**.
-   - If another record still references it (e.g., the same prompt was
-     captured twice with different attribution), the file is retained
-     and the consent journal logs the retention reason.
+   `payload_hash` values from every targeted trace record's envelope.
+2. For each `payload_hash`:
+   - Query the records table for any non-forgotten record whose envelope
+     references the same `payload_hash`. If the count is zero, **all**
+     `sources/` files associated with that hash are deleted.
+   - Sources are stored at `sources/<payload_hash>.<ext>` going forward
+     (single canonical path per blob); existing capture-write code
+     already obeys this layout per brief §3. If a legacy record exists
+     where multiple `payload_ref` paths share one hash, all matching
+     paths are deleted in the same step — the index walk is over
+     `payload_hash`, not over `payload_ref`.
+   - If the count is non-zero (the blob is still referenced by a live
+     record — same prompt captured twice with different attribution),
+     the file is retained and the consent journal logs the retention.
 3. The consent journal records, per forgotten record:
    `{record_id, payload_hash, sources_action: "deleted" | "retained-shared"}`
-   so an auditor can verify after the fact whether raw bytes were erased.
-4. `payload_hash` is still retained on the (now redacted) record itself
-   as the audit anchor — the hash alone is not user-recoverable PII; the
-   bytes it pointed to are gone.
+   so an auditor can verify whether raw bytes were erased.
+4. `payload_hash` itself is retained on the (now redacted) record as the
+   audit anchor — the hash alone is not user-recoverable PII; the bytes
+   it pointed to are gone.
 
-Refcount tracking lives in the existing `sources/` index already maintained
-by the capture pipeline (it must be — `payload_ref` deduplication across
-events is brief §3 behavior). This PR only consults it on forget; if the
-existing implementation lacks a refcount, surfacing that gap as a separate
-issue is acceptable, but #77 cannot ship until *some* sources-deletion
-path lands or the issue's privacy acceptance is downgraded.
+Refcount tracking is a SQL `COUNT(*)` over the records table keyed on
+`extra_frontmatter.trace.payload_hash` (or the same field surfaced by an
+extracted virtual column, paralleling §6.1). It does not rely on a
+separate sources-side index. If `payload_ref` is ever observed to deviate
+from `sources/<payload_hash>.<ext>` for an existing record, that's a
+capture-pipeline bug, surfaced as a separate issue; the forget code
+itself stays hash-keyed.
 
 ### 8.2 Other concerns
 
@@ -538,10 +569,11 @@ adjustment is needed, that's a finding, not planned work.
   `TraceLinkOrphan`; the entire turn rolls back.
 - **Tool-call-id mismatch rejected**: a `tool_output` whose
   `tool_call_id` differs from its parent's returns `TraceLinkOrphan`.
-- **Forget deletes sources**: `forget --session <id>` removes
-  `sources/<payload_ref>` for every trace record where no other live
-  record references the same `payload_hash`. Asserts file removal +
-  consent journal entries `{deleted, retained-shared}`.
+- **Forget deletes sources by hash**: `forget --session <id>` deletes
+  every `sources/<payload_hash>.<ext>` whose `payload_hash` is no
+  longer referenced by any live record. Asserts file removal even
+  when the original `payload_ref` differed across records that shared
+  the same hash. Consent journal records `{deleted, retained-shared}`.
 - Duplicate-`sequence` write returns `TraceSequenceConflict`, store state
   unchanged.
 - `forget --session <id>` zeros bodies of all trace records, leaves

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -187,6 +187,18 @@ ALTER TABLE records ADD COLUMN trace_sequence INTEGER
 ALTER TABLE records ADD COLUMN trace_parent_event_id TEXT
   GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.parent_event_id')) VIRTUAL;
 
+ALTER TABLE records ADD COLUMN trace_capture_event_id TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.capture_event_id')) VIRTUAL;
+
+-- Idempotency: the same CaptureEvent may not produce two records.
+-- Replays of the same JSONL file therefore upsert into the existing row
+-- (no new sequence allocation) instead of duplicating the logical event.
+CREATE UNIQUE INDEX records_trace_event_id
+  ON records(trace_capture_event_id)
+  WHERE trace_capture_event_id IS NOT NULL;
+
+-- Sequence monotonicity within a turn (excluding the synthetic
+-- turn_summary, which has no sequence of its own).
 CREATE UNIQUE INDEX records_trace_seq
   ON records(trace_session_id, trace_turn_id, trace_sequence)
   WHERE trace_event IS NOT NULL AND trace_event != 'turn_summary';
@@ -196,37 +208,53 @@ CREATE INDEX records_trace_parent
   WHERE trace_parent_event_id IS NOT NULL;
 ```
 
-The unique index enforces sequence monotonicity at the database boundary,
-turning a duplicate `sequence` into a typed `TraceSequenceConflict` error
-instead of silent corruption.
+The unique indices enforce two invariants at the database boundary:
 
-### 6.2 Retrieve targets — store-level reads only
+- **Idempotent replay** — `capture_event_id` is the stable event identity.
+  A second `capture_trace --from <same file>` is absorbed as no-op upserts
+  on existing rows; no fresh sequences allocated.
+- **Sequence monotonicity** — within a `(session_id, turn_id)` no two
+  events share a `sequence`. Surfaced as a typed `TraceSequenceConflict`.
 
-The current `retrieve` IDL is incompatible with what #77 needs to read back:
+### 6.2 Reconstruction surface and `retrieve` IDL gap
 
-- `DataTurn.turn_id` is `integer` (capture envelopes carry strings).
-- `DataTurn.turn` is a single `TurnItem` with one role — it cannot represent
-  an ordered, multi-role event sequence inside a turn.
-- `TurnItem.turn_id` is also integer.
+Issue #77's acceptance reads **"A full agent turn can be reconstructed from
+trace records and links"** and its verification step is **"Run turn
+reconstruction tests"** — the linkage and reconstruction *capability* is
+what's gated, not a specific public surface.
 
-Reshaping the IDL is a brief-level change (CLAUDE.md §5/§4) and is
-**out of scope for #77**. This PR therefore:
+Even so, the current public `retrieve` IDL cannot today expose a
+reconstructed turn:
 
-1. Persists records with the linkage needed to reconstruct any future shape:
-   `(session_id, turn_id, sequence, parent_event_id)` plus `member_event_ids`
-   on the turn summary.
-2. Adds a **store-internal** read API on `MemoryStore` —
-   `list_trace_events(session_id, turn_id) -> Vec<MemoryRecord>` ordered by
-   `sequence` — that the existing `retrieve` verb can call when (and only
-   when) the IDL evolves. Until then, this method is exercised by the
-   integration tests below to satisfy the issue's "full agent turn can be
-   reconstructed" acceptance criterion.
-3. Files a follow-up issue: *Evolve `retrieve(target=Turn|Session)` IDL to
-   carry an ordered event array and string `turn_id`*. Linked from the PR
-   and listed in `docs/design/traceability.md`.
+- `DataTurn.turn_id` is `integer`; capture envelopes carry strings.
+- `DataTurn.turn` is a single `TurnItem` — one role, no event ordering —
+  so a multi-message, multi-tool turn cannot round-trip through it.
 
-The unique sequence index from §6.1 still ships — it protects the linkage
-even though the public retrieve verb cannot yet expose it.
+Two ways to close this gap. Both are explicit choices, not silent deferral:
+
+**Choice X (default, recommended): rescope the public read surface to a
+follow-up.** This PR adds a store-internal
+`MemoryStore::list_trace_events(session_id, turn_id) -> Vec<MemoryRecord>`
+ordered by `sequence`. Reconstruction tests run against that method,
+satisfying #77's acceptance criterion. A follow-up issue is filed to evolve
+`retrieve(target=Turn|Session)` to carry an ordered event array and string
+`turn_id`; #77's PR links to it and notes that first-party CLI/MCP/SDK
+clients cannot read trace records back through `retrieve` until that
+follow-up lands.
+
+**Choice Y: bundle the IDL evolution into this PR.** Mutates the public
+contract — IDL schema change, regenerate via `cairn-codegen`, update
+`retrieve` verb in store, regen docs via `cairn-docgen --write`. Larger
+diff; the change must run alongside any consumers that already deserialize
+`DataTurn`.
+
+Default is **X** because the issue scope (and the user's earlier "A.
+persistence only") explicitly excluded surface-level work. Choosing Y is a
+re-scoping conversation, not a review-loop fix.
+
+The unique sequence + capture_event_id indices from §6.1 ship in either
+choice — they protect the linkage regardless of which read surface is
+exposed first.
 
 ## 7. CLI verb (`cairn-cli/src/verbs/capture_trace.rs`)
 
@@ -247,19 +275,25 @@ Pseudocode:
 async fn run(args: CaptureTraceArgs, store: &dyn MemoryStore) -> Result<...> {
     refuse_if_degraded(...)?;
     let events = read_jsonl::<CaptureEvent>(&args.from).await?;  // streaming, bounded buffer
+
+    // Persist every event. Idempotent on capture_event_id (§6.1) — replays
+    // upsert into existing rows.
     for event in &events {
         event.validate()?;                                       // existing envelope validation
         let classified = classify(event)?;                       // (hook_name, payload tag) → TraceEvent
-        let link = build_link(store, event, classified).await?;  // assigns next sequence per (session, turn)
+        let link = build_link(store, event, classified).await?;  // assigns next sequence per (session, turn) for new rows; reuses for replay
         let record = pipeline::capture_trace::project(event, classified, link)?;
-        store.write(record).await?;                              // WAL two-phase, §5.6
+        store.upsert_trace(record).await?;                       // WAL two-phase, §5.6
     }
-    if let Some(stop_event) = events.iter().rfind(|e| is_stop(e)) {
-        let turn_records = store
-            .list_trace_events(stop_event.session_id()?, stop_event.turn_id()?)
-            .await?;
+
+    // Emit one `turn_summary` per closed turn boundary in the file.
+    // A turn is "closed" when the file contains a Stop event (or an explicit
+    // `end_of_turn` sentinel) for that `(session_id, turn_id)`. Multi-turn
+    // input files are supported — each closed turn gets its own summary.
+    for (session_id, turn_id) in closed_turns(&events) {
+        let turn_records = store.list_trace_events(&session_id, &turn_id).await?;
         let summary = pipeline::turn::summarize_turn(&turn_records)?;
-        store.write(summary).await?;
+        store.upsert_trace(summary).await?;
     }
     Ok(success_response(trace_id))
 }
@@ -311,6 +345,13 @@ a path *does* need adjustment, that's a finding, not planned work.
   `sequence` order with parent/child edges intact. Asserts full-turn
   reconstruction directly at the store boundary (the public retrieve verb
   does not yet expose this shape — see §6.2).
+- **Idempotent replay**: running `capture_trace --from` twice on the same
+  file produces identical store state — no duplicate rows, no new
+  sequences, exactly one `turn_summary` per closed turn. Asserts row
+  counts and `capture_event_id` uniqueness.
+- **Multi-turn input**: a JSONL containing two complete turns yields two
+  `turn_summary` records, each with `member_event_ids` pointing only at
+  its own turn's events.
 - Duplicate-`sequence` write returns `TraceSequenceConflict`, store state
   unchanged.
 - `forget --session <id>` zeros bodies of all trace records, leaves
@@ -344,9 +385,10 @@ crates/cairn-test-fixtures/src/...                   # trace fixtures (JSONL inp
   free at write time but rebuild on read. If retrieve perf suffers, fall back
   to a denormalized `trace_links` side table populated via trigger. Defer
   until benchmarks show a problem.
-- **Sequence assignment under crash.** `next_link_for` reads max sequence
+- **Sequence assignment under crash.** `build_link` reads max sequence
   then writes — a crash between commits could leave a gap. Acceptable
-  (gaps are not corruption); the unique index prevents duplicates.
+  (gaps are not corruption); the unique index prevents duplicates and
+  the `capture_event_id` index keeps replay idempotent.
 - **Body cap of 4 KiB.** Could truncate useful context for long tool outputs.
   Mitigated by `payload_ref` pointing at full bytes in `sources/`. Tunable
   via config; default conservative.

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -92,11 +92,21 @@ Validation invariants. **Field-level** (`TraceLink::validate`, pure):
   tiebreaker so concurrent events with identical wall-clock timestamps
   still produce a deterministic, replay-stable order.
 - A backfilled event whose `captured_at` precedes already-persisted
-  events triggers a **renumber within the affected turn**: the
-  transaction reads the turn's existing rows, recomputes sequences over
-  the union (existing ∪ new), and rewrites the old rows in place. The
-  unique sequence index lets the rewrite happen as `UPDATE` against the
-  same rows; no row is dropped or reinserted.
+  events triggers a **two-phase renumber within the affected turn**:
+  1. **Park** the turn's existing trace rows by rewriting each row's
+     `extra_frontmatter.trace.sequence` to `-1 - i` for `i = 0..M-1`
+     where `i` walks the rows in their pre-existing order. Distinct
+     negatives, so the unique index `records_trace_seq` (which keys on
+     `(session_id, turn_id, sequence)`) holds at every statement.
+  2. **Reassign** sequences over the union (existing ∪ new) sorted by
+     `(captured_at, capture_event_id)`; write the final positive `0..N`
+     values to every row.
+  Both phases run inside the same `BEGIN IMMEDIATE` transaction; the
+  intermediate (negative) state is invisible to other connections, and
+  a crash rolls back to pre-renumber. SQLite checks uniqueness at the
+  end of each statement on a non-deferred index; the parked sentinels
+  guarantee no transient collision because every value is unique within
+  the turn at every step. No row is dropped or reinserted.
 - A backfill into a closed turn (one whose `turn_summary` row already
   exists) is admitted; the transaction additionally recomputes and
   upserts the summary so `member_event_ids` reflects current turn state
@@ -542,44 +552,57 @@ reasoning — lives in `sources/<payload_hash>` referenced by every trace
 record's envelope. Leaving those bytes on disk after `forget --session`
 defeats the privacy story.
 
-**One canonical identity for source blobs: `payload_hash`.** The existing
+**One canonical identity for source blobs: `payload_hash`. Refcounting is
+scoped to the forgetting principal, never global.** The existing
 `CaptureEvent` carries both `payload_hash` (sha256 of bytes) and
-`payload_ref` (vault-relative path under `sources/`). Refcounting and
-deletion both key on `payload_hash` — never on `payload_ref` — to avoid
-the failure mode where two refs point at the same content and only one
-gets cleaned up.
+`payload_ref` (vault-relative path under `sources/`). Deletion keys on
+`payload_hash` so duplicate `payload_ref` paths cannot leave bytes
+behind. Refcounting keys on the **same isolation boundary as the
+forgetting record** so the operation never reveals whether bytes are
+shared with another principal.
 
 Concretely:
 
 1. `forget --record <id>` and `forget --session <id>` collect the set of
-   `payload_hash` values from every targeted trace record's envelope.
-2. For each `payload_hash`:
-   - Query the records table for any non-forgotten record whose envelope
-     references the same `payload_hash`. If the count is zero, **all**
-     `sources/` files associated with that hash are deleted.
-   - Sources are stored at `sources/<payload_hash>.<ext>` going forward
-     (single canonical path per blob); existing capture-write code
-     already obeys this layout per brief §3. If a legacy record exists
-     where multiple `payload_ref` paths share one hash, all matching
-     paths are deleted in the same step — the index walk is over
-     `payload_hash`, not over `payload_ref`.
-   - If the count is non-zero (the blob is still referenced by a live
-     record — same prompt captured twice with different attribution),
-     the file is retained and the consent journal logs the retention.
+   `payload_hash` values from every targeted trace record, **paired
+   with the record's scope** (`scope.tenant`, `scope.user`,
+   `scope.agent`).
+2. For each `(payload_hash, scope)`:
+   - Query the records table for any other live record sharing the same
+     `payload_hash` **AND** matching scope dimensions
+     (same tenant, same user, same agent). If the count is zero in
+     this scope, the corresponding `sources/<payload_hash>.<ext>`
+     entries the principal owns are **deleted**.
+   - If the count is non-zero (the principal has another live record
+     referencing the same blob — same prompt captured twice in their
+     own session), the file is retained.
+   - **Cross-scope references are never inspected.** If a record under
+     a different `(tenant, user, agent)` happens to share the
+     `payload_hash`, this principal's forget proceeds as if no other
+     reference exists. The shared blob remains on disk for the other
+     principal's record (which lives in its own `sources/` namespace if
+     scoped storage is in use, or in a shared blob whose deletion is
+     governed by *that* principal's lifecycle, not this one).
+   - Implementation note: P0 stores `sources/` per-principal already
+     (brief §3 isolation rule). When P1+ shared content addressing
+     ships, blob deletion will move to a refcount maintained at the
+     blob layer with no per-principal disclosure. #77 does not
+     introduce that shared layer; it stays inside the per-principal
+     boundary.
 3. The consent journal records, per forgotten record:
-   `{record_id, payload_hash, sources_action: "deleted" | "retained-shared"}`
-   so an auditor can verify whether raw bytes were erased.
-4. `payload_hash` itself is retained on the (now redacted) record as the
+   `{record_id, payload_hash, sources_action: "deleted" | "retained-self"}`.
+   `retained-self` means the same principal still has a live record
+   referencing the blob. There is no `retained-shared` outcome — the
+   journal never reveals cross-principal blob coincidence.
+4. `payload_hash` itself stays on the (now redacted) record as the
    audit anchor — the hash alone is not user-recoverable PII; the bytes
-   it pointed to are gone.
+   it pointed to are gone for this principal.
 
-Refcount tracking is a SQL `COUNT(*)` over the `trace_payload_hash`
-generated column added in §6.1 — `SELECT COUNT(*) FROM records WHERE
-trace_payload_hash = ? AND id NOT IN (<forgetting set>)`. The index
-`records_trace_payload_hash` keeps the lookup O(log n). If `payload_ref`
-is ever observed to deviate from `sources/<payload_hash>.<ext>` for an
-existing record, that's a capture-pipeline bug surfaced as a separate
-issue; the forget code stays hash-keyed.
+Refcount SQL: `SELECT COUNT(*) FROM records WHERE trace_payload_hash = ?
+AND scope_tenant IS ? AND scope_user IS ? AND scope_agent IS ? AND id
+NOT IN (<forgetting set>)`. The `trace_payload_hash` index from §6.1
+keeps it O(log n). The scope columns are existing generated columns on
+the records table (added by prior migrations, not new in this PR).
 
 ### 8.2 Other concerns
 
@@ -639,11 +662,18 @@ adjustment is needed, that's a finding, not planned work.
   `TraceLinkOrphan`; the entire turn rolls back.
 - **Tool-call-id mismatch rejected**: a `tool_output` whose
   `tool_call_id` differs from its parent's returns `TraceLinkOrphan`.
-- **Forget deletes sources by hash**: `forget --session <id>` deletes
-  every `sources/<payload_hash>.<ext>` whose `payload_hash` is no
-  longer referenced by any live record. Asserts file removal even
-  when the original `payload_ref` differed across records that shared
-  the same hash. Consent journal records `{deleted, retained-shared}`.
+- **Forget deletes sources by hash, scoped to principal**:
+  `forget --session <id>` deletes every `sources/<payload_hash>.<ext>`
+  whose hash has no other live record under the **same**
+  `(tenant, user, agent)`. Asserts file removal when the originating
+  `payload_ref` paths differ but the hash is the same. Consent journal
+  records `{deleted, retained-self}` only — no cross-principal leak.
+- **Forget privacy boundary**: a record under principal A and another
+  under principal B share the same `payload_hash`. Forgetting A's
+  record proceeds as if B's reference does not exist; the consent
+  journal never mentions B and never produces a `retained-shared`
+  entry. (Whether A's bytes are physically deleted depends on the P0
+  per-principal layout — assert the journal entry, not the file path.)
 - Duplicate-`sequence` write returns `TraceSequenceConflict`, store state
   unchanged.
 - `forget --session <id>` zeros bodies of all trace records, leaves

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -277,7 +277,10 @@ Bodies cap at 4 KiB each; full content stays in `sources/` referenced by
 
 ## 6. Store (`cairn-store-sqlite`)
 
-### 6.1 Migration `0003_trace_links.sql`
+### 6.1 Migration `0022_trace_links.sql`
+
+(Number follows the existing migration sequence — `0021` is the most
+recently committed migration.)
 
 Generated columns over the existing records table extracting trace fields
 from `extra_frontmatter` JSON (SQLite supports `GENERATED ALWAYS AS ... VIRTUAL`
@@ -343,63 +346,43 @@ The unique indices enforce three invariants at the database boundary:
 
 ### 6.2 `MemoryStore` contract additions
 
-Per CLAUDE.md §5/invariant 4 ("implement behind an existing trait"), the
-trace path needs three new method on `MemoryStore`. None alter existing
-methods; all are additive:
+**Established pattern: transactional work uses `SqliteMemoryStore::with_tx`
+(inherent), not a trait method.** `MemoryStore` is `dyn`-compatible by
+design — generic-method `transaction(...)` would break that. The existing
+verb layer (consolidate, promote) reaches into the concrete
+`SqliteMemoryStore` for atomic multi-statement writes; trace persistence
+follows the same pattern.
+
+Additions to the SQLite store (none touch the dyn trait):
 
 ```rust
-trait MemoryStore {
-    // ... existing methods ...
-
-    /// Idempotent write keyed on the stable identity in
-    /// `record.extra_frontmatter.trace.capture_event_id` (for raw events)
-    /// or on `record.id` (for `turn_summary`). The store SHALL NOT allocate
-    /// a new row when a matching identity already exists; it MAY no-op or
-    /// update mutable columns (body, salience, redaction state).
-    async fn upsert_trace(&self, record: MemoryRecord) -> Result<(), StoreError>;
-
-    /// Returns trace records for a turn ordered by
-    /// `extra_frontmatter.trace.sequence`. Excludes `turn_summary`.
-    async fn list_trace_events(
-        &self,
-        session_id: &SessionId,
-        turn_id: &str,
+impl StoreTx<'_> {
+    pub fn upsert_trace(&mut self, record: &MemoryRecord)
+        -> Result<UpsertOutcome, StoreError>;
+    pub fn list_trace_events(
+        &self, session_id: &SessionId, turn_id: &str,
     ) -> Result<Vec<MemoryRecord>, StoreError>;
-
-    /// Run `f` inside a single store-level transaction. Implementations on
-    /// SQLite use `BEGIN IMMEDIATE` so concurrent `capture_trace` invocations
-    /// serialize at the file-lock boundary rather than racing on
-    /// `build_link`'s read-max-then-write. The closure receives a
-    /// `&dyn MemoryStoreTx` — the same trait surface the closure needs
-    /// (`upsert_trace`, `list_trace_events`) bound to the open transaction.
-    async fn transaction<'a, F, T>(
-        &'a self,
-        f: F,
-    ) -> Result<T, StoreError>
-    where
-        F: for<'tx> FnOnce(&'tx dyn MemoryStoreTx) -> BoxFuture<'tx, Result<T, StoreError>>
-            + Send
-            + 'a,
-        T: Send + 'a;
-}
-
-trait MemoryStoreTx: Send + Sync {
-    async fn upsert_trace(&self, record: MemoryRecord) -> Result<(), StoreError>;
-    async fn list_trace_events(
-        &self,
-        session_id: &SessionId,
-        turn_id: &str,
-    ) -> Result<Vec<MemoryRecord>, StoreError>;
+    pub fn turn_summary_exists(
+        &self, session_id: &SessionId, turn_id: &str,
+    ) -> Result<bool, StoreError>;
 }
 ```
 
-The exact callback shape (BoxFuture vs RPITIT, `MemoryStoreTx` as a sealed
-trait) is an implementation detail; the contract is: there exists a way to
-submit a closure that runs atomically against the store, with access to
-the trace methods. Test doubles in `cairn-test-fixtures` implement the
-same trait pair so that pure-core unit tests do not need a real SQLite
-file. WAL §5.6 guarantees still apply — `transaction(...)` is the
-verb-level wrapper *around* the WAL state machine, not a replacement for it.
+`upsert_trace` reuses the existing `upsert_in_tx` plumbing — idempotency
+flows from the new `records_trace_event_id` and `records_trace_summary`
+unique indices (§6.1) plus the deterministic summary record id (§5.2),
+not from new logic in the upsert helper.
+
+The CLI verb takes `&SqliteMemoryStore` directly (not `&dyn MemoryStore`),
+matching how `consolidate` and `promote` already work. The pure pipeline
+functions in `cairn-core` (`project`, `summarize_turn`,
+`order_by_captured_at`, `assign_sequences`) stay dyn-store-free and
+adapter-free, so unit tests need no SQLite. Integration tests use a real
+in-memory `SqliteMemoryStore` via `cairn-test-fixtures`.
+
+WAL §5.6 guarantees still apply — `with_tx` runs inside the same
+`tokio_rusqlite` worker thread that the WAL state machine uses; the
+trace path is a verb-level wrapper *around* it, not a replacement.
 
 ### 6.3 Reconstruction surface and `retrieve` IDL gap
 
@@ -702,10 +685,9 @@ crates/cairn-core/src/domain/mod.rs                  # +pub mod trace
 crates/cairn-core/src/pipeline/capture_trace.rs      # NEW
 crates/cairn-core/src/pipeline/turn.rs               # NEW
 crates/cairn-core/src/pipeline/mod.rs                # +pub mod
-crates/cairn-store-sqlite/migrations/0003_trace_links.sql  # NEW
-crates/cairn-store-sqlite/src/...                    # +upsert_trace, +list_trace_events, +transaction impl (BEGIN IMMEDIATE)
-crates/cairn-core/src/contract/memory_store.rs       # +upsert_trace, +list_trace_events, +transaction (additive — see §6.2)
-crates/cairn-test-fixtures/src/memory_store.rs       # extend in-memory double for new methods
+crates/cairn-store-sqlite/src/migrations/sql/0022_trace_links.sql  # NEW
+crates/cairn-store-sqlite/src/store/tx.rs            # +upsert_trace, +list_trace_events, +turn_summary_exists on StoreTx
+crates/cairn-store-sqlite/migrations/0022_trace_links.sql  # new generated columns + indices (number is next-after-0021)
 crates/cairn-cli/src/verbs/capture_trace.rs          # replace stub (uses existing IDL `from` flag)
 crates/cairn-test-fixtures/src/...                   # trace fixtures (JSONL inputs)
 ```

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -92,6 +92,24 @@ Validation invariants. **Field-level** (`TraceLink::validate`, pure):
 - `parent_event_id` is set iff `trace_event ∈ {PostTool, ToolOutput}`.
 - `tool_call_id` is set iff `trace_event ∈ {PreTool, PostTool, ToolOutput}`.
 
+**Ordering** (derived, not allocated from store state):
+
+- `sequence` is **derived from `CaptureEvent.captured_at`** (RFC 3339
+  timestamp on every envelope), not from a read-max-then-write counter.
+  The projector sorts a turn's events by `(captured_at, capture_event_id)`
+  and assigns `sequence = 0..N` in that order; `capture_event_id` is the
+  tiebreaker so concurrent events with identical wall-clock timestamps
+  still produce a deterministic, replay-stable order.
+- A backfilled event whose `captured_at` precedes already-persisted
+  events triggers a **renumber within the affected turn**: the
+  transaction reads the turn's existing rows, recomputes sequences over
+  the union (existing ∪ new), and rewrites the old rows in place. The
+  unique sequence index lets the rewrite happen as `UPDATE` against the
+  same rows; no row is dropped or reinserted.
+- A backfill is rejected with `TraceBackfillClosed` if the affected turn
+  is already closed (a `turn_summary` row exists) — see referential
+  invariant below.
+
 **Referential** (enforced inside `transaction(...)` before commit;
 violations roll back the entire turn):
 
@@ -103,6 +121,16 @@ violations roll back the entire turn):
 - `member_event_ids` on a `TurnSummary` MUST be exactly the set of
   non-summary trace records persisted under the same
   `(session_id, turn_id)`. Drift surfaces as `TraceSummaryMembership`.
+- **Closed-turn writes are rejected.** Once a `turn_summary` row exists
+  for `(session_id, turn_id)`, any further event write for that turn
+  fails with `TraceBackfillClosed` and rolls the transaction back. The
+  importer surfaces this in the verb's `failed_turns` list so the caller
+  can choose to (a) `forget` the turn and re-import from a fixed source,
+  or (b) accept the loss. This rule eliminates the stale-summary failure
+  mode: a summary, once written, is the authoritative member set for
+  that turn. Re-summarizing on every close-turn write would be the
+  alternative, but that complicates `member_event_ids` audits and adds a
+  non-deterministic write back into a "finalized" record.
 - `sequence` strictly monotonic within `(session_id, turn_id)` —
   enforced at the store layer (UNIQUE index), surfaced as
   `TraceSequenceConflict`.
@@ -427,16 +455,25 @@ async fn run(args: CaptureTraceArgs, store: &dyn MemoryStore) -> Result<...> {
         };
         let group = projected;
         let result = store.transaction(|tx| async move {
-            for (event, classified) in &group {
-                // Inside the tx, build_link's read-max-then-write is
-                // serialized by the WAL state machine (§5.6) — concurrent
-                // writers are sequenced, not racing.
-                let link = build_link(tx, event, *classified).await?;
-                let resolved = resolve_body(tx, event).await?; // hash-verified text
+            // Reject if the turn is already closed (summary present).
+            if tx.turn_summary_exists(&session_id, &turn_id).await? {
+                return Err(TraceError::BackfillClosed { session_id, turn_id });
+            }
+
+            // Sequences come from captured_at ordering across the union of
+            // (already-persisted events ∪ this batch). Concurrent writes
+            // serialize at BEGIN IMMEDIATE, so the read+rewrite is
+            // race-free within a single transaction.
+            let existing = tx.list_trace_events(&session_id, &turn_id).await?;
+            let ordered = order_by_captured_at(existing, &group)?;  // pure
+            let renumbered = assign_sequences(&ordered);            // pure
+
+            for entry in &renumbered {
+                let resolved = resolve_body(tx, entry.event).await?; // hash-verified
                 let record = pipeline::capture_trace::project(
-                    event, *classified, &resolved, link,
+                    entry.event, entry.classified, &resolved, entry.link.clone(),
                 )?;
-                tx.upsert_trace(record).await?;
+                tx.upsert_trace(record).await?;  // updates seq on existing rows; inserts new
             }
             if turn_is_closed(&group) {
                 let turn_records = tx.list_trace_events(&session_id, &turn_id).await?;
@@ -564,6 +601,17 @@ adjustment is needed, that's a finding, not planned work.
   event leaves the *first* turn fully persisted (events + summary) and
   the *second* turn unwritten — no partial prefix. Re-running with the
   fixed file completes the second turn idempotently.
+- **Out-of-order backfill (open turn)**: import events `[A@t=2, B@t=3]`
+  for an open turn, then a follow-up batch `[C@t=1]`. Final
+  `list_trace_events` ordering is `[C, A, B]` (sequence renumbered by
+  `captured_at`). No row is dropped; `capture_event_id` is preserved.
+- **Backfill rejected on closed turn**: attempting to write any event
+  to a turn whose `turn_summary` already exists returns
+  `TraceBackfillClosed` and the transaction rolls back. The summary's
+  `member_event_ids` remains intact.
+- **Ties on `captured_at`**: two events with identical timestamps
+  produce a stable order keyed on `capture_event_id`; the same input
+  always yields the same sequence assignment.
 - **Orphan parent rejected**: a `post_tool` whose `parent_event_id`
   points at a non-existent or cross-turn `pre_tool` returns
   `TraceLinkOrphan`; the entire turn rolls back.

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -74,17 +74,8 @@ pub struct TraceLink {
 }
 ```
 
-Serialization into `extra_frontmatter`:
-
-```yaml
-trace_event: pre_tool
-trace:
-  session_id: 01ARZ3...
-  turn_id: "turn-4"
-  sequence: 2
-  capture_event_id: 01HQ...
-  tool_call_id: call_abc
-```
+Serialization into `extra_frontmatter` is shown in §5.1 below; all trace
+fields live at `extra_frontmatter.trace.*` (the single canonical path).
 
 Validation invariants. **Field-level** (`TraceLink::validate`, pure):
 
@@ -106,9 +97,10 @@ Validation invariants. **Field-level** (`TraceLink::validate`, pure):
   the union (existing ∪ new), and rewrites the old rows in place. The
   unique sequence index lets the rewrite happen as `UPDATE` against the
   same rows; no row is dropped or reinserted.
-- A backfill is rejected with `TraceBackfillClosed` if the affected turn
-  is already closed (a `turn_summary` row exists) — see referential
-  invariant below.
+- A backfill into a closed turn (one whose `turn_summary` row already
+  exists) is admitted; the transaction additionally recomputes and
+  upserts the summary so `member_event_ids` reflects current turn state
+  — see referential invariant below.
 
 **Referential** (enforced inside `transaction(...)` before commit;
 violations roll back the entire turn):
@@ -121,16 +113,19 @@ violations roll back the entire turn):
 - `member_event_ids` on a `TurnSummary` MUST be exactly the set of
   non-summary trace records persisted under the same
   `(session_id, turn_id)`. Drift surfaces as `TraceSummaryMembership`.
-- **Closed-turn writes are rejected.** Once a `turn_summary` row exists
-  for `(session_id, turn_id)`, any further event write for that turn
-  fails with `TraceBackfillClosed` and rolls the transaction back. The
-  importer surfaces this in the verb's `failed_turns` list so the caller
-  can choose to (a) `forget` the turn and re-import from a fixed source,
-  or (b) accept the loss. This rule eliminates the stale-summary failure
-  mode: a summary, once written, is the authoritative member set for
-  that turn. Re-summarizing on every close-turn write would be the
-  alternative, but that complicates `member_event_ids` audits and adds a
-  non-deterministic write back into a "finalized" record.
+- **Closed-turn writes recompute the summary.** A `turn_summary` is a
+  *snapshot of current turn state*, not a write-once finalization. When
+  a late event lands for a turn whose summary already exists, the
+  transaction (a) admits the new event, (b) renumbers sequences over
+  the union, and (c) **upserts the summary** with a fresh
+  `member_event_ids` reflecting the new state. The summary's record id
+  is deterministic on `(session_id, turn_id)` (§5.2), so the upsert
+  targets the same row — no duplicate summaries. Idempotent replay
+  still produces no-op summary rewrites because the inputs are
+  unchanged. Result: late `tool_output` / `post_tool` / `stop` events
+  reconcile cleanly without operator intervention. The
+  `member_event_ids` invariant continues to hold because it is
+  *recomputed*, never *retained from a prior commit*.
 - `sequence` strictly monotonic within `(session_id, turn_id)` —
   enforced at the store layer (UNIQUE index), surfaced as
   `TraceSequenceConflict`.
@@ -176,8 +171,24 @@ Builds a `MemoryRecord` with:
 - `visibility = MemoryVisibility::Private`
 - `scope = ScopeTuple { session_id: Some(link.session_id), .. }`
 - `body` = privacy-filtered text per event type (see §5.3)
-- `extra_frontmatter` = `{trace_event, trace}` plus carry-through of
-  `payload_hash` and `capture_event_id` from the envelope
+- `extra_frontmatter` = `{trace_event, trace}` only. `trace`
+  itself contains `payload_hash` (and `payload_ref`) carried through
+  from the envelope. There is **no top-level `payload_hash` key**: all
+  trace metadata lives at `extra_frontmatter.trace.*`. This single
+  canonical path is the one indexes, generated columns, and forget SQL
+  query against. Concretely the YAML shape is:
+
+```yaml
+trace_event: pre_tool
+trace:
+  session_id: 01ARZ3...
+  turn_id: "turn-4"
+  sequence: 2
+  capture_event_id: 01HQ...
+  payload_hash: "sha256:..."     # from CaptureEvent.payload_hash
+  payload_ref: "sources/..."     # from CaptureEvent.payload_ref
+  tool_call_id: call_abc
+```
 - `actor_chain` cloned from the `CaptureEvent` — preserves sensor/author
   attribution
 - `provenance` filled from `CaptureEvent` metadata (sensor, mode, captured_at)
@@ -276,6 +287,14 @@ ALTER TABLE records ADD COLUMN trace_parent_event_id TEXT
 
 ALTER TABLE records ADD COLUMN trace_capture_event_id TEXT
   GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.capture_event_id')) VIRTUAL;
+ALTER TABLE records ADD COLUMN trace_payload_hash TEXT
+  GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.payload_hash')) VIRTUAL;
+
+-- Forget refcounting reads this column to decide whether a sources/
+-- blob can be deleted. Index keeps the COUNT(*) cheap.
+CREATE INDEX records_trace_payload_hash
+  ON records(trace_payload_hash)
+  WHERE trace_payload_hash IS NOT NULL;
 
 -- Idempotency for raw events: same CaptureEvent may not produce two rows.
 CREATE UNIQUE INDEX records_trace_event_id
@@ -455,11 +474,6 @@ async fn run(args: CaptureTraceArgs, store: &dyn MemoryStore) -> Result<...> {
         };
         let group = projected;
         let result = store.transaction(|tx| async move {
-            // Reject if the turn is already closed (summary present).
-            if tx.turn_summary_exists(&session_id, &turn_id).await? {
-                return Err(TraceError::BackfillClosed { session_id, turn_id });
-            }
-
             // Sequences come from captured_at ordering across the union of
             // (already-persisted events ∪ this batch). Concurrent writes
             // serialize at BEGIN IMMEDIATE, so the read+rewrite is
@@ -475,7 +489,14 @@ async fn run(args: CaptureTraceArgs, store: &dyn MemoryStore) -> Result<...> {
                 )?;
                 tx.upsert_trace(record).await?;  // updates seq on existing rows; inserts new
             }
-            if turn_is_closed(&group) {
+
+            // The turn is "closed" if a Stop event is in the persisted set
+            // OR a turn_summary already exists. In either case, recompute
+            // the summary from current state — late events reconcile by
+            // upserting the deterministic-id summary row.
+            let already_summarized =
+                tx.turn_summary_exists(&session_id, &turn_id).await?;
+            if turn_is_closed(&renumbered) || already_summarized {
                 let turn_records = tx.list_trace_events(&session_id, &turn_id).await?;
                 let summary = pipeline::turn::summarize_turn(
                     &session_id, &turn_id, &turn_records,
@@ -552,13 +573,13 @@ Concretely:
    audit anchor — the hash alone is not user-recoverable PII; the bytes
    it pointed to are gone.
 
-Refcount tracking is a SQL `COUNT(*)` over the records table keyed on
-`extra_frontmatter.trace.payload_hash` (or the same field surfaced by an
-extracted virtual column, paralleling §6.1). It does not rely on a
-separate sources-side index. If `payload_ref` is ever observed to deviate
-from `sources/<payload_hash>.<ext>` for an existing record, that's a
-capture-pipeline bug, surfaced as a separate issue; the forget code
-itself stays hash-keyed.
+Refcount tracking is a SQL `COUNT(*)` over the `trace_payload_hash`
+generated column added in §6.1 — `SELECT COUNT(*) FROM records WHERE
+trace_payload_hash = ? AND id NOT IN (<forgetting set>)`. The index
+`records_trace_payload_hash` keeps the lookup O(log n). If `payload_ref`
+is ever observed to deviate from `sources/<payload_hash>.<ext>` for an
+existing record, that's a capture-pipeline bug surfaced as a separate
+issue; the forget code stays hash-keyed.
 
 ### 8.2 Other concerns
 
@@ -605,10 +626,11 @@ adjustment is needed, that's a finding, not planned work.
   for an open turn, then a follow-up batch `[C@t=1]`. Final
   `list_trace_events` ordering is `[C, A, B]` (sequence renumbered by
   `captured_at`). No row is dropped; `capture_event_id` is preserved.
-- **Backfill rejected on closed turn**: attempting to write any event
-  to a turn whose `turn_summary` already exists returns
-  `TraceBackfillClosed` and the transaction rolls back. The summary's
-  `member_event_ids` remains intact.
+- **Backfill on closed turn resummarizes**: a turn already has events +
+  summary; importing one more `tool_output` for that turn updates
+  sequences and rewrites the summary row in place. The summary's
+  `member_event_ids` now includes the new event; the row id is
+  unchanged. No duplicate summary, no error.
 - **Ties on `captured_at`**: two events with identical timestamps
   produce a stable order keyed on `capture_event_id`; the same input
   always yields the same sequence assignment.

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -126,10 +126,17 @@ Builds a `MemoryRecord` with:
 ```rust
 pub fn summarize_turn(
     session_id: &SessionId,
-    turn_id: u64,
+    turn_id: &str,                      // opaque, matches TraceLink.turn_id
     events: &[MemoryRecord],
 ) -> Result<MemoryRecord, TurnSummaryError>
 ```
+
+The summary record uses a **deterministic record id** derived from
+`(session_id, turn_id)` — `RecordId(format!("turnsum:{session_id}:{turn_id}"))`,
+ULID-like prefix or a hash, picked to fit the existing `RecordId` newtype.
+That id is what `upsert_trace` keys on for summary rows: a replay of the
+same turn produces the same id, so the second write is a no-op upsert into
+the existing row instead of a duplicate.
 
 Concatenates ordered events into a single `TurnSummary` record. No LLM —
 deterministic format:
@@ -190,15 +197,20 @@ ALTER TABLE records ADD COLUMN trace_parent_event_id TEXT
 ALTER TABLE records ADD COLUMN trace_capture_event_id TEXT
   GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.capture_event_id')) VIRTUAL;
 
--- Idempotency: the same CaptureEvent may not produce two records.
--- Replays of the same JSONL file therefore upsert into the existing row
--- (no new sequence allocation) instead of duplicating the logical event.
+-- Idempotency for raw events: same CaptureEvent may not produce two rows.
 CREATE UNIQUE INDEX records_trace_event_id
   ON records(trace_capture_event_id)
   WHERE trace_capture_event_id IS NOT NULL;
 
--- Sequence monotonicity within a turn (excluding the synthetic
--- turn_summary, which has no sequence of its own).
+-- Idempotency for the synthetic turn_summary: exactly one summary per
+-- (session_id, turn_id). The summary's record id is also derived
+-- deterministically from the same pair (§5.2) so upserts are stable on
+-- both the primary key and this index.
+CREATE UNIQUE INDEX records_trace_summary
+  ON records(trace_session_id, trace_turn_id)
+  WHERE trace_event = 'turn_summary';
+
+-- Sequence monotonicity within a turn (excluding turn_summary).
 CREATE UNIQUE INDEX records_trace_seq
   ON records(trace_session_id, trace_turn_id, trace_sequence)
   WHERE trace_event IS NOT NULL AND trace_event != 'turn_summary';
@@ -208,13 +220,17 @@ CREATE INDEX records_trace_parent
   WHERE trace_parent_event_id IS NOT NULL;
 ```
 
-The unique indices enforce two invariants at the database boundary:
+The unique indices enforce three invariants at the database boundary:
 
-- **Idempotent replay** — `capture_event_id` is the stable event identity.
-  A second `capture_trace --from <same file>` is absorbed as no-op upserts
-  on existing rows; no fresh sequences allocated.
+- **Idempotent event replay** — `capture_event_id` is the stable event
+  identity. A second `capture_trace --from <same file>` is absorbed as
+  no-op upserts on existing rows; no fresh sequences allocated.
+- **Idempotent summary replay** — at most one `turn_summary` per
+  `(session_id, turn_id)`. Combined with the deterministic record id
+  derived in §5.2, replays converge on the same row.
 - **Sequence monotonicity** — within a `(session_id, turn_id)` no two
-  events share a `sequence`. Surfaced as a typed `TraceSequenceConflict`.
+  non-summary events share a `sequence`. Surfaced as a typed
+  `TraceSequenceConflict`.
 
 ### 6.2 Reconstruction surface and `retrieve` IDL gap
 
@@ -276,24 +292,39 @@ async fn run(args: CaptureTraceArgs, store: &dyn MemoryStore) -> Result<...> {
     refuse_if_degraded(...)?;
     let events = read_jsonl::<CaptureEvent>(&args.from).await?;  // streaming, bounded buffer
 
-    // Persist every event. Idempotent on capture_event_id (§6.1) — replays
-    // upsert into existing rows.
-    for event in &events {
-        event.validate()?;                                       // existing envelope validation
-        let classified = classify(event)?;                       // (hook_name, payload tag) → TraceEvent
-        let link = build_link(store, event, classified).await?;  // assigns next sequence per (session, turn) for new rows; reuses for replay
-        let record = pipeline::capture_trace::project(event, classified, link)?;
-        store.upsert_trace(record).await?;                       // WAL two-phase, §5.6
-    }
+    // Validate the full file *before* writing anything. A malformed event
+    // anywhere in the file aborts the import with no rows persisted.
+    let projected: Vec<(_, _, _)> = events.iter()
+        .map(|event| {
+            event.validate()?;
+            let classified = classify(event)?;
+            Ok((event, classified))
+        })
+        .collect::<Result<_, _>>()?;
 
-    // Emit one `turn_summary` per closed turn boundary in the file.
-    // A turn is "closed" when the file contains a Stop event (or an explicit
-    // `end_of_turn` sentinel) for that `(session_id, turn_id)`. Multi-turn
-    // input files are supported — each closed turn gets its own summary.
-    for (session_id, turn_id) in closed_turns(&events) {
-        let turn_records = store.list_trace_events(&session_id, &turn_id).await?;
-        let summary = pipeline::turn::summarize_turn(&turn_records)?;
-        store.upsert_trace(summary).await?;
+    // Group by (session_id, turn_id). Each turn group is one transaction:
+    // either all of its events plus the summary land, or none do. A
+    // mid-import failure for turn N never strands a partial prefix of
+    // turn N's events committed.
+    for (session_id, turn_id, group) in group_by_turn(&projected) {
+        store.transaction(|tx| async move {
+            for (event, classified) in &group {
+                // Inside the tx, build_link's read-max-then-write is
+                // serialized by the WAL state machine (§5.6) — concurrent
+                // writers are sequenced, not racing.
+                let link = build_link(tx, event, *classified).await?;
+                let record = pipeline::capture_trace::project(event, *classified, link)?;
+                tx.upsert_trace(record).await?;
+            }
+            if turn_is_closed(&group) {
+                let turn_records = tx.list_trace_events(&session_id, &turn_id).await?;
+                let summary = pipeline::turn::summarize_turn(
+                    &session_id, &turn_id, &turn_records,
+                )?;
+                tx.upsert_trace(summary).await?;
+            }
+            Ok::<_, TraceError>(())
+        }).await?;
     }
     Ok(success_response(trace_id))
 }
@@ -352,6 +383,10 @@ a path *does* need adjustment, that's a finding, not planned work.
 - **Multi-turn input**: a JSONL containing two complete turns yields two
   `turn_summary` records, each with `member_event_ids` pointing only at
   its own turn's events.
+- **Atomicity per turn**: a JSONL whose second turn contains a malformed
+  event leaves the *first* turn fully persisted (events + summary) and
+  the *second* turn unwritten — no partial prefix. Re-running with the
+  fixed file completes the second turn idempotently.
 - Duplicate-`sequence` write returns `TraceSequenceConflict`, store state
   unchanged.
 - `forget --session <id>` zeros bodies of all trace records, leaves

--- a/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md
@@ -21,6 +21,8 @@ and forget. A full agent turn must be reconstructable from these records.
 - Sensor adapters that translate harness payloads into `CaptureEvent`s (#84).
 - LLM-synthesized turn summaries (P1+).
 - P2 tree-structured sessions beyond simple parent/child turn links.
+- IDL evolution of `retrieve(target=Turn|Session)` to carry an ordered
+  event array and string `turn_id`. Tracked as a follow-up; see §6.2.
 
 ## 3. Approach
 
@@ -56,7 +58,11 @@ pub enum TraceEvent {
 #[serde(deny_unknown_fields)]
 pub struct TraceLink {
     pub session_id: SessionId,
-    pub turn_id: u64,
+    /// Opaque harness-supplied turn id. Mirrors `CaptureRefs.turn_id`
+    /// (`Option<String>` in the capture envelope) — kept as a string
+    /// end-to-end so producers do not need a numeric remapping layer.
+    /// The trace projector rejects events with `refs.turn_id == None`.
+    pub turn_id: String,
     pub sequence: u64,                          // monotonic within turn
     pub capture_event_id: CaptureEventId,       // back-ref to raw envelope
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -74,7 +80,7 @@ Serialization into `extra_frontmatter`:
 trace_event: pre_tool
 trace:
   session_id: 01ARZ3...
-  turn_id: 4
+  turn_id: "turn-4"
   sequence: 2
   capture_event_id: 01HQ...
   tool_call_id: call_abc
@@ -174,7 +180,7 @@ ALTER TABLE records ADD COLUMN trace_event TEXT
   GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace_event')) VIRTUAL;
 ALTER TABLE records ADD COLUMN trace_session_id TEXT
   GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.session_id')) VIRTUAL;
-ALTER TABLE records ADD COLUMN trace_turn_id INTEGER
+ALTER TABLE records ADD COLUMN trace_turn_id TEXT
   GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.turn_id')) VIRTUAL;
 ALTER TABLE records ADD COLUMN trace_sequence INTEGER
   GENERATED ALWAYS AS (json_extract(extra_frontmatter, '$.trace.sequence')) VIRTUAL;
@@ -194,42 +200,79 @@ The unique index enforces sequence monotonicity at the database boundary,
 turning a duplicate `sequence` into a typed `TraceSequenceConflict` error
 instead of silent corruption.
 
-### 6.2 Retrieve targets
+### 6.2 Retrieve targets — store-level reads only
 
-`retrieve(target=Turn)` and `retrieve(target=Session)` already exist in the
-IDL with `DataTurn` / `TurnItem` wire shape. Implement them in the SQLite
-store:
+The current `retrieve` IDL is incompatible with what #77 needs to read back:
 
-- `Turn`: `SELECT ... WHERE trace_session_id=? AND trace_turn_id=? ORDER BY trace_sequence`,
-  fold into `TurnItem` per role mapping (user_message → User,
-  agent_message → Assistant, pre_tool/post_tool/tool_output → Tool with
-  `tool_calls` array).
-- `Session`: paged across turns using the cursor field already in the IDL.
+- `DataTurn.turn_id` is `integer` (capture envelopes carry strings).
+- `DataTurn.turn` is a single `TurnItem` with one role — it cannot represent
+  an ordered, multi-role event sequence inside a turn.
+- `TurnItem.turn_id` is also integer.
+
+Reshaping the IDL is a brief-level change (CLAUDE.md §5/§4) and is
+**out of scope for #77**. This PR therefore:
+
+1. Persists records with the linkage needed to reconstruct any future shape:
+   `(session_id, turn_id, sequence, parent_event_id)` plus `member_event_ids`
+   on the turn summary.
+2. Adds a **store-internal** read API on `MemoryStore` —
+   `list_trace_events(session_id, turn_id) -> Vec<MemoryRecord>` ordered by
+   `sequence` — that the existing `retrieve` verb can call when (and only
+   when) the IDL evolves. Until then, this method is exercised by the
+   integration tests below to satisfy the issue's "full agent turn can be
+   reconstructed" acceptance criterion.
+3. Files a follow-up issue: *Evolve `retrieve(target=Turn|Session)` IDL to
+   carry an ordered event array and string `turn_id`*. Linked from the PR
+   and listed in `docs/design/traceability.md`.
+
+The unique sequence index from §6.1 still ships — it protects the linkage
+even though the public retrieve verb cannot yet expose it.
 
 ## 7. CLI verb (`cairn-cli/src/verbs/capture_trace.rs`)
 
-Replace the current stub. Pseudocode:
+The published IDL (`crates/cairn-idl/schema/verbs/capture_trace.json`) is:
+
+```json
+{ "from": "<path>", "session_id": "<optional>" }
+```
+
+`from` is a path to a **trace log file** containing one JSON-encoded
+`CaptureEvent` per line (JSONL). The verb does not accept an inline event
+batch and there is no `is_stop` flag — the stop boundary is recovered from
+the events themselves (an event whose `hook_name == "Stop"`).
+
+Pseudocode:
 
 ```rust
 async fn run(args: CaptureTraceArgs, store: &dyn MemoryStore) -> Result<...> {
     refuse_if_degraded(...)?;
-    for event in args.events {
-        let classified = classify(&event)?;          // hook_name + payload tag
-        let link = next_link_for(&store, &event).await?;
-        let record = pipeline::capture_trace::project(&event, classified, link)?;
-        store.write(record).await?;                  // WAL two-phase, §5.6
+    let events = read_jsonl::<CaptureEvent>(&args.from).await?;  // streaming, bounded buffer
+    for event in &events {
+        event.validate()?;                                       // existing envelope validation
+        let classified = classify(event)?;                       // (hook_name, payload tag) → TraceEvent
+        let link = build_link(store, event, classified).await?;  // assigns next sequence per (session, turn)
+        let record = pipeline::capture_trace::project(event, classified, link)?;
+        store.write(record).await?;                              // WAL two-phase, §5.6
     }
-    if args.is_stop {
-        let turn = store.list_turn(session, turn_id).await?;
-        let summary = pipeline::turn::summarize_turn(...)?;
+    if let Some(stop_event) = events.iter().rfind(|e| is_stop(e)) {
+        let turn_records = store
+            .list_trace_events(stop_event.session_id()?, stop_event.turn_id()?)
+            .await?;
+        let summary = pipeline::turn::summarize_turn(&turn_records)?;
         store.write(summary).await?;
     }
-    Ok(success_response(...))
+    Ok(success_response(trace_id))
 }
 ```
 
 Classification rule: `(CaptureEvent.refs.hook_name, payload tag) → TraceEvent`.
-Static table — no LLM.
+Static table — no LLM. `hook_name` lives in the existing `CapturePayload`
+hook variant; payload tag covers non-hook surfaces (CLI/MCP message capture).
+
+**No IDL changes.** The verb shape and CLI flags stay byte-identical to the
+current schema; the docgen output should be unchanged. If a flag does need
+to change later (e.g., to surface `trace_id` in human output), that's a
+separate scoped change with `cairn-docgen --write` re-run.
 
 ## 8. Privacy, forget, search — no new code paths
 
@@ -263,8 +306,11 @@ a path *does* need adjustment, that's a finding, not planned work.
 
 ### 9.3 Integration (`cairn-store-sqlite/tests/`)
 
-- End-to-end `capture_trace` → store → `retrieve(target=Turn)` returns the
-  expected `DataTurn` with `tool_calls` populated, ordering preserved.
+- End-to-end `capture_trace --from <fixture.jsonl>` → store →
+  `MemoryStore::list_trace_events(session, turn)` returns records in
+  `sequence` order with parent/child edges intact. Asserts full-turn
+  reconstruction directly at the store boundary (the public retrieve verb
+  does not yet expose this shape — see §6.2).
 - Duplicate-`sequence` write returns `TraceSequenceConflict`, store state
   unchanged.
 - `forget --session <id>` zeros bodies of all trace records, leaves
@@ -286,9 +332,10 @@ crates/cairn-core/src/pipeline/capture_trace.rs      # NEW
 crates/cairn-core/src/pipeline/turn.rs               # NEW
 crates/cairn-core/src/pipeline/mod.rs                # +pub mod
 crates/cairn-store-sqlite/migrations/0003_trace_links.sql  # NEW
-crates/cairn-store-sqlite/src/...                    # retrieve(Turn|Session) impl
-crates/cairn-cli/src/verbs/capture_trace.rs          # replace stub
-crates/cairn-test-fixtures/src/...                   # trace fixtures
+crates/cairn-store-sqlite/src/...                    # +list_trace_events impl
+crates/cairn-core/src/contract/memory_store.rs       # +list_trace_events trait method
+crates/cairn-cli/src/verbs/capture_trace.rs          # replace stub (uses existing IDL `from` flag)
+crates/cairn-test-fixtures/src/...                   # trace fixtures (JSONL inputs)
 ```
 
 ## 11. Risks

--- a/skills/cairn/SKILL.md
+++ b/skills/cairn/SKILL.md
@@ -143,11 +143,11 @@ cairn retrieve --session SESSION_ID --cursor CURSOR
 ```
 
 ```bash
-cairn retrieve --session SESSION_ID --turn 0
+cairn retrieve --session SESSION_ID --turn TURN_ID
 ```
 
 ```bash
-cairn retrieve --session SESSION_ID --turn 0 --include tool_calls
+cairn retrieve --session SESSION_ID --turn TURN_ID --include tool_calls
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

- Persists the seven trace event types (user/agent message, pre/post tool, tool output, stop, turn summary) as linked, idempotent `MemoryKind::Trace` records (brief §5.0).
- Migration `0022_trace_links.sql` adds 7 generated columns + 5 unique/secondary indices: idempotency on `capture_event_id`, one summary per turn, sequence monotonicity per turn, parent-event lookup, payload-hash refcount.
- CLI verb `cairn capture_trace --from <jsonl>` runs each turn inside its own transaction; out-of-order backfills renumber via two-phase parking on negative sentinels; closed-turn writes resummarize deterministically.
- `summarize_turn` rolls up turn members; `summary_record_id` is deterministic (SHA-256 → ULID) so re-summarize is idempotent.
- Forget-side hook (`StoreTx::payload_hash_count_in_scope`) lands the per-(tenant,user,agent) refcount used to decide concrete payload deletion; the verb wiring waits on issue #9.

## Out of scope (intentional)

- Hook handlers (#79), sensor adapters (#84), Claude Code hook map (#102).
- Public `retrieve(target=Turn|Session)` IDL evolution — captured as a follow-up.
- Trace-aware extension to the `forget` verb — blocked on the base verb (#9).

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo nextest run --workspace --locked --no-fail-fast` — 2253 passed, 5 skipped
- `cargo test --doc --workspace --locked` — 4 passed
- `./scripts/check-core-boundary.sh` — clean
- `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check` — clean
- `cargo run -p cairn-cli --bin cairn-docgen --locked -- --check` — clean

## Test plan

- [x] proptest turn round-trip (64 cases): random N=1..=8 events, random `captured_at` → `list_trace_events` ordering matches `(captured_at, capture_event_id)` and summary `member_event_ids` covers the full set
- [x] CLI snapshot of `capture_trace` response envelope
- [x] integration tests: single-turn persist+summarize, multi-turn independence, malformed turn isolated, replay idempotent, closed-turn resummarize on late event

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-02-issue-77-trace-records-design.md`
- Plan: `docs/superpowers/plans/2026-05-02-issue-77-trace-records.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)