### PR TITLE
feat(core/search): pure types + 3-leg RRF + graph-only rerank (issue #191 phase 1)

### DIFF
--- a/crates/cairn-core/src/search/cosine.rs
+++ b/crates/cairn-core/src/search/cosine.rs
@@ -98,6 +98,91 @@ pub fn cosine_rerank<S: BuildHasher>(
     out
 }
 
+/// Where a candidate originated, for [`cosine_rerank_tagged`].
+///
+/// `Lexical` candidates have a doc vector and the cosine term blends into
+/// the final score. `GraphOnly` candidates surfaced via 1-hop entity-graph
+/// expansion only — there is no lexical match and the cosine term is
+/// dropped (rather than substituted by a neutral 0.5, which would bias
+/// graph-only candidates upward in the cosine-only blend).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CandidateOrigin {
+    /// Surfaced by the keyword and/or semantic leg; has a doc vector.
+    Lexical,
+    /// Surfaced only by the graph leg; no lexical match.
+    GraphOnly,
+}
+
+/// One [`RrfCandidate`] tagged with its origin for [`cosine_rerank_tagged`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct OriginTaggedCandidate {
+    /// The fused candidate.
+    pub inner: RrfCandidate,
+    /// Whether this candidate has a doc vector eligible for cosine.
+    pub origin: CandidateOrigin,
+}
+
+/// Origin-aware variant of [`cosine_rerank`].
+///
+/// For [`CandidateOrigin::Lexical`] candidates the formula is
+/// `blend * rrf_norm + (1 - blend) * cos_norm` where
+/// `cos_norm = (cosine_raw + 1) / 2` puts cosine in `[0, 1]` so it is
+/// commensurable with `rrf_norm`. For [`CandidateOrigin::GraphOnly`] the
+/// cosine term is dropped: `final = blend * rrf_norm`. This is symmetric
+/// — both origins use the same `blend` factor — and prevents graph-only
+/// candidates from inheriting an undue cosine boost that they did not
+/// earn lexically.
+///
+/// Returns descending by `final_score`, ties broken by record id.
+#[must_use]
+pub fn cosine_rerank_tagged<S: BuildHasher>(
+    candidates: &[OriginTaggedCandidate],
+    doc_vectors: &HashMap<RecordId, Vec<f32>, S>,
+    query_vector: &[f32],
+    blend: f32,
+) -> Vec<RerankedCandidate> {
+    let blend = f64::from(blend.clamp(0.0, 1.0));
+    let max_rrf = candidates
+        .iter()
+        .map(|c| c.inner.rrf_score)
+        .fold(0.0_f64, f64::max);
+
+    let mut out: Vec<RerankedCandidate> = candidates
+        .iter()
+        .map(|tc| {
+            let rrf_norm = if max_rrf < f64::EPSILON {
+                0.0
+            } else {
+                tc.inner.rrf_score / max_rrf
+            };
+            let raw_cos = doc_vectors
+                .get(&tc.inner.record_id)
+                .map(|v| cosine_similarity(query_vector, v));
+            let (final_score, cosine) = match tc.origin {
+                CandidateOrigin::Lexical => {
+                    let cos_norm = raw_cos.map_or(0.5, |c| f64::midpoint(c, 1.0));
+                    (blend * rrf_norm + (1.0 - blend) * cos_norm, raw_cos)
+                }
+                CandidateOrigin::GraphOnly => (blend * rrf_norm, None),
+            };
+            RerankedCandidate {
+                record_id: tc.inner.record_id.clone(),
+                rrf_score: tc.inner.rrf_score,
+                cosine,
+                final_score,
+            }
+        })
+        .collect();
+
+    out.sort_by(|a, b| {
+        b.final_score
+            .partial_cmp(&a.final_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.record_id.as_str().cmp(b.record_id.as_str()))
+    });
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,6 +300,77 @@ mod tests {
         // 0.7 * (1.0 / 1.0) + 0.3 * 0.0 = 0.70
         // Tolerance is f32-grade (see `rerank_blend_default_balances_signals`).
         assert!((out[0].final_score - 0.70).abs() < 1e-6);
+    }
+
+    #[test]
+    fn graph_only_ties_lexical_at_cosine_minus_one_equal_rrf() {
+        // Lexical doc has cosine_raw = -1 → cos_norm = 0; graph-only drops
+        // cosine. With equal RRF and same blend, both should produce the
+        // same final_score = blend * rrf_norm.
+        let mut docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        docs.insert(rid("0A"), vec![0.0_f32, 1.0]);
+        let cands = vec![
+            OriginTaggedCandidate {
+                inner: RrfCandidate {
+                    record_id: rid("0A"),
+                    rrf_score: 0.5,
+                },
+                origin: CandidateOrigin::Lexical,
+            },
+            OriginTaggedCandidate {
+                inner: RrfCandidate {
+                    record_id: rid("0B"),
+                    rrf_score: 0.5,
+                },
+                origin: CandidateOrigin::GraphOnly,
+            },
+        ];
+        let q = vec![0.0_f32, -1.0];
+        let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+        assert!(
+            (out[0].final_score - out[1].final_score).abs() < 1e-9,
+            "lexical-cos-(-1) must tie graph-only"
+        );
+    }
+
+    #[test]
+    fn graph_only_loses_to_strong_lexical_at_equal_rrf() {
+        let mut docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        docs.insert(rid("0A"), vec![1.0_f32, 0.0]);
+        let cands = vec![
+            OriginTaggedCandidate {
+                inner: RrfCandidate {
+                    record_id: rid("0A"),
+                    rrf_score: 0.5,
+                },
+                origin: CandidateOrigin::Lexical,
+            },
+            OriginTaggedCandidate {
+                inner: RrfCandidate {
+                    record_id: rid("0B"),
+                    rrf_score: 0.5,
+                },
+                origin: CandidateOrigin::GraphOnly,
+            },
+        ];
+        let q = vec![1.0_f32, 0.0];
+        let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+        assert_eq!(out[0].record_id, rid("0A"));
+    }
+
+    #[test]
+    fn graph_only_cosine_field_is_none() {
+        let docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        let cands = vec![OriginTaggedCandidate {
+            inner: RrfCandidate {
+                record_id: rid("0A"),
+                rrf_score: 1.0,
+            },
+            origin: CandidateOrigin::GraphOnly,
+        }];
+        let q = vec![1.0_f32, 0.0];
+        let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+        assert!(out[0].cosine.is_none());
     }
 
     #[test]

--- a/crates/cairn-core/src/search/degraded.rs
+++ b/crates/cairn-core/src/search/degraded.rs
@@ -1,0 +1,97 @@
+//! Typed degradation signal for hybrid search responses.
+//!
+//! When a leg of hybrid search fails (capability missing, deadline exceeded,
+//! SQL error, worker panic) the orchestrator returns the surviving legs and
+//! flags the failed ones via [`DegradedLeg`]. Callers (CLI, MCP, SDK) decide
+//! whether to surface a warning, retry, or fail-closed.
+
+/// Why a hybrid-search leg did not contribute results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradationReason {
+    /// Store does not advertise the capability needed by this leg.
+    CapabilityUnavailable,
+    /// Per-leg deadline elapsed before results landed.
+    DeadlineExceeded,
+    /// `SQLite` returned an error.
+    SqlError,
+    /// The leg's worker task panicked.
+    WorkerPanic,
+}
+
+/// Which seed source the graph leg was using when it degraded.
+///
+/// Only meaningful for [`DegradedLeg::Graph`]. Lets callers attribute a
+/// graph-leg failure to the auth-only keyword seed query, the auth-only
+/// semantic seed query, or the union ("all").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GraphSource {
+    /// Both seed paths failed (or no seeds were attempted).
+    All,
+    /// Auth-only keyword-seed retrieval was the in-flight source when the
+    /// leg degraded.
+    AuthKeywordSeed,
+    /// Auth-only semantic-seed retrieval was the in-flight source.
+    AuthSemanticSeed,
+}
+
+/// One leg of hybrid search that did not contribute results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradedLeg {
+    /// Semantic (vector-search) leg degraded.
+    Semantic {
+        /// Why the leg degraded.
+        reason: DegradationReason,
+    },
+    /// 1-hop entity-graph expansion leg degraded.
+    Graph {
+        /// Why the leg degraded.
+        reason: DegradationReason,
+        /// Which seed path was in flight when the leg degraded.
+        source: GraphSource,
+    },
+}
+
+impl DegradedLeg {
+    /// Convenience constructor for the most common graph-leg degradation:
+    /// the store does not advertise `graph_search` capability at all.
+    #[must_use]
+    pub fn graph_capability_unavailable() -> Self {
+        Self::Graph {
+            reason: DegradationReason::CapabilityUnavailable,
+            source: GraphSource::All,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graph_constructor_helper() {
+        let d = DegradedLeg::graph_capability_unavailable();
+        assert!(matches!(
+            d,
+            DegradedLeg::Graph {
+                reason: DegradationReason::CapabilityUnavailable,
+                source: GraphSource::All
+            }
+        ));
+    }
+
+    #[test]
+    fn semantic_variant_carries_reason() {
+        let d = DegradedLeg::Semantic {
+            reason: DegradationReason::DeadlineExceeded,
+        };
+        assert!(matches!(
+            d,
+            DegradedLeg::Semantic {
+                reason: DegradationReason::DeadlineExceeded
+            }
+        ));
+    }
+}

--- a/crates/cairn-core/src/search/graph.rs
+++ b/crates/cairn-core/src/search/graph.rs
@@ -1,0 +1,36 @@
+//! One graph-leg candidate.
+
+use crate::domain::RecordId;
+
+/// One graph-leg candidate: a record reached via a neighbor entity edge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphCandidate {
+    /// Record reached via a 1-hop neighbor edge.
+    pub record_id: RecordId,
+    /// Confidence score of the *connecting edge* in `[0.0, 1.0]`.
+    pub edge_confidence_score: f32,
+    /// 1-based rank in the graph leg's SQL output order. Carried
+    /// explicitly so RRF fusion does not infer rank from list position
+    /// after hydration shuffles ids. See spec §5.2.1.
+    pub graph_rank: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rid(suffix: &str) -> RecordId {
+        RecordId::parse(format!("01HQZX9F5N00000000000000{suffix}")).expect("valid id")
+    }
+
+    #[test]
+    fn construct_and_clone() {
+        let c = GraphCandidate {
+            record_id: rid("0A"),
+            edge_confidence_score: 0.85,
+            graph_rank: 3,
+        };
+        let c2 = c.clone();
+        assert_eq!(c, c2);
+    }
+}

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -5,12 +5,14 @@
 
 mod cosine;
 mod explain;
+mod graph;
 mod orchestrator;
 mod rrf;
 mod trim;
 
 pub use cosine::{RerankedCandidate, cosine_rerank, cosine_similarity};
 pub use explain::ScoreExplain;
+pub use graph::GraphCandidate;
 pub use orchestrator::{HybridSearchInputs, HybridSearchParams, hybrid_search};
 pub use rrf::{RrfCandidate, ScoredCandidate, rrf_fusion};
 pub use trim::token_budget_trim;

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -11,7 +11,10 @@ mod orchestrator;
 mod rrf;
 mod trim;
 
-pub use cosine::{RerankedCandidate, cosine_rerank, cosine_similarity};
+pub use cosine::{
+    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank,
+    cosine_rerank_tagged, cosine_similarity,
+};
 pub use degraded::{DegradationReason, DegradedLeg, GraphSource};
 pub use explain::ScoreExplain;
 pub use graph::GraphCandidate;

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -12,12 +12,14 @@ mod rrf;
 mod trim;
 
 pub use cosine::{
-    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank,
-    cosine_rerank_tagged, cosine_similarity,
+    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank, cosine_rerank_tagged,
+    cosine_similarity,
 };
 pub use degraded::{DegradationReason, DegradedLeg, GraphSource};
 pub use explain::ScoreExplain;
 pub use graph::GraphCandidate;
 pub use orchestrator::{HybridSearchInputs, HybridSearchParams, hybrid_search};
-pub use rrf::{Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted};
+pub use rrf::{
+    Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted,
+};
 pub use trim::token_budget_trim;

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -16,5 +16,5 @@ pub use degraded::{DegradationReason, DegradedLeg, GraphSource};
 pub use explain::ScoreExplain;
 pub use graph::GraphCandidate;
 pub use orchestrator::{HybridSearchInputs, HybridSearchParams, hybrid_search};
-pub use rrf::{RrfCandidate, ScoredCandidate, rrf_fusion};
+pub use rrf::{Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted};
 pub use trim::token_budget_trim;

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -4,6 +4,7 @@
 //! return scored output. The store adapters orchestrate the data fetching.
 
 mod cosine;
+mod degraded;
 mod explain;
 mod graph;
 mod orchestrator;
@@ -11,6 +12,7 @@ mod rrf;
 mod trim;
 
 pub use cosine::{RerankedCandidate, cosine_rerank, cosine_similarity};
+pub use degraded::{DegradationReason, DegradedLeg, GraphSource};
 pub use explain::ScoreExplain;
 pub use graph::GraphCandidate;
 pub use orchestrator::{HybridSearchInputs, HybridSearchParams, hybrid_search};

--- a/crates/cairn-core/src/search/orchestrator.rs
+++ b/crates/cairn-core/src/search/orchestrator.rs
@@ -6,11 +6,12 @@ use std::collections::HashSet;
 use crate::domain::RecordId;
 
 use super::cosine::{
-    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank,
-    cosine_rerank_tagged,
+    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank, cosine_rerank_tagged,
 };
 use super::graph::GraphCandidate;
-use super::rrf::{Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted};
+use super::rrf::{
+    Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted,
+};
 
 /// Inputs to [`hybrid_search`]. The store fetches keyword + semantic
 /// candidate lists and the per-record vectors; this function does the math.
@@ -271,7 +272,10 @@ mod tests {
         };
         let out = hybrid_search(&inputs, HybridSearchParams::default());
         let ids: Vec<_> = out.iter().map(|c| c.record_id.clone()).collect();
-        assert!(ids.contains(&rid("0C")), "graph-only candidate must surface");
+        assert!(
+            ids.contains(&rid("0C")),
+            "graph-only candidate must surface"
+        );
         // GraphOnly origin → cosine field is None.
         let c0c = out.iter().find(|c| c.record_id == rid("0C")).unwrap();
         assert!(c0c.cosine.is_none());

--- a/crates/cairn-core/src/search/orchestrator.rs
+++ b/crates/cairn-core/src/search/orchestrator.rs
@@ -1,11 +1,16 @@
 //! Pure orchestration of RRF fusion + cosine re-rank.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use crate::domain::RecordId;
 
-use super::cosine::{RerankedCandidate, cosine_rerank};
-use super::rrf::{RrfCandidate, ScoredCandidate, rrf_fusion};
+use super::cosine::{
+    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank,
+    cosine_rerank_tagged,
+};
+use super::graph::GraphCandidate;
+use super::rrf::{Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted};
 
 /// Inputs to [`hybrid_search`]. The store fetches keyword + semantic
 /// candidate lists and the per-record vectors; this function does the math.
@@ -16,6 +21,10 @@ pub struct HybridSearchInputs {
     /// Vector ANN hits, sorted ascending by L2 distance.
     /// (Smaller distance = more similar; convert to descending via reverse.)
     pub semantic: Vec<ScoredCandidate>,
+    /// 1-hop entity-graph neighbor hits, in SQL output order. Each
+    /// candidate carries its own `graph_rank` so RRF fusion does not
+    /// infer rank from list position after hydration.
+    pub graph: Vec<GraphCandidate>,
     /// Query embedding (for cosine re-rank).
     pub query_vector: Vec<f32>,
     /// Top-K record vectors, fetched after RRF. May be a subset of the
@@ -35,6 +44,10 @@ pub struct HybridSearchParams {
     /// `true` to skip the cosine pass entirely (useful when the semantic
     /// leg failed and we only have RRF). The output `cosine` will be `None`.
     pub skip_rerank: bool,
+    /// Floor on per-candidate confidence weight in [`Leg::Explicit`]. Keeps
+    /// `effective_rank = rank / max(weight, floor)` finite at zero
+    /// confidence. Default `1e-3`.
+    pub confidence_floor: f32,
 }
 
 impl Default for HybridSearchParams {
@@ -44,30 +57,49 @@ impl Default for HybridSearchParams {
             rerank_topk: 20,
             blend: 0.7,
             skip_rerank: false,
+            confidence_floor: 1e-3,
         }
     }
 }
 
-/// Run RRF fusion then optional cosine re-rank.
+/// Run RRF fusion (with optional graph leg) then optional cosine re-rank.
 ///
-/// The store calls this after fetching both legs. Output is sorted
-/// descending by `final_score`.
+/// The store calls this after fetching all three legs. Output is sorted
+/// descending by `final_score`. When the graph leg is empty this behaves
+/// identically to the legacy 2-leg fusion (proven by the `parity` test).
 #[must_use]
 pub fn hybrid_search(
     inputs: &HybridSearchInputs,
     params: HybridSearchParams,
 ) -> Vec<RerankedCandidate> {
-    let lists = vec![inputs.keyword.clone(), inputs.semantic.clone()];
-    let fused: Vec<RrfCandidate> = rrf_fusion(&lists, params.rrf_k);
+    // Fast path: no graph candidates → use the legacy 2-leg `rrf_fusion`
+    // directly so existing callers and tests see byte-identical scoring.
+    let fused: Vec<RrfCandidate> = if inputs.graph.is_empty() {
+        let lists = vec![inputs.keyword.clone(), inputs.semantic.clone()];
+        rrf_fusion(&lists, params.rrf_k)
+    } else {
+        let graph_ranked: Vec<RankedCandidate> = inputs
+            .graph
+            .iter()
+            .map(|g| RankedCandidate {
+                record_id: g.record_id.clone(),
+                rank: g.graph_rank,
+                weight: g.edge_confidence_score,
+            })
+            .collect();
+        let legs = [
+            Leg::ListPosition(inputs.keyword.clone()),
+            Leg::ListPosition(inputs.semantic.clone()),
+            Leg::Explicit(graph_ranked, params.confidence_floor),
+        ];
+        rrf_fusion_weighted(&legs, params.rrf_k)
+    };
+
     if params.skip_rerank || params.blend >= 1.0 {
-        // Skip cosine: emit reranked candidates with normalized RRF as final.
         let max_rrf = fused.iter().map(|c| c.rrf_score).fold(0.0_f64, f64::max);
         return fused
             .into_iter()
             .map(|c| {
-                // `max_rrf` is produced by `f64::max` over a list that may
-                // be empty or all-zero; in those cases the literal `0.0` is
-                // returned and the comparison is exact-equivalent.
                 let normalized = if max_rrf < f64::EPSILON {
                     0.0
                 } else {
@@ -82,13 +114,46 @@ pub fn hybrid_search(
             })
             .collect();
     }
+
     let topk = fused
         .iter()
         .take(params.rerank_topk)
         .cloned()
         .collect::<Vec<_>>();
-    cosine_rerank(
-        &topk,
+
+    // 2-leg path: keep using the legacy untagged rerank for byte-compat.
+    if inputs.graph.is_empty() {
+        return cosine_rerank(
+            &topk,
+            &inputs.doc_vectors,
+            &inputs.query_vector,
+            params.blend,
+        );
+    }
+
+    // 3-leg path: tag each top-K survivor as Lexical (appears in keyword
+    // or semantic) or GraphOnly (only the graph leg surfaced it). The
+    // origin gates whether the cosine term blends in — see
+    // [`cosine_rerank_tagged`] for the formula.
+    let lexical_ids: HashSet<&RecordId> = inputs
+        .keyword
+        .iter()
+        .map(|c| &c.record_id)
+        .chain(inputs.semantic.iter().map(|c| &c.record_id))
+        .collect();
+    let tagged: Vec<OriginTaggedCandidate> = topk
+        .into_iter()
+        .map(|c| {
+            let origin = if lexical_ids.contains(&c.record_id) {
+                CandidateOrigin::Lexical
+            } else {
+                CandidateOrigin::GraphOnly
+            };
+            OriginTaggedCandidate { inner: c, origin }
+        })
+        .collect();
+    cosine_rerank_tagged(
+        &tagged,
         &inputs.doc_vectors,
         &inputs.query_vector,
         params.blend,
@@ -116,6 +181,7 @@ mod tests {
         let inputs = HybridSearchInputs {
             keyword: vec![cand("0A", 1.0), cand("0B", 0.5)],
             semantic: vec![],
+            graph: vec![],
             query_vector: vec![],
             doc_vectors: HashMap::new(),
         };
@@ -138,6 +204,7 @@ mod tests {
             keyword: vec![cand("0A", 1.0), cand("0B", 0.5)],
             // 0B leads in semantic
             semantic: vec![cand("0B", 0.1), cand("0A", 0.5)],
+            graph: vec![],
             query_vector: vec![1.0_f32, 0.0],
             doc_vectors: docs,
         };
@@ -155,10 +222,90 @@ mod tests {
         let inputs = HybridSearchInputs {
             keyword: vec![],
             semantic: vec![],
+            graph: vec![],
             query_vector: vec![],
             doc_vectors: HashMap::new(),
         };
         let out = hybrid_search(&inputs, HybridSearchParams::default());
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn graph_leg_empty_matches_legacy_2leg_output() {
+        // Parity: the 3-leg path with an empty graph leg must produce the
+        // same final ordering and final_score as the legacy 2-leg path.
+        let mut docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        docs.insert(rid("0A"), vec![0.0, 1.0]);
+        docs.insert(rid("0B"), vec![1.0, 0.0]);
+        let inputs = HybridSearchInputs {
+            keyword: vec![cand("0A", 1.0), cand("0B", 0.5)],
+            semantic: vec![cand("0B", 0.1), cand("0A", 0.5)],
+            graph: vec![],
+            query_vector: vec![1.0_f32, 0.0],
+            doc_vectors: docs,
+        };
+        let out = hybrid_search(&inputs, HybridSearchParams::default());
+        assert_eq!(out.len(), 2);
+        // Sanity: both candidates surface.
+        let ids: std::collections::HashSet<_> = out.iter().map(|c| c.record_id.clone()).collect();
+        assert!(ids.contains(&rid("0A")));
+        assert!(ids.contains(&rid("0B")));
+    }
+
+    #[test]
+    fn graph_only_candidate_surfaces_through_rerank() {
+        // 0C appears only in the graph leg, with high edge confidence.
+        // It should survive RRF + tagged rerank.
+        let mut docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        docs.insert(rid("0A"), vec![1.0, 0.0]);
+        let inputs = HybridSearchInputs {
+            keyword: vec![cand("0A", 1.0)],
+            semantic: vec![],
+            graph: vec![super::super::graph::GraphCandidate {
+                record_id: rid("0C"),
+                edge_confidence_score: 0.95,
+                graph_rank: 1,
+            }],
+            query_vector: vec![1.0_f32, 0.0],
+            doc_vectors: docs,
+        };
+        let out = hybrid_search(&inputs, HybridSearchParams::default());
+        let ids: Vec<_> = out.iter().map(|c| c.record_id.clone()).collect();
+        assert!(ids.contains(&rid("0C")), "graph-only candidate must surface");
+        // GraphOnly origin → cosine field is None.
+        let c0c = out.iter().find(|c| c.record_id == rid("0C")).unwrap();
+        assert!(c0c.cosine.is_none());
+    }
+
+    #[test]
+    fn three_leg_high_confidence_outranks_low_confidence_at_same_rank() {
+        // Two graph-only candidates at graph_rank 1, differing only by
+        // edge confidence. Higher confidence must rank higher.
+        let docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        let inputs_high = HybridSearchInputs {
+            keyword: vec![],
+            semantic: vec![],
+            graph: vec![super::super::graph::GraphCandidate {
+                record_id: rid("0A"),
+                edge_confidence_score: 1.0,
+                graph_rank: 1,
+            }],
+            query_vector: vec![1.0_f32, 0.0],
+            doc_vectors: docs.clone(),
+        };
+        let inputs_low = HybridSearchInputs {
+            keyword: vec![],
+            semantic: vec![],
+            graph: vec![super::super::graph::GraphCandidate {
+                record_id: rid("0B"),
+                edge_confidence_score: 0.3,
+                graph_rank: 1,
+            }],
+            query_vector: vec![1.0_f32, 0.0],
+            doc_vectors: docs,
+        };
+        let out_high = hybrid_search(&inputs_high, HybridSearchParams::default());
+        let out_low = hybrid_search(&inputs_low, HybridSearchParams::default());
+        assert!(out_high[0].rrf_score > out_low[0].rrf_score);
     }
 }

--- a/crates/cairn-core/src/search/rrf.rs
+++ b/crates/cairn-core/src/search/rrf.rs
@@ -24,6 +24,90 @@ pub struct RrfCandidate {
     pub rrf_score: f64,
 }
 
+/// One element of an explicit-rank input list to [`rrf_fusion_weighted`].
+///
+/// Unlike [`ScoredCandidate`] (rank inferred from list position), this
+/// carries `rank` and `weight` per candidate. Used by the graph leg where
+/// the SQL output order is the rank and the connecting-edge confidence
+/// is the weight, surviving hydration which may re-order results by id.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RankedCandidate {
+    /// Record id.
+    pub record_id: RecordId,
+    /// 1-based rank in the source list.
+    pub rank: usize,
+    /// Confidence weight in `[0.0, 1.0]`. Used to compute
+    /// `effective_rank = rank / max(weight, floor)`.
+    pub weight: f32,
+}
+
+/// One leg of [`rrf_fusion_weighted`].
+///
+/// `ListPosition` is the legacy shape (rank inferred from index, no
+/// weighting). `Explicit` carries per-candidate rank and weight, and the
+/// per-leg `floor` clamps weight from below to keep `effective_rank`
+/// finite at zero confidence.
+#[derive(Debug, Clone)]
+pub enum Leg {
+    /// Rank inferred from slice index. Equivalent to a single input of
+    /// [`rrf_fusion`].
+    ListPosition(Vec<ScoredCandidate>),
+    /// Rank carried per-candidate; confidence penalty applied with `floor`.
+    Explicit(Vec<RankedCandidate>, f32),
+}
+
+/// Confidence-weighted Reciprocal Rank Fusion.
+///
+/// Behaves identically to [`rrf_fusion`] for [`Leg::ListPosition`] legs
+/// (proven by the `list_position_matches_legacy_fusion` test). For
+/// [`Leg::Explicit`] legs each contribution is `1.0 / (k +
+/// rank/max(weight, floor))`, so a low-confidence neighbor at rank 1
+/// contributes less than a high-confidence one at the same rank, but
+/// always contributes more than a list of equal length and rank with no
+/// confidence penalty would.
+#[must_use]
+pub fn rrf_fusion_weighted(legs: &[Leg], k: usize) -> Vec<RrfCandidate> {
+    use std::collections::HashMap;
+    let mut acc: HashMap<RecordId, f64> = HashMap::new();
+    #[allow(clippy::cast_precision_loss)]
+    let kf = k as f64;
+    for leg in legs {
+        match leg {
+            Leg::ListPosition(list) => {
+                for (i, c) in list.iter().enumerate() {
+                    #[allow(clippy::cast_precision_loss)]
+                    let r = (i + 1) as f64;
+                    *acc.entry(c.record_id.clone()).or_insert(0.0) += 1.0 / (kf + r);
+                }
+            }
+            Leg::Explicit(list, floor) => {
+                let f = f64::from((*floor).max(1e-6));
+                for c in list {
+                    #[allow(clippy::cast_precision_loss)]
+                    let raw_rank = c.rank as f64;
+                    let weight = f64::from(c.weight).max(f);
+                    let effective = raw_rank / weight;
+                    *acc.entry(c.record_id.clone()).or_insert(0.0) += 1.0 / (kf + effective);
+                }
+            }
+        }
+    }
+    let mut out: Vec<RrfCandidate> = acc
+        .into_iter()
+        .map(|(record_id, rrf_score)| RrfCandidate {
+            record_id,
+            rrf_score,
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        b.rrf_score
+            .partial_cmp(&a.rrf_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.record_id.as_str().cmp(b.record_id.as_str()))
+    });
+    out
+}
+
 /// Reciprocal Rank Fusion over `inputs`.
 ///
 /// Each input list must be pre-sorted descending by its own score.
@@ -129,6 +213,56 @@ mod tests {
                 .map(|c| c.record_id.as_str().to_owned())
                 .collect::<Vec<_>>(),
         );
+    }
+
+    #[test]
+    fn weighted_extracted_outranks_inferred_at_same_rank() {
+        let extracted = vec![RankedCandidate {
+            record_id: rid("0A"),
+            rank: 1,
+            weight: 1.0,
+        }];
+        let inferred = vec![RankedCandidate {
+            record_id: rid("0B"),
+            rank: 1,
+            weight: 0.6,
+        }];
+        let out = rrf_fusion_weighted(
+            &[
+                Leg::Explicit(extracted, 1e-3),
+                Leg::Explicit(inferred, 1e-3),
+            ],
+            60,
+        );
+        assert_eq!(out[0].record_id, rid("0A"));
+    }
+
+    #[test]
+    fn list_position_matches_legacy_fusion() {
+        let list = vec![
+            ScoredCandidate {
+                record_id: rid("0A"),
+                score: 1.0,
+            },
+            ScoredCandidate {
+                record_id: rid("0B"),
+                score: 0.5,
+            },
+        ];
+        let legacy = rrf_fusion(std::slice::from_ref(&list), 60);
+        let weighted = rrf_fusion_weighted(&[Leg::ListPosition(list)], 60);
+        assert_eq!(legacy, weighted);
+    }
+
+    #[test]
+    fn confidence_floor_prevents_div_by_zero() {
+        let zero_conf = vec![RankedCandidate {
+            record_id: rid("0A"),
+            rank: 1,
+            weight: 0.0,
+        }];
+        let out = rrf_fusion_weighted(&[Leg::Explicit(zero_conf, 1e-3)], 60);
+        assert!(out[0].rrf_score.is_finite());
     }
 
     #[test]

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -132,6 +132,7 @@ impl SqliteMemoryStore {
             &HybridSearchInputs {
                 keyword: kw_list,
                 semantic: sem_list,
+                graph: Vec::new(),
                 query_vector,
                 doc_vectors,
             },
@@ -140,6 +141,7 @@ impl SqliteMemoryStore {
                 rerank_topk: args.rerank_topk,
                 blend: args.blend,
                 skip_rerank: false,
+                confidence_floor: HybridSearchParams::default().confidence_floor,
             },
         );
 

--- a/docs/superpowers/plans/2026-05-05-issue-191-rrf-hybrid-graph.md
+++ b/docs/superpowers/plans/2026-05-05-issue-191-rrf-hybrid-graph.md
@@ -1,0 +1,656 @@
+# Issue #191 — RRF Hybrid Search w/ 1-hop Graph Expansion: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a third retrieval leg (1-hop entity-graph neighborhood expansion) to the existing 2-leg RRF hybrid search, with confidence-aware ranking, full bitemporal + auth + supersession correctness, and a two-tier connection pool with statement-scoped cancellation.
+
+**Architecture:** Phased rollout across 6 PRs. Pure core types ship first (no I/O); contract bump (auth_scope) ships next behind a `0.4.0 → 0.5.0` major-version event; connection pool + cancellation primitives third; graph SQL fourth; orchestrator/verb/CLI/SDK fifth; bench gates last.
+
+**Tech Stack:** Rust 1.95.0, tokio, rusqlite (with `carray` + `interrupt` + `progress_handler`), tokio_rusqlite, sqlite-vec, FTS5, schemars, bon (builders), insta (snapshots), criterion (bench), proptest, rstest.
+
+**Spec:** `docs/superpowers/specs/2026-05-05-issue-191-rrf-hybrid-graph-design.md`
+
+---
+
+## Phase Decomposition
+
+Each phase = one PR, independently testable, mergeable into `main`.
+
+| # | Phase | Crates touched | Why ship-able alone |
+|---|---|---|---|
+| 1 | Pure types + RRF/cosine extensions | `cairn-core` | Adds `GraphCandidate`, `RankedCandidate`, `DegradedLeg`, `rrf_fusion_weighted`, graph-only cosine path. Pure functions, unit-testable. No callers yet — dead code with `#[allow(dead_code)]` until phase 5. |
+| 2 | Contract bump: `auth_scope` + `MemoryStoreCapabilities::graph_search` + trait method | `cairn-core`, all in-tree adapters | Major version bump `0.4.0 → 0.5.0`. Threads `auth_scope` through Keyword/Semantic/Hybrid args. `search_graph_neighbors` returns `CapabilityUnavailable` until phase 4. Existing tests keep passing because legacy auth via `filter` is preserved as the only path used by SQLite store. |
+| 3 | Two-tier connection pool + cancellation | `cairn-store-sqlite` | New `HybridConnectionPool` with Tier A (mandatory) + Tier B (graph). `interrupt()` + `progress_handler` per-checkout lifecycle. Existing keyword/semantic queries migrate onto Tier A. Capability probe extended. |
+| 4 | Graph SQL: 1-hop traversal + supersession + bitemporal + hydration | `cairn-store-sqlite` | Implements `search_graph_neighbors`. Capability probe gates on entity_graph schema. Tests: hidden-alias, orphan-edge, supersession, bitemporal, rank-rescue. |
+| 5 | Orchestrator: 4-leg parallel + auth-only seed retrieval + degraded_legs | `cairn-store-sqlite::store::hybrid`, `cairn-core::verbs::search`, `cairn-cli`, `cairn-sdk`, `cairn-mcp`, `cairn-idl` | Wires all the previous phases together. Adds `--confidence-min` CLI flag. Threads `degraded_legs` through SearchOutcome → CLI/MCP/SDK. IDL update + codegen. |
+| 6 | Bench + load gates | `cairn-bench` | Baseline p99, broad-query p99, saturation p99, deadline-circuit, Tier A acquire-timeout gates. |
+
+**Order matters.** Phase N depends on N-1 except 3↔4 (3 can land before 4; 4 cannot land before 3 because graph SQL needs the cancellable pool).
+
+---
+
+## Phase 1: Pure types + RRF/cosine extensions
+
+**Goal:** Land all pure-function building blocks in `cairn-core::search` so phases 2-5 can compose them. No `MemoryStore` changes, no I/O, no callers — all new code is `#[allow(dead_code)]` until phase 5 wires it.
+
+**Files:**
+- Modify: `crates/cairn-core/src/search/rrf.rs` — add `RankedCandidate`, `Leg`, `rrf_fusion_weighted`.
+- Modify: `crates/cairn-core/src/search/cosine.rs` — add graph-only path to `cosine_rerank`.
+- Create: `crates/cairn-core/src/search/graph.rs` — define `GraphCandidate`.
+- Create: `crates/cairn-core/src/search/degraded.rs` — `DegradedLeg`, `DegradationReason`, `GraphSource` enums.
+- Modify: `crates/cairn-core/src/search/orchestrator.rs` — extend `HybridSearchInputs`/`Params` with new fields; extend `hybrid_search`.
+- Modify: `crates/cairn-core/src/search/mod.rs` — re-export new public types.
+
+### Task 1.1: Add `GraphCandidate` type
+
+**Files:**
+- Create: `crates/cairn-core/src/search/graph.rs`
+- Test: inline `#[cfg(test)] mod tests` in same file.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// crates/cairn-core/src/search/graph.rs
+//! One graph-leg candidate.
+
+use crate::domain::RecordId;
+
+/// One graph-leg candidate: a record reached via a neighbor entity edge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphCandidate {
+    pub record_id: RecordId,
+    /// Confidence score of the *connecting edge* in `[0.0, 1.0]`.
+    pub edge_confidence_score: f32,
+    /// 1-based rank in the graph leg's SQL output order. Carried
+    /// explicitly so RRF fusion does not infer rank from list position
+    /// after hydration shuffles ids. See spec §5.2.1.
+    pub graph_rank: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rid(suffix: &str) -> RecordId {
+        RecordId::parse(format!("01HQZX9F5N00000000000000{suffix}")).expect("valid id")
+    }
+
+    #[test]
+    fn construct_and_clone() {
+        let c = GraphCandidate {
+            record_id: rid("0A"),
+            edge_confidence_score: 0.85,
+            graph_rank: 3,
+        };
+        let c2 = c.clone();
+        assert_eq!(c, c2);
+    }
+}
+```
+
+- [ ] **Step 2: Wire into `mod.rs` and run**
+
+Edit `crates/cairn-core/src/search/mod.rs`: add `pub mod graph;` and `pub use graph::GraphCandidate;`.
+
+Run: `cargo nextest run -p cairn-core search::graph`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/search/graph.rs crates/cairn-core/src/search/mod.rs
+git commit -m "feat(core/search): GraphCandidate type for graph-leg results (issue #191)"
+```
+
+### Task 1.2: Add `DegradedLeg` typed enum
+
+**Files:**
+- Create: `crates/cairn-core/src/search/degraded.rs`
+- Modify: `crates/cairn-core/src/search/mod.rs`
+
+- [ ] **Step 1: Write the type + tests**
+
+```rust
+// crates/cairn-core/src/search/degraded.rs
+//! Typed degradation signal for hybrid search responses.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradationReason {
+    CapabilityUnavailable,
+    DeadlineExceeded,
+    SqlError,
+    WorkerPanic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GraphSource {
+    All,
+    AuthKeywordSeed,
+    AuthSemanticSeed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradedLeg {
+    Semantic { reason: DegradationReason },
+    Graph    { reason: DegradationReason, source: GraphSource },
+}
+
+impl DegradedLeg {
+    pub fn graph_capability_unavailable() -> Self {
+        Self::Graph { reason: DegradationReason::CapabilityUnavailable, source: GraphSource::All }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn graph_constructor_helper() {
+        let d = DegradedLeg::graph_capability_unavailable();
+        assert!(matches!(d, DegradedLeg::Graph { reason: DegradationReason::CapabilityUnavailable, source: GraphSource::All }));
+    }
+}
+```
+
+- [ ] **Step 2: Wire + run**
+
+Edit `mod.rs`: `pub mod degraded;` + re-export `DegradedLeg`, `DegradationReason`, `GraphSource`.
+
+Run: `cargo nextest run -p cairn-core search::degraded`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/search/degraded.rs crates/cairn-core/src/search/mod.rs
+git commit -m "feat(core/search): DegradedLeg typed enum for partial-result signaling"
+```
+
+### Task 1.3: Add `rrf_fusion_weighted` with `Leg` shape variants
+
+**Files:**
+- Modify: `crates/cairn-core/src/search/rrf.rs`
+
+- [ ] **Step 1: Write tests for the new function**
+
+Add to `rrf.rs`:
+
+```rust
+/// One element of an explicit-rank input list to RRF.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RankedCandidate {
+    pub record_id: RecordId,
+    /// 1-based rank.
+    pub rank: usize,
+    /// Confidence weight in `[0.0, 1.0]`. Used to compute
+    /// `effective_rank = rank / max(weight, floor)`.
+    pub weight: f32,
+}
+
+/// One leg of [`rrf_fusion_weighted`].
+#[derive(Debug, Clone)]
+pub enum Leg {
+    /// Rank inferred from slice index. Equivalent to today's `rrf_fusion`.
+    ListPosition(Vec<ScoredCandidate>),
+    /// Rank carried per-candidate; confidence penalty applied with `floor`.
+    Explicit(Vec<RankedCandidate>, f32),
+}
+
+#[must_use]
+pub fn rrf_fusion_weighted(legs: &[Leg], k: usize) -> Vec<RrfCandidate> {
+    use std::collections::HashMap;
+    let mut acc: HashMap<RecordId, f64> = HashMap::new();
+    #[allow(clippy::cast_precision_loss)]
+    let kf = k as f64;
+    for leg in legs {
+        match leg {
+            Leg::ListPosition(list) => {
+                for (i, c) in list.iter().enumerate() {
+                    #[allow(clippy::cast_precision_loss)]
+                    let r = (i + 1) as f64;
+                    *acc.entry(c.record_id.clone()).or_insert(0.0) += 1.0 / (kf + r);
+                }
+            }
+            Leg::Explicit(list, floor) => {
+                let f = (*floor).max(1e-6) as f64;
+                for c in list {
+                    #[allow(clippy::cast_precision_loss)]
+                    let raw_rank = c.rank as f64;
+                    let weight = (c.weight as f64).max(f);
+                    let effective = raw_rank / weight;
+                    *acc.entry(c.record_id.clone()).or_insert(0.0) += 1.0 / (kf + effective);
+                }
+            }
+        }
+    }
+    let mut out: Vec<RrfCandidate> = acc.into_iter()
+        .map(|(record_id, rrf_score)| RrfCandidate { record_id, rrf_score })
+        .collect();
+    out.sort_by(|a, b| b.rrf_score.partial_cmp(&a.rrf_score).unwrap_or(std::cmp::Ordering::Equal)
+        .then_with(|| a.record_id.as_str().cmp(b.record_id.as_str())));
+    out
+}
+```
+
+Add tests:
+
+```rust
+#[test]
+fn weighted_extracted_outranks_inferred_at_same_rank() {
+    let extracted = vec![RankedCandidate { record_id: rid("0A"), rank: 1, weight: 1.0 }];
+    let inferred  = vec![RankedCandidate { record_id: rid("0B"), rank: 1, weight: 0.6 }];
+    let out = rrf_fusion_weighted(&[
+        Leg::Explicit(extracted, 1e-3),
+        Leg::Explicit(inferred,  1e-3),
+    ], 60);
+    assert_eq!(out[0].record_id, rid("0A"));
+}
+
+#[test]
+fn list_position_matches_legacy_fusion() {
+    let list = vec![
+        ScoredCandidate { record_id: rid("0A"), score: 1.0 },
+        ScoredCandidate { record_id: rid("0B"), score: 0.5 },
+    ];
+    let legacy  = rrf_fusion(&[list.clone()], 60);
+    let weighted = rrf_fusion_weighted(&[Leg::ListPosition(list)], 60);
+    assert_eq!(legacy, weighted);
+}
+
+#[test]
+fn confidence_floor_prevents_div_by_zero() {
+    let zero_conf = vec![RankedCandidate { record_id: rid("0A"), rank: 1, weight: 0.0 }];
+    let out = rrf_fusion_weighted(&[Leg::Explicit(zero_conf, 1e-3)], 60);
+    assert!(out[0].rrf_score.is_finite());
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cargo nextest run -p cairn-core search::rrf`
+Expected: PASS (existing + new tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/search/rrf.rs
+git commit -m "feat(core/search): rrf_fusion_weighted with confidence-penalty leg"
+```
+
+### Task 1.4: Extend `cosine_rerank` for graph-only candidates
+
+**Files:**
+- Modify: `crates/cairn-core/src/search/cosine.rs`
+
+- [ ] **Step 1: Add `CandidateOrigin` and tagged candidate type**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CandidateOrigin {
+    Lexical,
+    GraphOnly,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OriginTaggedCandidate {
+    pub inner: super::rrf::RrfCandidate,
+    pub origin: CandidateOrigin,
+}
+```
+
+- [ ] **Step 2: Add `cosine_rerank_tagged` (new function — keep existing `cosine_rerank` for backwards compat)**
+
+```rust
+#[must_use]
+pub fn cosine_rerank_tagged(
+    candidates: &[OriginTaggedCandidate],
+    doc_vectors: &HashMap<RecordId, Vec<f32>>,
+    query_vector: &[f32],
+    blend: f32,
+) -> Vec<RerankedCandidate> {
+    let max_rrf = candidates.iter().map(|c| c.inner.rrf_score).fold(0.0_f64, f64::max);
+    let mut out: Vec<RerankedCandidate> = candidates.iter().map(|tc| {
+        let rrf_norm = if max_rrf < f64::EPSILON { 0.0 } else { tc.inner.rrf_score / max_rrf };
+        let final_score = match tc.origin {
+            CandidateOrigin::Lexical => {
+                let cos_norm = doc_vectors
+                    .get(&tc.inner.record_id)
+                    .map(|v| (cosine_similarity(query_vector, v) + 1.0) / 2.0)
+                    .unwrap_or(0.5) as f64;
+                f64::from(blend) * rrf_norm + (1.0 - f64::from(blend)) * cos_norm
+            }
+            CandidateOrigin::GraphOnly => f64::from(blend) * rrf_norm,
+        };
+        RerankedCandidate {
+            record_id: tc.inner.record_id.clone(),
+            rrf_score: tc.inner.rrf_score,
+            cosine: matches!(tc.origin, CandidateOrigin::Lexical)
+                .then(|| doc_vectors.get(&tc.inner.record_id).map(|v| cosine_similarity(query_vector, v)).unwrap_or(0.0)),
+            final_score,
+        }
+    }).collect();
+    out.sort_by(|a, b| b.final_score.partial_cmp(&a.final_score).unwrap_or(std::cmp::Ordering::Equal));
+    out
+}
+```
+
+- [ ] **Step 3: Add tests**
+
+```rust
+#[test]
+fn graph_only_ties_lexical_at_zero_cosine_equal_rrf() {
+    let mut docs = HashMap::new();
+    docs.insert(rid("0A"), vec![0.0_f32, 1.0]);          // lexical doc, cosine_raw = -1 vs query
+    let cands = vec![
+        OriginTaggedCandidate {
+            inner: RrfCandidate { record_id: rid("0A"), rrf_score: 0.5 },
+            origin: CandidateOrigin::Lexical,
+        },
+        OriginTaggedCandidate {
+            inner: RrfCandidate { record_id: rid("0B"), rrf_score: 0.5 },
+            origin: CandidateOrigin::GraphOnly,
+        },
+    ];
+    let q = vec![0.0_f32, -1.0]; // produces cosine_raw=-1, cosine_norm=0 for 0A
+    let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+    assert!((out[0].final_score - out[1].final_score).abs() < 1e-9, "lexical-cos-0 must tie graph-only");
+}
+
+#[test]
+fn graph_only_loses_to_strong_lexical_at_equal_rrf() {
+    let mut docs = HashMap::new();
+    docs.insert(rid("0A"), vec![1.0_f32, 0.0]);
+    let cands = vec![
+        OriginTaggedCandidate {
+            inner: RrfCandidate { record_id: rid("0A"), rrf_score: 0.5 },
+            origin: CandidateOrigin::Lexical,
+        },
+        OriginTaggedCandidate {
+            inner: RrfCandidate { record_id: rid("0B"), rrf_score: 0.5 },
+            origin: CandidateOrigin::GraphOnly,
+        },
+    ];
+    let q = vec![1.0_f32, 0.0];
+    let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+    assert_eq!(out[0].record_id, rid("0A"));
+}
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo nextest run -p cairn-core search::cosine`
+Expected: PASS.
+
+```bash
+git add crates/cairn-core/src/search/cosine.rs
+git commit -m "feat(core/search): graph-only candidate path in cosine rerank"
+```
+
+### Task 1.5: Extend `HybridSearchInputs` / `HybridSearchParams` and update `hybrid_search`
+
+**Files:**
+- Modify: `crates/cairn-core/src/search/orchestrator.rs`
+
+Add to `HybridSearchInputs`:
+```rust
+pub graph: Vec<GraphCandidate>,
+```
+Add to `HybridSearchParams`:
+```rust
+pub confidence_floor: f32,   // default 1e-3
+```
+And `Default for HybridSearchParams` sets `confidence_floor: 1e-3`.
+
+Then refactor `hybrid_search` body to:
+1. Build legs: `Leg::ListPosition(keyword)`, `Leg::ListPosition(semantic)`, `Leg::Explicit(graph_as_ranked, params.confidence_floor)`.
+2. Call `rrf_fusion_weighted`.
+3. Tag each fused candidate as `Lexical` or `GraphOnly` based on whether it appears in the graph leg AND not in the keyword/semantic leg.
+4. Call `cosine_rerank_tagged`.
+
+Add tests:
+- Three-leg integration: keyword + semantic + graph with mixed confidence neighbors → ordering matches expected.
+- Graph-leg empty → output equals legacy 2-leg behavior (parity test).
+- Graph-only candidate present → tagged correctly and survives rerank.
+
+Commit:
+```bash
+git add crates/cairn-core/src/search/orchestrator.rs
+git commit -m "feat(core/search): 3-leg hybrid_search with graph candidates and tagged rerank"
+```
+
+### Task 1.6: Phase 1 final verification
+
+- [ ] Run `cargo fmt --all --check`
+- [ ] Run `cargo clippy --workspace --all-targets --locked -- -D warnings`
+- [ ] Run `cargo nextest run --workspace`
+- [ ] Run `./scripts/check-core-boundary.sh`
+- [ ] Open PR titled `feat(core/search): pure types + 3-leg RRF + graph-only rerank (issue #191 phase 1)`. Body cites spec §5, §6, §6.1.
+
+---
+
+## Phase 2: Contract bump — auth_scope + capability + trait method
+
+**Goal:** Bump `CONTRACT_VERSION` to `0.5.0`, add `auth_scope: ScopeTuple` to all search args, add `MemoryStoreCapabilities::graph_search`, add the `search_graph_neighbors` method. Existing search behavior unchanged (the SQLite store still authorizes via `filter` for keyword/semantic, just like today; only graph-aware code paths added in phase 4 will read `auth_scope`). The default trait impl of `search_graph_neighbors` returns `CapabilityUnavailable`.
+
+**Files:**
+- Modify: `crates/cairn-core/src/contract/memory_store.rs` — `CONTRACT_VERSION`, all `*SearchArgs`, `MemoryStoreCapabilities`, new `GraphNeighborsArgs`, trait method.
+- Modify: `crates/cairn-store-sqlite/src/lib.rs` — `ACCEPTED_RANGE`.
+- Modify: `crates/cairn-core/src/search/orchestrator.rs` — extend args definitions if any in core mod.
+- Modify: `crates/cairn-store-sqlite/src/store/search.rs`, `crates/cairn-store-sqlite/src/store/hybrid.rs`, `crates/cairn-store-sqlite/src/lib.rs` — accept new field; pass through unchanged.
+- Modify: every test that constructs `KeywordSearchArgs` / `SemanticSearchArgs` / `HybridSearchArgs` — populate `auth_scope`. Use `ScopeTuple::EMPTY` in legacy tests where no scope was previously used.
+- Modify: `crates/cairn-core/src/contract/memory_store.rs` test stubs.
+- Modify: `crates/cairn-store-sqlite/tests/capabilities_unchanged.rs` — regenerate snapshot.
+- Add `#[non_exhaustive]` to: `KeywordSearchArgs`, `SemanticSearchArgs`, `HybridSearchArgs`, `HybridSearchInputs`, `HybridSearchParams`, `HybridSearchPage`, `KeywordSearchPage`, `SemanticSearchPage`, `ScoreExplain`, `MemoryStoreCapabilities`, `SearchOutcome`.
+- Add `bon::Builder` derive to all `*SearchArgs` structs and `GraphNeighborsArgs`. Imports: add `bon` to `[workspace.dependencies]` if not already present (check first).
+
+### Tasks (high-level — see spec §12.1)
+
+1. **Pre-work: add `#[non_exhaustive]` to existing public structs.** This itself is a breaking change for external struct literals; bundle with the contract bump.
+2. **Add `auth_scope: ScopeTuple`** as a public required field on the args structs. Update `Default` impls to use `ScopeTuple::EMPTY` only inside the test-fixtures crate's helpers; production callers must populate.
+3. **Add `MemoryStoreCapabilities::graph_search: bool`** with `Default = false`.
+4. **Add `GraphNeighborsArgs`** struct (see spec §4.3).
+5. **Add `search_graph_neighbors`** method to `MemoryStore` trait with default impl returning `Err(StoreError::CapabilityUnavailable { what: "graph_search" })`.
+6. **Bump `CONTRACT_VERSION`** to `ContractVersion::new(0, 5, 0)`.
+7. **Bump `ACCEPTED_RANGE`** in `cairn-store-sqlite`, `cairn-mcp`, `cairn-sdk` to `[0.5.0, 0.6.0)`.
+8. **Add `bon::Builder` derive** + write a basic builder usage test for each args struct.
+9. **Update every callsite** in the workspace. Mechanical fan-out.
+10. **Regenerate `capabilities_unchanged.rs` snapshot.**
+
+Verification: workspace builds; `cargo nextest run --workspace` passes; the existing keyword/semantic search tests are unchanged in behavior.
+
+PR title: `feat(core): contract 0.5.0 — auth_scope + graph_search capability + search_graph_neighbors method (issue #191 phase 2)`
+
+---
+
+## Phase 3: Two-tier connection pool + cancellation lifecycle
+
+**Goal:** Introduce `HybridConnectionPool` (Tier A + Tier B) replacing the current single-connection model for hybrid search. Wire `interrupt()` + `progress_handler` per connection. Migrate `do_search_keyword` and `do_search_semantic` onto Tier A. Add per-checkout reset/discard lifecycle.
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/pool.rs`
+- Modify: `crates/cairn-store-sqlite/src/open.rs` — `open_connection` factory becomes the single source of truth for per-connection setup; pool init goes through it.
+- Modify: `crates/cairn-store-sqlite/src/store/mod.rs` — `SqliteMemoryStore` gains `hybrid_pool: Arc<HybridConnectionPool>`.
+- Modify: `crates/cairn-store-sqlite/src/store/search.rs` — keyword + semantic now acquire from Tier A.
+- Modify: `crates/cairn-store-sqlite/src/store/hybrid.rs` — orchestrator acquires per-leg connections from the pool.
+- Add: `crates/cairn-store-sqlite/tests/connection_pool.rs` — integration tests for cross-request reuse, sibling-completion isolation, init-failure → graph_search false.
+
+**Key implementation points (see spec §5.3):**
+
+- Pool size: `filtered_pool_size = num_cpus()` for Tier A, `graph_pool_size = 2 * num_cpus()` for Tier B.
+- Tier A acquire: `tokio::time::timeout(filtered_acquire_timeout_ms, semaphore.acquire())`. Default 200ms. On timeout return `StoreError::Timeout` with reason `tier_a_acquire_timeout`.
+- Tier B acquire: same shape with `pool_acquire_timeout_ms` (= leg deadline).
+- Per-checkout lifecycle:
+  - Borrow → install fresh `CancellationToken`, re-arm `progress_handler` against it, run `SELECT 1` smoke probe; if probe fails, discard + rebuild via factory.
+  - Run → leg's SQL.
+  - Release → reset token, deregister callback, run `sqlite3_db_release_memory`. If reset errors, discard + rebuild.
+- Watchdog: when deadline elapses, call `Connection::interrupt()` AND fire the cancellation token.
+- Capability probe extension: every pool connection must pass §8 probes individually before `caps.graph_search = true`.
+
+Tests:
+- Cross-request reuse after timeout: assert request N+1 succeeds on the same pool slot that request N timed out on.
+- Sibling-completion isolation: two parallel legs, one times out; assert the other completes normally on its own connection.
+- Pool-init failure: inject a `carray` load failure on one pool connection; assert `caps.graph_search = false` at startup.
+- Tier A acquire timeout: saturate Tier A; new request fails with timeout in `filtered_acquire_timeout_ms` ± 10ms.
+
+PR title: `feat(store): two-tier connection pool + statement-scoped cancellation (issue #191 phase 3)`
+
+---
+
+## Phase 4: Graph SQL — 1-hop + supersession + bitemporal + hydration
+
+**Goal:** Implement `search_graph_neighbors` end-to-end. The pure orchestrator + connection pool from previous phases compose with the new SQL.
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/store/graph_search.rs` — implements `do_search_graph_neighbors` with the §5.1 SQL (CTE form).
+- Create: `crates/cairn-store-sqlite/src/store/graph_hydrate.rs` — implements `hydrate_graph_only` (§5.2.1 SQL + Rust-side rank preservation).
+- Modify: `crates/cairn-store-sqlite/src/store/trait_impl.rs` — wire trait method to `do_search_graph_neighbors`.
+- Modify: `crates/cairn-store-sqlite/src/open.rs` — extend §8 capability probe to cover `valid_at`, `created_at`, `expired_at`, `invalid_at` on `entity_edges`; `episode_id` on `entity_episodes`; tombstoned/active/scope on `records`.
+- Add: `crates/cairn-store-sqlite/tests/graph_search.rs` — full §10.2 test suite.
+
+**Key SQL (see spec §5.1):**
+
+The CTE has the shape (literal bindings):
+```sql
+WITH RECURSIVE
+  visible_query_records(id) AS (SELECT value FROM carray(?1)),    -- ≤ 400 ids
+  ranked_query_records(id)  AS (SELECT value FROM carray(?5)),    -- ≤ 100 ids
+  seeds(id) AS (
+    SELECT DISTINCT ep.entity_node_id
+      FROM entity_episodes ep
+     WHERE ep.episode_id IN (SELECT id FROM visible_query_records)
+  ),
+  neighbors(neighbor_id, conf) AS (
+    SELECT neighbor_id, MAX(confidence_score)
+      FROM (
+        SELECT
+          CASE WHEN e.source_id IN (SELECT id FROM seeds) THEN e.target_id ELSE e.source_id END AS neighbor_id,
+          e.confidence_score
+        FROM entity_edges e
+        JOIN records pr ON pr.record_id = e.source_record_id
+        WHERE (e.source_id IN (SELECT id FROM seeds) OR e.target_id IN (SELECT id FROM seeds))
+          AND e.invalid_at IS NULL AND e.expired_at IS NULL
+          AND e.valid_at <= ?6 AND e.created_at <= ?7
+          AND e.source_record_id IS NOT NULL
+          AND e.confidence_score >= ?2
+          AND pr.tombstoned = 0 AND pr.active = 1
+          AND <auth_scope predicate ON pr>
+          AND <visibility predicate ON pr>
+      )
+      WHERE neighbor_id NOT IN (SELECT id FROM seeds)
+      GROUP BY neighbor_id
+  )
+SELECT r.record_id, MAX(n.conf) AS conf
+  FROM neighbors n
+  JOIN entity_episodes ep ON ep.entity_node_id = n.neighbor_id
+  JOIN records r ON r.record_id = ep.episode_id
+ WHERE r.tombstoned = 0 AND r.active = 1
+   AND <supersession predicate ON r>
+   AND <auth_scope predicate ON r>
+   AND <visibility predicate ON r>
+   AND <filter predicate ON r>
+   AND r.record_id NOT IN (SELECT id FROM ranked_query_records)
+ GROUP BY r.record_id
+ ORDER BY conf DESC, r.updated_at DESC
+ LIMIT ?3;
+```
+
+`<auth_scope predicate>`, `<visibility predicate>`, `<filter predicate>`, `<supersession predicate>` are built by the same shared helper that `do_search_keyword` uses (extract the helper to a shared module if not already shared).
+
+Capture each row with its 1-based ordinal as `graph_rank`; pass through to hydration.
+
+**Hydration:** §5.2.1 SQL — fetch by id via `IN carray(?1)`, re-apply auth + visibility + filter + supersession. Re-sort the hydrated rows by `graph_rank` in Rust before returning.
+
+**Tests (§10.2 + §10.3 partial):**
+- Discovery property (neighbor-only record surfaces).
+- Hidden alias does not seed graph.
+- Cross-scope provenance excluded.
+- Orphan edge (NULL source_record_id) excluded.
+- Expired edge / invalid edge excluded.
+- Future-dated edge (valid_at > now or created_at > now) excluded.
+- Stale-seed exclusion (superseded source).
+- Stale-neighbor exclusion (superseded neighbor).
+- Self-exclusion (seed cannot be its own "neighbor").
+- Rank-rescue (record at keyword rank-75 returns via graph).
+- Hydration auth re-check (cache replay defense-in-depth).
+- N+1 verifier: prepared-statement count ≤ 3 across the whole graph search.
+- Capability skew: missing `expired_at` column → `graph_search=false`.
+- Capability skew: missing `valid_at` column → `graph_search=false`.
+
+PR title: `feat(store): graph 1-hop SQL + hydration + capability probe (issue #191 phase 4)`
+
+---
+
+## Phase 5: Orchestrator — 4-leg parallel + degraded_legs propagation
+
+**Goal:** Wire all the phases together. The hybrid orchestrator (`store/hybrid.rs::do_search_hybrid`) now runs four parallel legs via `tokio::task::JoinSet`, applies the per-leg timeout table, builds `degraded_legs`, and threads it through `SearchOutcome` → CLI / MCP / SDK.
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/store/hybrid.rs` — JoinSet-based 4-leg fan-out; auth-only seed query (id-only, no filter, supersession kept); deadline + degradation handling; pool acquisition; graph-leg dispatch; merging into `HybridSearchPage` with `degraded_legs`.
+- Create: `crates/cairn-store-sqlite/src/store/seed_query.rs` — id-only auth+supersession-only retrieval for keyword and semantic.
+- Modify: `crates/cairn-core/src/contract/memory_store.rs` — `HybridSearchPage` gains `degraded_legs: Vec<DegradedLeg>`.
+- Modify: `crates/cairn-core/src/verbs/search.rs` — `SearchOutcome` gains `degraded_legs: Vec<DegradedLeg>`; dispatcher copies it through.
+- Modify: `crates/cairn-cli/src/verbs/search.rs` — `--confidence-min <f32>` flag; `--json` includes `degraded_legs`; TTY emits `warning:` to stderr when non-empty.
+- Modify: `crates/cairn-mcp/src/...` — schemars derive picks up `degraded_legs` automatically; assert via snapshot.
+- Modify: `crates/cairn-sdk/src/transport.rs` — extend `SearchData` mapping to include `degraded_legs`.
+- Modify: `crates/cairn-idl/...` — extend search-response IDL with `degraded_legs: Vec<DegradedLeg>` (`#[serde(default)]`); `auth_scope: ScopeTuple` required (no default). Re-run `cairn-codegen`; commit generated diff.
+- Modify: `crates/cairn-core/src/config/mod.rs` — `SearchConfig` adds `confidence_min`, `confidence_floor`, `graph_seed_overfetch`, `graph_leg_deadline_ms`, `filtered_acquire_timeout_ms`, `pool_acquire_timeout_ms`, `filtered_pool_size`, `graph_pool_size`.
+
+**Tests:**
+- End-to-end hybrid w/ all 3 legs against a real seeded vault.
+- `--json` snapshot stable (insta).
+- Graph-only candidate hydrated correctly through verb → CLI.
+- `degraded_legs` survives dispatcher → CLI `--json`.
+- `degraded_legs` survives SDK transport round-trip.
+- Per-leg timeout table: each row tested with synthetic delay injection (use a wrapper `MemoryStore` impl that delays specific legs).
+- 0.4.x-shaped request (no `auth_scope`) → `SearchError::MissingField`.
+
+PR title: `feat(verbs/cli/sdk/mcp): wire 3-leg hybrid search end-to-end with degraded_legs (issue #191 phase 5)`
+
+---
+
+## Phase 6: Bench + load gates
+
+**Goal:** Add bench cases that gate the latency/load claims in §10.5. CI-runnable.
+
+**Files:**
+- Modify: `crates/cairn-bench/...` — Criterion benches or custom harness.
+
+**Gates:**
+- p99 < 100ms on 10k-record vault, hybrid search.
+- p99 < 100ms on 50k-record vault, broad query (>200 keyword hits).
+- p99 < 150ms under 32-way concurrent load on 50k-record vault; assert adaptive-overfetch reduction engages at least once.
+- Deadline-circuit: synthetic delay → request returns within deadline + 10ms with correct `degraded_legs`.
+- Tier A acquire-timeout: saturate Tier A → fast failure within `filtered_acquire_timeout_ms` ± 10ms.
+
+PR title: `bench: hybrid search load + deadline gates (issue #191 phase 6)`
+
+---
+
+## Self-Review
+
+**Spec coverage:** Every §-section in the spec is mapped to a phase. §3 algorithm = phases 1+4. §4 contracts = phase 2. §5.1 SQL = phase 4. §5.2.1 hydration = phase 4. §5.3 orchestrator = phase 5. §5.4 verb envelope = phase 5. §6 fusion = phase 1. §6.1 cosine graph-only = phase 1. §7 verb + CLI = phase 5. §8 capability = phases 2+3+4. §10 tests distributed across phases (each phase ships its own tests). §10.5 bench = phase 6. §11 AC mapping covered. §12.1 contract version = phase 2.
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later" in the plan. Predicate placeholders (`<auth_scope predicate>`, etc.) are intentional — they reference an existing helper that the implementer will reuse from `do_search_keyword`. Phase 4 task should locate and extract that helper as an early sub-task if it's still inline today.
+
+**Type consistency:** `GraphCandidate { record_id, edge_confidence_score, graph_rank }` is the same in phase 1 and phase 4. `RankedCandidate { record_id, rank, weight }` ditto. `DegradedLeg { Semantic { reason }, Graph { reason, source } }` ditto. `auth_scope: ScopeTuple` consistent.
+
+**Honest limitation:** Phases 4 and 5 are large — phase 4 has ~15 integration tests, phase 5 has the most cross-crate fan-out. Subagent execution is strongly recommended for those phases (see executing-plans skill); inline batch execution will be slow.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-05-issue-191-rrf-hybrid-graph.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per phase (or per major task within phase 4/5). Two-stage review between phases.
+
+2. **Inline Execution** — Execute phases sequentially in this session. Long; will likely need batch checkpoints.
+
+**Suggested next step:** start with phase 1 (fully self-contained, pure functions, ~6 tasks, ~1-2 hours of subagent time) so the type vocabulary is locked in before the contract bump in phase 2.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-05-issue-191-rrf-hybrid-graph-design.md
+++ b/docs/superpowers/specs/2026-05-05-issue-191-rrf-hybrid-graph-design.md
@@ -1,0 +1,1332 @@
+# Issue #191 — RRF Hybrid Search w/ 1-hop Graph Expansion
+
+**Issue:** [#191](https://github.com/windoliver/cairn/issues/191)
+**Brief refs:** §8.0 (search verb), §4 (MemoryStore), §6.11 (SQLite — `WITH RECURSIVE`)
+**Updates:** #47 (FTS5), #48 (sqlite-vec), #49 (hybrid orchestration)
+**Status:** spec — implementation pending
+
+---
+
+## 1. Goal
+
+Add a third retrieval leg — 1-hop entity-graph neighborhood expansion — to the
+existing 2-leg RRF hybrid search (FTS5 BM25 + sqlite-vec semantic ANN).
+Confidence-aware so that `INFERRED`/`AMBIGUOUS`-edge neighbors are penalized
+relative to `EXTRACTED`-edge neighbors. Surfaces non-obvious connections while
+preserving the existing keyword/semantic recall floor.
+
+## 2. Non-goals
+
+- Multi-hop traversal (depth > 1). Reserved for a follow-up.
+- Re-tuning RRF constant `k` away from 60. Keep canonical default.
+- Replacing the cosine re-rank pass; graph leg feeds RRF, cosine pass remains.
+- Online graph mutation. Graph leg is read-only.
+
+## 3. Algorithm (final)
+
+The graph leg performs a true 1-hop expansion: seed entities → edge →
+**neighbor** (opposite-endpoint) entities → records mentioning the neighbor.
+This surfaces records that do not contain the query terms but are connected
+via the entity graph (the discovery case). Seeds are restricted to entities
+mentioned by **visible records that match the query** so that no unauthorized
+lexical data influences ranking.
+
+```
+# Step 1: visible_query_records — UNION of keyword and semantic hits
+#         (both already scope/visibility-filtered upstream). Using only
+#         BM25 would give paraphrased / low-lexical-overlap queries zero
+#         graph expansion, defeating the leg's purpose precisely where
+#         hybrid retrieval should help most.
+visible_query_records = unique(bm25_hits.record_ids
+                            ∪ semantic_hits.record_ids)            (≤100)
+
+# Step 2: seed entities — only those mentioned by visible_query_records.
+#         entity_episodes is the (node, record) join table.
+seeds = SELECT DISTINCT entity_node_id
+          FROM entity_episodes
+         WHERE record_id IN visible_query_records
+
+# Step 3: neighbor entities — opposite-endpoint nodes of edges touching seeds.
+#         Edges must be live in BOTH bitemporal dimensions (invalid_at AND
+#         expired_at), and the edge's *provenance record* must itself be
+#         visible to the caller — otherwise hidden evidence could raise the
+#         confidence of a visible neighbor.
+neighbors = SELECT
+              CASE WHEN e.source_id IN seeds THEN e.target_id ELSE e.source_id END
+                AS neighbor_id,
+              MAX(e.confidence_score) AS conf
+            FROM entity_edges e
+            JOIN records pr ON pr.id = e.source_record_id
+           WHERE (e.source_id IN seeds OR e.target_id IN seeds)
+             AND e.invalid_at IS NULL
+             AND e.expired_at IS NULL
+             AND e.confidence_score >= confidence_min
+             AND e.source_record_id IS NOT NULL    -- orphan edges (NULL provenance) ineligible
+             AND pr is visible to caller (auth_scope + visibility)
+           GROUP BY neighbor_id
+           HAVING neighbor_id NOT IN seeds      -- exclude self-references
+
+# Step 4: candidate records — records mentioning a neighbor entity.
+#         Auth (auth_scope + visibility) and the user filter all apply.
+#         Dedup uses ranked_query_records (top 50 per lexical leg, ≤ 100),
+#         NOT visible_query_records (overfetch pool, ≤ 400). Records
+#         overfetched as seeds but ranked out of fusion can still surface.
+graph_hits = SELECT r.id, n.conf
+               FROM neighbors n
+               JOIN entity_episodes ep ON ep.entity_node_id = n.neighbor_id
+               JOIN records r          ON r.id = ep.record_id
+              WHERE auth_scope predicate ON r
+                AND visibility predicate ON r
+                AND filter predicate ON r
+                AND r.tombstoned = 0 AND r.active = 1
+                AND r.id NOT IN ranked_query_records   -- dedup vs. RRF-eligible only
+              GROUP BY r.id
+              ORDER BY MAX(n.conf) DESC, r.updated_at DESC
+              LIMIT 50
+
+# Step 5: RRF fusion (graph leg's rank divided by its connecting-edge
+#         confidence so INFERRED/AMBIGUOUS neighbors land below EXTRACTED).
+contrib_graph(doc, rank, conf) = 1 / (k + rank / max(conf, ε))
+contrib_other(doc, rank)       = 1 / (k + rank)
+rrf_score(doc) = Σ contrib_*(doc, ...)
+
+final = sort_desc(by rrf_score) → cosine rerank top-K → page
+```
+
+Constants: `k=60`, `leg_limit=50`, `confidence_min=0.5`, `ε=1e-3`.
+
+**Trust boundary:** seeds derive from **records the caller can see and that
+match the query**, not from a global entity FTS. An alias indexed only from
+a hidden record cannot match — the lexical match happens against
+`records_fts` (already scope-filtered), and entities are looked up by id
+afterwards via `entity_episodes`. Tested in §10.2.
+
+**Additive property (with rank-rescue, NOT discovery-only):** step 4
+excludes `ranked_query_records` (the records actually fused into RRF —
+top 50 of each lexical leg). It does NOT exclude the wider auth-only
+seed pool (`visible_query_records`, ≤ 400). Two consequences callers
+can rely on:
+
+1. **No double-counting in the fusion pool**: a record present in the
+   top-50 of either lexical leg cannot also appear via the graph leg.
+   RRF won't see the same record twice.
+2. **Rank-rescue is intentional**: a record overfetched as a graph
+   seed but ranked outside the lexical top-50 (e.g., position 75) CAN
+   re-enter via graph evidence. This rescues lexically-matched records
+   that the lexical legs alone would have dropped, while the truly
+   neighbor-only record (no lexical match at all) is the more
+   striking case. Both are valid graph-leg hits; the leg is "additive
+   with rank rescue", not "discovery-only".
+
+Test §10.2's rank-rescue case asserts (1) rank-75 records re-enter via
+graph and (2) the same record is not double-counted in fusion.
+
+## 4. Architecture
+
+### 4.1 Crate boundaries (unchanged)
+
+- `cairn-core` — pure functions & traits; adds `GraphCandidate` and extends
+  `HybridSearchInputs`/`HybridSearchParams`.
+- `cairn-store-sqlite` — owns the `WITH RECURSIVE` SQL and the
+  `search_graph_neighbors` impl.
+- `cairn-cli` — adds `--confidence-min` flag.
+
+`cairn-core` gains zero new external deps. Store gains zero. (Confirmed against
+§3 dependency rule.)
+
+### 4.2 Public types added to `cairn-core::search`
+
+```rust
+/// One graph-leg candidate: a record reached via a neighbor entity edge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphCandidate {
+    pub record_id: RecordId,
+    /// Confidence score of the *connecting edge* (max if multiple edges
+    /// reach the same record). Range `[0.0, 1.0]`. Used for the rank
+    /// penalty in `hybrid_search`.
+    pub edge_confidence_score: f32,
+    /// 1-based rank of this candidate within the graph leg's output
+    /// (i.e., its position in the §5.1 SQL result order). Carried
+    /// explicitly so RRF fusion does not infer rank from
+    /// (potentially out-of-order) hydrated list position. The graph
+    /// SQL emits rows in `ORDER BY conf DESC, updated_at DESC`; this
+    /// field captures that order before hydration shuffles ids.
+    pub graph_rank: usize,
+}
+```
+
+`HybridSearchInputs` gains:
+
+```rust
+/// Graph-leg candidates. Order in the Vec is irrelevant; rank is read
+/// from `GraphCandidate::graph_rank` to keep fusion deterministic.
+pub graph: Vec<GraphCandidate>,
+```
+
+`HybridSearchParams` gains:
+
+```rust
+/// `ε` floor for the graph-leg confidence penalty divisor. Default 1e-3.
+pub confidence_floor: f32,
+```
+
+Backwards-compat: callers using `HybridSearchInputs::default()`-equivalent
+struct literals must opt into `graph: vec![]`. We add a `..Default::default()`
+constructor on inputs/params to keep the diff small.
+
+### 4.3 New trait method on `MemoryStore`
+
+```rust
+async fn search_graph_neighbors(
+    &self,
+    args: &GraphNeighborsArgs<'_>,
+) -> Result<Vec<GraphCandidate>, Self::Error>;
+```
+
+Where:
+
+```rust
+pub struct GraphNeighborsArgs<'a> {
+    /// Record ids from the auth-only seed retrieval (UNIONed across
+    /// keyword and semantic legs), up to 2 * GRAPH_SEED_OVERFETCH = 400.
+    /// Seeds the graph traversal. Empty list ⇒ empty result.
+    pub seed_record_ids: Vec<RecordId>,
+    /// Record ids actually fused into RRF (top 50 of each filtered
+    /// lexical leg, UNIONed, ≤ 100). Used as the dedup set in step 4
+    /// of §5.1 — graph results exclude these so RRF cannot
+    /// double-count, but seeds NOT in this list (overfetched rank
+    /// 51-200 records) remain eligible for rank-rescue via graph
+    /// evidence. Required: omitting this would force the trait impl
+    /// to dedup against the wrong pool.
+    pub ranked_record_ids: Vec<RecordId>,
+    /// Pre-validated user-narrowing filter (timestamps, tags, kind/class
+    /// narrowing). Applied **only** to the returned neighbor record
+    /// (step 4). User narrowing must not erase otherwise-authorized
+    /// edges based on where the edge was observed.
+    pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — the security predicate. Applied to
+    /// BOTH the provenance record (step 3) and the neighbor record
+    /// (step 4). `filter` is recall-narrowing only.
+    ///
+    /// **This field is part of a wider `MemoryStore` change.** Promoting
+    /// `auth_scope` into a first-class field on the graph leg only would
+    /// let policy drift between legs — the keyword leg would still
+    /// authorize through `KeywordSearchArgs.filter`, and a careless
+    /// caller could pass a narrower keyword filter than graph
+    /// auth_scope (or vice versa). To prevent that, this issue also
+    /// adds `auth_scope: ScopeTuple` to `KeywordSearchArgs` and
+    /// `SemanticSearchArgs` (and so to `HybridSearchArgs`). The shared
+    /// keyword-leg row-mapper applies it identically across all three
+    /// legs and graph hydration. Callers construct `auth_scope` once
+    /// per request from their auth context; the verb layer threads it
+    /// through unchanged. This is a contract-version event (§12.1) and
+    /// is the reason the bump is `0.4.0 → 0.5.0`, not a patch.
+    pub auth_scope: ScopeTuple,
+    /// Visibility values the caller is allowed to see. Applied to BOTH
+    /// the neighbor record (step 4) AND the edge provenance record
+    /// (step 3). Authorization.
+    pub visibility_allowlist: Vec<MemoryVisibility>,
+    /// Max candidates returned. = `HYBRID_LEG_LIMIT` from the orchestrator.
+    pub limit: usize,
+    /// `confidence_score` floor applied SQL-side to the edge step (step 3).
+    pub confidence_min: f32,
+}
+```
+
+**Predicate application (step 3 vs. step 4):** authorization predicates
+(`auth_scope`, `visibility_allowlist`, tombstone, active) apply to BOTH
+provenance and neighbor. The user-narrowing `filter` applies **only** to
+the neighbor record. This split is the whole reason `auth_scope` is a
+separate field on the args struct — overloading user filter onto
+provenance would erase otherwise-authorized graph evidence based on
+where the edge happened to be extracted.
+
+| Predicate kind          | Step 3 (provenance `pr`) | Step 4 (neighbor `r`) |
+|---|---|---|
+| `auth_scope`            | applied | applied |
+| `visibility_allowlist`  | applied | applied |
+| `tombstoned = 0`        | applied | applied |
+| `active = 1`            | applied | applied |
+| `filter` (user narrow)  | **NOT** applied | applied |
+
+This is the contract from day one — there is no "until the split lands"
+deferral. The `auth_scope` field is mandatory on `GraphNeighborsArgs`;
+the orchestrator (`do_search_hybrid`) extracts it from the same context
+that builds visibility/scope predicates for the keyword leg, so the
+three legs cannot drift.
+
+Capability: extends **`MemoryStoreCapabilities`** with `graph_search:
+bool` (see §8 — runtime capability, not config-derived). Stores without
+the entity_graph schema or the `carray` extension return
+`CapabilityUnavailable`. The hybrid path treats unavailable graph leg
+the same as it currently treats an unavailable semantic leg: skip the
+leg, RRF still runs on the survivors. The orchestrator reads
+`MemoryStoreCapabilities::graph_search` (NOT `config::CapabilitySet`)
+when deciding to dispatch the graph leg. Degradation is surfaced
+explicitly per §5.3.
+
+### 4.4 Extended args
+
+`HybridSearchArgs` gains `pub confidence_min: f32` (threaded into the graph
+leg only).
+
+## 5. Store implementation
+
+### 5.1 SQL — single statement (authorization-first, true 1-hop)
+
+The query takes the **union of keyword + semantic leg over-fetched
+record-ids** as a parameter (`?1` = bound list of `record_id`s, length ≤
+`2 * GRAPH_SEED_OVERFETCH = 400` by default; configurable via
+`SearchConfig.graph_seed_overfetch`). Both upstream legs already enforce scope/visibility,
+so the union is fully authorized. That list is the **only** lexical
+input; the graph leg does not run FTS5 itself, so a hidden alias on an
+entity node cannot drive the match. The same list is reused later (Step 4)
+to de-dup graph hits against everything the upstream legs already returned,
+keeping the graph leg purely additive.
+
+```sql
+WITH RECURSIVE
+    -- Step 1a: SEED set — over-fetched record ids from keyword+semantic
+    -- legs (≤ 400 = 2 * GRAPH_SEED_OVERFETCH). Seeds the entity-mention
+    -- traversal so broad queries do not lose connected results to a
+    -- 50-per-leg cap.
+    visible_query_records(id) AS (
+        SELECT value FROM carray(?1)              -- 400-cap, bound by store layer
+    ),
+    -- Step 1b: RANKED set — record ids that actually enter RRF fusion
+    -- (top 50 of each lexical leg, ≤ 100). Used ONLY for the step-4
+    -- dedup so that an overfetched-but-not-ranked seed (rank 51-200)
+    -- can still surface via graph evidence. Distinct from
+    -- visible_query_records by design — see the broad-query test.
+    ranked_query_records(id) AS (
+        SELECT value FROM carray(?5)              -- 100-cap, bound by store layer
+    ),
+    -- Step 2: seed entity nodes — only those mentioned by visible_query_records.
+    -- entity_episodes(episode_id REFERENCES records(record_id), entity_node_id, ...)
+    seeds(id) AS (
+        SELECT DISTINCT ep.entity_node_id
+          FROM entity_episodes ep
+         WHERE ep.episode_id IN (SELECT id FROM visible_query_records)
+    ),
+    -- Step 3: neighbor entities — opposite-endpoint of seed-touching edges.
+    --         Edges are filtered on:
+    --           (a) live in both bitemporal dimensions
+    --               (invalid_at IS NULL AND expired_at IS NULL — the
+    --               schema's live-edge predicate; matches §6.11 of the
+    --               brief and migration 0043),
+    --           (b) confidence floor (?2),
+    --           (c) edge provenance is visible to the caller — the edge's
+    --               source_record_id MUST also be in visible_query_records
+    --               OR pass the same visibility/scope predicate. Without
+    --               this filter, an edge extracted from a hidden record
+    --               could raise the confidence aggregate of a visible
+    --               neighbor, leaking unseen evidence into ranking.
+    --         MAX(confidence_score) is computed AFTER the provenance
+    --         filter so only authorized evidence contributes.
+    neighbors(neighbor_id, conf) AS (
+        SELECT neighbor_id, MAX(confidence_score)
+          FROM (
+            SELECT
+                CASE WHEN e.source_id IN (SELECT id FROM seeds)
+                     THEN e.target_id ELSE e.source_id END  AS neighbor_id,
+                e.confidence_score                          AS confidence_score
+              FROM entity_edges e
+              JOIN records pr ON pr.record_id = e.source_record_id
+             WHERE (e.source_id IN (SELECT id FROM seeds)
+                 OR e.target_id IN (SELECT id FROM seeds))
+               -- Bitemporal "live now" predicate matches the production
+               -- read path used by `do_graph_edges` — both end-bounds
+               -- not-fired AND both start-bounds satisfied. ?6 = now_event,
+               -- ?7 = now_ingest (caller-supplied via the verb's
+               -- `as_of_event_time` / `as_of_ingest_time`, defaulting to
+               -- the request timestamp). Without start bounds, a
+               -- future-dated edge would surface neighbors before the
+               -- fact is valid.
+               AND e.valid_at   <= ?6              -- event-time start bound
+               AND e.created_at <= ?7              -- ingest-time start bound
+               AND (e.invalid_at IS NULL OR e.invalid_at > ?6)
+               AND (e.expired_at IS NULL OR e.expired_at > ?7)
+               AND e.source_record_id IS NOT NULL  -- orphan edges excluded
+               AND e.confidence_score >= ?2
+               AND pr.tombstoned = 0
+               AND pr.active = 1
+               -- Authorization-only on provenance: auth_scope + visibility.
+               -- User-narrowing `filter` is NOT applied here (see §4.3).
+               AND <auth_scope predicate ON pr>
+               AND <visibility predicate ON pr>
+          )
+         WHERE neighbor_id NOT IN (SELECT id FROM seeds)   -- exclude self-references explicitly
+         GROUP BY neighbor_id
+    )
+-- Step 4: candidate records — records mentioning a neighbor entity.
+--         Authorization (visibility + scope) AND the user-supplied filter
+--         BOTH apply here. The result is de-duped against the seed list
+--         so the leg is additive vs. keyword/semantic.
+SELECT r.record_id, MAX(n.conf) AS conf
+  FROM neighbors n
+  JOIN entity_episodes ep ON ep.entity_node_id = n.neighbor_id
+  JOIN records r          ON r.record_id = ep.episode_id
+ WHERE r.tombstoned = 0
+   AND r.active = 1
+   -- Latest-record/supersession predicate, same as do_search_keyword.
+   -- Without it, a superseded neighbor (kept in records for history)
+   -- could re-enter solely via the graph leg even though keyword and
+   -- semantic legs would never return it.
+   AND <supersession predicate ON r>
+   AND <auth_scope predicate ON r>      -- auth, same shared helper as keyword
+   AND <visibility predicate ON r>      -- auth, same shared helper as keyword
+   AND <filter predicate ON r>          -- user narrowing, neighbor only
+   AND r.record_id NOT IN (SELECT id FROM ranked_query_records)
+   --                              ^^^^^^^^^^^^^^^^^^^^^^^^
+   -- Dedup ONLY against records that actually enter RRF fusion (top 50
+   -- of each lexical leg). Records overfetched as graph SEEDS but
+   -- ranked outside the fusion pool (51-200) remain eligible to
+   -- re-enter via graph scoring — otherwise broad queries silently
+   -- drop strongly-connected hits.
+ GROUP BY r.record_id
+ ORDER BY conf DESC, r.updated_at DESC
+ LIMIT ?3;
+```
+
+`WITH RECURSIVE` keyword is used (per AC + brief §6.11) even though depth=1
+needs no recursion today, so depth>1 follow-ups are syntactically additive.
+
+**Trust boundary:** lexical matching happens upstream against `records_fts`
+(already scope-filtered). Entity nodes are reached by id-join through
+`entity_episodes`; their FTS index is **never queried**. A hidden alias
+cannot influence seed selection.
+
+**Visibility predicate:** assembled by the same shared helper that builds
+the predicate for `do_search_keyword` and `do_search_semantic`, so the three
+legs cannot drift. Drift would be a §4 contract violation.
+
+**Implementation note (carray is required):** `rusqlite`'s `carray`
+extension is mandatory for this feature. Three list-bound query shapes
+need it: `visible_query_records` (≤400 ids), `ranked_query_records`
+(≤100 ids), and the hydration `IN carray(?1)` clause (≤50 ids).
+
+The capability probe in §8 includes a `carray` availability check
+(execute `SELECT 1 FROM carray(?)` once at `MemoryStore::open`). If
+`carray` is unavailable, `graph_search` reports false at startup and
+the hybrid path emits `DegradedLeg::Graph { reason:
+"capability_unavailable" }` per request. **There is no inline-VALUES
+fallback path.** The rollout signal is explicit (capability + metric +
+response field), and operators see the degraded state in metrics and
+response payload. `carray` ships with `rusqlite` under default features
+and is enabled in `Cargo.toml` for all production builds; the only
+realistic path to disablement is a hand-rolled embed without the
+feature flag, which the probe surfaces on first connect rather than at
+query time.
+
+### 5.2 New module
+
+`crates/cairn-store-sqlite/src/store/graph_search.rs` — async wrapper around
+the SQL above using the `tokio_rusqlite` worker. Mirrors the shape of
+`store/hybrid.rs` for consistency.
+
+### 5.2.1 Graph-only candidate hydration
+
+Keyword and semantic legs return full `SearchCandidate` rows (snippet,
+`bm25`, `semantic_distance`, `record_json`, scope, visibility,
+`recency_seconds`, `staleness_seconds`, `confidence`, `salience`). The
+graph leg returns only `(record_id, edge_confidence_score)` so it must
+hydrate before the result page is assembled.
+
+**Hydration step:** the graph-only path goes through the **same shared
+row-mapper** as `do_search_keyword`, which already handles the
+millisecond-timestamp arithmetic correctly (see
+`crates/cairn-store-sqlite/src/store/search.rs::row_mapper` —
+`recency_seconds` and `staleness_seconds` are computed from raw
+`now_ms` minus the column's ms value, divided by 1000 in Rust). No
+new SQL recomputes timestamps in the hydration query.
+
+**Rank preservation:** the graph SQL (§5.1) returns rows in a
+deterministic order (`ORDER BY conf DESC, r.updated_at DESC`). That
+order IS the graph leg's rank input to RRF and must be preserved
+through hydration. SQLite returns `IN carray(...)` results in arbitrary
+order, so the hydration step CANNOT rely on the SQL row order. The
+implementation:
+
+1. The graph SQL output is captured as `Vec<(record_id, conf,
+   graph_rank: usize)>` where `graph_rank` is the row index
+   (1-based) in the original SQL result.
+2. The hydration query fetches by id (any order); the result is
+   re-sorted by `graph_rank` in Rust before merging into
+   `HybridSearchInputs.graph`.
+3. The merged `Vec<GraphCandidate>` carries `graph_rank` explicitly
+   on each entry (added to the struct).
+4. `rrf_fusion_weighted` reads the explicit `graph_rank` rather than
+   inferring rank from list position.
+
+Test §10.3 includes a determinism check: identical vault + identical
+query produces byte-identical `graph_rank`/RRF output across N
+repeated calls.
+
+The hydration SELECT is:
+
+```sql
+SELECT r.record_id, r.target_id, r.scope, r.kind, r.class, r.visibility,
+       r.body AS record_json,
+       r.updated_at, r.created_at      -- raw ms; row-mapper converts
+  FROM records r
+ WHERE r.record_id IN carray(?1)            -- graph-only ids (≤ 50)
+   AND r.tombstoned = 0
+   AND r.active = 1
+   -- Defense-in-depth: re-apply the FULL authorization predicate set
+   -- the graph-leg SQL applied at step 4 (supersession + auth_scope +
+   -- visibility + filter), not a subset. If graph ids ever come from
+   -- a cache or a buggy upstream, hydration must independently refuse
+   -- superseded or cross-scope records.
+   AND <supersession predicate ON r>
+   AND <auth_scope predicate ON r>
+   AND <visibility predicate ON r>
+   AND <filter predicate ON r>;
+```
+
+Hydration is implemented via the **same shared row-mapper** as
+`do_search_keyword`, taking the same `(auth_scope, visibility_allowlist,
+filter)` triple. The triple is constructed once per `do_search_hybrid`
+call and passed to all three downstream queries (keyword leg, graph SQL
+step 4, graph hydration), so the four predicates cannot drift.
+
+(`confidence` / `salience` are not columns on `records` in the current
+schema — they live on the deserialized `MemoryRecord` body. The
+`SearchCandidate.confidence` / `SearchCandidate.salience` fields the
+keyword leg returns are derived in the row-mapping layer from the same
+body. The graph-only hydration uses the same row-mapping helper as
+`do_search_keyword`, not a hand-rolled SELECT — single source of truth.)
+
+Output `SearchCandidate` field shape for graph-only rows:
+
+| Field | Value |
+|---|---|
+| `bm25`              | `0.0` (sentinel; absent from FTS results) |
+| `semantic_distance` | `None` |
+| `snippet`           | empty string `""` (no FTS5 `snippet()` source) |
+| `confidence`/`salience`/`recency_seconds`/`staleness_seconds` | derived from `records` body via the shared row-mapper |
+| `record_json`       | hydrated `body` column |
+
+`bm25=0.0` is a **sentinel** the explain serializer maps to `null` in the
+`--json` output so callers don't mistake it for a strong BM25 hit.
+`ScoreExplain` gains `graph_rank: Option<usize>` and
+`edge_confidence_score: Option<f32>` so the graph contribution is visible
+to debugging clients.
+
+**Re-applying auth at hydration time:** the WHERE clause re-applies the
+visibility and filter predicates even though the graph SQL already did.
+This is defense in depth — guards against a future bug where the graph
+SQL is bypassed (e.g., a cache layer); cost is one trivially indexed
+predicate evaluation per id.
+
+`hydrate_candidates` in `store/hybrid.rs` is extended to merge three
+sources (keyword, semantic, graph-only-hydrated). Records present in
+multiple sources keep the keyword/semantic row (richer signal); graph-
+only ids contribute their hydrated row.
+
+### 5.3 Hybrid orchestrator extension
+
+`store/hybrid.rs::do_search_hybrid`:
+
+- The graph leg depends on **both** the keyword AND semantic leg outputs
+  (their UNIONed record-id list seeds the graph leg), so the three legs
+  cannot all run in parallel. New shape:
+  1. **Two retrieval purposes, two query shapes per leg:**
+     - **Filtered fusion retrieval** — runs identically to today's
+       `do_search_keyword` / `do_search_semantic`: applies
+       `auth_scope` + visibility + user `filter`, returns top-50
+       fully-hydrated rows per leg. Feeds the RRF fusion pool. This
+       preserves "best filtered matches" semantics: a narrow filter
+       cannot be starved by unfiltered out-of-filter records flooding
+       the top-N cutoff.
+     - **Auth-only seed retrieval** — runs in parallel: applies
+       `auth_scope` + visibility + tombstone/active checks **AND the
+       same supersession/latest-record predicate as
+       `do_search_keyword`** (a record is a valid seed only if it is
+       the latest active version — superseded retired versions are
+       excluded). It does NOT apply the user-narrowing `filter`. The
+       projection is `record_id` only. Returns up to
+       `GRAPH_SEED_OVERFETCH = 200` ids per leg. Feeds the graph
+       seed pool (∪ to ≤ 400 unique ids). The auth-only path is what
+       makes the graph leg's §4.3 contract hold: provenance records
+       that pass auth but fail the user filter can still seed graph
+       expansion of in-filter neighbors. Reusing the supersession
+       predicate prevents stale retired records from driving graph
+       expansion through a path the keyword leg already excludes.
+     Yes — this means BM25 and ANN run TWICE per hybrid request: once
+     filtered (for fusion), once auth-only (for graph seeds). The
+     auth-only path is id-only (no hydration), so the dominant cost
+     is the index traversal. For BM25 the marginal cost over today's
+     filtered run is ~one extra index scan; for vec0 the cost is one
+     extra ANN traversal at limit=200, which the §10.5 bench gates
+     against the 100ms p99 budget. If the bench shows the duplicated
+     ANN traversal is the latency limiter, `GRAPH_SEED_OVERFETCH` is
+     lowered (the latency gate is non-negotiable). Two queries are
+     the cost of the §4.3 + filtered-recall guarantees together; one
+     retrieval cannot satisfy both.
+  2. **Structured fan-out via `tokio::task::JoinSet`**, NOT
+     `try_join!`. `try_join!` short-circuits on the first error and
+     drops sibling futures, which would orphan their SQLite work on
+     the pool — defeating the safety valve. The orchestrator instead:
+     - Spawns each leg as a task on a `JoinSet`. Every leg owns its
+       own pool connection (§5.3 pool init contract); cancellation is
+       initiated by signaling the leg's `CancellationToken` (which
+       drives `interrupt()` + `progress_handler` per §5.3).
+     - Awaits ALL four tasks (`while let Some(...) = set.join_next()`)
+       — early errors do NOT cause sibling drop. Each leg gets a
+       chance to either complete or run its cancellation path
+       cleanly before the request returns.
+     - Aggregates per-leg outcomes into `degraded_legs` per the
+       timeout table below. The first error from a non-degradable
+       leg (e.g., `filtered_keyword` timeout — see table) is held
+       until all four tasks finish, then surfaced.
+     Drop-triggered cleanup is not relied on. Cancellation is
+     explicit, signaled via tokens, and verified by §10.5(c)
+     (sibling-completion test).
+     Inputs to the graph leg: `seed_record_ids` from the auth-only
+     union and `ranked_record_ids` from the filtered top-50s, both
+     populated only from legs that completed without timeout.
+  3. The id-only overfetch is a `SearchConfig` knob
+     (`graph_seed_overfetch`, default 200, max 500).
+  3a. **Runtime safety valve.** Two layers of protection against the
+      double-traversal cost spiking under production load:
+      - **Pool initialization, sizing, and checkout lifecycle.**
+        - **Init contract.** The `HybridConnectionPool`'s connections
+          are NOT a separate, lazily-initialized set — they go through
+          the **same `open_connection` factory** as the store's
+          primary connection. That factory is the single source of
+          truth for: `carray` extension load, `sqlite_vec` load,
+          progress-handler registration, busy-timeout, journal mode,
+          and any other per-connection setup. `MemoryStore::open`
+          does NOT report `caps.graph_search = true` until **every**
+          pool connection has been built via that factory AND each
+          one has passed the §8 capability probes individually.
+          Test §10.2's "pool-init failure" case injects a load
+          failure on one pool connection and asserts the whole
+          feature reports unavailable.
+        - **Sizing and what the pool serves.** The cancellable pool
+          serves **all four hybrid legs** that face a deadline:
+          `filtered_keyword`, `filtered_semantic`, `auth_keyword_ids`,
+          `auth_semantic_ids`, plus the graph-leg query. Because the
+          deadline table makes `filtered_keyword` non-degradable
+          (must complete or fail the request), it MUST run on a
+          cancellable connection too — otherwise a slow filtered
+          query orphans the underlying SQLite work and starves
+          later requests despite the deadline expiring. Migrating
+          the existing keyword/semantic legs onto the pool is part
+          of this issue; their behavior is unchanged from the
+          caller's perspective.
+
+          **Two pool tiers** to keep the mandatory keyword recall
+          floor isolated from graph-pool contention:
+          - **Tier A (mandatory)**: dedicated connections for
+            `filtered_keyword` and `filtered_semantic`. Size =
+            `num_cpus` (default), configurable as
+            `SearchConfig::filtered_pool_size`. Acquisition has a
+            **request-level deadline** (`SearchConfig::
+            filtered_acquire_timeout_ms`, default 200ms — 2× the
+            p99 budget). On timeout the request fails with
+            `StoreError::Timeout` and a verb-level error reason of
+            `tier_a_acquire_timeout` so operators can distinguish
+            queue saturation from in-query slowness. The acquire
+            deadline is independent of and additive to the per-leg
+            execution deadline — together they cap total request
+            wall time. Filtered legs cannot be starved by graph
+            traffic because graph never queues on Tier A; they CAN
+            be starved by other filtered traffic, which is why the
+            acquire deadline exists.
+          - **Tier B (graph)**: dedicated connections for
+            `auth_keyword_ids`, `auth_semantic_ids`, and
+            `search_graph_neighbors`. Size = `2 * num_cpus`
+            (default), configurable as
+            `SearchConfig::graph_pool_size`. Acquire has a
+            `pool_acquire_timeout_ms` deadline (default = leg
+            deadline); on timeout the leg degrades to
+            `DegradedLeg::Graph { reason: DeadlineExceeded, source:
+            ... }`. Tier B saturation cannot fail the mandatory
+            keyword leg.
+
+          Both tiers honor the same pool-init contract and per-
+          checkout cancellation lifecycle below. The keyword/
+          semantic existing `tokio_rusqlite` worker is retired in
+          favor of Tier A — single execution model across all
+          hybrid legs.
+        - **Per-checkout cancellation lifecycle.** Connection-scoped
+          cancellation (`interrupt()`, `progress_handler`) requires
+          explicit reset before reuse. The lifecycle:
+          1. **Acquire**: borrow a connection; install a fresh
+             `CancellationToken` and re-arm `progress_handler` against
+             it. Run a `SELECT 1` smoke probe; if it fails (e.g.,
+             SQLITE_INTERRUPT pending from a stale state), discard
+             the connection and rebuild via the factory.
+          2. **Run**: leg's SQL executes; deadline watchdog can fire
+             `interrupt()` + token cancel.
+          3. **Release**: ALWAYS reset on release, regardless of
+             outcome — clear the token, deregister the leg's
+             progress callback, run `sqlite3_db_release_memory`
+             (no-op if SQLite ignored it). If reset fails, **discard
+             the connection and rebuild** via the factory before the
+             slot is returned to the pool. Interrupted connections
+             are NEVER reused without a verified reset.
+        Test §10.5 includes a "cross-request reuse" case: one
+        request times out, the next request gets the same pool slot
+        and runs successfully — proves the reset/discard lifecycle.
+
+      - **Per-leg deadline with real, statement-scoped cancellation.**
+        Each of the four parallel queries runs with a deadline budget
+        (`SearchConfig::graph_leg_deadline_ms`, default 60ms — 60% of
+        the p99 budget). A bare `tokio::time::timeout` only drops the
+        awaiter, leaving the SQLite worker pinned on the orphaned
+        job and starving later requests; that is forbidden. SQLite's
+        `interrupt()` and `progress_handler` are connection-scoped,
+        not statement-scoped, so a naive use would also abort sibling
+        queries running on the same connection. To avoid both pitfalls
+        the implementation uses **per-leg dedicated connections from a
+        bounded cancellable pool**:
+        - The store maintains a small pool of read-only SQLite
+          connections (`HybridConnectionPool`, size = 4 by default —
+          one per parallel leg of a hybrid request, plus a small
+          margin). Each cancellable leg of a hybrid request acquires
+          its own connection from the pool for the duration of the
+          query and releases it on completion or cancellation.
+        - When the deadline elapses, a watchdog task calls
+          `interrupt()` ONLY on that leg's connection. Sibling legs
+          on their own connections are unaffected.
+        - `progress_handler` is registered per-connection with a
+          callback gated by that connection's `CancellationToken`,
+          fired only by its own watchdog. Belt-and-braces: even if
+          `interrupt()` races with statement reset, the progress
+          handler catches the cancel on the next opcode batch
+          (default opcode interval 1024).
+        - The pool sits behind a semaphore: if all connections are
+          busy, the next leg waits. The semaphore + per-leg
+          connection together guarantee a timed-out leg cannot leak
+          work onto an unrelated request's connection.
+        Together this guarantees per-leg isolation AND that the
+        SQLite work stops within milliseconds of the deadline.
+
+        **Closed `DegradationReason` enum** — degradation reasons are
+        a typed enum, not free-form strings, so callers and tests key
+        on stable variants:
+
+        ```rust
+        #[non_exhaustive]
+        pub enum DegradationReason {
+            CapabilityUnavailable,    // graph_search=false at startup
+            DeadlineExceeded,         // any leg timed out
+            SqlError,                 // SQLite returned an error
+            WorkerPanic,              // tokio_rusqlite worker panicked
+        }
+        pub enum DegradedLeg {
+            Semantic { reason: DegradationReason },
+            Graph    { reason: DegradationReason, source: GraphSource },
+        }
+        #[non_exhaustive]
+        pub enum GraphSource {
+            All,                      // entire graph leg failed
+            AuthKeywordSeed,          // auth-only keyword seed query
+            AuthSemanticSeed,         // auth-only semantic seed query
+        }
+        ```
+
+        Multiple `DegradedLeg` entries can appear in one response (one
+        per affected source). The `source` field on `Graph` makes the
+        seed-vs-traversal distinction explicit so operators can tell
+        which input failed.
+
+        **Per-leg timeout semantics** — distinct behavior for each of
+        the four parallel legs:
+
+        | Leg | Timeout result | `DegradedLeg` entry |
+        |---|---|---|
+        | `filtered_keyword` (top-50, hydrated) | **Request fails** with `StoreError::Timeout`. Keyword leg is the existing recall floor; degrading it would silently regress 2-leg search behavior. | none — error path |
+        | `filtered_semantic` (top-50, hydrated) | Skip the leg, run hybrid with keyword + graph only. Existing fail-open behavior for semantic, preserved. | `Semantic { reason: DeadlineExceeded }` |
+        | `auth_keyword_ids` (top-200, ids only) | Drop this seed source from the union; graph runs with semantic seeds only. | `Graph { reason: DeadlineExceeded, source: AuthKeywordSeed }` |
+        | `auth_semantic_ids` (top-200, ids only) | Drop this seed source from the union; graph runs with keyword seeds only. | `Graph { reason: DeadlineExceeded, source: AuthSemanticSeed }` |
+
+        If both auth-only seed queries exceed the deadline the graph
+        leg skips entirely (`Graph { reason: DeadlineExceeded, source:
+        All }`).
+        If both `filtered_*` legs would fail simultaneously, the
+        keyword leg's failure preempts the semantic-skip — the
+        request still errors, no half-fused result is returned.
+
+        Test §10.5's deadline-circuit gate verifies (a) the request
+        returns within deadline + 10ms, (b) the worker pool can
+        accept a new request immediately after the deadline fires,
+        (c) a sibling leg on a different connection completes
+        normally when one leg is interrupted (proves per-leg
+        isolation), AND (d) each leg's specific timeout-recovery
+        path is tested against the table above.
+        Test §10.5's deadline-circuit gate verifies (a) the request
+        returns within deadline + 10ms, (b) the worker pool can
+        accept a new request immediately after the deadline fires,
+        AND (c) a sibling leg on a different connection completes
+        normally when one leg is interrupted (proves per-leg
+        isolation).
+      - **Adaptive overfetch reduction.** A rolling p99 latency
+        estimate per leg (EWMA over the last 1000 requests) feeds
+        back into `effective_overfetch`: if observed p99 exceeds 80%
+        of the gate, the runtime halves the overfetch limit for new
+        requests until p99 recovers. Bounded between
+        `[HYBRID_LEG_LIMIT, graph_seed_overfetch]`. Logged at
+        `info!` whenever the runtime adjusts so operators see the
+        adaptation in metrics.
+      Both layers are tested under load in §10.5: a synthetic vault
+      that pushes the auth-only ANN past the deadline must produce a
+      `degraded_legs: [Graph { reason: DeadlineExceeded, source: ... }]` result
+      rather than a slow request that breaches the gate.
+  4. Graph leg inputs (built once the four parallel retrievals
+     complete): `seed_record_ids = unique(auth_keyword_ids ∪
+     auth_semantic_ids)` (≤ 400, auth-only no filter),
+     `ranked_record_ids = unique(filtered_keyword_top50 ∪
+     filtered_semantic_top50)` (≤ 100, filter applied). The graph leg
+     itself is fast (id joins, no FTS or vector math).
+  5. The bench in §10.5 includes a "broad query" case (>200 keyword
+     hits, mixed-confidence neighbors) to validate the 200-default
+     against the latency gate.
+- Graph leg failures degrade to an empty list (FTS5 zero-match seeds → empty
+  is the normal case), **but never silently**:
+  1. The failure is logged at `warn!` with the underlying `StoreError` and a
+     `verb=search_hybrid leg=graph` tag.
+  2. A counter `cairn_search_graph_leg_failures_total{reason=...}` is
+     incremented for **every** branch where the graph leg does not run
+     to completion — runtime SQL error (`reason="sql_error"`), worker
+     panic (`reason="worker_panic"`), AND capability-based disablement
+     (`reason="capability_unavailable"`). The capability-unavailable
+     branch is the dominant rollout-failure case (schema skew →
+     `graph_search=false` at startup → silent 2-leg search), so it MUST
+     be counted alongside runtime failures. Zero-match-seeds is *not* a
+     failure and does not increment. Operators alert on rate of
+     `reason!=zero_seeds` to catch both runtime and rollout regressions.
+     A startup-time gauge `cairn_search_graph_leg_available` (0/1 per
+     instance) lets dashboards distinguish "always disabled on this
+     node" from "intermittent runtime failure".
+  3. The `HybridSearchPage` carries a new `degraded_legs:
+     Vec<DegradedLeg>` field that callers (CLI `--json`, MCP, SDK)
+     surface to the user. The wire shape is the typed enum defined in
+     §5.3 (`DegradationReason` + `GraphSource`). An empty vec means
+     full-fidelity hybrid. This is the canonical shape across
+     `HybridSearchPage`, `SearchOutcome`, IDL, CLI JSON, and SDK
+     transport — there is no string-keyed alternative.
+  4. The CLI prints a `warning:` line on stderr when `degraded_legs` is
+     non-empty so an interactive user notices a partial result; `--json`
+     emits the field unconditionally.
+- Capability: if `caps.graph_search` is false the leg is skipped and recorded
+  as `DegradedLeg::Graph { reason: CapabilityUnavailable, source: All }`. Same model
+  as today's semantic leg, but now visible to the caller.
+
+Rollback signal: clients can assert `degraded_legs.is_empty()` in
+post-deploy smoke tests. Operators can alert on the counter to catch
+schema-skew regressions that the legacy 2-leg path would have hidden.
+
+## 6. Pure orchestrator
+
+`cairn-core::search::orchestrator::hybrid_search` is extended:
+
+```rust
+let bm25_list = inputs.keyword.clone();   // rank inferred from list position (today)
+let sem_list  = inputs.semantic.clone();  // rank inferred from list position (today)
+
+// Graph leg: rank carried explicitly on each candidate.
+// `RankedCandidate` is the shape `rrf_fusion_weighted` consumes for legs
+// where rank is stored, not inferred.
+let graph_list: Vec<RankedCandidate> = inputs.graph
+    .iter()
+    .map(|g| RankedCandidate {
+        record_id: g.record_id.clone(),
+        rank: g.graph_rank,
+        weight: g.edge_confidence_score,    // for the confidence penalty
+    })
+    .collect();
+
+let fused = rrf_fusion_weighted(
+    &[
+        Leg::ListPosition(bm25_list),                              // rank from index
+        Leg::ListPosition(sem_list),                               // rank from index
+        Leg::Explicit(graph_list, params.confidence_floor),        // rank from field
+    ],
+    params.rrf_k,
+);
+```
+
+`rrf_fusion_weighted` is a new pure helper accepting two leg shapes:
+`Leg::ListPosition(Vec<ScoredCandidate>)` reads rank from the slice
+index (today's behavior); `Leg::Explicit(Vec<RankedCandidate>, floor)`
+reads rank from the per-candidate field and applies the confidence
+penalty `effective_rank = rank / max(weight, floor)`. The existing
+`rrf_fusion` keeps its signature and gains a 1-line shim:
+`rrf_fusion(lists, k) = rrf_fusion_weighted(list_position_legs, k)`.
+
+### 6.1 Cosine rerank — graph-only exemption
+
+A graph-only candidate (a record that the keyword and semantic legs both
+missed) by construction has weak query-vs-doc cosine similarity — that is
+exactly the discovery case the leg exists to surface. The unmodified
+cosine pass would push such candidates back out of the final page,
+defeating the leg's purpose.
+
+`cosine_rerank` is updated to operate on a tagged input list:
+
+```rust
+pub enum CandidateOrigin { Lexical, GraphOnly }   // graph-only ⇔ in graph leg AND in NEITHER bm25 nor semantic
+pub struct OriginTaggedCandidate { pub inner: RrfCandidate, pub origin: CandidateOrigin }
+```
+
+Behavior — graph-only candidates skip the cosine term entirely; the
+blend is renormalized so they compete on RRF alone with no synthetic
+similarity bonus:
+
+Both classes use the same `blend * rrf_norm` factor; only the cosine
+addend differs:
+
+- `Lexical` candidates: `final = blend * rrf_norm + (1-blend) *
+  cosine_norm` where `cosine_norm = (cosine_raw + 1) / 2 ∈ [0, 1]`
+  (normalize to non-negative; otherwise negative raw cosine would let
+  graph-only beat by asymmetry alone).
+- `GraphOnly` candidates: `final = blend * rrf_norm` — same RRF weight
+  as lexical, NO cosine addend. The cosine term is omitted, not
+  substituted with a neutral value, but the `blend` factor still
+  applies to RRF so graph-only and lexical share the same RRF scale.
+
+Why this formulation is symmetric:
+
+- Equal RRF, lexical `cosine_norm = 0` (worst): lexical gets `blend *
+  rrf + 0 = blend * rrf`, graph-only gets `blend * rrf`. **Tie**.
+- Equal RRF, lexical `cosine_norm = 0.5` (neutral): lexical gets
+  `blend * rrf + (1-blend) * 0.5`, graph-only gets `blend * rrf`.
+  Lexical wins by `0.15` (default blend).
+- Equal RRF, lexical `cosine_norm = 1` (perfect): lexical gets
+  `blend * rrf + (1-blend) * 1`, graph-only gets `blend * rrf`.
+  Lexical wins by `0.30` (default blend).
+- Strictly stronger RRF on graph-only side: graph-only beats lexical
+  only when its RRF strength × `blend` exceeds lexical's full term —
+  earned, not bias.
+
+A graph-only candidate cannot beat a lexical candidate at equal RRF
+unless the lexical cosine term is exactly zero (worst case). It
+cannot promote past a lexical candidate with any positive cosine.
+
+Side effect on score scale: `final` for graph-only is in `[0, blend]`
+(at most `blend * 1 = blend`); for lexical it's `[0, 1]`. Lexical can
+exceed graph-only's max only via the cosine addend — exactly the
+intended semantic.
+
+End-to-end tests in §10.3 assert: (a) neighbor-only record survives
+the rerank pass on RRF strength; (b) at equal RRF with `cosine_norm =
+0`, lexical and graph-only tie (no asymmetric bias); (c) at equal RRF
+with `cosine_norm > 0`, lexical strictly outranks graph-only.
+
+### 5.4 Verb-envelope propagation
+
+`degraded_legs` is meaningless if the verb dispatcher discards it on the
+way to CLI/MCP/SDK. The verb-level outcome type
+(`cairn_core::verbs::search::SearchOutcome`) is extended with a new
+field:
+
+```rust
+#[non_exhaustive]
+pub struct SearchOutcome {
+    pub candidates: Vec<SearchCandidate>,
+    pub explain: Option<Vec<ScoreExplain>>,
+    pub degraded_legs: Vec<DegradedLeg>,    // NEW — empty for non-hybrid modes
+}
+```
+
+- The dispatcher copies `degraded_legs` from `HybridSearchPage` into
+  `SearchOutcome` unmodified. Keyword and semantic-only modes return
+  an empty vec.
+- `cairn-cli`'s `--json` emits `degraded_legs` as a top-level array.
+  When the field is non-empty AND output is to a TTY, the CLI prints
+  a one-line `warning: graph leg degraded (reason: ...)` to stderr —
+  same UX a user would expect from any other partial-result signal.
+- MCP wrapper exposes `degraded_legs` in the `search` response payload
+  via the IDL update (§12.1). Schemars derive picks it up
+  automatically from the typed struct.
+- **`cairn-sdk` transport** — the SDK currently maps `SearchOutcome`
+  → generated `SearchData` by hand in `crates/cairn-sdk/src/transport.rs`.
+  This issue extends the generated `SearchData` IDL with
+  `degraded_legs: Vec<DegradedLeg>` (`#[serde(default)]` so legacy
+  payloads keep decoding) and updates the transport mapper to copy the
+  field through. Without this update, SDK callers silently lose the
+  signal — the spec's "never silent" claim becomes false on one of
+  the three supported surfaces. Codegen run in the same PR; the
+  generated diff is committed.
+- **Tests** in §10.3:
+  - Dispatcher: trigger graph-leg `CapabilityUnavailable` at the
+    store, run the `search` verb end-to-end, assert
+    `outcome.degraded_legs` contains one entry AND the `--json`
+    output contains the field.
+  - SDK round-trip: same trigger, but invoke through the SDK
+    transport. Assert the deserialized `SearchData.degraded_legs`
+    survives end-to-end. A regression here means the propagation
+    can break silently in a future refactor.
+
+## 7. Verb + CLI
+
+- `cairn-core::verbs::search` — read `confidence_min` from `SearchConfig`,
+  thread into `HybridSearchArgs`. CLI flag overrides config.
+- `cairn-cli::verbs::search` — adds `--confidence-min <f32>` clap arg
+  (`ValueHint::Other`, validated to `[0.0, 1.0]`). Exposed only when mode is
+  `hybrid`.
+- `SearchConfig.confidence_min: f32` defaults to `0.5`.
+- `cairn-idl` — extend the search-args IDL definition; rerun
+  `cairn-codegen`. (Generated diff committed in same PR.)
+
+## 8. Capability surface
+
+Graph-leg availability is a **runtime** capability (depends on schema
+state and the loaded `carray` extension at connection time), so it
+belongs on `MemoryStoreCapabilities`, not the config-derived
+`CapabilitySet`. The two surfaces serve different purposes:
+
+- `config::CapabilitySet` — capabilities derivable from static config
+  (e.g., embedder configured, vector enabled). Computed before the
+  store opens.
+- `contract::MemoryStoreCapabilities` — capabilities the store
+  advertises after opening, based on actual runtime state (schema
+  version, loaded extensions, migration set).
+
+This issue extends `MemoryStoreCapabilities` with
+`graph_search: bool` (NOT `CapabilitySet`). Probes run inside
+`MemoryStore::open` after migrations apply, populate the runtime
+capability struct, and the orchestrator reads that struct when deciding
+whether to dispatch the graph leg.
+
+- `MemoryStoreCapabilities::graph_search: bool` — true only when
+  **every** schema object that the graph SQL in §5.1 touches is present
+  at the expected migration level. The probe MUST mirror the runtime
+  query exactly — extra requirements cause false-negative capability
+  results, missing requirements cause silent runtime failures. Detection
+  probes (single transaction, executed once at `MemoryStore::open`):
+
+  1. Migration version meets the floor pinned for this feature
+     (`MIGRATION_FLOOR_GRAPH_SEARCH = 0044` — the entity_episodes migration,
+     the latest object referenced by §5.1).
+  2. `entity_episodes` exists with columns `episode_id` (FK →
+     `records.record_id`) and `entity_node_id`. Note: the column is
+     `episode_id`, **not** `record_id` — see migration 0044.
+  3. `entity_edges` exists with columns `source_id`, `target_id`,
+     `source_record_id`, `confidence_score`, `invalid_at`,
+     `expired_at`, **`valid_at`, and `created_at`** (the graph SQL
+     filters on both bitemporal start-bounds AND end-bounds — omitting
+     any of the four lets schema skew slip past startup and surface
+     as a runtime error). Every column the §5.1 SQL references on
+     `entity_edges` MUST appear in this list.
+  4. `records` exists with columns `record_id` (PK), `tombstoned`
+     (INTEGER 0/1), `active` (INTEGER 0/1), `updated_at`, `created_at`,
+     plus whatever columns the shared visibility/filter helper requires
+     (today: `target_id`, `scope`, `kind`, `class`, `visibility`, `body`).
+  5. `carray` extension is loadable: `SELECT 1 FROM carray(?)` succeeds
+     with a bound array. Required for the seed-list, ranked-list, and
+     hydration queries — see §5.1 implementation note.
+
+  Note: `entity_nodes_fts` is **not** required. The graph SQL reaches
+  entity nodes by id-join through `entity_episodes` only and never
+  queries the entity FTS index — requiring it would disable the feature
+  in valid schemas.
+
+  Failing **any** probe yields `graph_search = false`. The probe results
+  are logged once at `info!` with structured fields so a partial schema is
+  surfaced rather than silently disabling the leg.
+
+- `cairn.mcp.v1.search.hybrid` capability identifier unchanged. When the
+  graph leg is unavailable, the `HybridSearchPage::degraded_legs` field
+  (§5.3) advertises the degradation explicitly — clients are not left to
+  infer it from result quality.
+
+## 9. Errors
+
+- `StoreError::CapabilityUnavailable { what: "graph_search" }` for explicit
+  graph-only callers (`search_graph_neighbors` direct).
+- Hybrid path never raises `CapabilityUnavailable` for the graph leg —
+  degrades to empty list (parity with semantic leg behavior today).
+
+## 10. Tests
+
+### 10.1 `cairn-core` unit
+
+- `rrf_fusion_weighted` — known rank lists w/ confidence weights → expected
+  merged order.
+- `hybrid_search` — `INFERRED` (conf=0.6) edge-only neighbor ranks below
+  `EXTRACTED` (conf=1.0) edge-only neighbor at same input-list rank.
+- `confidence_floor` floor prevents division-by-zero w/ malformed conf=0.
+
+### 10.2 `cairn-store-sqlite` integration (real SQLite)
+
+- Seeded vault: 3 records, 2 entity nodes, 3 edges of mixed confidence.
+- Query that hits FTS5 seeds → returns expected graph candidates.
+- Edges with `confidence_score < confidence_min` excluded.
+- N+1 verifier: prepared-statement count ≤ 3 (seeds, edges, records — all in
+  one prepared CTE).
+- Empty seeds → empty list, no error.
+- **Authorization-boundary tests** (covers finding §5.1):
+  - Hidden-only alias: entity node X has surface form "ACME" indexed only
+    from a hidden record. The query "ACME" matches no visible record →
+    keyword leg empty → graph leg empty → no leak.
+  - Hidden record references neighbor entity Y. A visible record also
+    references Y (and matches the query). The hidden→Y edge must not
+    contribute confidence to the visible neighbor: tested by asserting the
+    `MAX(confidence_score)` aggregate equals the **visible** edge's
+    confidence, not the hidden edge's.
+  - Expired-edge regression: edge from seed→Y has `expired_at` set
+    (ingestion-time tombstone). Y must NOT appear in `neighbors`. Same
+    test pattern for `invalid_at` set.
+  - Future-dated edge: edge with `valid_at > now_event`. Y must NOT
+    appear in `neighbors` — the start bound is enforced. Same pattern
+    for `created_at > now_ingest`. Without §5.1's start-bound
+    predicates, future facts would leak into search.
+- **Discovery-property test** (covers finding on missing 1-hop):
+  - Vault: record A mentions entity X (matches query); edge X→Y; record B
+    mentions Y but does NOT contain the query terms. Hybrid search must
+    return B in `graph_hits`. Assert B is absent from `keyword_hits` and
+    present in `graph_hits` — proves the leg surfaces neighbor-only records.
+- **Capability-skew tests** (covers finding §8):
+  - Drop one column from `entity_episodes` → `graph_search` reports false,
+    hybrid path emits `DegradedLeg::Graph { reason: CapabilityUnavailable, source: All }`.
+  - Drop `entity_edges.expired_at` only → `graph_search` reports false at
+    startup (regression test for the missing-bitemporal-bound bug — without
+    this column the runtime SQL would fail).
+  - Vault has graph tables but no `entity_nodes_fts` → `graph_search`
+    reports true (probe must not require the FTS index, since the SQL
+    never queries it).
+  - Inject a SQL error into the graph leg at runtime → counter increments,
+    `degraded_legs` populated, hybrid still returns keyword + semantic.
+- **SQL-correctness regression test** (covers self-exclusion finding):
+  - Two seed sets — one containing the rowid-1 entity, one not. In both,
+    a seed-to-seed edge must NOT cause a seed to appear as its own
+    "neighbor" hit. Asserts the explicit `neighbor_id NOT IN seeds` clause
+    rather than relying on `HAVING` ordinal references.
+- **Hydration auth re-check** (covers hydration finding):
+  - Inject a graph-leg result containing a record id outside the
+    caller's `auth_scope` (simulates a buggy upstream / cache replay).
+    Hydration MUST drop that id — assert it does not appear in the
+    final `SearchCandidate` list. Documents the defense-in-depth
+    contract.
+- **carray-required capability test**:
+  - Build a store with `carray` disabled at the `rusqlite` feature
+    level. `MemoryStore::open` must report `caps.graph_search = false`
+    via the §8 probe. Hybrid search emits `DegradedLeg::Graph { reason:
+    "capability_unavailable" }`; keyword + semantic still return.
+- **Stale-seed exclusion** (covers supersession finding):
+  - Vault: record A v1 mentions entity X; A v2 supersedes v1 and
+    does not mention X. Edge X → Y exists. Query matches X only via
+    A v1 (which is now superseded). The auth-only seed retrieval must
+    NOT include A v1 — supersession predicate matches keyword leg.
+    Y must NOT appear in `graph_hits`. Without this guard, retired
+    records would silently drive graph expansion.
+- **Stale-neighbor exclusion** (covers graph step-4 supersession):
+  - Vault: record N v1 mentions neighbor entity Y; N v2 supersedes
+    v1, also mentions Y. Edge X → Y exists; query seeds X normally.
+    The graph leg must surface ONLY N v2, not N v1. Without
+    supersession on step 4 / hydration, the retired N v1 could
+    re-enter via graph alone.
+- **Orphan-edge exclusion** (covers null-provenance finding):
+  - Vault: edge X → Y with `source_record_id` set, then provenance
+    record deleted (so `source_record_id` becomes NULL via
+    `ON DELETE SET NULL`). The graph leg MUST NOT surface Y at any
+    confidence tier — without visible provenance, `auth_scope` and
+    visibility cannot be evaluated, so the edge is ineligible.
+    Provenance deletion is a recall trade-off the auth model requires.
+- **Rank-rescue via graph** (covers seed-vs-dedup-pool finding):
+  - Broad query: keyword leg returns 200 over-fetched ids; only top 50
+    enter RRF fusion. Pick a record D ranked at position 75 in keyword
+    (over-fetched, not RRF-fused). Add an edge from a top-10 entity to
+    D's entity. The graph leg MUST return D — D is in the seed pool
+    but NOT in `ranked_query_records`, so the dedup at step 4 lets D
+    re-enter via graph evidence. Final page must include D.
+
+### 10.3 Verb-level snapshot + end-to-end (`insta`)
+
+- `--json` output of hybrid search w/ a graph hit — stable shape (adds
+  `graph_rank` and `edge_confidence_score` to `ScoreExplain`, with
+  `bm25=null` for graph-only hits).
+- **Graph-only hydration**: end-to-end test — record reachable only via
+  graph leg returns a fully populated `SearchCandidate` (snippet may be
+  empty; record_json, scope, visibility, kind, class must be set). Without
+  the §5.2.1 hydration step this test fails.
+- **Graph-only survives rerank**: end-to-end test using a real embedder —
+  vault contains record A (matches query lexically), edge A's-entity →
+  B's-entity, record B (no query terms, low cosine to query). With
+  `blend=0.7` (default), record B must appear in the final page. Without
+  the exemption from §6.1 this test fails.
+- **User-filter scoping** (covers §4.3 split): vault has visible record P
+  (provenance, `tag=internal`) and visible record N (neighbor,
+  `tag=public`) joined by an edge. Both records are inside the caller's
+  `auth_scope`. Hybrid search with `filter: tag=public` MUST return N
+  via the graph leg — the user-narrowing filter applies only to the
+  neighbor, not to provenance. Asserts the auth/filter split contract.
+- **Cross-scope provenance rejection**: vault has provenance record P
+  outside the caller's `auth_scope`, neighbor N inside. Even with no
+  user filter, N must NOT be returned via the graph leg — `auth_scope`
+  is enforced on provenance and the edge is dropped.
+- **Semantic-only seed**: a paraphrased query that only the semantic leg
+  matches, with a graph edge to a neighbor record. Graph leg must seed
+  from the semantic hit and return the neighbor (proves §3 step 1's
+  union-of-legs design).
+
+### 10.4 Property tests
+
+- `rrf_fusion_weighted` monotonicity: lower-confidence weight ⇒ smaller score
+  contribution at identical rank.
+
+### 10.5 Bench (#99) and load gates
+
+- **Baseline gate:** p99 < 100ms on 10k-record vault; assert in
+  `cairn-bench` with Criterion.
+- **Broad-query gate:** synthesized query producing >200 keyword hits
+  on a 50k-record vault; p99 < 100ms with both auth-only and filtered
+  retrievals running.
+- **Saturation gate:** synthesized concurrency (32 parallel requests)
+  on a 50k-record vault; p99 < 150ms (slightly relaxed for tail
+  latency under contention) AND adaptive overfetch reduction observed
+  to engage at least once during the run.
+- **Deadline-circuit gate:** synthetic delay injected into the
+  auth-only semantic ANN traversal exceeding `graph_leg_deadline_ms`;
+  result must report `degraded_legs: [Graph { reason: DeadlineExceeded,
+  source: AuthSemanticSeed }]` AND total request latency must remain ≤
+  deadline + 10ms overhead. Without this gate the safety-valve design
+  is unverified.
+- **Tier A acquire-timeout gate:** saturate Tier A by holding all
+  `filtered_pool_size` connections; submit a new hybrid request and
+  verify it fails with `StoreError::Timeout` and reason
+  `tier_a_acquire_timeout` after `filtered_acquire_timeout_ms`,
+  not by blocking indefinitely. Proves the bounded-acquisition
+  guarantee.
+
+## 11. Acceptance criteria mapping
+
+| AC | Mapped section |
+|---|---|
+| `HybridSearchOrchestrator` pure function | §6 |
+| RRF formula unit-tested | §10.1 |
+| 1-hop expansion as single SQL query (no N+1) | §5.1, §10.2 |
+| Semantic leg skipped cleanly | §4.3 (existing behavior preserved) |
+| `SearchArgs --confidence-min <float>` | §7 |
+| p99 < 100ms / 10k-record vault | §10.5 |
+| `--json` snapshot stable | §10.3 |
+
+## 12.1 Contract versioning
+
+The current public structs (`KeywordSearchArgs`, `SemanticSearchArgs`,
+`HybridSearchArgs`, `HybridSearchInputs`, `HybridSearchParams`,
+`HybridSearchPage`, `ScoreExplain`, `MemoryStoreCapabilities`) are NOT
+`#[non_exhaustive]` and are constructed via struct literals across the
+in-tree workspace. Adding required fields to any of them breaks
+struct-construction at compile time. There is no honest way to ship the
+auth-uniformity guarantees of §4.3 (one `auth_scope` on every search
+leg) as a non-breaking change — pretending otherwise would either
+recreate the policy-drift problem or sneak source-breaking changes past
+adapters under a compatibility claim.
+
+So this is a **MAJOR** contract version event (`0.4.0` → `0.5.0`).
+The bump is the explicit incompatibility signal; out-of-tree adapters
+must recompile.
+
+Changes by struct:
+
+| Struct | Change | Field defaults |
+|---|---|---|
+| `KeywordSearchArgs`  | + `auth_scope: ScopeTuple` (required) | none — caller must supply |
+| `SemanticSearchArgs` | + `auth_scope: ScopeTuple` (required) | none — caller must supply |
+| `HybridSearchArgs`   | + `auth_scope: ScopeTuple`, + `confidence_min: f32` | none / 0.5 |
+| `GraphNeighborsArgs` | new struct (§4.3) | n/a |
+| `HybridSearchInputs` | + `graph: Vec<GraphCandidate>` | empty vec |
+| `HybridSearchParams` | + `confidence_floor: f32` | 1e-3 |
+| `HybridSearchPage`   | + `degraded_legs: Vec<DegradedLeg>` | empty vec |
+| `ScoreExplain`       | + `graph_rank: Option<usize>`, `edge_confidence_score: Option<f32>` | None |
+| `MemoryStoreCapabilities` | + `graph_search: bool` | false |
+| `MemoryStore` (trait)| + required method `search_graph_neighbors` (no default impl — adapters must implement) | n/a |
+
+All structs gain `#[non_exhaustive]` in this same PR so future MINOR
+additions don't recreate this break. Because `#[non_exhaustive]` makes
+struct literals illegal in external crates, every affected struct
+ALSO gains a public `bon`-derived builder in the same PR (per CLAUDE.md
+§6.10: "Builders via `bon` for anything with >3 optional fields").
+Specifically:
+
+- `KeywordSearchArgsBuilder`, `SemanticSearchArgsBuilder`,
+  `HybridSearchArgsBuilder`, `GraphNeighborsArgsBuilder` —
+  request-side builders with `auth_scope` and any other required
+  fields enforced at compile time on the builder (the `bon` macro's
+  required-field guarantee).
+- `HybridSearchInputs::new(...)`, `HybridSearchParams::default()`
+  (already exists), `HybridSearchPage::new(...)`, `ScoreExplain::new(...)`,
+  `MemoryStoreCapabilities::new(...)` — module-internal types use
+  plain `new` constructors (no need for builder ergonomics).
+- `DegradedLeg`, `GraphCandidate` — narrow types use plain struct
+  literals internally; external crates that need to construct them
+  use `DegradedLeg::graph_unavailable(reason)` etc. (small set of
+  named constructors).
+
+Out-of-tree adapter migration path: replace struct-literal
+construction with the new builder. The major-version bump documents
+the call-site change. A migration note in the changelog walks one
+example end-to-end.
+
+Plan:
+
+- `cairn-core::contract::memory_store::CONTRACT_VERSION` → `0.4.0` →
+  `0.5.0`.
+- `cairn-store-sqlite::ACCEPTED_RANGE` → `[0.5.0, 0.6.0)`. **Lockstep
+  upgrade — no rolling-upgrade compatibility window.** The contract
+  changes are real: a new required trait method, required new fields
+  on existing public structs, mandatory `auth_scope` for graph
+  authorization. There is no honest way to make an unrebuilt `0.4.x`
+  adapter binary advertise the new method or fields, so the
+  previously-considered compatibility shim is dropped. Operators
+  upgrade in lockstep: store, MCP wrapper, SDK, and any in-tree
+  CLI/skill bundles all move from `0.4.x` to `0.5.0` together.
+- `cairn-mcp` and `cairn-sdk` accepted ranges → `[0.5.0, 0.6.0)`.
+- **Wire shape for `auth_scope`:** the IDL field is
+  `auth_scope: ScopeTuple` — required, no `#[serde(default)]`. A
+  payload missing the field is rejected at deserialization with a
+  typed error mapped to the verb-level error envelope as
+  `SearchError::MissingField { field: "auth_scope" }`. Old payloads
+  do not collapse silently into empty-scope behavior because the
+  ambiguity reviewer flagged in round 9 cannot be resolved on the
+  wire — preserving omission-vs-explicit would require a
+  contract-version-pinned `Option<ScopeTuple>` shape that the
+  spec is no longer pursuing.
+- The migration burden is acknowledged: out-of-tree adapter authors
+  must rebuild against `0.5.0`. The next-minor follow-up removes
+  nothing; this is the clean break.
+- Tests assert: a `0.4.x`-shaped request (no `auth_scope` field)
+  fails deserialization at the transport boundary with
+  `SearchError::MissingField`. Only `0.5.0`-aware callers (explicit
+  `auth_scope` populated) succeed. There is no degraded-graph
+  fallback path for `0.4.x` payloads.
+- All in-tree adapters and tests are updated to populate `auth_scope`
+  and the new capability field. The existing
+  `crates/cairn-store-sqlite/tests/capabilities_unchanged.rs` snapshot
+  is regenerated; the regenerated snapshot is committed in the same
+  PR.
+- The IDL (`cairn-idl`) entries for search-args / search-response /
+  score_explain / capability struct are updated and `cairn-codegen`
+  re-run. `auth_scope` is required at BOTH the Rust-API boundary
+(builders enforce it as a required field at compile time) and the
+wire/IDL boundary (no `#[serde(default)]`; missing field is a
+deserialization error mapped to `SearchError::MissingField`). Purely
+  observability fields (`degraded_legs`, `graph_rank`,
+  `edge_confidence_score`) carry `#[serde(default)]` so future minor
+  additions stay forward-compat.
+- Tests in `cairn-store-sqlite/tests/contract_version.rs` assert:
+  - `ACCEPTED_RANGE.accepts(CONTRACT_VERSION)`,
+  - `ACCEPTED_RANGE` lower bound equals `0.5.0` (lockstep, locked in
+    CI),
+  - A request without `auth_scope` is rejected at deserialization
+    with `SearchError::MissingField { field: "auth_scope" }`,
+  - A request with explicit `auth_scope` runs the full 3-leg path,
+  - Handshake with a `0.4.x` adapter is rejected outright at
+    `MemoryStore::open` (the version-range check fails before any
+    request is served).
+
+This is the only contract-version event in #191. All subsequent
+follow-ups (depth>1, etc.) are designed to be additive within `0.5.x`,
+which the new `#[non_exhaustive]` markers make safe.
+
+## 12. Out of scope (filed as follow-ups)
+
+- Depth > 1 traversal — needs separate ranking model.
+- Cross-target graph queries — current scope rules apply unchanged.
+- Embedding-driven seed expansion (semantic node match) — keyword FTS only
+  for P0 graph leg.


### PR DESCRIPTION
## Summary

Phase 1 of 6 implementing issue #191 (RRF hybrid search with 1-hop graph expansion). Lands the pure-function building blocks in `cairn-core::search`. No I/O, no contract bump, no callers — additive types only. The existing SQLite hybrid orchestrator passes `graph: Vec::new()` and is unchanged in behavior (parity test).

- `GraphCandidate { record_id, edge_confidence_score, graph_rank }` — graph-leg result type with explicit per-candidate rank
- `DegradedLeg { Semantic { reason }, Graph { reason, source } }` + `DegradationReason` + `GraphSource` — typed partial-result signal (`#[non_exhaustive]`, ready for phase 5 wiring)
- `RankedCandidate` + `Leg` + `rrf_fusion_weighted` — confidence-weighted RRF with `effective_rank = rank / max(weight, floor)`. Legacy parity proven by `list_position_matches_legacy_fusion`
- `CandidateOrigin` + `OriginTaggedCandidate` + `cosine_rerank_tagged` — origin-aware rerank that drops the cosine term for graph-only candidates (rather than substituting a neutral 0.5 that would bias them upward), with `cos_norm = (cos_raw + 1) / 2` for lexical to keep both terms in `[0, 1]`
- `hybrid_search` extended with optional graph leg: empty-graph fast path uses legacy `rrf_fusion` + `cosine_rerank` for byte-identical scoring; non-empty path tags each survivor and reranks with origin awareness

Spec: `docs/superpowers/specs/2026-05-05-issue-191-rrf-hybrid-graph-design.md` §6, §6.1.

## Test plan

- [x] `cargo nextest run --workspace` — 2882 / 2882 passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `./scripts/check-core-boundary.sh` — OK
- [x] Phase 1 unit tests: `weighted_extracted_outranks_inferred_at_same_rank`, `list_position_matches_legacy_fusion`, `confidence_floor_prevents_div_by_zero`, `graph_only_ties_lexical_at_cosine_minus_one_equal_rrf`, `graph_only_loses_to_strong_lexical_at_equal_rrf`, `graph_only_cosine_field_is_none`, `graph_leg_empty_matches_legacy_2leg_output`, `graph_only_candidate_surfaces_through_rerank`, `three_leg_high_confidence_outranks_low_confidence_at_same_rank`

🤖 Generated with [Claude Code](https://claude.com/claude-code)