### PR TITLE
feat(core): contract 0.5.0 — auth_scope + graph_search capability (issue #191 phase 2)

### DIFF
--- a/crates/cairn-bench/src/adapter.rs
+++ b/crates/cairn-bench/src/adapter.rs
@@ -87,6 +87,7 @@ impl Adapter for Bm25Adapter<'_> {
         let args = KeywordSearchArgs {
             query: rewritten,
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 10,
             cursor: None,
@@ -127,6 +128,7 @@ impl Adapter for VectorAdapter<'_> {
         let args = SemanticSearchArgs {
             query: q.query.clone(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 10,
             model_label: self.model_label.clone(),
@@ -235,6 +237,7 @@ impl Adapter for GraphHybridAdapter<'_> {
             let args = HybridSearchArgs {
                 query: cleaned,
                 filter: None,
+                auth_scope: cairn_core::domain::ScopeTuple::default(),
                 visibility_allowlist: vec![MemoryVisibility::Private],
                 limit: 10,
                 model_label: self.model_label.clone(),
@@ -242,6 +245,7 @@ impl Adapter for GraphHybridAdapter<'_> {
                 rrf_k: self.rrf_k,
                 rerank_topk: self.rerank_topk,
                 with_explain: false,
+                confidence_floor: 1e-3,
             };
             let page = self
                 .store
@@ -457,6 +461,7 @@ impl Adapter for HybridAdapter<'_> {
         let args = HybridSearchArgs {
             query: cleaned,
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 10,
             model_label: self.model_label.clone(),
@@ -464,6 +469,7 @@ impl Adapter for HybridAdapter<'_> {
             rrf_k: self.rrf_k,
             rerank_topk: self.rerank_topk,
             with_explain: false,
+            confidence_floor: 1e-3,
         };
         let page = self
             .store

--- a/crates/cairn-cli/src/plugins/verify.rs
+++ b/crates/cairn-cli/src/plugins/verify.rs
@@ -308,11 +308,12 @@ mod tests {
                     graph_edges: false,
                     transactions: false,
                     per_record_consent_model: false,
+                    graph_search: false,
                 };
                 &CAPS
             }
             fn supported_contract_versions(&self) -> VersionRange {
-                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
             }
             async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
                 Err("stub: upsert not implemented".into())
@@ -407,11 +408,12 @@ mod tests {
                     graph_edges: false,
                     transactions: false,
                     per_record_consent_model: false,
+                    graph_search: false,
                 };
                 &CAPS
             }
             fn supported_contract_versions(&self) -> VersionRange {
-                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
             }
             async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
                 Err("stub: upsert not implemented".into())
@@ -483,12 +485,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 "#;
 

--- a/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_human.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_human.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/cairn-cli/tests/plugins_list_snapshot.rs
+assertion_line: 9
 expression: text
 ---
 NAME                  CONTRACT              VERSION-RANGE     SOURCE
 cairn-mcp             MCPServer             [0.1.0, 0.2.0)    bundled:cairn-mcp
 cairn-sensors-local   SensorIngress         [0.1.0, 0.2.0)    bundled:cairn-sensors-local
-cairn-store-sqlite    MemoryStore           [0.4.0, 0.5.0)    bundled:cairn-store-sqlite
+cairn-store-sqlite    MemoryStore           [0.5.0, 0.6.0)    bundled:cairn-store-sqlite
 cairn-workflows       WorkflowOrchestrator  [0.1.0, 0.2.0)    bundled:cairn-workflows

--- a/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
@@ -44,8 +44,8 @@ expression: json
       },
       "contract": "MemoryStore",
       "contract_version_range": {
-        "max_exclusive": "0.5.0",
-        "min": "0.4.0"
+        "max_exclusive": "0.6.0",
+        "min": "0.5.0"
       },
       "name": "cairn-store-sqlite",
       "source": "bundled:cairn-store-sqlite"

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -22,7 +22,17 @@ use crate::search::ScoreExplain;
 /// `RecordVersion.schema_version` landed for the §6.4 stale-schema
 /// lint — adding required public fields is a struct-construction
 /// break, so the handshake range shifts to `[0.4.0, 0.5.0)`.
-pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 4, 0);
+/// Bumped 0.4 → 0.5 in #191 when `auth_scope: ScopeTuple` landed as
+/// a required public field on `KeywordSearchArgs`, `SemanticSearchArgs`,
+/// `HybridSearchArgs`, and the new `GraphNeighborsArgs`. Promoting
+/// `auth_scope` out of the user `filter` is the structural break:
+/// authorization now flows through a dedicated field that applies
+/// identically to lexical legs, graph traversal, and graph hydration,
+/// while `filter` keeps its narrowing-only role. The companion
+/// `MemoryStoreCapabilities::graph_search` flag and the
+/// `search_graph_neighbors` trait method (default impl returns
+/// `CapabilityUnavailable`) ship in the same bump.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 5, 0);
 
 /// Errors raised by `MemoryStore` implementations. Adapters define their
 /// own concrete type (e.g. `cairn_store_sqlite::StoreError`); this is the
@@ -36,7 +46,7 @@ pub type StoreError = Box<dyn std::error::Error + Send + Sync + 'static>;
 ///
 /// Cairn queries this before dispatching ANN-, FTS-, or graph-using verbs;
 /// missing capability → `CapabilityUnavailable` (brief §4.1).
-// Four capability flags mirror the four distinct store dimensions; a state
+// Five capability flags mirror the five distinct store dimensions; a state
 // machine would add indirection with no gain here.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -56,6 +66,14 @@ pub struct MemoryStoreCapabilities {
     /// `list_consent_models` is the authoritative read path and any
     /// active record missing from its result is corruption.
     pub per_record_consent_model: bool,
+    /// Whether `search_graph_neighbors` (1-hop entity-graph expansion) is
+    /// supported. Issue #191. `false` means the hybrid orchestrator skips
+    /// the graph leg with a [`crate::search::DegradedLeg::Graph`] entry
+    /// in the response; `true` means the adapter has all of the
+    /// `entity_edges` / `entity_episodes` / `records` columns the §5.1
+    /// SQL needs (probed at startup) and `carray` / `interrupt`
+    /// extensions are loaded.
+    pub graph_search: bool,
 }
 
 /// A `MemoryRecord` at a specific store version.
@@ -287,6 +305,33 @@ pub trait MemoryStore: Send + Sync {
     ) -> Result<HybridSearchPage, StoreError> {
         let _ = args;
         Err(String::from("capability unavailable: vector").into())
+    }
+
+    /// 1-hop entity-graph neighborhood expansion (Issue #191).
+    ///
+    /// Returns records whose entities are 1-hop neighbors of the seed set
+    /// in the bitemporal entity graph, with edge confidence preserved as
+    /// the RRF weight via `GraphCandidate::edge_confidence_score`. The
+    /// orchestrator uses this as the third leg of hybrid search; see spec
+    /// §5.1 for the SQL.
+    ///
+    /// `args.auth_scope` and `args.visibility_allowlist` are applied to
+    /// BOTH the edge provenance record and the neighbor record;
+    /// `args.filter` is applied only to the neighbor (recall narrowing).
+    ///
+    /// Returns `CapabilityUnavailable` when
+    /// `capabilities().graph_search` is `false`. The default impl returns
+    /// `CapabilityUnavailable` so adapters that don't ship the §8 capability
+    /// probe compile without boilerplate.
+    ///
+    /// # Errors
+    /// Default impl returns `"capability unavailable: graph_search"`.
+    async fn search_graph_neighbors(
+        &self,
+        args: &GraphNeighborsArgs<'_>,
+    ) -> Result<Vec<crate::search::GraphCandidate>, StoreError> {
+        let _ = args;
+        Err("capability unavailable: graph_search".into())
     }
 
     // ── Lint support (#96) ────────────────────────────────────────────────────
@@ -669,10 +714,18 @@ pub struct KeywordSearchArgs<'a> {
     /// FTS error variant on `StoreError`.
     pub query: String,
     /// Pre-validated filter tree from
-    /// [`crate::domain::filter::validate_filter`]. Callers fold scope-tuple
-    /// narrowing into this tree (or rely on the `visibility_allowlist`)
-    /// before invoking the store — see [`MemoryStore::search_keyword`].
+    /// [`crate::domain::filter::validate_filter`]. Recall-narrowing only
+    /// (kind/class/tags/timestamps). Authorization predicates (scope,
+    /// visibility) MUST go through `auth_scope` and `visibility_allowlist`
+    /// — see Issue #191 for the rationale.
     pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — the security predicate. The store
+    /// applies it identically across this leg, the semantic leg, the
+    /// graph leg, and graph hydration so policy cannot drift between
+    /// retrieval paths. Use [`ScopeTuple::default()`] when no narrowing
+    /// is required; a populated tuple narrows on each non-`None`
+    /// dimension. Issue #191.
+    pub auth_scope: ScopeTuple,
     /// Visibility values the caller is allowed to see; empty = no filter.
     pub visibility_allowlist: Vec<MemoryVisibility>,
     /// Maximum number of candidates to return in this page.
@@ -719,6 +772,8 @@ pub struct SemanticSearchArgs<'a> {
     pub query: String,
     /// Pre-validated filter tree. Same semantics as in [`KeywordSearchArgs`].
     pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — see [`KeywordSearchArgs::auth_scope`].
+    pub auth_scope: ScopeTuple,
     /// Visibility values the caller is allowed to see; empty = no filter.
     pub visibility_allowlist: Vec<MemoryVisibility>,
     /// Number of nearest neighbours to return (top-K).
@@ -758,6 +813,8 @@ pub struct HybridSearchArgs<'a> {
     /// [`crate::domain::filter::validate_filter`]. Same semantics as in
     /// [`KeywordSearchArgs`].
     pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — see [`KeywordSearchArgs::auth_scope`].
+    pub auth_scope: ScopeTuple,
     /// Visibility values the caller is allowed to see; empty = no filter.
     pub visibility_allowlist: Vec<MemoryVisibility>,
     /// Number of results.
@@ -773,6 +830,45 @@ pub struct HybridSearchArgs<'a> {
     /// When true, the store populates the page's `explain` block. See
     /// [`KeywordSearchArgs::with_explain`].
     pub with_explain: bool,
+    /// Floor on per-graph-candidate confidence weight in the RRF leg.
+    /// Default `1e-3`. Issue #191.
+    pub confidence_floor: f32,
+}
+
+/// Args for [`MemoryStore::search_graph_neighbors`] (Issue #191, spec §4.3).
+///
+/// Authorization predicates (`auth_scope`, `visibility_allowlist`) apply to
+/// both the edge provenance record and the neighbor record; `filter` is
+/// recall-narrowing only and applies to the neighbor record. See spec
+/// §4.3 "Predicate application" for the full table.
+#[derive(Debug, Clone)]
+pub struct GraphNeighborsArgs<'a> {
+    /// Record ids from auth-only seed retrieval (UNION-ed across keyword
+    /// and semantic legs), up to `2 * GRAPH_SEED_OVERFETCH = 400`.
+    /// Seeds the graph traversal; an empty list yields an empty result.
+    pub seed_record_ids: Vec<RecordId>,
+    /// Record ids actually fused into RRF (top of each filtered lexical
+    /// leg, UNION-ed, ≤ 100). Used as the dedup set in step 4 of §5.1 —
+    /// graph results exclude these so RRF cannot double-count, but seeds
+    /// not in this list (overfetched rank 51-200 records) remain
+    /// eligible for rank-rescue via graph evidence.
+    pub ranked_record_ids: Vec<RecordId>,
+    /// Pre-validated user-narrowing filter. Applied **only** to the
+    /// returned neighbor record. User narrowing must not erase
+    /// otherwise-authorized edges based on where the edge was observed.
+    pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — applied to BOTH provenance and
+    /// neighbor. See [`KeywordSearchArgs::auth_scope`].
+    pub auth_scope: ScopeTuple,
+    /// Visibility values the caller is allowed to see. Applied to BOTH
+    /// the neighbor record and the edge provenance record.
+    pub visibility_allowlist: Vec<MemoryVisibility>,
+    /// Max candidates returned. Equals `HYBRID_LEG_LIMIT` from the
+    /// orchestrator.
+    pub limit: usize,
+    /// `confidence_score` floor applied SQL-side to the edge step.
+    /// Edges below this threshold are excluded entirely.
+    pub confidence_min: f32,
 }
 
 /// One page of hybrid candidates.
@@ -840,6 +936,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: false,
+                graph_search: false,
             };
             &CAPS
         }
@@ -884,7 +981,7 @@ mod tests {
     impl MemoryStorePlugin for StubStore {
         const NAME: &'static str = "stub";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 4, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 5, 0), ContractVersion::new(0, 6, 0));
     }
 
     #[tokio::test]
@@ -906,6 +1003,7 @@ mod tests {
             .search_semantic(&SemanticSearchArgs {
                 query: "test".into(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: vec![],
                 limit: 10,
                 model_label: "bge-small-en-v1.5".into(),
@@ -920,6 +1018,7 @@ mod tests {
             .search_hybrid(&HybridSearchArgs {
                 query: "test".into(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: vec![],
                 limit: 10,
                 model_label: "bge-small-en-v1.5".into(),
@@ -927,6 +1026,7 @@ mod tests {
                 rrf_k: 60,
                 rerank_topk: 20,
                 with_explain: false,
+                confidence_floor: 1e-3,
             })
             .await;
         assert!(
@@ -1013,15 +1113,11 @@ mod tests {
         assert!(err.to_string().contains("bitemporal_graph"));
     }
 
-    /// `CONTRACT_VERSION` for the `MemoryStore` trait is locked to 0.4.0.
-    /// 0.3 hosted the additive-co-evolution chain (#253 consent-model
-    /// gate, #186 bitemporal-KG methods, #49 search explain plumbing,
-    /// all default-initializable). #258 bumped to 0.4 because adding
-    /// the required `schema_version: Option<SchemaVersion>` fields to
-    /// public `StoredRecord` / `RecordVersion` is a struct-construction
-    /// break — handshake range shifted to `[0.4.0, 0.5.0)`.
+    /// `CONTRACT_VERSION` for the `MemoryStore` trait is locked to 0.5.0.
+    /// #258 bumped 0.3→0.4 (per-row `schema_version`). #191 bumped 0.4→0.5
+    /// (`auth_scope`, `graph_search` capability + trait method).
     #[test]
-    fn contract_version_locked_to_0_4_0() {
-        assert_eq!(CONTRACT_VERSION, ContractVersion::new(0, 4, 0));
+    fn contract_version_locked_to_0_5_0() {
+        assert_eq!(CONTRACT_VERSION, ContractVersion::new(0, 5, 0));
     }
 }

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -610,6 +610,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: false,
+                graph_search: false,
             };
             &CAPS
         }
@@ -654,15 +655,15 @@ mod tests {
     impl MemoryStorePlugin for StubStore {
         const NAME: &'static str = "stub-store";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     fn compatible() -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
     }
 
     fn incompatible() -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 5, 0), ContractVersion::new(0, 6, 0))
+        VersionRange::new(ContractVersion::new(0, 6, 0), ContractVersion::new(0, 7, 0))
     }
 
     #[test]
@@ -759,12 +760,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 "#
     }

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -13,6 +13,7 @@ use crate::config::{CairnConfig, CapabilitySet};
 use crate::contract::memory_store::{
     HybridSearchArgs, KeywordSearchArgs, MemoryStore, SearchCandidate, SemanticSearchArgs,
 };
+use crate::domain::ScopeTuple;
 use crate::domain::taxonomy::MemoryVisibility;
 use crate::search::{ScoreExplain, token_budget_trim};
 
@@ -153,6 +154,7 @@ pub async fn run(
             let args = KeywordSearchArgs {
                 query: request.query.clone(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: visibility,
                 limit: request.limit,
                 cursor: None,
@@ -165,6 +167,7 @@ pub async fn run(
             let args = SemanticSearchArgs {
                 query: request.query.clone(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: visibility,
                 limit: request.limit,
                 model_label: request.model_label.clone(),
@@ -177,6 +180,7 @@ pub async fn run(
             let args = HybridSearchArgs {
                 query: request.query.clone(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: visibility,
                 limit: request.limit,
                 model_label: request.model_label.clone(),
@@ -184,6 +188,7 @@ pub async fn run(
                 rrf_k: config.search.rrf_k,
                 rerank_topk: config.search.rerank_topk,
                 with_explain: request.explain,
+                confidence_floor: 1e-3,
             };
             let page = store.search_hybrid(&args).await?;
             (page.candidates, page.explain)
@@ -342,6 +347,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: true,
+                graph_search: false,
             },
             last_hybrid: Mutex::new(None),
         };
@@ -392,6 +398,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: true,
+                graph_search: false,
             },
             last_hybrid: Mutex::new(None),
         };
@@ -434,6 +441,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: true,
+                graph_search: false,
             },
             last_hybrid: Mutex::new(None),
         };
@@ -466,6 +474,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: true,
+                graph_search: false,
             },
             last_hybrid: Mutex::new(None),
         };
@@ -531,6 +540,7 @@ mod tests {
                     graph_edges: false,
                     transactions: true,
                     per_record_consent_model: true,
+                    graph_search: false,
                 };
                 &CAPS
             }

--- a/crates/cairn-core/tests/conformance_tier1.rs
+++ b/crates/cairn-core/tests/conformance_tier1.rs
@@ -27,12 +27,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 
 [features]
@@ -58,11 +58,13 @@ impl MemoryStore for StubStore {
             graph_edges: false,
             transactions: false,
             per_record_consent_model: false,
+
+            graph_search: false,
         };
         &CAPS
     }
     fn supported_contract_versions(&self) -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
     }
     async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
         Err("stub: upsert not implemented".into())

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -50,11 +50,13 @@ mod compatible_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
         }
         async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
             Err("stub: upsert not implemented".into())
@@ -94,7 +96,7 @@ mod compatible_plugin {
     impl MemoryStorePlugin for FakeStore {
         const NAME: &'static str = "fake-compat";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     register_plugin!(MemoryStore, FakeStore, "fake-compat");
@@ -118,6 +120,8 @@ mod future_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -223,12 +227,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 "#;
 
@@ -247,11 +251,13 @@ patch = 0
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
         }
         async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
             Err("stub: upsert not implemented".into())
@@ -291,7 +297,7 @@ patch = 0
     impl MemoryStorePlugin for FakeStore {
         const NAME: &'static str = "fake-with-manifest";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     register_plugin!(MemoryStore, FakeStore, "fake-with-manifest", MANIFEST_TOML);
@@ -328,6 +334,8 @@ mod incompatible_factory_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -404,6 +412,8 @@ mod config_driven_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -448,7 +458,7 @@ mod config_driven_plugin {
     impl MemoryStorePlugin for PathStore {
         const NAME: &'static str = "path-store";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     register_plugin_with!(
@@ -477,6 +487,8 @@ mod name_mismatch_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -521,7 +533,7 @@ mod name_mismatch_plugin {
     impl MemoryStorePlugin for BadNameStore {
         const NAME: &'static str = "actual-name";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     // NAME const = "actual-name" but macro literal = "wrong-name"
@@ -817,6 +829,8 @@ mod factory_error_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -861,7 +875,7 @@ mod factory_error_plugin {
     impl MemoryStorePlugin for FailingStore {
         const NAME: &'static str = "failing-store";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     register_plugin_with!(

--- a/crates/cairn-mcp/tests/search_tool.rs
+++ b/crates/cairn-mcp/tests/search_tool.rs
@@ -40,6 +40,8 @@ impl MemoryStore for EmptyStore {
             graph_edges: false,
             transactions: true,
             per_record_consent_model: true,
+
+            graph_search: false,
         };
         &CAPS
     }

--- a/crates/cairn-sdk/tests/search_dispatch.rs
+++ b/crates/cairn-sdk/tests/search_dispatch.rs
@@ -42,6 +42,8 @@ impl MemoryStore for EmptyStore {
             graph_edges: false,
             transactions: true,
             per_record_consent_model: true,
+
+            graph_search: false,
         };
         &CAPS
     }

--- a/crates/cairn-store-sqlite/examples/gbrain_compare.rs
+++ b/crates/cairn-store-sqlite/examples/gbrain_compare.rs
@@ -366,6 +366,7 @@ async fn run_queries(
             let args = KeywordSearchArgs {
                 query: rewritten,
                 filter: None,
+                auth_scope: cairn_core::domain::ScopeTuple::default(),
                 visibility_allowlist: vec![MemoryVisibility::Private],
                 limit: 10,
                 cursor: None,
@@ -399,6 +400,7 @@ async fn run_semantic(
         let args = SemanticSearchArgs {
             query: q.query.clone(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 10,
             model_label: model_label.to_owned(),

--- a/crates/cairn-store-sqlite/plugin.toml
+++ b/crates/cairn-store-sqlite/plugin.toml
@@ -3,12 +3,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 
 [features]

--- a/crates/cairn-store-sqlite/src/lib.rs
+++ b/crates/cairn-store-sqlite/src/lib.rs
@@ -52,9 +52,11 @@ pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
 /// raised to 0.3.0 in #253 (`per_record_consent_model`), and to 0.4.0
 /// in #258 (per-row `schema_version` stamp on `StoredRecord` and
 /// `RecordVersion` — adding required public fields is a struct-
-/// construction break).
+/// construction break). Raised to 0.5.0 in #191 (`auth_scope` on
+/// `*SearchArgs`, `MemoryStoreCapabilities::graph_search`,
+/// `search_graph_neighbors` trait method).
 pub const ACCEPTED_RANGE: VersionRange =
-    VersionRange::new(ContractVersion::new(0, 4, 0), ContractVersion::new(0, 5, 0));
+    VersionRange::new(ContractVersion::new(0, 5, 0), ContractVersion::new(0, 6, 0));
 
 // Compile-time guard: this crate's accepted range must include the host
 // CONTRACT_VERSION. If we ever bump CONTRACT_VERSION without bumping the

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -36,6 +36,8 @@ fn base_caps(vector: bool) -> MemoryStoreCapabilities {
         graph_edges: true,
         transactions: true,
         per_record_consent_model: true,
+
+        graph_search: false,
     }
 }
 

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -81,6 +81,7 @@ impl SqliteMemoryStore {
         let kw_args = KeywordSearchArgs {
             query: args.query.clone(),
             filter: args.filter,
+            auth_scope: args.auth_scope.clone(),
             visibility_allowlist: args.visibility_allowlist.clone(),
             limit: HYBRID_LEG_LIMIT,
             cursor: None,
@@ -89,6 +90,7 @@ impl SqliteMemoryStore {
         let sem_args = SemanticSearchArgs {
             query: args.query.clone(),
             filter: args.filter,
+            auth_scope: args.auth_scope.clone(),
             visibility_allowlist: args.visibility_allowlist.clone(),
             limit: HYBRID_LEG_LIMIT,
             model_label: args.model_label.clone(),

--- a/crates/cairn-store-sqlite/src/store/mod.rs
+++ b/crates/cairn-store-sqlite/src/store/mod.rs
@@ -69,6 +69,8 @@ impl Default for SqliteMemoryStore {
                 graph_edges: true,
                 transactions: true,
                 per_record_consent_model: true,
+
+                graph_search: false,
             },
             _cancel: None,
             fts_column_weights: [10.0, 10.0, 5.0, 1.0],

--- a/crates/cairn-store-sqlite/src/store/search.rs
+++ b/crates/cairn-store-sqlite/src/store/search.rs
@@ -1039,6 +1039,7 @@ mod tests {
         let args = KeywordSearchArgs {
             query: "feedback".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 5,
             cursor: None,

--- a/crates/cairn-store-sqlite/tests/hybrid_search.rs
+++ b/crates/cairn-store-sqlite/tests/hybrid_search.rs
@@ -45,6 +45,7 @@ async fn hybrid_returns_results() {
         .search_semantic(&SemanticSearchArgs {
             query: "alice".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 5,
             model_label: kind.as_str().to_owned(),
@@ -60,6 +61,7 @@ async fn hybrid_returns_results() {
     let args = HybridSearchArgs {
         query: "alice".into(),
         filter: None,
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private],
         limit: 5,
         model_label: kind.as_str().to_owned(),
@@ -67,6 +69,7 @@ async fn hybrid_returns_results() {
         rrf_k: 60,
         rerank_topk: 20,
         with_explain: false,
+        confidence_floor: 1e-3,
     };
     let page = store.search_hybrid(&args).await.expect("hybrid search");
     assert!(!page.candidates.is_empty(), "hybrid returned 0 results");
@@ -94,6 +97,7 @@ async fn hybrid_capability_unavailable_without_embedder() {
     let args = HybridSearchArgs {
         query: "anything".into(),
         filter: None,
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private],
         limit: 5,
         model_label: EmbeddingModelKind::default().as_str().to_owned(),
@@ -101,6 +105,7 @@ async fn hybrid_capability_unavailable_without_embedder() {
         rrf_k: 60,
         rerank_topk: 20,
         with_explain: false,
+        confidence_floor: 1e-3,
     };
     let result = store.search_hybrid(&args).await;
     assert!(result.is_err(), "expected CapabilityUnavailable");

--- a/crates/cairn-store-sqlite/tests/search_keyword.rs
+++ b/crates/cairn-store-sqlite/tests/search_keyword.rs
@@ -56,6 +56,7 @@ fn args(query: &str, limit: usize) -> KeywordSearchArgs<'static> {
     KeywordSearchArgs {
         query: query.to_owned(),
         filter: None,
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private],
         limit,
         cursor: None,

--- a/crates/cairn-store-sqlite/tests/search_keyword_e2e.rs
+++ b/crates/cairn-store-sqlite/tests/search_keyword_e2e.rs
@@ -34,6 +34,7 @@ fn args(query: &str, limit: usize) -> KeywordSearchArgs<'static> {
     KeywordSearchArgs {
         query: query.to_owned(),
         filter: None,
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private],
         limit,
         cursor: None,

--- a/crates/cairn-store-sqlite/tests/search_keyword_golden.rs
+++ b/crates/cairn-store-sqlite/tests/search_keyword_golden.rs
@@ -140,6 +140,7 @@ async fn golden_search_args_keyword_filters_to_user_private() {
     let key_args = KeywordSearchArgs {
         query: args.query.clone(),
         filter: Some(validated),
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private, MemoryVisibility::Public],
         limit,
         cursor: None,
@@ -168,6 +169,7 @@ async fn golden_leaf_eq_filter_narrows_to_user_kind() {
     let key_args = KeywordSearchArgs {
         query: "dark".to_owned(),
         filter: Some(validated),
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private, MemoryVisibility::Public],
         limit: 10,
         cursor: None,
@@ -198,6 +200,7 @@ async fn golden_or_with_not_admits_public_or_non_private() {
     let key_args = KeywordSearchArgs {
         query: "dark OR vim".to_owned(),
         filter: Some(validated),
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private, MemoryVisibility::Public],
         limit: 10,
         cursor: None,

--- a/crates/cairn-store-sqlite/tests/search_semantic.rs
+++ b/crates/cairn-store-sqlite/tests/search_semantic.rs
@@ -31,6 +31,7 @@ async fn search_semantic_capability_unavailable_without_embedder() {
         .search_semantic(&SemanticSearchArgs {
             query: "hello".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![],
             limit: 5,
             model_label: "bge-small-en-v1.5".into(),
@@ -64,6 +65,7 @@ async fn search_semantic_returns_results_after_upsert() {
         .search_semantic(&SemanticSearchArgs {
             query: "hello".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![],
             limit: 10,
             model_label: EmbeddingModelKind::BgeSmallEnV1_5.as_str().into(),
@@ -101,6 +103,7 @@ async fn search_semantic_with_vector_returns_results() {
         .search_semantic(&SemanticSearchArgs {
             query: "hello world".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![],
             limit: 10,
             model_label: "bge-small-en-v1.5".into(),

--- a/crates/cairn-store-sqlite/tests/search_semantic_capability.rs
+++ b/crates/cairn-store-sqlite/tests/search_semantic_capability.rs
@@ -13,6 +13,7 @@ async fn no_embedder_returns_capability_unavailable() {
         .search_semantic(&SemanticSearchArgs {
             query: "test".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![],
             limit: 5,
             model_label: "bge-small-en-v1.5".into(),

--- a/crates/cairn-test-fixtures/src/store.rs
+++ b/crates/cairn-test-fixtures/src/store.rs
@@ -99,6 +99,8 @@ impl MemoryStore for FixtureStore {
             graph_edges: false,
             transactions: false,
             per_record_consent_model: true,
+
+            graph_search: false,
         };
         static CAPS_LEGACY_ONLY: MemoryStoreCapabilities = MemoryStoreCapabilities {
             fts: false,
@@ -106,6 +108,8 @@ impl MemoryStore for FixtureStore {
             graph_edges: false,
             transactions: false,
             per_record_consent_model: false,
+
+            graph_search: false,
         };
         if self.legacy_only_override.load(Ordering::SeqCst) {
             &CAPS_LEGACY_ONLY


### PR DESCRIPTION
## Summary

Phase 2 of 6 implementing issue #191. Bumps the `MemoryStore` contract from 0.4.0 to 0.5.0:

- Promotes `auth_scope: ScopeTuple` out of the user filter into a dedicated required field on `KeywordSearchArgs`, `SemanticSearchArgs`, `HybridSearchArgs`, and the new `GraphNeighborsArgs`. Authorization predicates apply identically across lexical legs, graph traversal, and graph hydration; the user filter is recall-narrowing only.
- Adds `MemoryStoreCapabilities::graph_search: bool` (default `false`).
- Adds `MemoryStore::search_graph_neighbors(args: &GraphNeighborsArgs<'_>) -> Result<Vec<GraphCandidate>, _>` with a default impl returning `CapabilityUnavailable`. SQLite implementation lands in phase 4; the orchestrator wiring lands in phase 5.
- `HybridSearchArgs` gains `confidence_floor: f32` (default `1e-3`) for the graph leg's RRF weight floor.
- `cairn-store-sqlite::ACCEPTED_RANGE` raised to `[0.5.0, 0.6.0)`. Plugin manifest TOML and fixture manifests updated.

Behavior of existing retrieval paths is unchanged. The new field threads through every callsite as `ScopeTuple::default()` until the SQL planner reads it in phase 4.

Spec: `docs/superpowers/specs/2026-05-05-issue-191-rrf-hybrid-graph-design.md` §4.3, §12.1.

**Builds on:** #296 (phase 1).

## Notes

- `bon::Builder` derive on args structs and `#[non_exhaustive]` on the search-args public structs were proposed in the plan but deferred to keep this PR mechanical. The breaking 0.5.0 bump is justified by the new required `auth_scope` field; future breakage from `#[non_exhaustive]` can land separately.

## Test plan

- [x] `cargo nextest run --workspace` — 2881 / 2882 passing (1 timing-sensitive flake in `cairn-workflows::consent_mirror::tick_runs_concurrently_with_no_pending_migration`, unrelated to phase 2)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo nextest run -p cairn-core contract::registry` — passes (`rejects_incompatible_contract_version` updated to use `(0,6,0)..(0,7,0)`)
- [x] Snapshot tests `plugins_list_snapshot__plugins_list_human/json` regenerated to show `[0.5.0, 0.6.0)` for `cairn-store-sqlite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
