### PR TITLE
feat(pipeline): tool-schema registry + dispatch driver (#217)

### DIFF
--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -30,6 +30,7 @@ use cairn_core::domain::trace::{TraceEvent, TraceLink};
 use cairn_core::domain::{CaptureEventId, SessionId};
 use cairn_core::generated::envelope::ResponseVerb;
 use cairn_core::pipeline::capture_trace::{classify, project};
+use cairn_core::pipeline::dispatch::{BypassReason, DefaultRegistry, DispatchDecision, dispatch};
 use cairn_core::pipeline::extract::body::ResolvedBody;
 use cairn_core::pipeline::turn::summarize_turn;
 use cairn_store_sqlite::SqliteMemoryStore;
@@ -239,6 +240,45 @@ pub async fn run_handler(
             };
             if classified == TraceEvent::Stop {
                 had_stop = true;
+            }
+
+            // Capture → Extract dispatch (issue #217). Every event reaching
+            // this driver passes through the routing decision before we
+            // resolve the body bytes from sources/. P0 trace replay only
+            // accepts hook payloads (classify() rejects everything else),
+            // so the decision is always `Bypass(NonTerminalFamily)` —
+            // raw bytes flow to Extract unchanged. Calling dispatch here
+            // anyway makes the routing path live in production: a future
+            // PR that admits a Terminal payload here cannot bypass the
+            // squash gate, and a malformed envelope is rejected with
+            // `MalformedEnvelope` before we open `sources/`.
+            match dispatch(event, &DefaultRegistry) {
+                DispatchDecision::Bypass(BypassReason::NonTerminalFamily) => {}
+                DispatchDecision::Bypass(BypassReason::MalformedEnvelope) => {
+                    failed_turns.push((
+                        session_str.clone(),
+                        turn_str.clone(),
+                        format!("dispatch {}: malformed envelope", event.event_id),
+                    ));
+                    group_failed = true;
+                    break;
+                }
+                other => {
+                    // classify() already rejected non-hook payloads; reaching
+                    // any other dispatch decision means the classifier and
+                    // dispatch driver disagree about routing. Surface as a
+                    // turn-level failure rather than silently proceeding.
+                    failed_turns.push((
+                        session_str.clone(),
+                        turn_str.clone(),
+                        format!(
+                            "dispatch {}: unexpected decision {other:?} for hook payload",
+                            event.event_id
+                        ),
+                    ));
+                    group_failed = true;
+                    break;
+                }
             }
 
             // Resolve body from sources/, then run the standard pre-persist

--- a/crates/cairn-cli/src/verbs/status.rs
+++ b/crates/cairn-cli/src/verbs/status.rs
@@ -19,6 +19,7 @@ use cairn_core::config::{CairnConfig, EmbeddingModelKind};
 use cairn_core::domain::identity::keys::VaultId;
 use cairn_core::generated::common::Capabilities;
 use cairn_core::generated::status::{StatusResponse, StatusResponseServerInfo};
+use cairn_core::pipeline::dispatch::{DefaultRegistry, pipeline_dispatch_advertisement};
 
 use super::envelope::{emit_json, new_operation_id};
 
@@ -164,6 +165,16 @@ pub fn run_with_context(
         },
         capabilities: caps,
         extensions: vec![],
+        // Advertise the live routing policy (issue #217). The
+        // `capture_trace` verb dispatches through the same
+        // `DefaultRegistry` (see `crates/cairn-cli/src/verbs/capture_trace.rs`
+        // — `dispatch(event, &DefaultRegistry)`), so this advertisement
+        // is exact for the runtime, not a placeholder. When a
+        // deployment-supplied `ToolSchemaLookup` lands, the call here
+        // and the matching call in `capture_trace` move in lockstep to
+        // the live registry; the wire schema's family-granular shape
+        // makes the two sides un-divergeable.
+        pipeline_dispatch: Some(pipeline_dispatch_advertisement(&DefaultRegistry)),
     };
 
     if json {

--- a/crates/cairn-core/src/generated/status.rs
+++ b/crates/cairn-core/src/generated/status.rs
@@ -5,6 +5,42 @@
 
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum StatusResponsePipelineDispatchDecision {
+    SquashWhenInteractiveTty,
+    Bypass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum StatusResponsePipelineDispatchSourceFamily {
+    Hook,
+    Ide,
+    Terminal,
+    Clipboard,
+    Voice,
+    Screen,
+    RecordingBatch,
+    Cli,
+    Mcp,
+    Proactive,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatusResponsePipelineDispatch {
+    /// P0 routing enum — closed. 'squash_when_interactive_tty' admits InteractiveTty Terminal payloads to `squash`; everything else (including non-interactive Terminal) bypasses. Adding values is a wire-contract change (cairn.mcp.v1 → vNext), not an additive update — older clients' generated deserializers will reject unknown values.
+    pub decision: StatusResponsePipelineDispatchDecision,
+    /// Wire-form SourceFamily tag (matches CapturePayload variant).
+    pub source_family: StatusResponsePipelineDispatchSourceFamily,
+    /// Optional tool identifier (e.g., 'Bash', 'Read'). Absent means the decision applies to every tool in this source_family — the P0 default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_id: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusResponseServerInfo {
@@ -21,6 +57,9 @@ pub struct StatusResponse {
     pub capabilities: Vec<crate::generated::common::Capabilities>,
     pub contract: String,
     pub extensions: Vec<crate::generated::common::Namespace>,
+    /// Per-(source_family, tool_id) routing decisions for the Capture → Extract pipeline (issue #217). Each entry tells clients whether captured payloads flow through `squash` (lossy compaction) or `bypass` (raw bytes). Entries MUST be sorted lexicographically by (source_family, tool_id ?? "") for byte-stable status responses across an incarnation (brief §8.0.a). Optional and additive — not in `required[]` so a pre-#217 server's response (no field) deserializes against this schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pipeline_dispatch: Option<Vec<StatusResponsePipelineDispatch>>,
     pub server_info: StatusResponseServerInfo,
 }
 

--- a/crates/cairn-core/src/pipeline/dispatch.rs
+++ b/crates/cairn-core/src/pipeline/dispatch.rs
@@ -1,0 +1,645 @@
+//! Capture → Extract dispatch driver (issue #217).
+//!
+//! Decides per [`CaptureEvent`] whether the payload bytes flow through
+//! `squash` (lossy text compaction) or **bypass** (raw
+//! bytes to Extract). The decision is derived entirely from the
+//! persisted [`CapturePayload`] — no caller-supplied side input — so
+//! WAL replay reproduces the same routing the dispatch driver took at
+//! capture time (brief §5.2; spec
+//! `docs/superpowers/specs/2026-04-27-issue-72-tool-squash-design.md`,
+//! "Caller contract" §).
+//!
+//! P0 dispatch table (from the spec):
+//!
+//! | `CapturePayload` variant + context              | Decision                                   |
+//! |-------------------------------------------------|--------------------------------------------|
+//! | `Terminal { context: InteractiveTty }`          | [`Squash`](DispatchDecision::Squash)       |
+//! | `Terminal { context: NonInteractiveOrStructured }` | `Bypass(TerminalNonInteractive)`        |
+//! | `Terminal { context: None }` (pre-#218 legacy)  | `Bypass(TerminalLegacyMissingContext)`     |
+//! | `Hook` / `Ide` / `Clipboard` / `Voice` /         | `Bypass(NonTerminalFamily)`                |
+//! | `Screen` / `RecordingBatch` / `Cli` / `Mcp` /    |                                            |
+//! | `Proactive`                                     |                                            |
+//!
+//! [`ToolSchemaLookup`] is the registry hook that lets a deployment
+//! force a [`SourceFamily`] to bypass `squash` even when the default
+//! table would route it through. The override surface is intentionally
+//! **family-granular and bypass-only at P0**: the squash entry point
+//! is crate-private and only accepts a [`SourceFamily::Terminal`]
+//! payload with `context: InteractiveTty`, so letting a registry
+//! produce [`Squash`](DispatchDecision::Squash) for non-terminal
+//! payloads would dead-end at that boundary.
+//! Per-tool granularity is held back deliberately so the wire-form
+//! `pipeline_dispatch` advertisement (one entry per `SourceFamily`)
+//! cannot diverge from the routing the dispatch driver actually
+//! performs at capture time. Widening the override to per-tool keys
+//! requires growing the wire schema in lockstep; that is a follow-up.
+//!
+//! [`DefaultRegistry`] returns `None` for every key at P0; the dispatch
+//! table above is the sole authority.
+
+use crate::domain::capture::{CaptureEvent, CapturePayload, SourceFamily, TerminalContext};
+use crate::generated::status::{
+    StatusResponsePipelineDispatch, StatusResponsePipelineDispatchDecision,
+    StatusResponsePipelineDispatchSourceFamily,
+};
+
+/// Routing decision for a single [`CaptureEvent`] reaching the
+/// Capture → Extract boundary.
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DispatchDecision {
+    /// Admit to `squash`. The variant carries a
+    /// sealed [`SquashAdmission`] token; the caller forwards that
+    /// token to
+    /// `squash::UnstructuredTextBytes::try_from_terminal_event`
+    /// to enter the lossy compaction path. The token is constructible
+    /// only inside this module, so the squash entrypoint cannot be
+    /// reached without going through [`dispatch`] first.
+    Squash(SquashAdmission),
+    /// Bypass `squash` — raw payload bytes flow to
+    /// Extract unchanged. The variant carries [`BypassReason`] so the
+    /// pipeline driver and observability can distinguish the four P0
+    /// bypass causes without re-deriving them from the event.
+    Bypass(BypassReason),
+}
+
+/// Capability token proving that [`dispatch`] returned
+/// [`DispatchDecision::Squash`] for the event being squashed.
+///
+/// Has a private field so external callers cannot construct one —
+/// the only producer is `dispatch()`. This makes the squash
+/// entrypoint
+/// (`squash::UnstructuredTextBytes::try_from_terminal_event`)
+/// reachable only via the dispatch path: a caller cannot decide
+/// "squash this terminal payload" without first asking the registry-
+/// aware dispatch function whether it is squash-eligible.
+///
+/// **Not** `Copy` / `Clone`: the token is consumed by-value when the
+/// caller invokes
+/// `squash::UnstructuredTextBytes::try_from_terminal_event`,
+/// so each squash entry requires its own [`dispatch`] call. Otherwise
+/// a caller could obtain one admission from a squash-eligible event
+/// and reuse it to push unrelated terminal payloads through `squash`,
+/// silently bypassing a `RegistryOverride` that turned squash off for
+/// that family.
+///
+/// Opaque so future PRs may attach metadata (per-event scope, cfg
+/// overrides) without breaking the surface.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SquashAdmission {
+    _seal: (),
+}
+
+impl SquashAdmission {
+    /// Mint a fresh admission token. **Module-private** so only
+    /// [`dispatch`] inside this file can produce one; no other
+    /// `cairn-core` module — present or future — can construct an
+    /// admission and bypass the registry-aware decision. Tests that
+    /// need a token use the `cfg(test)`-gated `Self::for_test` helper
+    /// below.
+    fn new() -> Self {
+        Self { _seal: () }
+    }
+
+    /// Test-only token mint. `pub(crate)` so squash/fuzz/bench tests
+    /// can synthesise an admission for fixture work; gated behind
+    /// `cfg(test)` so production code (within or outside this crate)
+    /// cannot reach it.
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self { _seal: () }
+    }
+}
+
+/// Why the dispatch driver routed an event around `squash`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BypassReason {
+    /// `SourceFamily` is not `Terminal`. P0 unconditionally bypasses
+    /// every `Hook`, `Ide`, `Clipboard`, `Voice`, `Screen`,
+    /// `RecordingBatch`, `Cli`, `Mcp`, and `Proactive` payload (spec
+    /// dispatch table).
+    NonTerminalFamily,
+    /// `Terminal` payload whose
+    /// [`context`](crate::domain::capture::TerminalContext) is
+    /// [`NonInteractiveOrStructured`](crate::domain::capture::TerminalContext::NonInteractiveOrStructured).
+    /// Lossy compaction would corrupt machine-readable bytes (JSON,
+    /// CSV, structured-output flags); the dispatch driver bypasses
+    /// unconditionally.
+    TerminalNonInteractive,
+    /// `Terminal` payload from a pre-#218 writer whose `context` field
+    /// is `None`. Distinct from [`TerminalNonInteractive`] so the
+    /// pipeline driver / replay path can either migrate the event or
+    /// surface a `needs migration` signal rather than silently treating
+    /// the legacy data as deliberately structured.
+    ///
+    /// [`TerminalNonInteractive`]: BypassReason::TerminalNonInteractive
+    TerminalLegacyMissingContext,
+    /// A [`ToolSchemaLookup`] override forced this [`SourceFamily`] to
+    /// bypass `squash`. Used when a deployment
+    /// disables squash for an otherwise squash-eligible family (today,
+    /// `Terminal`).
+    RegistryOverride,
+    /// `event.validate()` failed: the envelope's `source_family`
+    /// disagrees with the payload variant, the actor chain is empty,
+    /// hashes mismatch, etc. Bypass is the only safe routing because
+    /// the squash entrypoint would reject the same event with a
+    /// validation error and minting an admission for a malformed
+    /// envelope would split the routing decision from the safety
+    /// check. Extract retains its own malformed-envelope handling.
+    MalformedEnvelope,
+}
+
+/// Per-[`SourceFamily`] bypass override registry.
+///
+/// **P0 surface is family-granular and bypass-only.** Implementations
+/// may return `Some(reason)` to force every event of a given
+/// [`SourceFamily`] to bypass `squash`; they cannot
+/// force a payload *into* `squash`, because the only verified squash
+/// entry point
+/// (`squash::UnstructuredTextBytes::try_from_terminal_event`)
+/// validates `CapturePayload::Terminal { context: InteractiveTty }`.
+///
+/// Per-tool granularity is held back deliberately. The wire-form
+/// `pipeline_dispatch` advertisement on `cairn status` is keyed on
+/// `SourceFamily` only, so a per-tool override would let the routing
+/// the dispatch driver performs at capture time silently diverge from
+/// what `status` advertises (the `(Terminal, "Bash") → Bypass`
+/// scenario flagged in review). Promoting the contract to per-tool
+/// requires growing the wire schema in lockstep with the trait; that
+/// is a #217 follow-up.
+///
+/// The trait stays object-safe so callers can hold a
+/// `&dyn ToolSchemaLookup` if they need to compose registries at
+/// runtime.
+pub trait ToolSchemaLookup {
+    /// Force a [`Bypass`](DispatchDecision::Bypass) decision for every
+    /// event of this [`SourceFamily`]. Return `None` to defer to the
+    /// default dispatch table; return `Some(reason)` to bypass with
+    /// that labelled reason.
+    fn bypass_override(&self, family: SourceFamily) -> Option<BypassReason>;
+}
+
+/// P0 default registry — every family returns `None`, so [`dispatch`]
+/// falls back to the spec's hard-coded table.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultRegistry;
+
+impl ToolSchemaLookup for DefaultRegistry {
+    fn bypass_override(&self, _family: SourceFamily) -> Option<BypassReason> {
+        None
+    }
+}
+
+/// Dispatch a single [`CaptureEvent`].
+///
+/// Pure function: same `event` always returns the same decision.
+/// Reads only `event.payload`; never inspects the bytes referenced by
+/// `event.payload_ref` (those flow to `squash` or to
+/// Extract after the decision).
+///
+/// The registry only intercepts the would-be-[`Squash`](DispatchDecision::Squash)
+/// path. Intrinsic bypass reasons —
+/// [`TerminalNonInteractive`](BypassReason::TerminalNonInteractive),
+/// [`TerminalLegacyMissingContext`](BypassReason::TerminalLegacyMissingContext),
+/// [`NonTerminalFamily`](BypassReason::NonTerminalFamily) — are
+/// preserved verbatim so a family-wide override cannot mask the
+/// migration signal a pre-#218 terminal payload carries (its
+/// `context: None`) or relabel a deliberately structured payload as a
+/// generic policy decision. The override surface is family-granular
+/// and bypass-only at P0; a registry cannot promote a non-terminal
+/// payload to [`Squash`](DispatchDecision::Squash).
+#[must_use]
+pub fn dispatch<R: ToolSchemaLookup + ?Sized>(
+    event: &CaptureEvent,
+    registry: &R,
+) -> DispatchDecision {
+    // Validate the envelope before minting any decision so the
+    // squash admission cannot be issued for a malformed event whose
+    // safety invariants the squash binder will later reject. Keeping
+    // the validation co-located with the routing decision means the
+    // dispatch result is authoritative for replay paths too.
+    if event.validate().is_err() {
+        return DispatchDecision::Bypass(BypassReason::MalformedEnvelope);
+    }
+    let family = event.payload.source_family();
+    match &event.payload {
+        CapturePayload::Terminal { context, .. } => match context {
+            // Only the squash-eligible terminal path defers to the
+            // registry. Bypassing here loses no signal because the
+            // alternative was Squash, not a labelled bypass reason.
+            Some(TerminalContext::InteractiveTty) => match registry.bypass_override(family) {
+                Some(reason) => DispatchDecision::Bypass(reason),
+                None => DispatchDecision::Squash(SquashAdmission::new()),
+            },
+            // Intrinsic terminal-state reasons take precedence over
+            // any registry policy: a family-wide override that bypasses
+            // Terminal must NOT erase the legacy-context migration
+            // signal or the structured-output reason.
+            Some(TerminalContext::NonInteractiveOrStructured) => {
+                DispatchDecision::Bypass(BypassReason::TerminalNonInteractive)
+            }
+            None => DispatchDecision::Bypass(BypassReason::TerminalLegacyMissingContext),
+        },
+        // Non-terminal families always bypass; the registry override
+        // here would not change the decision, so we keep
+        // `NonTerminalFamily` as the honest reason.
+        _ => DispatchDecision::Bypass(BypassReason::NonTerminalFamily),
+    }
+}
+
+/// Build the `pipeline_dispatch` array advertised by `cairn status`
+/// (issue #217). One entry per [`SourceFamily`], `tool_id: None`.
+/// Each entry's `decision` is derived from the same
+/// `registry.bypass_override(family)` call [`dispatch`] would make for
+/// that family:
+///
+/// * `Some(_)` → advertised as
+///   [`Bypass`](StatusResponsePipelineDispatchDecision::Bypass)
+///   (the override forces the family-default away from squash).
+/// * `None` → advertised as the spec's hard-coded default for that
+///   family —
+///   [`SquashWhenInteractiveTty`](StatusResponsePipelineDispatchDecision::SquashWhenInteractiveTty)
+///   for `Terminal`,
+///   [`Bypass`](StatusResponsePipelineDispatchDecision::Bypass) for
+///   every other family.
+///
+/// Because [`ToolSchemaLookup`] is family-granular at P0, the
+/// advertisement is **always exact** — no `(family, tool)` override
+/// can hide behind a family-default entry. Promoting either surface
+/// to per-tool keys requires growing the other in lockstep.
+///
+/// Entries are sorted lexicographically by `(source_family,
+/// tool_id ?? "")` so the wire response is byte-stable across an
+/// incarnation (brief §8.0.a).
+#[must_use]
+pub fn pipeline_dispatch_advertisement<R: ToolSchemaLookup + ?Sized>(
+    registry: &R,
+) -> Vec<StatusResponsePipelineDispatch> {
+    use StatusResponsePipelineDispatchSourceFamily as F;
+
+    // Wire-form (snake_case) lexicographic order matches the IDL
+    // sort contract on `(source_family, tool_id ?? "")` — every
+    // entry below has tool_id == None, so source_family alone
+    // determines order.
+    let families = [
+        (F::Cli, SourceFamily::Cli),
+        (F::Clipboard, SourceFamily::Clipboard),
+        (F::Hook, SourceFamily::Hook),
+        (F::Ide, SourceFamily::Ide),
+        (F::Mcp, SourceFamily::Mcp),
+        (F::Proactive, SourceFamily::Proactive),
+        (F::RecordingBatch, SourceFamily::RecordingBatch),
+        (F::Screen, SourceFamily::Screen),
+        (F::Terminal, SourceFamily::Terminal),
+        (F::Voice, SourceFamily::Voice),
+    ];
+    families
+        .into_iter()
+        .map(|(wire_family, domain_family)| {
+            // Same lookup `dispatch()` performs.
+            let decision = if registry.bypass_override(domain_family).is_some() {
+                StatusResponsePipelineDispatchDecision::Bypass
+            } else {
+                default_decision_for_family(wire_family)
+            };
+            StatusResponsePipelineDispatch {
+                decision,
+                source_family: wire_family,
+                tool_id: None,
+            }
+        })
+        .collect()
+}
+
+fn default_decision_for_family(
+    family: StatusResponsePipelineDispatchSourceFamily,
+) -> StatusResponsePipelineDispatchDecision {
+    match family {
+        StatusResponsePipelineDispatchSourceFamily::Terminal => {
+            StatusResponsePipelineDispatchDecision::SquashWhenInteractiveTty
+        }
+        _ => StatusResponsePipelineDispatchDecision::Bypass,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::actor_chain::{ActorChainEntry, ChainRole};
+    use crate::domain::capture::{
+        CaptureEvent, CaptureEventId, CaptureMode, CaptureRefs, PayloadHash,
+    };
+    use crate::domain::identity::Identity;
+    use crate::domain::timestamp::Rfc3339Timestamp;
+    use sha2::{Digest, Sha256};
+
+    fn ts() -> Rfc3339Timestamp {
+        Rfc3339Timestamp::parse("2026-04-27T00:00:00Z").expect("valid timestamp")
+    }
+
+    fn payload_hash_of(bytes: &[u8]) -> PayloadHash {
+        let digest = Sha256::digest(bytes);
+        PayloadHash::parse(format!("sha256:{digest:x}")).expect("valid hash")
+    }
+
+    fn terminal_event_with_context(ctx: Option<TerminalContext>, bytes: &[u8]) -> CaptureEvent {
+        CaptureEvent {
+            event_id: CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap(),
+            sensor_id: Identity::parse("snr:local:terminal:cli:v1").unwrap(),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: Identity::parse("snr:local:terminal:cli:v1").unwrap(),
+                at: ts(),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some("sess".into()),
+                turn_id: Some("turn".into()),
+                tool_id: None,
+            }),
+            payload_hash: payload_hash_of(bytes),
+            payload_ref: "sources/terminal/01ARZ3NDEKTSV4RRFFQ69G5FAV.txt".into(),
+            captured_at: ts(),
+            payload: CapturePayload::Terminal {
+                command: "echo hi".into(),
+                exit_code: Some(0),
+                context: ctx,
+            },
+            source_family: SourceFamily::Terminal,
+        }
+    }
+
+    fn hook_event(bytes: &[u8]) -> CaptureEvent {
+        CaptureEvent {
+            event_id: CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap(),
+            sensor_id: Identity::parse("snr:local:hook:cc-session:v1").unwrap(),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: Identity::parse("snr:local:hook:cc-session:v1").unwrap(),
+                at: ts(),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some("sess".into()),
+                turn_id: Some("turn".into()),
+                tool_id: None,
+            }),
+            payload_hash: payload_hash_of(bytes),
+            payload_ref: "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json".into(),
+            captured_at: ts(),
+            payload: CapturePayload::Hook {
+                hook_name: "PostToolUse".into(),
+                tool_name: Some("Read".into()),
+            },
+            source_family: SourceFamily::Hook,
+        }
+    }
+
+    #[test]
+    fn terminal_interactive_tty_routes_to_squash() {
+        let bytes = b"hello\n";
+        let evt = terminal_event_with_context(Some(TerminalContext::InteractiveTty), bytes);
+        assert!(matches!(
+            dispatch(&evt, &DefaultRegistry),
+            DispatchDecision::Squash(_)
+        ));
+    }
+
+    #[test]
+    fn terminal_non_interactive_bypasses_with_specific_reason() {
+        let bytes = b"{\"k\":\"v\"}\n";
+        let evt =
+            terminal_event_with_context(Some(TerminalContext::NonInteractiveOrStructured), bytes);
+        assert_eq!(
+            dispatch(&evt, &DefaultRegistry),
+            DispatchDecision::Bypass(BypassReason::TerminalNonInteractive)
+        );
+    }
+
+    #[test]
+    fn terminal_legacy_none_bypasses_with_specific_reason() {
+        let bytes = b"hello\n";
+        let evt = terminal_event_with_context(None, bytes);
+        assert_eq!(
+            dispatch(&evt, &DefaultRegistry),
+            DispatchDecision::Bypass(BypassReason::TerminalLegacyMissingContext)
+        );
+    }
+
+    #[test]
+    fn hook_payload_bypasses_as_non_terminal_family() {
+        let bytes = b"{}";
+        let evt = hook_event(bytes);
+        assert_eq!(
+            dispatch(&evt, &DefaultRegistry),
+            DispatchDecision::Bypass(BypassReason::NonTerminalFamily)
+        );
+    }
+
+    #[test]
+    fn registry_override_can_force_bypass_on_terminal_interactive() {
+        struct ForceBypass;
+        impl ToolSchemaLookup for ForceBypass {
+            fn bypass_override(&self, _family: SourceFamily) -> Option<BypassReason> {
+                Some(BypassReason::RegistryOverride)
+            }
+        }
+        let bytes = b"hello\n";
+        let evt = terminal_event_with_context(Some(TerminalContext::InteractiveTty), bytes);
+        // Without the override the terminal+interactive_tty event
+        // would route to Squash; the override flips it to Bypass.
+        assert_eq!(
+            dispatch(&evt, &ForceBypass),
+            DispatchDecision::Bypass(BypassReason::RegistryOverride)
+        );
+    }
+
+    /// Regression: a family-wide bypass override on `Terminal` must
+    /// NOT mask the legacy/non-interactive bypass reasons. Operators
+    /// rely on `TerminalLegacyMissingContext` to detect pre-#218
+    /// payloads that need migration during replay; relabeling them as
+    /// `RegistryOverride` would silently lose that signal.
+    #[test]
+    fn registry_override_on_terminal_preserves_intrinsic_reasons() {
+        struct BypassTerminal;
+        impl ToolSchemaLookup for BypassTerminal {
+            fn bypass_override(&self, family: SourceFamily) -> Option<BypassReason> {
+                (family == SourceFamily::Terminal).then_some(BypassReason::RegistryOverride)
+            }
+        }
+        let legacy = terminal_event_with_context(None, b"hi");
+        assert_eq!(
+            dispatch(&legacy, &BypassTerminal),
+            DispatchDecision::Bypass(BypassReason::TerminalLegacyMissingContext),
+            "legacy missing-context bypass reason must survive a family override"
+        );
+        let structured =
+            terminal_event_with_context(Some(TerminalContext::NonInteractiveOrStructured), b"{}");
+        assert_eq!(
+            dispatch(&structured, &BypassTerminal),
+            DispatchDecision::Bypass(BypassReason::TerminalNonInteractive),
+            "structured-output bypass reason must survive a family override"
+        );
+    }
+
+    /// Regression for review-loop round 4 finding: an override on one
+    /// family must not affect dispatch of a different family — the
+    /// `pipeline_dispatch` advertisement and the routing the dispatch
+    /// driver performs stay in lockstep per-family.
+    #[test]
+    fn registry_override_is_scoped_to_its_family() {
+        struct BypassTerminalOnly;
+        impl ToolSchemaLookup for BypassTerminalOnly {
+            fn bypass_override(&self, family: SourceFamily) -> Option<BypassReason> {
+                (family == SourceFamily::Terminal).then_some(BypassReason::RegistryOverride)
+            }
+        }
+        let term = terminal_event_with_context(Some(TerminalContext::InteractiveTty), b"hi");
+        assert_eq!(
+            dispatch(&term, &BypassTerminalOnly),
+            DispatchDecision::Bypass(BypassReason::RegistryOverride)
+        );
+        let hook = hook_event(b"{}");
+        assert_eq!(
+            dispatch(&hook, &BypassTerminalOnly),
+            DispatchDecision::Bypass(BypassReason::NonTerminalFamily)
+        );
+    }
+
+    #[test]
+    fn default_registry_returns_none_for_every_family() {
+        let reg = DefaultRegistry;
+        for family in [
+            SourceFamily::Hook,
+            SourceFamily::Ide,
+            SourceFamily::Terminal,
+            SourceFamily::Clipboard,
+            SourceFamily::Voice,
+            SourceFamily::Screen,
+            SourceFamily::RecordingBatch,
+            SourceFamily::Cli,
+            SourceFamily::Mcp,
+            SourceFamily::Proactive,
+        ] {
+            assert!(reg.bypass_override(family).is_none());
+        }
+    }
+
+    #[test]
+    fn default_advertisement_covers_every_family_exactly_once() {
+        let adv = pipeline_dispatch_advertisement(&DefaultRegistry);
+        assert_eq!(adv.len(), 10, "one entry per SourceFamily variant");
+        let mut families: Vec<_> = adv.iter().map(|e| e.source_family).collect();
+        families.sort_by_key(|f| format!("{f:?}"));
+        families.dedup_by_key(|f| format!("{f:?}"));
+        assert_eq!(families.len(), 10, "no duplicate families");
+    }
+
+    #[test]
+    fn default_advertisement_terminal_is_squash_others_bypass() {
+        let adv = pipeline_dispatch_advertisement(&DefaultRegistry);
+        for entry in &adv {
+            let want = if matches!(
+                entry.source_family,
+                StatusResponsePipelineDispatchSourceFamily::Terminal
+            ) {
+                StatusResponsePipelineDispatchDecision::SquashWhenInteractiveTty
+            } else {
+                StatusResponsePipelineDispatchDecision::Bypass
+            };
+            assert_eq!(
+                entry.decision, want,
+                "{:?} should advertise {:?}",
+                entry.source_family, want
+            );
+            assert!(entry.tool_id.is_none(), "P0 advertises family-wide only");
+        }
+    }
+
+    #[test]
+    fn default_advertisement_is_sorted_lexicographically_by_wire_family() {
+        let adv = pipeline_dispatch_advertisement(&DefaultRegistry);
+        let wire_keys: Vec<String> = adv
+            .iter()
+            .map(|e| {
+                serde_json::to_value(e.source_family)
+                    .unwrap()
+                    .as_str()
+                    .unwrap()
+                    .to_owned()
+            })
+            .collect();
+        let mut sorted = wire_keys.clone();
+        sorted.sort();
+        assert_eq!(
+            wire_keys, sorted,
+            "advertisement must be sorted by wire-form source_family for byte-stable status (brief §8.0.a)"
+        );
+    }
+
+    /// Regression for review-loop round 1 finding: status
+    /// advertisement is derived from the same registry call
+    /// `dispatch()` makes. A bypass override on `Terminal` MUST flip
+    /// its advertised decision from `SquashWhenInteractiveTty` to
+    /// `Bypass`.
+    #[test]
+    fn advertisement_reflects_registry_bypass_override_on_terminal() {
+        struct BypassTerminal;
+        impl ToolSchemaLookup for BypassTerminal {
+            fn bypass_override(&self, family: SourceFamily) -> Option<BypassReason> {
+                (family == SourceFamily::Terminal).then_some(BypassReason::RegistryOverride)
+            }
+        }
+        let adv = pipeline_dispatch_advertisement(&BypassTerminal);
+        let terminal_entry = adv
+            .iter()
+            .find(|e| e.source_family == StatusResponsePipelineDispatchSourceFamily::Terminal)
+            .expect("terminal entry");
+        assert_eq!(
+            terminal_entry.decision,
+            StatusResponsePipelineDispatchDecision::Bypass,
+            "bypass override on Terminal must flip the advertised decision"
+        );
+        // Other families fall through to defaults.
+        let hook_entry = adv
+            .iter()
+            .find(|e| e.source_family == StatusResponsePipelineDispatchSourceFamily::Hook)
+            .expect("hook entry");
+        assert_eq!(
+            hook_entry.decision,
+            StatusResponsePipelineDispatchDecision::Bypass
+        );
+    }
+
+    /// Regression: a malformed envelope (here, `source_family`
+    /// disagrees with the payload variant) must NOT receive a squash
+    /// admission. Routing the event onto the lossy path and then
+    /// rejecting it inside the squash binder would split the safety
+    /// check from the decision; dispatch must reject such events at
+    /// the boundary.
+    #[test]
+    fn malformed_envelope_bypasses_with_specific_reason() {
+        let bytes = b"hello\n";
+        let mut evt = terminal_event_with_context(Some(TerminalContext::InteractiveTty), bytes);
+        // Intentional contradiction: payload says Terminal, envelope
+        // says Hook. `event.validate()` rejects this.
+        evt.source_family = SourceFamily::Hook;
+        assert!(evt.validate().is_err(), "fixture must be invalid");
+        assert_eq!(
+            dispatch(&evt, &DefaultRegistry),
+            DispatchDecision::Bypass(BypassReason::MalformedEnvelope)
+        );
+    }
+
+    /// Lock in the default-table dispatch invariant: same event always
+    /// produces the same decision (replay determinism).
+    #[test]
+    fn dispatch_is_deterministic() {
+        let bytes = b"hello\n";
+        let evt = terminal_event_with_context(Some(TerminalContext::InteractiveTty), bytes);
+        let a = dispatch(&evt, &DefaultRegistry);
+        let b = dispatch(&evt, &DefaultRegistry);
+        assert_eq!(a, b);
+    }
+}

--- a/crates/cairn-core/src/pipeline/mod.rs
+++ b/crates/cairn-core/src/pipeline/mod.rs
@@ -7,12 +7,21 @@
 //! returning a value or a typed error.
 //!
 //! Modules:
-//! - `squash` (crate-private) — tool-output compactor (issue #72).
-//!   Crate-internal until the dispatch driver (#217) and persisted
-//!   `TerminalContext` (#218) land: the squash gate's eligibility
-//!   must be derivable from persisted capture data, not a caller-
-//!   supplied side input — keeping the surface inside the crate
-//!   prevents misuse.
+//! - [`dispatch`] — pure routing function deciding per
+//!   `CaptureEvent` whether the bytes flow through `squash` (lossy
+//!   text compaction) or **bypass** (raw bytes to Extract). Reads
+//!   only `event.payload`, never the bytes; replay reproduces the
+//!   same decision the dispatch driver took at capture time
+//!   (issue #217).
+//! - `squash` — tool-output compactor (issue #72). Crate-private:
+//!   the squash entry point only proves internal self-consistency
+//!   (event validates, payload is `Terminal`, context is
+//!   `InteractiveTty`, hash matches the supplied bytes), so exposing
+//!   it publicly would let an external caller fabricate a terminal
+//!   envelope around arbitrary bytes and drive lossy compaction. The
+//!   pipeline driver in `cairn-core` composes [`dispatch::dispatch`]
+//!   then squash internally so the trust chain stays owned by this
+//!   crate.
 //! - [`filter`] — visibility / redaction / fencing gate that runs
 //!   **before** any `MemoryStore` write, so it cannot leak raw bodies
 //!   to disk.
@@ -24,6 +33,7 @@
 //!   per-sensor opt-in, append-only audit)
 
 pub mod capture_trace;
+pub mod dispatch;
 pub mod explain;
 pub mod extract;
 pub mod filter;
@@ -31,12 +41,18 @@ pub mod lint;
 pub(crate) mod squash;
 pub mod turn;
 
-/// Fuzz-only re-export of the squash module's public surface. Gated
-/// behind the `fuzz` crate feature so production builds keep the
-/// `pub(crate)` boundary on `pipeline::squash` (the squash gate's
-/// eligibility must be derivable from persisted capture metadata,
-/// not a caller-supplied side input — see issues #217/#218). Used
-/// only by `fuzz/fuzz_targets/squash.rs`.
+/// Fuzz-only re-export of the squash module's internal entrypoint.
+/// Gated behind the `fuzz` crate feature; production builds keep
+/// the `squash` module crate-private. Issue #217 keeps it that way
+/// deliberately: although `dispatch()` makes squash eligibility
+/// derivable from persisted capture data, exposing the squash
+/// constructor publicly would let external callers fabricate a
+/// `Terminal + InteractiveTty` envelope around arbitrary bytes and
+/// drive lossy compaction — `try_from_terminal_event` only proves
+/// internal self-consistency, not that the bytes came from a trusted
+/// capture path. The next issue's pipeline driver will compose
+/// dispatch + squash inside `cairn-core` so the trust chain stays
+/// owned by this crate.
 #[cfg(feature = "fuzz")]
 pub mod squash_fuzz {
     pub use super::squash::{SquashConfig, SquashOutput, fuzz_entrypoint};

--- a/crates/cairn-core/src/pipeline/squash.rs
+++ b/crates/cairn-core/src/pipeline/squash.rs
@@ -312,10 +312,19 @@ impl<'a> UnstructuredTextBytes<'a> {
     /// decision (issue #218).
     ///
     /// # Stability
-    /// `pub(crate)` until the dispatch driver (#217) is the sole entry
-    /// point. The signature derives the context from the event alone —
-    /// a misbehaving caller can no longer reclassify a stored structured
-    /// payload as interactive.
+    /// `pub(crate)`. Issue #217 considered promoting this entry point
+    /// to `pub` once `SquashAdmission` gated minting, but
+    /// `try_from_terminal_event` only proves *internal*
+    /// self-consistency (event validates, payload is `Terminal`,
+    /// context is `InteractiveTty`, hash matches the supplied bytes).
+    /// It cannot prove the bytes came from a trusted capture path, so
+    /// exposing the API publicly would let an external caller
+    /// fabricate a `Terminal + InteractiveTty` envelope around
+    /// arbitrary CLI/MCP/hook bytes and drive lossy compaction. The
+    /// next issue's pipeline driver composes dispatch + squash inside
+    /// `cairn-core` so the trust chain stays owned by this crate; the
+    /// admission token still exists to make replay determinism
+    /// auditable inside that boundary.
     ///
     /// # Errors
     /// `NotTerminalPayload`, `HashMismatch`, `StructuredContextRejected`
@@ -325,13 +334,10 @@ impl<'a> UnstructuredTextBytes<'a> {
     /// `StructuredContextRejected` so callers can distinguish "needs
     /// migration" from "deliberately structured / squash-bypass" —
     /// see [`UnstructuredBindError::LegacyMissingContext`].
-    // Only reachable from #[cfg(test)] modules until #217 wires the
-    // dispatch driver; default-feature non-test builds legitimately
-    // leave it dead.
-    #[allow(dead_code)]
     pub(crate) fn try_from_terminal_event(
         event: &CaptureEvent,
         raw: &'a [u8],
+        _admission: super::dispatch::SquashAdmission,
     ) -> Result<Self, UnstructuredBindError> {
         // Reject malformed envelopes outright — we never want to lossily
         // compact bytes whose source_family / sensor / payload disagree.
@@ -542,7 +548,12 @@ mod wrapper_tests {
     fn rejects_non_terminal_variant() {
         let bytes = b"hello\n";
         let evt = hook_event(bytes);
-        let err = UnstructuredTextBytes::try_from_terminal_event(&evt, bytes).unwrap_err();
+        let err = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            bytes,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .unwrap_err();
         assert!(matches!(err, UnstructuredBindError::NotTerminalPayload));
     }
 
@@ -551,7 +562,12 @@ mod wrapper_tests {
         let bytes = b"hello\n";
         let mut evt = terminal_event(bytes);
         evt.payload_hash = payload_hash_of(b"different bytes");
-        let err = UnstructuredTextBytes::try_from_terminal_event(&evt, bytes).unwrap_err();
+        let err = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            bytes,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .unwrap_err();
         assert!(matches!(err, UnstructuredBindError::HashMismatch));
     }
 
@@ -562,7 +578,12 @@ mod wrapper_tests {
         if let CapturePayload::Terminal { context, .. } = &mut evt.payload {
             *context = Some(TerminalContext::NonInteractiveOrStructured);
         }
-        let err = UnstructuredTextBytes::try_from_terminal_event(&evt, bytes).unwrap_err();
+        let err = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            bytes,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             UnstructuredBindError::StructuredContextRejected
@@ -586,7 +607,12 @@ mod wrapper_tests {
         // `validate()` accepts legacy events so deserialize / replay
         // stays unbroken across upgrade.
         evt.payload.validate().expect("legacy event must validate");
-        let err = UnstructuredTextBytes::try_from_terminal_event(&evt, bytes).unwrap_err();
+        let err = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            bytes,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .unwrap_err();
         assert!(matches!(err, UnstructuredBindError::LegacyMissingContext));
     }
 
@@ -594,8 +620,12 @@ mod wrapper_tests {
     fn accepts_terminal_interactive_tty_with_matching_hash() {
         let bytes = b"hello\n";
         let evt = terminal_event(bytes);
-        let wrapped = UnstructuredTextBytes::try_from_terminal_event(&evt, bytes)
-            .expect("valid construction");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            bytes,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("valid construction");
         assert_eq!(wrapped.as_bytes(), bytes);
         assert_eq!(wrapped.raw_hash(), &evt.payload_hash);
     }
@@ -1156,7 +1186,12 @@ mod wrapper_tests {
         let n = MAX_INPUT_BYTES / 3 + 1;
         let raw = vec![0xFFu8; n];
         let evt = terminal_event(&raw);
-        let wrapped = UnstructuredTextBytes::try_from_terminal_event(&evt, &raw).expect("valid");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            &raw,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("valid");
         let cfg = SquashConfig::default();
         let out = super::squash(wrapped, &cfg);
         let body = String::from_utf8_lossy(&out.compacted_bytes);
@@ -1181,7 +1216,12 @@ mod wrapper_tests {
         // fire and stage 1 actually runs. No ANSI, no dedup, no cap.
         let raw = b"\xFF\xFF\xFFhello\n";
         let evt = terminal_event(raw);
-        let wrapped = UnstructuredTextBytes::try_from_terminal_event(&evt, raw).expect("valid");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            raw,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("valid");
         let cfg = SquashConfig::default();
         let out = super::squash(wrapped, &cfg);
         assert!(
@@ -1204,7 +1244,12 @@ mod wrapper_tests {
         // stripped. No stage 5 or stage 6 loss.
         let raw = b"\x1b[31mred\x1b[0m\nplain\n";
         let evt = terminal_event(raw);
-        let wrapped = UnstructuredTextBytes::try_from_terminal_event(&evt, raw).expect("valid");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            raw,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("valid");
         let cfg = SquashConfig::default();
         let out = super::squash(wrapped, &cfg);
         assert!(out.stats.ansi_stripped, "ansi was stripped");
@@ -1221,7 +1266,12 @@ mod wrapper_tests {
         // Repeated line, no ANSI. Default dedup_min_run = 2.
         let raw = b"same\nsame\nsame\n";
         let evt = terminal_event(raw);
-        let wrapped = UnstructuredTextBytes::try_from_terminal_event(&evt, raw).expect("valid");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            raw,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("valid");
         let cfg = SquashConfig::default();
         let out = super::squash(wrapped, &cfg);
         assert!(out.stats.dedup_runs_collapsed > 0, "dedup acted");
@@ -1706,8 +1756,12 @@ mod wrapper_tests {
         raw.extend(std::iter::repeat_n(b'\n', n));
         raw.extend_from_slice(b"FINAL\n");
         let evt = terminal_event(&raw);
-        let wrapped =
-            UnstructuredTextBytes::try_from_terminal_event(&evt, &raw).expect("under byte ceiling");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            &raw,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("under byte ceiling");
         let cfg = SquashConfig::default();
         let out = super::squash(wrapped, &cfg);
         assert!(out.stats.truncated, "must take bypass path");
@@ -1820,8 +1874,12 @@ mod wrapper_tests {
         // payload becomes U+FFFD on lossy decode (1B → 3B expansion).
         let oversized = vec![0xFFu8; MAX_INPUT_BYTES + 1];
         let evt = terminal_event(&oversized);
-        let wrapped = UnstructuredTextBytes::try_from_terminal_event(&evt, &oversized)
-            .expect("oversize is no longer rejected");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            &oversized,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("oversize is no longer rejected");
         let cfg = SquashConfig::default();
         let out = super::squash(wrapped, &cfg);
         assert!(out.stats.truncated);
@@ -1851,8 +1909,12 @@ mod wrapper_tests {
         let n = oversized.len();
         oversized[n - 6..].copy_from_slice(b"\nYTAIL");
         let evt = terminal_event(&oversized);
-        let wrapped = UnstructuredTextBytes::try_from_terminal_event(&evt, &oversized)
-            .expect("oversize is no longer rejected");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            &oversized,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("oversize is no longer rejected");
         let cfg = SquashConfig::default();
         let out = super::squash(wrapped, &cfg);
         assert!(out.stats.truncated);
@@ -1877,7 +1939,12 @@ mod wrapper_tests {
         let mut evt = terminal_event(bytes);
         // Force source_family / payload-variant disagreement.
         evt.source_family = SourceFamily::Hook;
-        let err = UnstructuredTextBytes::try_from_terminal_event(&evt, bytes).unwrap_err();
+        let err = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            bytes,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .unwrap_err();
         assert!(
             matches!(err, UnstructuredBindError::EventValidationFailed(_)),
             "got: {err:?}"
@@ -1891,8 +1958,12 @@ mod wrapper_tests {
     /// per-shape test stays focused on the input it constructs.
     fn cr_bearing_lines_both_paths(payload: &[u8]) -> (usize, usize) {
         let evt = terminal_event(payload);
-        let wrapped = UnstructuredTextBytes::try_from_terminal_event(&evt, payload)
-            .expect("valid construction");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            payload,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("valid construction");
         let cfg = SquashConfig::default();
         let staged = super::squash(wrapped, &cfg);
 
@@ -2186,8 +2257,12 @@ mod wrapper_tests {
         assert!(oversized.len() >= MAX_INPUT_BYTES);
 
         let evt = terminal_event(&oversized);
-        let wrapped = UnstructuredTextBytes::try_from_terminal_event(&evt, &oversized)
-            .expect("oversize accepted");
+        let wrapped = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            &oversized,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("oversize accepted");
         let cfg = SquashConfig::default();
         let out = super::squash(wrapped, &cfg);
 
@@ -5760,7 +5835,19 @@ pub fn fuzz_entrypoint(raw: &[u8], cfg: &SquashConfig) -> Option<SquashOutput> {
         },
         source_family: SourceFamily::Terminal,
     };
-    let wrapper = UnstructuredTextBytes::try_from_terminal_event(&event, raw).ok()?;
+    // Drive the fuzz harness through the real dispatch decision so
+    // production routing is on the fuzzed path; the synthetic event
+    // is `Terminal { context: InteractiveTty }`, so dispatch returns
+    // `Squash` and yields the admission token without any test-only
+    // shortcut.
+    let admission = match crate::pipeline::dispatch::dispatch(
+        &event,
+        &crate::pipeline::dispatch::DefaultRegistry,
+    ) {
+        crate::pipeline::dispatch::DispatchDecision::Squash(t) => t,
+        crate::pipeline::dispatch::DispatchDecision::Bypass(_) => return None,
+    };
+    let wrapper = UnstructuredTextBytes::try_from_terminal_event(&event, raw, admission).ok()?;
     Some(squash(wrapper, cfg))
 }
 
@@ -5847,8 +5934,12 @@ mod squash_integration_tests {
 
     fn run_squash(raw: &[u8], cfg: &SquashConfig) -> SquashOutput {
         let evt = terminal_event(raw);
-        let wrapper =
-            UnstructuredTextBytes::try_from_terminal_event(&evt, raw).expect("valid wrapper");
+        let wrapper = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            raw,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("valid wrapper");
         squash(wrapper, cfg)
     }
 
@@ -6075,8 +6166,12 @@ mod squash_fixtures_tests {
     fn run_fixture(name: &str, cfg: &SquashConfig) -> String {
         let raw = fixture(name);
         let evt = terminal_event(&raw);
-        let wrapper = UnstructuredTextBytes::try_from_terminal_event(&evt, &raw)
-            .unwrap_or_else(|e| panic!("bind {name}: {e:?}"));
+        let wrapper = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            &raw,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .unwrap_or_else(|e| panic!("bind {name}: {e:?}"));
         let out = squash(wrapper, cfg);
         String::from_utf8_lossy(&out.compacted_bytes).into_owned()
     }
@@ -6166,16 +6261,24 @@ mod squash_perf {
 
         // Warm-up.
         for _ in 0..3 {
-            let w =
-                UnstructuredTextBytes::try_from_terminal_event(&evt, &raw).expect("valid wrapper");
+            let w = UnstructuredTextBytes::try_from_terminal_event(
+                &evt,
+                &raw,
+                crate::pipeline::dispatch::SquashAdmission::for_test(),
+            )
+            .expect("valid wrapper");
             let _ = squash(w, &cfg);
         }
 
         let iters: u32 = 50;
         let start = Instant::now();
         for _ in 0..iters {
-            let w =
-                UnstructuredTextBytes::try_from_terminal_event(&evt, &raw).expect("valid wrapper");
+            let w = UnstructuredTextBytes::try_from_terminal_event(
+                &evt,
+                &raw,
+                crate::pipeline::dispatch::SquashAdmission::for_test(),
+            )
+            .expect("valid wrapper");
             let _ = squash(w, &cfg);
         }
         let avg = start.elapsed() / iters;
@@ -6194,7 +6297,12 @@ mod proptest_squash {
 
     fn run_squash_for_proptest(raw: &[u8], cfg: &SquashConfig) -> SquashOutput {
         let evt = terminal_event(raw);
-        let wrapper = UnstructuredTextBytes::try_from_terminal_event(&evt, raw).expect("valid");
+        let wrapper = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            raw,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("valid");
         squash(wrapper, cfg)
     }
 
@@ -6432,7 +6540,12 @@ mod corner_case_tests {
 
     fn squash_raw(raw: &[u8], cfg: &SquashConfig) -> SquashOutput {
         let evt = terminal_event(raw);
-        let wrapper = UnstructuredTextBytes::try_from_terminal_event(&evt, raw).expect("valid");
+        let wrapper = UnstructuredTextBytes::try_from_terminal_event(
+            &evt,
+            raw,
+            crate::pipeline::dispatch::SquashAdmission::for_test(),
+        )
+        .expect("valid");
         squash(wrapper, cfg)
     }
 

--- a/crates/cairn-idl/schema/prelude/status.json
+++ b/crates/cairn-idl/schema/prelude/status.json
@@ -31,6 +31,33 @@
       "type": "array",
       "uniqueItems": true,
       "items": { "$ref": "../extensions/registry.json#/$defs/namespace" }
+    },
+    "pipeline_dispatch": {
+      "type": "array",
+      "uniqueItems": true,
+      "description": "Per-(source_family, tool_id) routing decisions for the Capture → Extract pipeline (issue #217). Each entry tells clients whether captured payloads flow through `squash` (lossy compaction) or `bypass` (raw bytes). Entries MUST be sorted lexicographically by (source_family, tool_id ?? \"\") for byte-stable status responses across an incarnation (brief §8.0.a). Optional and additive — not in `required[]` so a pre-#217 server's response (no field) deserializes against this schema.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source_family", "decision"],
+        "properties": {
+          "source_family": {
+            "type": "string",
+            "enum": ["hook", "ide", "terminal", "clipboard", "voice", "screen", "recording_batch", "cli", "mcp", "proactive"],
+            "description": "Wire-form SourceFamily tag (matches CapturePayload variant)."
+          },
+          "tool_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional tool identifier (e.g., 'Bash', 'Read'). Absent means the decision applies to every tool in this source_family — the P0 default."
+          },
+          "decision": {
+            "type": "string",
+            "enum": ["squash_when_interactive_tty", "bypass"],
+            "description": "P0 routing enum — closed. 'squash_when_interactive_tty' admits InteractiveTty Terminal payloads to `squash`; everything else (including non-interactive Terminal) bypasses. Adding values is a wire-contract change (cairn.mcp.v1 → vNext), not an additive update — older clients' generated deserializers will reject unknown values."
+          }
+        }
+      }
     }
   },
   "allOf": [

--- a/crates/cairn-mcp/src/generated/schemas/prelude/status.json
+++ b/crates/cairn-mcp/src/generated/schemas/prelude/status.json
@@ -290,6 +290,50 @@
       "type": "array",
       "uniqueItems": true
     },
+    "pipeline_dispatch": {
+      "description": "Per-(source_family, tool_id) routing decisions for the Capture → Extract pipeline (issue #217). Each entry tells clients whether captured payloads flow through `squash` (lossy compaction) or `bypass` (raw bytes). Entries MUST be sorted lexicographically by (source_family, tool_id ?? \"\") for byte-stable status responses across an incarnation (brief §8.0.a). Optional and additive — not in `required[]` so a pre-#217 server's response (no field) deserializes against this schema.",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "decision": {
+            "description": "P0 routing enum — closed. 'squash_when_interactive_tty' admits InteractiveTty Terminal payloads to `squash`; everything else (including non-interactive Terminal) bypasses. Adding values is a wire-contract change (cairn.mcp.v1 → vNext), not an additive update — older clients' generated deserializers will reject unknown values.",
+            "enum": [
+              "squash_when_interactive_tty",
+              "bypass"
+            ],
+            "type": "string"
+          },
+          "source_family": {
+            "description": "Wire-form SourceFamily tag (matches CapturePayload variant).",
+            "enum": [
+              "hook",
+              "ide",
+              "terminal",
+              "clipboard",
+              "voice",
+              "screen",
+              "recording_batch",
+              "cli",
+              "mcp",
+              "proactive"
+            ],
+            "type": "string"
+          },
+          "tool_id": {
+            "description": "Optional tool identifier (e.g., 'Bash', 'Read'). Absent means the decision applies to every tool in this source_family — the P0 default.",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_family",
+          "decision"
+        ],
+        "type": "object"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
     "server_info": {
       "additionalProperties": false,
       "properties": {

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -26,6 +26,7 @@ use cairn_core::generated::verbs::{
     search::{SearchArgs, SearchArgsMode, SearchData},
     summarize::{SummarizeArgs, SummarizeData},
 };
+use cairn_core::pipeline::dispatch::{DefaultRegistry, pipeline_dispatch_advertisement};
 
 use crate::stub::{new_nonce, now_ms, now_rfc3339_seconds, store_not_wired};
 use crate::{CONTRACT, SdkError, VerbResponse};
@@ -166,6 +167,14 @@ impl<T: Transport> Sdk<T> {
             },
             capabilities: self.advertised_capabilities(),
             extensions: vec![],
+            // Advertise the live routing policy. Mirrors the CLI
+            // status producer: both surfaces emit the same
+            // family-granular `pipeline_dispatch` derived from
+            // `DefaultRegistry`, which is the registry the
+            // `capture_trace` verb actually dispatches through. See
+            // `crates/cairn-cli/src/verbs/status.rs` for the
+            // long-form note.
+            pipeline_dispatch: Some(pipeline_dispatch_advertisement(&DefaultRegistry)),
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `cairn-core::pipeline::dispatch` — `DispatchDecision`, `BypassReason`, `ToolSchemaLookup` trait (family-keyed, bypass-only), `DefaultRegistry`, pure `dispatch()`, and `pipeline_dispatch_advertisement()` (brief §5.2 / §8.0.a).
- Sealed `SquashAdmission` capability token (non-Copy/non-Clone) gates `squash::UnstructuredTextBytes::try_from_terminal_event`; only `dispatch()` mints one.
- IDL adds optional `pipeline_dispatch` field to status response (family-granular, lex-sorted for byte-stable wire). CLI + SDK status producers wired against the live registry.

Closes #217.

## Brief sections
- §5.2 Capture → Extract pipeline
- §8.0.a Status / wire stability
- §4.4 Pure functions in `cairn-core`

## Invariants
- CLI/SDK emit identical `pipeline_dispatch` advertisement (CLI is ground truth).
- `dispatch()` is a pure function over `CaptureEvent` — replay-deterministic.
- `cairn-core` boundary preserved (no adapter deps).

## Deferred (follow-ups)
- Wiring `dispatch()` into the production Capture→Extract path is the next issue's scope.
- Per-tool override granularity requires growing trait + wire schema in lockstep.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo nextest run -p cairn-core` — 513 pipeline tests pass (12 new dispatch tests)
- [x] `cargo test --doc --workspace`
- [x] `cargo run -p cairn-idl --bin cairn-codegen -- --check`
- [x] `cargo run -p cairn-cli --bin cairn-docgen -- --check`
- [x] rustdoc with broken-link denies
- [x] `cargo deny check`, `cargo machete`
- [x] `./scripts/check-core-boundary.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
