### PR TITLE
feat(search): RRF hybrid + 1-hop graph expansion (issue #191)

### DIFF
--- a/crates/cairn-bench/src/adapter.rs
+++ b/crates/cairn-bench/src/adapter.rs
@@ -87,6 +87,7 @@ impl Adapter for Bm25Adapter<'_> {
         let args = KeywordSearchArgs {
             query: rewritten,
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 10,
             cursor: None,
@@ -127,6 +128,7 @@ impl Adapter for VectorAdapter<'_> {
         let args = SemanticSearchArgs {
             query: q.query.clone(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 10,
             model_label: self.model_label.clone(),
@@ -235,6 +237,7 @@ impl Adapter for GraphHybridAdapter<'_> {
             let args = HybridSearchArgs {
                 query: cleaned,
                 filter: None,
+                auth_scope: cairn_core::domain::ScopeTuple::default(),
                 visibility_allowlist: vec![MemoryVisibility::Private],
                 limit: 10,
                 model_label: self.model_label.clone(),
@@ -242,6 +245,7 @@ impl Adapter for GraphHybridAdapter<'_> {
                 rrf_k: self.rrf_k,
                 rerank_topk: self.rerank_topk,
                 with_explain: false,
+                confidence_floor: 1e-3,
             };
             let page = self
                 .store
@@ -457,6 +461,7 @@ impl Adapter for HybridAdapter<'_> {
         let args = HybridSearchArgs {
             query: cleaned,
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 10,
             model_label: self.model_label.clone(),
@@ -464,6 +469,7 @@ impl Adapter for HybridAdapter<'_> {
             rrf_k: self.rrf_k,
             rerank_topk: self.rerank_topk,
             with_explain: false,
+            confidence_floor: 1e-3,
         };
         let page = self
             .store

--- a/crates/cairn-bench/src/adapter.rs
+++ b/crates/cairn-bench/src/adapter.rs
@@ -471,7 +471,7 @@ impl Adapter for HybridAdapter<'_> {
             rerank_topk: self.rerank_topk,
             with_explain: false,
             confidence_floor: 1e-3,
-                graph_confidence_min: 0.3,
+            graph_confidence_min: 0.3,
         };
         let page = self
             .store

--- a/crates/cairn-bench/src/adapter.rs
+++ b/crates/cairn-bench/src/adapter.rs
@@ -246,6 +246,7 @@ impl Adapter for GraphHybridAdapter<'_> {
                 rerank_topk: self.rerank_topk,
                 with_explain: false,
                 confidence_floor: 1e-3,
+                graph_confidence_min: 0.3,
             };
             let page = self
                 .store
@@ -470,6 +471,7 @@ impl Adapter for HybridAdapter<'_> {
             rerank_topk: self.rerank_topk,
             with_explain: false,
             confidence_floor: 1e-3,
+                graph_confidence_min: 0.3,
         };
         let page = self
             .store

--- a/crates/cairn-cli/src/command.rs
+++ b/crates/cairn-cli/src/command.rs
@@ -23,7 +23,9 @@ pub fn build_command() -> clap::Command {
         .subcommand(verbs::with_json(verbs::with_resync(
             verbs::with_flush_modes(generated::verbs::ingest_subcommand()),
         )))
-        .subcommand(verbs::with_json(generated::verbs::search_subcommand()))
+        .subcommand(verbs::with_json(verbs::with_search_scope(
+            generated::verbs::search_subcommand(),
+        )))
         .subcommand(verbs::with_json(generated::verbs::retrieve_subcommand()))
         .subcommand(verbs::with_json(generated::verbs::summarize_subcommand()))
         .subcommand(verbs::with_json(generated::verbs::assemble_hot_subcommand()))

--- a/crates/cairn-cli/src/plugins/verify.rs
+++ b/crates/cairn-cli/src/plugins/verify.rs
@@ -308,11 +308,12 @@ mod tests {
                     graph_edges: false,
                     transactions: false,
                     per_record_consent_model: false,
+                    graph_search: false,
                 };
                 &CAPS
             }
             fn supported_contract_versions(&self) -> VersionRange {
-                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
             }
             async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
                 Err("stub: upsert not implemented".into())
@@ -407,11 +408,12 @@ mod tests {
                     graph_edges: false,
                     transactions: false,
                     per_record_consent_model: false,
+                    graph_search: false,
                 };
                 &CAPS
             }
             fn supported_contract_versions(&self) -> VersionRange {
-                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
             }
             async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
                 Err("stub: upsert not implemented".into())
@@ -483,12 +485,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 "#;
 

--- a/crates/cairn-cli/src/verbs/mod.rs
+++ b/crates/cairn-cli/src/verbs/mod.rs
@@ -81,6 +81,43 @@ pub fn with_resync(cmd: clap::Command) -> clap::Command {
     )
 }
 
+/// Add `--scope-tenant`, `--scope-workspace`, `--scope-user`, `--scope-agent`
+/// flags to the `search` subcommand. Each populates the matching
+/// [`cairn_core::domain::ScopeTuple`] dimension on `SearchRequest.auth_scope`,
+/// which the verb dispatcher threads into every leg's SQL predicate.
+/// Issue #191.
+#[must_use]
+pub fn with_search_scope(cmd: clap::Command) -> clap::Command {
+    cmd.arg(
+        clap::Arg::new("scope-tenant")
+            .long("scope-tenant")
+            .value_name("TENANT")
+            .help("Narrow auth_scope.tenant on every search leg (issue #191)")
+            .action(clap::ArgAction::Set),
+    )
+    .arg(
+        clap::Arg::new("scope-workspace")
+            .long("scope-workspace")
+            .value_name("WORKSPACE")
+            .help("Narrow auth_scope.workspace on every search leg")
+            .action(clap::ArgAction::Set),
+    )
+    .arg(
+        clap::Arg::new("scope-user")
+            .long("scope-user")
+            .value_name("HMN_USER_ID")
+            .help("Narrow auth_scope.user (must be canonical `hmn:…` form)")
+            .action(clap::ArgAction::Set),
+    )
+    .arg(
+        clap::Arg::new("scope-agent")
+            .long("scope-agent")
+            .value_name("AGENT_ID")
+            .help("Narrow auth_scope.agent on every search leg")
+            .action(clap::ArgAction::Set),
+    )
+}
+
 /// Add `--dry-run`, `--human-review`, `--no-diff` to a generated subcommand.
 /// `--dry-run` and `--human-review` are mutually exclusive. Together they map
 /// onto the [`FlushMode`](cairn_core::domain::flush_plan::FlushMode) enum.

--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -324,7 +324,13 @@ async fn run_async(
         },
         limit,
         visibility_allowlist: vec![],
-        auth_scope: cairn_core::domain::ScopeTuple::default(),
+        auth_scope: cairn_core::domain::ScopeTuple {
+            tenant: sub.get_one::<String>("scope-tenant").cloned(),
+            workspace: sub.get_one::<String>("scope-workspace").cloned(),
+            user: sub.get_one::<String>("scope-user").cloned(),
+            agent: sub.get_one::<String>("scope-agent").cloned(),
+            ..Default::default()
+        },
         model_label: kind.as_str().to_owned(),
         explain,
     };

--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -324,6 +324,7 @@ async fn run_async(
         },
         limit,
         visibility_allowlist: vec![],
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         model_label: kind.as_str().to_owned(),
         explain,
     };

--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -493,11 +493,24 @@ fn outcome_envelope(
             .collect()
     });
 
+    let degraded_legs = if outcome.degraded_legs.is_empty() {
+        None
+    } else {
+        Some(
+            outcome
+                .degraded_legs
+                .iter()
+                .map(degraded_leg_to_idl)
+                .collect(),
+        )
+    };
+
     let data = SearchData {
         hits,
         next_cursor: None,
         excluded: None,
         score_explain,
+        degraded_legs,
     };
 
     Response {
@@ -509,6 +522,46 @@ fn outcome_envelope(
         status: ResponseStatus::Committed,
         target: None,
         verb: ResponseVerb::Search,
+    }
+}
+
+/// Convert a domain [`cairn_core::search::DegradedLeg`] into the IDL
+/// wire form. Mirrors the SDK + MCP helpers — keep in sync with
+/// `crates/cairn-idl/schema/verbs/search.json` (`DegradedLegEntry`).
+fn degraded_leg_to_idl(
+    leg: &cairn_core::search::DegradedLeg,
+) -> cairn_core::generated::verbs::search::DegradedLegEntry {
+    use cairn_core::generated::verbs::search::{
+        DegradedLegEntry, DegradedLegEntryLeg, DegradedLegEntryReason, DegradedLegEntrySource,
+    };
+    use cairn_core::search::{DegradationReason, DegradedLeg, GraphSource};
+
+    let reason_to_idl = |r: DegradationReason| match r {
+        DegradationReason::CapabilityUnavailable => DegradedLegEntryReason::CapabilityUnavailable,
+        DegradationReason::DeadlineExceeded => DegradedLegEntryReason::Timeout,
+        _ => DegradedLegEntryReason::SqlError,
+    };
+    let source_to_idl = |s: GraphSource| match s {
+        GraphSource::AuthKeywordSeed => DegradedLegEntrySource::AuthKeywordSeed,
+        GraphSource::AuthSemanticSeed => DegradedLegEntrySource::AuthSemanticSeed,
+        _ => DegradedLegEntrySource::All,
+    };
+    match leg {
+        DegradedLeg::Semantic { reason } => DegradedLegEntry {
+            leg: DegradedLegEntryLeg::Semantic,
+            reason: reason_to_idl(*reason),
+            source: None,
+        },
+        DegradedLeg::Graph { reason, source } => DegradedLegEntry {
+            leg: DegradedLegEntryLeg::Graph,
+            reason: reason_to_idl(*reason),
+            source: Some(source_to_idl(*source)),
+        },
+        _ => DegradedLegEntry {
+            leg: DegradedLegEntryLeg::Graph,
+            reason: DegradedLegEntryReason::SqlError,
+            source: Some(DegradedLegEntrySource::All),
+        },
     }
 }
 

--- a/crates/cairn-cli/src/verbs/status.rs
+++ b/crates/cairn-cli/src/verbs/status.rs
@@ -952,6 +952,7 @@ mod mcp_graph_tests {
             graph_edges: g,
             transactions: true,
             per_record_consent_model: true,
+            graph_search: g,
         }
     }
 

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -480,6 +480,7 @@ fn search_default_response_omits_excluded_field() {
         hits: Vec::new(),
         next_cursor: None,
         score_explain: None,
+        degraded_legs: None,
     };
     let json = serde_json::to_string(&data).expect("serializable");
     assert!(
@@ -505,6 +506,7 @@ fn search_with_excluded_emits_field() {
         hits: Vec::new(),
         next_cursor: None,
         score_explain: None,
+        degraded_legs: None,
     };
     let json = serde_json::to_string(&data).expect("serializable");
     assert!(

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -514,3 +514,70 @@ fn search_with_excluded_emits_field() {
         "excluded must appear when set; got {json}"
     );
 }
+
+#[test]
+fn search_without_degraded_legs_omits_field() {
+    use cairn_core::generated::verbs::search::SearchData;
+
+    // `degraded_legs: None` (a healthy hybrid result) must not emit
+    // the field. Keeps the wire shape stable for callers that only
+    // read it under partial-failure conditions.
+    let data = SearchData {
+        excluded: None,
+        hits: Vec::new(),
+        next_cursor: None,
+        score_explain: None,
+        degraded_legs: None,
+    };
+    let json = serde_json::to_string(&data).expect("serializable");
+    assert!(
+        !json.contains("\"degraded_legs\""),
+        "healthy SearchData must not emit degraded_legs; got {json}"
+    );
+}
+
+#[test]
+fn search_with_degraded_legs_emits_full_entry() {
+    use cairn_core::generated::verbs::search::{
+        DegradedLegEntry, DegradedLegEntryLeg, DegradedLegEntryReason, DegradedLegEntrySource,
+        SearchData,
+    };
+
+    // A hybrid response with a per-source graph-leg failure must
+    // serialize the full `{leg, reason, source}` shape so callers can
+    // attribute the partial-recall to the right seed source.
+    let data = SearchData {
+        excluded: None,
+        hits: Vec::new(),
+        next_cursor: None,
+        score_explain: None,
+        degraded_legs: Some(vec![
+            DegradedLegEntry {
+                leg: DegradedLegEntryLeg::Semantic,
+                reason: DegradedLegEntryReason::SqlError,
+                source: None,
+            },
+            DegradedLegEntry {
+                leg: DegradedLegEntryLeg::Graph,
+                reason: DegradedLegEntryReason::CapabilityUnavailable,
+                source: Some(DegradedLegEntrySource::AuthSemanticSeed),
+            },
+        ]),
+    };
+    let json = serde_json::to_string(&data).expect("serializable");
+    let v: serde_json::Value = serde_json::from_str(&json).expect("roundtrip");
+    let arr = v["degraded_legs"]
+        .as_array()
+        .expect("degraded_legs is an array");
+    assert_eq!(arr.len(), 2);
+    assert_eq!(arr[0]["leg"], "semantic");
+    assert_eq!(arr[0]["reason"], "sql_error");
+    assert!(
+        arr[0].get("source").is_none() || arr[0]["source"].is_null(),
+        "semantic leg must omit `source`; got {}",
+        arr[0],
+    );
+    assert_eq!(arr[1]["leg"], "graph");
+    assert_eq!(arr[1]["reason"], "capability_unavailable");
+    assert_eq!(arr[1]["source"], "auth_semantic_seed");
+}

--- a/crates/cairn-cli/tests/sdk_cli_parity.rs
+++ b/crates/cairn-cli/tests/sdk_cli_parity.rs
@@ -331,6 +331,7 @@ fn status_parity_cli_vs_sdk_vs_mcp_with_fts_only_store() {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: true,
+                graph_search: false,
             },
         });
     let config = cairn_core::config::CairnConfig::default();

--- a/crates/cairn-cli/tests/search_scope_cli.rs
+++ b/crates/cairn-cli/tests/search_scope_cli.rs
@@ -1,0 +1,140 @@
+//! End-to-end CLI smoke test for `cairn search --scope-tenant …` (issue #191).
+//!
+//! Boots a real fixture vault with two-tenant seed records, invokes the
+//! CLI binary with `--scope-tenant`, and asserts the JSON envelope only
+//! contains rows from the requested tenant.
+
+#![allow(missing_docs)]
+
+use assert_cmd::Command;
+use cairn_core::domain::ScopeTuple;
+use cairn_test_fixtures::{RecordSpec, build_hybrid_test_vault};
+
+/// Helper: invoke `cairn search` with the given args and decode the JSON
+/// data block.
+fn run_cli_search(vault_root: &std::path::Path, args: &[&str]) -> serde_json::Value {
+    let output = Command::cargo_bin("cairn")
+        .expect("locate cairn binary")
+        .env("CAIRN_VAULT", vault_root)
+        .env("CAIRN_MOCK_EMBEDDER", "1")
+        .args(args)
+        .output()
+        .expect("run cli");
+    assert!(
+        output.status.success(),
+        "cli exit non-zero.\n  args: {args:?}\n  stderr: {}\n  stdout: {}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("envelope is JSON");
+    envelope["data"].clone()
+}
+
+#[tokio::test]
+async fn search_scope_tenant_flag_narrows_results() {
+    let vault = build_hybrid_test_vault(&[
+        RecordSpec::from_body("alpha shared keyword acme record one").with_scope(ScopeTuple {
+            tenant: Some("acme".into()),
+            user: Some("hmn:tafeng".into()),
+            ..Default::default()
+        }),
+        RecordSpec::from_body("alpha shared keyword globex record one").with_scope(ScopeTuple {
+            tenant: Some("globex".into()),
+            user: Some("hmn:tafeng".into()),
+            ..Default::default()
+        }),
+    ])
+    .await;
+
+    // Baseline: no scope flag, both tenants should surface.
+    let baseline = run_cli_search(
+        &vault.root,
+        &["search", "alpha", "--mode", "keyword", "--json"],
+    );
+    let hits = baseline["hits"].as_array().expect("hits is an array");
+    assert_eq!(
+        hits.len(),
+        2,
+        "baseline must return both tenants; got {hits:?}"
+    );
+
+    // With `--scope-tenant acme`, only the acme record returns.
+    let scoped = run_cli_search(
+        &vault.root,
+        &[
+            "search",
+            "alpha",
+            "--mode",
+            "keyword",
+            "--scope-tenant",
+            "acme",
+            "--json",
+        ],
+    );
+    let hits = scoped["hits"].as_array().expect("hits is an array");
+    assert_eq!(
+        hits.len(),
+        1,
+        "--scope-tenant acme must narrow to one record; got {hits:?}"
+    );
+    let id = hits[0]["record_id"].as_str().expect("record_id");
+    // Records are seeded in array order with suffix `00`, `01`, etc., so
+    // the acme one (index 0) ends in `00`.
+    assert!(
+        id.ends_with("00"),
+        "scoped result must be the acme record; got {id}",
+    );
+}
+
+#[tokio::test]
+async fn search_scope_tenant_unmatched_returns_empty() {
+    let vault = build_hybrid_test_vault(&[RecordSpec::from_body("alpha solo record").with_scope(
+        ScopeTuple {
+            tenant: Some("acme".into()),
+            user: Some("hmn:tafeng".into()),
+            ..Default::default()
+        },
+    )])
+    .await;
+    let data = run_cli_search(
+        &vault.root,
+        &[
+            "search",
+            "alpha",
+            "--mode",
+            "keyword",
+            "--scope-tenant",
+            "nonexistent",
+            "--json",
+        ],
+    );
+    let hits = data["hits"].as_array().expect("hits");
+    assert!(
+        hits.is_empty(),
+        "unmatched scope must return zero hits, not error; got {hits:?}",
+    );
+}
+
+#[test]
+fn search_help_lists_scope_flags() {
+    let out = Command::cargo_bin("cairn")
+        .expect("locate cairn binary")
+        .args(["search", "--help"])
+        .output()
+        .expect("cairn search --help");
+    assert!(out.status.success(), "exit: {:?}", out.status);
+    let stdout = String::from_utf8(out.stdout).expect("utf-8 stdout");
+    for flag in [
+        "--scope-tenant",
+        "--scope-workspace",
+        "--scope-user",
+        "--scope-agent",
+    ] {
+        assert!(
+            stdout.contains(flag),
+            "search --help missing {flag} flag.\nfull help:\n{stdout}",
+        );
+    }
+}

--- a/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_human.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_human.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/cairn-cli/tests/plugins_list_snapshot.rs
+assertion_line: 9
 expression: text
 ---
 NAME                  CONTRACT              VERSION-RANGE     SOURCE
 cairn-mcp             MCPServer             [0.1.0, 0.2.0)    bundled:cairn-mcp
 cairn-sensors-local   SensorIngress         [0.1.0, 0.2.0)    bundled:cairn-sensors-local
-cairn-store-sqlite    MemoryStore           [0.4.0, 0.5.0)    bundled:cairn-store-sqlite
+cairn-store-sqlite    MemoryStore           [0.5.0, 0.6.0)    bundled:cairn-store-sqlite
 cairn-workflows       WorkflowOrchestrator  [0.1.0, 0.2.0)    bundled:cairn-workflows

--- a/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
@@ -44,8 +44,8 @@ expression: json
       },
       "contract": "MemoryStore",
       "contract_version_range": {
-        "max_exclusive": "0.5.0",
-        "min": "0.4.0"
+        "max_exclusive": "0.6.0",
+        "min": "0.5.0"
       },
       "name": "cairn-store-sqlite",
       "source": "bundled:cairn-store-sqlite"

--- a/crates/cairn-core/src/config/mod.rs
+++ b/crates/cairn-core/src/config/mod.rs
@@ -1561,6 +1561,7 @@ rerank_topk: 20
             graph_edges: graph,
             transactions: true,
             per_record_consent_model: true,
+            graph_search: graph,
         }
     }
 

--- a/crates/cairn-core/src/config/mod.rs
+++ b/crates/cairn-core/src/config/mod.rs
@@ -401,6 +401,19 @@ pub struct SearchConfig {
     /// after candidate ranking + dedup. Char-count proxy for token budget;
     /// token-accurate trimming is P1 (see issue #49). Default `8000`.
     pub max_snippet_chars_per_page: usize,
+    /// Minimum entity-edge confidence score (`entity_edges.confidence_score`)
+    /// for the hybrid graph leg to admit an edge. Edges below this floor are
+    /// excluded from graph expansion entirely so weak/ambiguous evidence does
+    /// not dominate hybrid recall. Default `0.3` — matches `EdgeConfidence`'s
+    /// `Extracted` floor while excluding clearly unreliable links.
+    /// Range `[0.0, 1.0]`; values outside that range still parse but the
+    /// store clamps before use.
+    #[serde(default = "default_graph_confidence_min")]
+    pub graph_confidence_min: f32,
+}
+
+fn default_graph_confidence_min() -> f32 {
+    0.3
 }
 
 impl Default for SearchConfig {
@@ -415,6 +428,7 @@ impl Default for SearchConfig {
             rrf_k: 60,
             rerank_topk: 20,
             max_snippet_chars_per_page: 8000,
+            graph_confidence_min: default_graph_confidence_min(),
         }
     }
 }

--- a/crates/cairn-core/src/config/snapshots/cairn_core__config__tests__default_config_snapshot.snap
+++ b/crates/cairn-core/src/config/snapshots/cairn_core__config__tests__default_config_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cairn-core/src/config/mod.rs
+assertion_line: 1184
 expression: json
 ---
 {
@@ -59,7 +60,8 @@ expression: json
     ],
     "rrf_k": 60,
     "rerank_topk": 20,
-    "max_snippet_chars_per_page": 8000
+    "max_snippet_chars_per_page": 8000,
+    "graph_confidence_min": 0.3
   },
   "sensors": {
     "hooks": {

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -55,6 +55,7 @@
 ///             graph_edges: false,
 ///             transactions: false,
 ///             per_record_consent_model: false,
+///             graph_search: false,
 ///         };
 ///         &CAPS
 ///     }
@@ -78,7 +79,7 @@
 ///     const NAME: &'static str = "acme-store";
 ///     const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
 ///         ContractVersion::new(0, 1, 0),
-///         ContractVersion::new(0, 5, 0),
+///         ContractVersion::new(0, 6, 0),
 ///     );
 /// }
 ///
@@ -113,7 +114,7 @@
 ///
 /// [contract_version_range.max_exclusive]
 /// major = 0
-/// minor = 5
+/// minor = 6
 /// patch = 0
 /// "#;
 ///
@@ -130,6 +131,7 @@
 ///             graph_edges: false,
 ///             transactions: false,
 ///             per_record_consent_model: false,
+///             graph_search: false,
 ///         };
 ///         &CAPS
 ///     }
@@ -153,7 +155,7 @@
 ///     const NAME: &'static str = "acme-store";
 ///     const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
 ///         ContractVersion::new(0, 1, 0),
-///         ContractVersion::new(0, 5, 0),
+///         ContractVersion::new(0, 6, 0),
 ///     );
 /// }
 ///
@@ -408,7 +410,7 @@ macro_rules! __register_plugin_with_manifest_helper {
 ///     fn name(&self) -> &str { Self::NAME }
 ///     fn capabilities(&self) -> &MemoryStoreCapabilities {
 ///         static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
-///             fts: false, vector: false, graph_edges: false, transactions: false, per_record_consent_model: false,
+///             fts: false, vector: false, graph_edges: false, transactions: false, per_record_consent_model: false, graph_search: false,
 ///         };
 ///         &CAPS
 ///     }
@@ -432,7 +434,7 @@ macro_rules! __register_plugin_with_manifest_helper {
 ///     const NAME: &'static str = "config-store";
 ///     const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
 ///         ContractVersion::new(0, 1, 0),
-///         ContractVersion::new(0, 5, 0),
+///         ContractVersion::new(0, 6, 0),
 ///     );
 /// }
 ///

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -719,12 +719,18 @@ pub struct KeywordSearchArgs<'a> {
     /// visibility) MUST go through `auth_scope` and `visibility_allowlist`
     /// — see Issue #191 for the rationale.
     pub filter: Option<ValidatedFilter<'a>>,
-    /// Authorization scope tuple — the security predicate. The store
-    /// applies it identically across this leg, the semantic leg, the
-    /// graph leg, and graph hydration so policy cannot drift between
-    /// retrieval paths. Use [`ScopeTuple::default()`] when no narrowing
-    /// is required; a populated tuple narrows on each non-`None`
-    /// dimension. Issue #191.
+    /// Authorization scope tuple — the security predicate. Carried on the
+    /// args so v1.0 contract impls can begin enforcing scope without a
+    /// further breaking change.
+    ///
+    /// **v1 enforcement status (cairn-store-sqlite 0.5):** the SQL builders
+    /// do NOT yet fold `auth_scope` into the predicate. Multi-tenant
+    /// deployments MUST narrow via `visibility_allowlist` (and/or by
+    /// composing scope into `filter`) until the JSON1-based scope
+    /// predicate lands in a follow-up issue. `auth_scope` is accepted
+    /// and validated structurally but is otherwise inert in v1. Use
+    /// [`ScopeTuple::default()`] when no narrowing is required.
+    /// Issue #191.
     pub auth_scope: ScopeTuple,
     /// Visibility values the caller is allowed to see; empty = no filter.
     pub visibility_allowlist: Vec<MemoryVisibility>,
@@ -841,6 +847,15 @@ pub struct HybridSearchArgs<'a> {
 /// both the edge provenance record and the neighbor record; `filter` is
 /// recall-narrowing only and applies to the neighbor record. See spec
 /// §4.3 "Predicate application" for the full table.
+///
+/// **v1 seed-derivation caveat:** the orchestrator in
+/// `cairn-store-sqlite::do_search_hybrid` derives `seed_record_ids` from
+/// the already-filtered keyword/semantic candidate lists, so in practice
+/// `filter` does narrow seeding in v1. The independent auth-only seed
+/// query (which would let `filter` apply to neighbors only, per the spec)
+/// is deferred to the same follow-up that lands the `auth_scope`
+/// predicate. Callers narrowing aggressively via `filter` should expect
+/// reduced graph recall in v1.
 #[derive(Debug, Clone)]
 pub struct GraphNeighborsArgs<'a> {
     /// Record ids from auth-only seed retrieval (UNION-ed across keyword

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -719,18 +719,13 @@ pub struct KeywordSearchArgs<'a> {
     /// visibility) MUST go through `auth_scope` and `visibility_allowlist`
     /// — see Issue #191 for the rationale.
     pub filter: Option<ValidatedFilter<'a>>,
-    /// Authorization scope tuple — the security predicate. Carried on the
-    /// args so v1.0 contract impls can begin enforcing scope without a
-    /// further breaking change.
-    ///
-    /// **v1 enforcement status (cairn-store-sqlite 0.5):** the SQL builders
-    /// do NOT yet fold `auth_scope` into the predicate. Multi-tenant
-    /// deployments MUST narrow via `visibility_allowlist` (and/or by
-    /// composing scope into `filter`) until the JSON1-based scope
-    /// predicate lands in a follow-up issue. `auth_scope` is accepted
-    /// and validated structurally but is otherwise inert in v1. Use
-    /// [`ScopeTuple::default()`] when no narrowing is required.
-    /// Issue #191.
+    /// Authorization scope tuple — the security predicate. The store
+    /// applies it identically across this leg, the semantic leg, the
+    /// graph leg, and graph-only hydration so policy cannot drift
+    /// between retrieval paths. Use [`ScopeTuple::default()`] when no
+    /// narrowing is required; a populated tuple narrows on each
+    /// non-`None` dimension via JSON1 (`json_extract(scope, '$.tenant')
+    /// = ?`, etc.). Issue #191.
     pub auth_scope: ScopeTuple,
     /// Visibility values the caller is allowed to see; empty = no filter.
     pub visibility_allowlist: Vec<MemoryVisibility>,
@@ -844,18 +839,13 @@ pub struct HybridSearchArgs<'a> {
 /// Args for [`MemoryStore::search_graph_neighbors`] (Issue #191, spec §4.3).
 ///
 /// Authorization predicates (`auth_scope`, `visibility_allowlist`) apply to
-/// both the edge provenance record and the neighbor record; `filter` is
-/// recall-narrowing only and applies to the neighbor record. See spec
-/// §4.3 "Predicate application" for the full table.
-///
-/// **v1 seed-derivation caveat:** the orchestrator in
-/// `cairn-store-sqlite::do_search_hybrid` derives `seed_record_ids` from
-/// the already-filtered keyword/semantic candidate lists, so in practice
-/// `filter` does narrow seeding in v1. The independent auth-only seed
-/// query (which would let `filter` apply to neighbors only, per the spec)
-/// is deferred to the same follow-up that lands the `auth_scope`
-/// predicate. Callers narrowing aggressively via `filter` should expect
-/// reduced graph recall in v1.
+/// the neighbor record; `filter` is recall-narrowing only and applies to
+/// the neighbor record. The orchestrator in
+/// `cairn-store-sqlite::do_search_hybrid` runs an independent auth-only
+/// seed query so neighbors of records outside the user's narrowing
+/// `filter` remain reachable through graph traversal as long as they
+/// pass authorization. See spec §4.3 "Predicate application" for the
+/// full table.
 #[derive(Debug, Clone)]
 pub struct GraphNeighborsArgs<'a> {
     /// Record ids from auth-only seed retrieval (UNION-ed across keyword

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -22,7 +22,17 @@ use crate::search::ScoreExplain;
 /// `RecordVersion.schema_version` landed for the §6.4 stale-schema
 /// lint — adding required public fields is a struct-construction
 /// break, so the handshake range shifts to `[0.4.0, 0.5.0)`.
-pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 4, 0);
+/// Bumped 0.4 → 0.5 in #191 when `auth_scope: ScopeTuple` landed as
+/// a required public field on `KeywordSearchArgs`, `SemanticSearchArgs`,
+/// `HybridSearchArgs`, and the new `GraphNeighborsArgs`. Promoting
+/// `auth_scope` out of the user `filter` is the structural break:
+/// authorization now flows through a dedicated field that applies
+/// identically to lexical legs, graph traversal, and graph hydration,
+/// while `filter` keeps its narrowing-only role. The companion
+/// `MemoryStoreCapabilities::graph_search` flag and the
+/// `search_graph_neighbors` trait method (default impl returns
+/// `CapabilityUnavailable`) ship in the same bump.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 5, 0);
 
 /// Errors raised by `MemoryStore` implementations. Adapters define their
 /// own concrete type (e.g. `cairn_store_sqlite::StoreError`); this is the
@@ -36,7 +46,7 @@ pub type StoreError = Box<dyn std::error::Error + Send + Sync + 'static>;
 ///
 /// Cairn queries this before dispatching ANN-, FTS-, or graph-using verbs;
 /// missing capability → `CapabilityUnavailable` (brief §4.1).
-// Four capability flags mirror the four distinct store dimensions; a state
+// Five capability flags mirror the five distinct store dimensions; a state
 // machine would add indirection with no gain here.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -56,6 +66,14 @@ pub struct MemoryStoreCapabilities {
     /// `list_consent_models` is the authoritative read path and any
     /// active record missing from its result is corruption.
     pub per_record_consent_model: bool,
+    /// Whether `search_graph_neighbors` (1-hop entity-graph expansion) is
+    /// supported. Issue #191. `false` means the hybrid orchestrator skips
+    /// the graph leg with a [`crate::search::DegradedLeg::Graph`] entry
+    /// in the response; `true` means the adapter has all of the
+    /// `entity_edges` / `entity_episodes` / `records` columns the §5.1
+    /// SQL needs (probed at startup) and `carray` / `interrupt`
+    /// extensions are loaded.
+    pub graph_search: bool,
 }
 
 /// A `MemoryRecord` at a specific store version.
@@ -287,6 +305,33 @@ pub trait MemoryStore: Send + Sync {
     ) -> Result<HybridSearchPage, StoreError> {
         let _ = args;
         Err(String::from("capability unavailable: vector").into())
+    }
+
+    /// 1-hop entity-graph neighborhood expansion (Issue #191).
+    ///
+    /// Returns records whose entities are 1-hop neighbors of the seed set
+    /// in the bitemporal entity graph, with edge confidence preserved as
+    /// the RRF weight via `GraphCandidate::edge_confidence_score`. The
+    /// orchestrator uses this as the third leg of hybrid search; see spec
+    /// §5.1 for the SQL.
+    ///
+    /// `args.auth_scope` and `args.visibility_allowlist` are applied to
+    /// BOTH the edge provenance record and the neighbor record;
+    /// `args.filter` is applied only to the neighbor (recall narrowing).
+    ///
+    /// Returns `CapabilityUnavailable` when
+    /// `capabilities().graph_search` is `false`. The default impl returns
+    /// `CapabilityUnavailable` so adapters that don't ship the §8 capability
+    /// probe compile without boilerplate.
+    ///
+    /// # Errors
+    /// Default impl returns `"capability unavailable: graph_search"`.
+    async fn search_graph_neighbors(
+        &self,
+        args: &GraphNeighborsArgs<'_>,
+    ) -> Result<Vec<crate::search::GraphCandidate>, StoreError> {
+        let _ = args;
+        Err("capability unavailable: graph_search".into())
     }
 
     // ── Lint support (#96) ────────────────────────────────────────────────────
@@ -669,10 +714,18 @@ pub struct KeywordSearchArgs<'a> {
     /// FTS error variant on `StoreError`.
     pub query: String,
     /// Pre-validated filter tree from
-    /// [`crate::domain::filter::validate_filter`]. Callers fold scope-tuple
-    /// narrowing into this tree (or rely on the `visibility_allowlist`)
-    /// before invoking the store — see [`MemoryStore::search_keyword`].
+    /// [`crate::domain::filter::validate_filter`]. Recall-narrowing only
+    /// (kind/class/tags/timestamps). Authorization predicates (scope,
+    /// visibility) MUST go through `auth_scope` and `visibility_allowlist`
+    /// — see Issue #191 for the rationale.
     pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — the security predicate. The store
+    /// applies it identically across this leg, the semantic leg, the
+    /// graph leg, and graph hydration so policy cannot drift between
+    /// retrieval paths. Use [`ScopeTuple::default()`] when no narrowing
+    /// is required; a populated tuple narrows on each non-`None`
+    /// dimension. Issue #191.
+    pub auth_scope: ScopeTuple,
     /// Visibility values the caller is allowed to see; empty = no filter.
     pub visibility_allowlist: Vec<MemoryVisibility>,
     /// Maximum number of candidates to return in this page.
@@ -719,6 +772,8 @@ pub struct SemanticSearchArgs<'a> {
     pub query: String,
     /// Pre-validated filter tree. Same semantics as in [`KeywordSearchArgs`].
     pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — see [`KeywordSearchArgs::auth_scope`].
+    pub auth_scope: ScopeTuple,
     /// Visibility values the caller is allowed to see; empty = no filter.
     pub visibility_allowlist: Vec<MemoryVisibility>,
     /// Number of nearest neighbours to return (top-K).
@@ -758,6 +813,8 @@ pub struct HybridSearchArgs<'a> {
     /// [`crate::domain::filter::validate_filter`]. Same semantics as in
     /// [`KeywordSearchArgs`].
     pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — see [`KeywordSearchArgs::auth_scope`].
+    pub auth_scope: ScopeTuple,
     /// Visibility values the caller is allowed to see; empty = no filter.
     pub visibility_allowlist: Vec<MemoryVisibility>,
     /// Number of results.
@@ -773,6 +830,45 @@ pub struct HybridSearchArgs<'a> {
     /// When true, the store populates the page's `explain` block. See
     /// [`KeywordSearchArgs::with_explain`].
     pub with_explain: bool,
+    /// Floor on per-graph-candidate confidence weight in the RRF leg.
+    /// Default `1e-3`. Issue #191.
+    pub confidence_floor: f32,
+}
+
+/// Args for [`MemoryStore::search_graph_neighbors`] (Issue #191, spec §4.3).
+///
+/// Authorization predicates (`auth_scope`, `visibility_allowlist`) apply to
+/// both the edge provenance record and the neighbor record; `filter` is
+/// recall-narrowing only and applies to the neighbor record. See spec
+/// §4.3 "Predicate application" for the full table.
+#[derive(Debug, Clone)]
+pub struct GraphNeighborsArgs<'a> {
+    /// Record ids from auth-only seed retrieval (UNION-ed across keyword
+    /// and semantic legs), up to `2 * GRAPH_SEED_OVERFETCH = 400`.
+    /// Seeds the graph traversal; an empty list yields an empty result.
+    pub seed_record_ids: Vec<RecordId>,
+    /// Record ids actually fused into RRF (top of each filtered lexical
+    /// leg, UNION-ed, ≤ 100). Used as the dedup set in step 4 of §5.1 —
+    /// graph results exclude these so RRF cannot double-count, but seeds
+    /// not in this list (overfetched rank 51-200 records) remain
+    /// eligible for rank-rescue via graph evidence.
+    pub ranked_record_ids: Vec<RecordId>,
+    /// Pre-validated user-narrowing filter. Applied **only** to the
+    /// returned neighbor record. User narrowing must not erase
+    /// otherwise-authorized edges based on where the edge was observed.
+    pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — applied to BOTH provenance and
+    /// neighbor. See [`KeywordSearchArgs::auth_scope`].
+    pub auth_scope: ScopeTuple,
+    /// Visibility values the caller is allowed to see. Applied to BOTH
+    /// the neighbor record and the edge provenance record.
+    pub visibility_allowlist: Vec<MemoryVisibility>,
+    /// Max candidates returned. Equals `HYBRID_LEG_LIMIT` from the
+    /// orchestrator.
+    pub limit: usize,
+    /// `confidence_score` floor applied SQL-side to the edge step.
+    /// Edges below this threshold are excluded entirely.
+    pub confidence_min: f32,
 }
 
 /// One page of hybrid candidates.
@@ -840,6 +936,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: false,
+                graph_search: false,
             };
             &CAPS
         }
@@ -884,7 +981,7 @@ mod tests {
     impl MemoryStorePlugin for StubStore {
         const NAME: &'static str = "stub";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 4, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 5, 0), ContractVersion::new(0, 6, 0));
     }
 
     #[tokio::test]
@@ -906,6 +1003,7 @@ mod tests {
             .search_semantic(&SemanticSearchArgs {
                 query: "test".into(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: vec![],
                 limit: 10,
                 model_label: "bge-small-en-v1.5".into(),
@@ -920,6 +1018,7 @@ mod tests {
             .search_hybrid(&HybridSearchArgs {
                 query: "test".into(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: vec![],
                 limit: 10,
                 model_label: "bge-small-en-v1.5".into(),
@@ -927,6 +1026,7 @@ mod tests {
                 rrf_k: 60,
                 rerank_topk: 20,
                 with_explain: false,
+                confidence_floor: 1e-3,
             })
             .await;
         assert!(
@@ -1014,15 +1114,11 @@ mod tests {
         assert!(err.to_string().contains("bitemporal_graph"));
     }
 
-    /// `CONTRACT_VERSION` for the `MemoryStore` trait is locked to 0.4.0.
-    /// 0.3 hosted the additive-co-evolution chain (#253 consent-model
-    /// gate, #186 bitemporal-KG methods, #49 search explain plumbing,
-    /// all default-initializable). #258 bumped to 0.4 because adding
-    /// the required `schema_version: Option<SchemaVersion>` fields to
-    /// public `StoredRecord` / `RecordVersion` is a struct-construction
-    /// break — handshake range shifted to `[0.4.0, 0.5.0)`.
+    /// `CONTRACT_VERSION` for the `MemoryStore` trait is locked to 0.5.0.
+    /// #258 bumped 0.3→0.4 (per-row `schema_version`). #191 bumped 0.4→0.5
+    /// (`auth_scope`, `graph_search` capability + trait method).
     #[test]
-    fn contract_version_locked_to_0_4_0() {
-        assert_eq!(CONTRACT_VERSION, ContractVersion::new(0, 4, 0));
+    fn contract_version_locked_to_0_5_0() {
+        assert_eq!(CONTRACT_VERSION, ContractVersion::new(0, 5, 0));
     }
 }

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -834,6 +834,12 @@ pub struct HybridSearchArgs<'a> {
     /// Floor on per-graph-candidate confidence weight in the RRF leg.
     /// Default `1e-3`. Issue #191.
     pub confidence_floor: f32,
+    /// Minimum `entity_edges.confidence_score` an edge must clear to
+    /// participate in graph expansion. Edges below this floor are
+    /// excluded inside the `neighbors` CTE before contributing to RRF
+    /// candidate generation. Plumbed from `SearchConfig.graph_confidence_min`
+    /// (default `0.3`). Issue #191 round-2 review #3.
+    pub graph_confidence_min: f32,
 }
 
 /// Args for [`MemoryStore::search_graph_neighbors`] (Issue #191, spec §4.3).
@@ -1038,6 +1044,7 @@ mod tests {
                 rerank_topk: 20,
                 with_explain: false,
                 confidence_floor: 1e-3,
+                graph_confidence_min: 0.3,
             })
             .await;
         assert!(

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -871,7 +871,9 @@ pub struct GraphNeighborsArgs<'a> {
     pub confidence_min: f32,
 }
 
-/// One page of hybrid candidates.
+/// One page of hybrid candidates. Issue #191 added the `degraded_legs`
+/// vector so callers can distinguish "no results" from "results but a
+/// leg silently dropped out due to capability or SQL failure".
 #[derive(Debug, Clone, PartialEq)]
 pub struct HybridSearchPage {
     /// Candidates, sorted descending by blended `final_score`.
@@ -880,6 +882,10 @@ pub struct HybridSearchPage {
     /// when the matching args' `with_explain` was true. For the hybrid
     /// page, all fields are populated where applicable.
     pub explain: Option<Vec<ScoreExplain>>,
+    /// Legs that did not contribute results. Empty on the happy path.
+    /// Most common entry: `DegradedLeg::graph_capability_unavailable()`
+    /// when the store does not advertise `graph_search`. Issue #191.
+    pub degraded_legs: Vec<crate::search::DegradedLeg>,
 }
 
 /// A single candidate row from a search query, with the signal columns the

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -610,6 +610,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: false,
+                graph_search: false,
             };
             &CAPS
         }
@@ -654,15 +655,15 @@ mod tests {
     impl MemoryStorePlugin for StubStore {
         const NAME: &'static str = "stub-store";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     fn compatible() -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
     }
 
     fn incompatible() -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 5, 0), ContractVersion::new(0, 6, 0))
+        VersionRange::new(ContractVersion::new(0, 6, 0), ContractVersion::new(0, 7, 0))
     }
 
     #[test]
@@ -759,12 +760,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 "#
     }

--- a/crates/cairn-core/src/generated/schemas/verbs/search.json
+++ b/crates/cairn-core/src/generated/schemas/verbs/search.json
@@ -63,6 +63,13 @@
     "Data": {
       "additionalProperties": false,
       "properties": {
+        "degraded_legs": {
+          "description": "Per-leg degradation entries when one or more search legs (semantic, graph, or graph seed sources) failed or were unavailable. Empty/absent when every requested leg contributed. Lets callers distinguish a low-recall result from a partial-failure result without inspecting server logs.",
+          "items": {
+            "$ref": "#/$defs/DegradedLegEntry"
+          },
+          "type": "array"
+        },
         "excluded": {
           "description": "Per-record exclusions; present only when args.explain is true.",
           "items": {
@@ -89,6 +96,42 @@
       },
       "required": [
         "hits"
+      ],
+      "type": "object"
+    },
+    "DegradedLegEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "leg": {
+          "description": "Which hybrid leg degraded.",
+          "enum": [
+            "semantic",
+            "graph"
+          ],
+          "type": "string"
+        },
+        "reason": {
+          "description": "Why the leg degraded.",
+          "enum": [
+            "sql_error",
+            "capability_unavailable",
+            "timeout"
+          ],
+          "type": "string"
+        },
+        "source": {
+          "description": "Graph-leg only: which seed source was in flight when the leg degraded. Absent for non-graph legs.",
+          "enum": [
+            "all",
+            "auth_keyword_seed",
+            "auth_semantic_seed"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "leg",
+        "reason"
       ],
       "type": "object"
     },

--- a/crates/cairn-core/src/generated/verbs/search.rs
+++ b/crates/cairn-core/src/generated/verbs/search.rs
@@ -8,6 +8,44 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
+pub enum DegradedLegEntryLeg {
+    Semantic,
+    Graph,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum DegradedLegEntryReason {
+    SqlError,
+    CapabilityUnavailable,
+    Timeout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum DegradedLegEntrySource {
+    All,
+    AuthKeywordSeed,
+    AuthSemanticSeed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DegradedLegEntry {
+    /// Which hybrid leg degraded.
+    pub leg: DegradedLegEntryLeg,
+    /// Why the leg degraded.
+    pub reason: DegradedLegEntryReason,
+    /// Graph-leg only: which seed source was in flight when the leg degraded. Absent for non-graph legs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<DegradedLegEntrySource>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum HitTrust {
     Verified,
     Unverified,
@@ -307,6 +345,9 @@ impl<'de> ::serde::Deserialize<'de> for SearchArgs {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SearchData {
+    /// Per-leg degradation entries when one or more search legs (semantic, graph, or graph seed sources) failed or were unavailable. Empty/absent when every requested leg contributed. Lets callers distinguish a low-recall result from a partial-failure result without inspecting server logs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub degraded_legs: Option<Vec<DegradedLegEntry>>,
     /// Per-record exclusions; present only when args.explain is true.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub excluded: Option<Vec<crate::generated::common::RecordExclusion>>,

--- a/crates/cairn-core/src/search/cosine.rs
+++ b/crates/cairn-core/src/search/cosine.rs
@@ -98,6 +98,91 @@ pub fn cosine_rerank<S: BuildHasher>(
     out
 }
 
+/// Where a candidate originated, for [`cosine_rerank_tagged`].
+///
+/// `Lexical` candidates have a doc vector and the cosine term blends into
+/// the final score. `GraphOnly` candidates surfaced via 1-hop entity-graph
+/// expansion only — there is no lexical match and the cosine term is
+/// dropped (rather than substituted by a neutral 0.5, which would bias
+/// graph-only candidates upward in the cosine-only blend).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CandidateOrigin {
+    /// Surfaced by the keyword and/or semantic leg; has a doc vector.
+    Lexical,
+    /// Surfaced only by the graph leg; no lexical match.
+    GraphOnly,
+}
+
+/// One [`RrfCandidate`] tagged with its origin for [`cosine_rerank_tagged`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct OriginTaggedCandidate {
+    /// The fused candidate.
+    pub inner: RrfCandidate,
+    /// Whether this candidate has a doc vector eligible for cosine.
+    pub origin: CandidateOrigin,
+}
+
+/// Origin-aware variant of [`cosine_rerank`].
+///
+/// For [`CandidateOrigin::Lexical`] candidates the formula is
+/// `blend * rrf_norm + (1 - blend) * cos_norm` where
+/// `cos_norm = (cosine_raw + 1) / 2` puts cosine in `[0, 1]` so it is
+/// commensurable with `rrf_norm`. For [`CandidateOrigin::GraphOnly`] the
+/// cosine term is dropped: `final = blend * rrf_norm`. This is symmetric
+/// — both origins use the same `blend` factor — and prevents graph-only
+/// candidates from inheriting an undue cosine boost that they did not
+/// earn lexically.
+///
+/// Returns descending by `final_score`, ties broken by record id.
+#[must_use]
+pub fn cosine_rerank_tagged<S: BuildHasher>(
+    candidates: &[OriginTaggedCandidate],
+    doc_vectors: &HashMap<RecordId, Vec<f32>, S>,
+    query_vector: &[f32],
+    blend: f32,
+) -> Vec<RerankedCandidate> {
+    let blend = f64::from(blend.clamp(0.0, 1.0));
+    let max_rrf = candidates
+        .iter()
+        .map(|c| c.inner.rrf_score)
+        .fold(0.0_f64, f64::max);
+
+    let mut out: Vec<RerankedCandidate> = candidates
+        .iter()
+        .map(|tc| {
+            let rrf_norm = if max_rrf < f64::EPSILON {
+                0.0
+            } else {
+                tc.inner.rrf_score / max_rrf
+            };
+            let raw_cos = doc_vectors
+                .get(&tc.inner.record_id)
+                .map(|v| cosine_similarity(query_vector, v));
+            let (final_score, cosine) = match tc.origin {
+                CandidateOrigin::Lexical => {
+                    let cos_norm = raw_cos.map_or(0.5, |c| f64::midpoint(c, 1.0));
+                    (blend * rrf_norm + (1.0 - blend) * cos_norm, raw_cos)
+                }
+                CandidateOrigin::GraphOnly => (blend * rrf_norm, None),
+            };
+            RerankedCandidate {
+                record_id: tc.inner.record_id.clone(),
+                rrf_score: tc.inner.rrf_score,
+                cosine,
+                final_score,
+            }
+        })
+        .collect();
+
+    out.sort_by(|a, b| {
+        b.final_score
+            .partial_cmp(&a.final_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.record_id.as_str().cmp(b.record_id.as_str()))
+    });
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,6 +300,77 @@ mod tests {
         // 0.7 * (1.0 / 1.0) + 0.3 * 0.0 = 0.70
         // Tolerance is f32-grade (see `rerank_blend_default_balances_signals`).
         assert!((out[0].final_score - 0.70).abs() < 1e-6);
+    }
+
+    #[test]
+    fn graph_only_ties_lexical_at_cosine_minus_one_equal_rrf() {
+        // Lexical doc has cosine_raw = -1 → cos_norm = 0; graph-only drops
+        // cosine. With equal RRF and same blend, both should produce the
+        // same final_score = blend * rrf_norm.
+        let mut docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        docs.insert(rid("0A"), vec![0.0_f32, 1.0]);
+        let cands = vec![
+            OriginTaggedCandidate {
+                inner: RrfCandidate {
+                    record_id: rid("0A"),
+                    rrf_score: 0.5,
+                },
+                origin: CandidateOrigin::Lexical,
+            },
+            OriginTaggedCandidate {
+                inner: RrfCandidate {
+                    record_id: rid("0B"),
+                    rrf_score: 0.5,
+                },
+                origin: CandidateOrigin::GraphOnly,
+            },
+        ];
+        let q = vec![0.0_f32, -1.0];
+        let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+        assert!(
+            (out[0].final_score - out[1].final_score).abs() < 1e-9,
+            "lexical-cos-(-1) must tie graph-only"
+        );
+    }
+
+    #[test]
+    fn graph_only_loses_to_strong_lexical_at_equal_rrf() {
+        let mut docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        docs.insert(rid("0A"), vec![1.0_f32, 0.0]);
+        let cands = vec![
+            OriginTaggedCandidate {
+                inner: RrfCandidate {
+                    record_id: rid("0A"),
+                    rrf_score: 0.5,
+                },
+                origin: CandidateOrigin::Lexical,
+            },
+            OriginTaggedCandidate {
+                inner: RrfCandidate {
+                    record_id: rid("0B"),
+                    rrf_score: 0.5,
+                },
+                origin: CandidateOrigin::GraphOnly,
+            },
+        ];
+        let q = vec![1.0_f32, 0.0];
+        let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+        assert_eq!(out[0].record_id, rid("0A"));
+    }
+
+    #[test]
+    fn graph_only_cosine_field_is_none() {
+        let docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        let cands = vec![OriginTaggedCandidate {
+            inner: RrfCandidate {
+                record_id: rid("0A"),
+                rrf_score: 1.0,
+            },
+            origin: CandidateOrigin::GraphOnly,
+        }];
+        let q = vec![1.0_f32, 0.0];
+        let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+        assert!(out[0].cosine.is_none());
     }
 
     #[test]

--- a/crates/cairn-core/src/search/degraded.rs
+++ b/crates/cairn-core/src/search/degraded.rs
@@ -1,0 +1,97 @@
+//! Typed degradation signal for hybrid search responses.
+//!
+//! When a leg of hybrid search fails (capability missing, deadline exceeded,
+//! SQL error, worker panic) the orchestrator returns the surviving legs and
+//! flags the failed ones via [`DegradedLeg`]. Callers (CLI, MCP, SDK) decide
+//! whether to surface a warning, retry, or fail-closed.
+
+/// Why a hybrid-search leg did not contribute results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradationReason {
+    /// Store does not advertise the capability needed by this leg.
+    CapabilityUnavailable,
+    /// Per-leg deadline elapsed before results landed.
+    DeadlineExceeded,
+    /// `SQLite` returned an error.
+    SqlError,
+    /// The leg's worker task panicked.
+    WorkerPanic,
+}
+
+/// Which seed source the graph leg was using when it degraded.
+///
+/// Only meaningful for [`DegradedLeg::Graph`]. Lets callers attribute a
+/// graph-leg failure to the auth-only keyword seed query, the auth-only
+/// semantic seed query, or the union ("all").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GraphSource {
+    /// Both seed paths failed (or no seeds were attempted).
+    All,
+    /// Auth-only keyword-seed retrieval was the in-flight source when the
+    /// leg degraded.
+    AuthKeywordSeed,
+    /// Auth-only semantic-seed retrieval was the in-flight source.
+    AuthSemanticSeed,
+}
+
+/// One leg of hybrid search that did not contribute results.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradedLeg {
+    /// Semantic (vector-search) leg degraded.
+    Semantic {
+        /// Why the leg degraded.
+        reason: DegradationReason,
+    },
+    /// 1-hop entity-graph expansion leg degraded.
+    Graph {
+        /// Why the leg degraded.
+        reason: DegradationReason,
+        /// Which seed path was in flight when the leg degraded.
+        source: GraphSource,
+    },
+}
+
+impl DegradedLeg {
+    /// Convenience constructor for the most common graph-leg degradation:
+    /// the store does not advertise `graph_search` capability at all.
+    #[must_use]
+    pub fn graph_capability_unavailable() -> Self {
+        Self::Graph {
+            reason: DegradationReason::CapabilityUnavailable,
+            source: GraphSource::All,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graph_constructor_helper() {
+        let d = DegradedLeg::graph_capability_unavailable();
+        assert!(matches!(
+            d,
+            DegradedLeg::Graph {
+                reason: DegradationReason::CapabilityUnavailable,
+                source: GraphSource::All
+            }
+        ));
+    }
+
+    #[test]
+    fn semantic_variant_carries_reason() {
+        let d = DegradedLeg::Semantic {
+            reason: DegradationReason::DeadlineExceeded,
+        };
+        assert!(matches!(
+            d,
+            DegradedLeg::Semantic {
+                reason: DegradationReason::DeadlineExceeded
+            }
+        ));
+    }
+}

--- a/crates/cairn-core/src/search/graph.rs
+++ b/crates/cairn-core/src/search/graph.rs
@@ -1,0 +1,36 @@
+//! One graph-leg candidate.
+
+use crate::domain::RecordId;
+
+/// One graph-leg candidate: a record reached via a neighbor entity edge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphCandidate {
+    /// Record reached via a 1-hop neighbor edge.
+    pub record_id: RecordId,
+    /// Confidence score of the *connecting edge* in `[0.0, 1.0]`.
+    pub edge_confidence_score: f32,
+    /// 1-based rank in the graph leg's SQL output order. Carried
+    /// explicitly so RRF fusion does not infer rank from list position
+    /// after hydration shuffles ids. See spec §5.2.1.
+    pub graph_rank: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rid(suffix: &str) -> RecordId {
+        RecordId::parse(format!("01HQZX9F5N00000000000000{suffix}")).expect("valid id")
+    }
+
+    #[test]
+    fn construct_and_clone() {
+        let c = GraphCandidate {
+            record_id: rid("0A"),
+            edge_confidence_score: 0.85,
+            graph_rank: 3,
+        };
+        let c2 = c.clone();
+        assert_eq!(c, c2);
+    }
+}

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -5,12 +5,14 @@
 
 mod cosine;
 mod explain;
+mod graph;
 mod orchestrator;
 mod rrf;
 mod trim;
 
 pub use cosine::{RerankedCandidate, cosine_rerank, cosine_similarity};
 pub use explain::ScoreExplain;
+pub use graph::GraphCandidate;
 pub use orchestrator::{HybridSearchInputs, HybridSearchParams, hybrid_search};
 pub use rrf::{RrfCandidate, ScoredCandidate, rrf_fusion};
 pub use trim::token_budget_trim;

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -11,7 +11,10 @@ mod orchestrator;
 mod rrf;
 mod trim;
 
-pub use cosine::{RerankedCandidate, cosine_rerank, cosine_similarity};
+pub use cosine::{
+    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank,
+    cosine_rerank_tagged, cosine_similarity,
+};
 pub use degraded::{DegradationReason, DegradedLeg, GraphSource};
 pub use explain::ScoreExplain;
 pub use graph::GraphCandidate;

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -12,12 +12,14 @@ mod rrf;
 mod trim;
 
 pub use cosine::{
-    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank,
-    cosine_rerank_tagged, cosine_similarity,
+    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank, cosine_rerank_tagged,
+    cosine_similarity,
 };
 pub use degraded::{DegradationReason, DegradedLeg, GraphSource};
 pub use explain::ScoreExplain;
 pub use graph::GraphCandidate;
 pub use orchestrator::{HybridSearchInputs, HybridSearchParams, hybrid_search};
-pub use rrf::{Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted};
+pub use rrf::{
+    Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted,
+};
 pub use trim::token_budget_trim;

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -16,5 +16,5 @@ pub use degraded::{DegradationReason, DegradedLeg, GraphSource};
 pub use explain::ScoreExplain;
 pub use graph::GraphCandidate;
 pub use orchestrator::{HybridSearchInputs, HybridSearchParams, hybrid_search};
-pub use rrf::{RrfCandidate, ScoredCandidate, rrf_fusion};
+pub use rrf::{Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted};
 pub use trim::token_budget_trim;

--- a/crates/cairn-core/src/search/mod.rs
+++ b/crates/cairn-core/src/search/mod.rs
@@ -4,6 +4,7 @@
 //! return scored output. The store adapters orchestrate the data fetching.
 
 mod cosine;
+mod degraded;
 mod explain;
 mod graph;
 mod orchestrator;
@@ -11,6 +12,7 @@ mod rrf;
 mod trim;
 
 pub use cosine::{RerankedCandidate, cosine_rerank, cosine_similarity};
+pub use degraded::{DegradationReason, DegradedLeg, GraphSource};
 pub use explain::ScoreExplain;
 pub use graph::GraphCandidate;
 pub use orchestrator::{HybridSearchInputs, HybridSearchParams, hybrid_search};

--- a/crates/cairn-core/src/search/orchestrator.rs
+++ b/crates/cairn-core/src/search/orchestrator.rs
@@ -6,11 +6,12 @@ use std::collections::HashSet;
 use crate::domain::RecordId;
 
 use super::cosine::{
-    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank,
-    cosine_rerank_tagged,
+    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank, cosine_rerank_tagged,
 };
 use super::graph::GraphCandidate;
-use super::rrf::{Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted};
+use super::rrf::{
+    Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted,
+};
 
 /// Inputs to [`hybrid_search`]. The store fetches keyword + semantic
 /// candidate lists and the per-record vectors; this function does the math.
@@ -271,7 +272,10 @@ mod tests {
         };
         let out = hybrid_search(&inputs, HybridSearchParams::default());
         let ids: Vec<_> = out.iter().map(|c| c.record_id.clone()).collect();
-        assert!(ids.contains(&rid("0C")), "graph-only candidate must surface");
+        assert!(
+            ids.contains(&rid("0C")),
+            "graph-only candidate must surface"
+        );
         // GraphOnly origin → cosine field is None.
         let c0c = out.iter().find(|c| c.record_id == rid("0C")).unwrap();
         assert!(c0c.cosine.is_none());

--- a/crates/cairn-core/src/search/orchestrator.rs
+++ b/crates/cairn-core/src/search/orchestrator.rs
@@ -1,11 +1,16 @@
 //! Pure orchestration of RRF fusion + cosine re-rank.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use crate::domain::RecordId;
 
-use super::cosine::{RerankedCandidate, cosine_rerank};
-use super::rrf::{RrfCandidate, ScoredCandidate, rrf_fusion};
+use super::cosine::{
+    CandidateOrigin, OriginTaggedCandidate, RerankedCandidate, cosine_rerank,
+    cosine_rerank_tagged,
+};
+use super::graph::GraphCandidate;
+use super::rrf::{Leg, RankedCandidate, RrfCandidate, ScoredCandidate, rrf_fusion, rrf_fusion_weighted};
 
 /// Inputs to [`hybrid_search`]. The store fetches keyword + semantic
 /// candidate lists and the per-record vectors; this function does the math.
@@ -16,6 +21,10 @@ pub struct HybridSearchInputs {
     /// Vector ANN hits, sorted ascending by L2 distance.
     /// (Smaller distance = more similar; convert to descending via reverse.)
     pub semantic: Vec<ScoredCandidate>,
+    /// 1-hop entity-graph neighbor hits, in SQL output order. Each
+    /// candidate carries its own `graph_rank` so RRF fusion does not
+    /// infer rank from list position after hydration.
+    pub graph: Vec<GraphCandidate>,
     /// Query embedding (for cosine re-rank).
     pub query_vector: Vec<f32>,
     /// Top-K record vectors, fetched after RRF. May be a subset of the
@@ -35,6 +44,10 @@ pub struct HybridSearchParams {
     /// `true` to skip the cosine pass entirely (useful when the semantic
     /// leg failed and we only have RRF). The output `cosine` will be `None`.
     pub skip_rerank: bool,
+    /// Floor on per-candidate confidence weight in [`Leg::Explicit`]. Keeps
+    /// `effective_rank = rank / max(weight, floor)` finite at zero
+    /// confidence. Default `1e-3`.
+    pub confidence_floor: f32,
 }
 
 impl Default for HybridSearchParams {
@@ -44,30 +57,49 @@ impl Default for HybridSearchParams {
             rerank_topk: 20,
             blend: 0.7,
             skip_rerank: false,
+            confidence_floor: 1e-3,
         }
     }
 }
 
-/// Run RRF fusion then optional cosine re-rank.
+/// Run RRF fusion (with optional graph leg) then optional cosine re-rank.
 ///
-/// The store calls this after fetching both legs. Output is sorted
-/// descending by `final_score`.
+/// The store calls this after fetching all three legs. Output is sorted
+/// descending by `final_score`. When the graph leg is empty this behaves
+/// identically to the legacy 2-leg fusion (proven by the `parity` test).
 #[must_use]
 pub fn hybrid_search(
     inputs: &HybridSearchInputs,
     params: HybridSearchParams,
 ) -> Vec<RerankedCandidate> {
-    let lists = vec![inputs.keyword.clone(), inputs.semantic.clone()];
-    let fused: Vec<RrfCandidate> = rrf_fusion(&lists, params.rrf_k);
+    // Fast path: no graph candidates → use the legacy 2-leg `rrf_fusion`
+    // directly so existing callers and tests see byte-identical scoring.
+    let fused: Vec<RrfCandidate> = if inputs.graph.is_empty() {
+        let lists = vec![inputs.keyword.clone(), inputs.semantic.clone()];
+        rrf_fusion(&lists, params.rrf_k)
+    } else {
+        let graph_ranked: Vec<RankedCandidate> = inputs
+            .graph
+            .iter()
+            .map(|g| RankedCandidate {
+                record_id: g.record_id.clone(),
+                rank: g.graph_rank,
+                weight: g.edge_confidence_score,
+            })
+            .collect();
+        let legs = [
+            Leg::ListPosition(inputs.keyword.clone()),
+            Leg::ListPosition(inputs.semantic.clone()),
+            Leg::Explicit(graph_ranked, params.confidence_floor),
+        ];
+        rrf_fusion_weighted(&legs, params.rrf_k)
+    };
+
     if params.skip_rerank || params.blend >= 1.0 {
-        // Skip cosine: emit reranked candidates with normalized RRF as final.
         let max_rrf = fused.iter().map(|c| c.rrf_score).fold(0.0_f64, f64::max);
         return fused
             .into_iter()
             .map(|c| {
-                // `max_rrf` is produced by `f64::max` over a list that may
-                // be empty or all-zero; in those cases the literal `0.0` is
-                // returned and the comparison is exact-equivalent.
                 let normalized = if max_rrf < f64::EPSILON {
                     0.0
                 } else {
@@ -82,13 +114,46 @@ pub fn hybrid_search(
             })
             .collect();
     }
+
     let topk = fused
         .iter()
         .take(params.rerank_topk)
         .cloned()
         .collect::<Vec<_>>();
-    cosine_rerank(
-        &topk,
+
+    // 2-leg path: keep using the legacy untagged rerank for byte-compat.
+    if inputs.graph.is_empty() {
+        return cosine_rerank(
+            &topk,
+            &inputs.doc_vectors,
+            &inputs.query_vector,
+            params.blend,
+        );
+    }
+
+    // 3-leg path: tag each top-K survivor as Lexical (appears in keyword
+    // or semantic) or GraphOnly (only the graph leg surfaced it). The
+    // origin gates whether the cosine term blends in — see
+    // [`cosine_rerank_tagged`] for the formula.
+    let lexical_ids: HashSet<&RecordId> = inputs
+        .keyword
+        .iter()
+        .map(|c| &c.record_id)
+        .chain(inputs.semantic.iter().map(|c| &c.record_id))
+        .collect();
+    let tagged: Vec<OriginTaggedCandidate> = topk
+        .into_iter()
+        .map(|c| {
+            let origin = if lexical_ids.contains(&c.record_id) {
+                CandidateOrigin::Lexical
+            } else {
+                CandidateOrigin::GraphOnly
+            };
+            OriginTaggedCandidate { inner: c, origin }
+        })
+        .collect();
+    cosine_rerank_tagged(
+        &tagged,
         &inputs.doc_vectors,
         &inputs.query_vector,
         params.blend,
@@ -116,6 +181,7 @@ mod tests {
         let inputs = HybridSearchInputs {
             keyword: vec![cand("0A", 1.0), cand("0B", 0.5)],
             semantic: vec![],
+            graph: vec![],
             query_vector: vec![],
             doc_vectors: HashMap::new(),
         };
@@ -138,6 +204,7 @@ mod tests {
             keyword: vec![cand("0A", 1.0), cand("0B", 0.5)],
             // 0B leads in semantic
             semantic: vec![cand("0B", 0.1), cand("0A", 0.5)],
+            graph: vec![],
             query_vector: vec![1.0_f32, 0.0],
             doc_vectors: docs,
         };
@@ -155,10 +222,90 @@ mod tests {
         let inputs = HybridSearchInputs {
             keyword: vec![],
             semantic: vec![],
+            graph: vec![],
             query_vector: vec![],
             doc_vectors: HashMap::new(),
         };
         let out = hybrid_search(&inputs, HybridSearchParams::default());
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn graph_leg_empty_matches_legacy_2leg_output() {
+        // Parity: the 3-leg path with an empty graph leg must produce the
+        // same final ordering and final_score as the legacy 2-leg path.
+        let mut docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        docs.insert(rid("0A"), vec![0.0, 1.0]);
+        docs.insert(rid("0B"), vec![1.0, 0.0]);
+        let inputs = HybridSearchInputs {
+            keyword: vec![cand("0A", 1.0), cand("0B", 0.5)],
+            semantic: vec![cand("0B", 0.1), cand("0A", 0.5)],
+            graph: vec![],
+            query_vector: vec![1.0_f32, 0.0],
+            doc_vectors: docs,
+        };
+        let out = hybrid_search(&inputs, HybridSearchParams::default());
+        assert_eq!(out.len(), 2);
+        // Sanity: both candidates surface.
+        let ids: std::collections::HashSet<_> = out.iter().map(|c| c.record_id.clone()).collect();
+        assert!(ids.contains(&rid("0A")));
+        assert!(ids.contains(&rid("0B")));
+    }
+
+    #[test]
+    fn graph_only_candidate_surfaces_through_rerank() {
+        // 0C appears only in the graph leg, with high edge confidence.
+        // It should survive RRF + tagged rerank.
+        let mut docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        docs.insert(rid("0A"), vec![1.0, 0.0]);
+        let inputs = HybridSearchInputs {
+            keyword: vec![cand("0A", 1.0)],
+            semantic: vec![],
+            graph: vec![super::super::graph::GraphCandidate {
+                record_id: rid("0C"),
+                edge_confidence_score: 0.95,
+                graph_rank: 1,
+            }],
+            query_vector: vec![1.0_f32, 0.0],
+            doc_vectors: docs,
+        };
+        let out = hybrid_search(&inputs, HybridSearchParams::default());
+        let ids: Vec<_> = out.iter().map(|c| c.record_id.clone()).collect();
+        assert!(ids.contains(&rid("0C")), "graph-only candidate must surface");
+        // GraphOnly origin → cosine field is None.
+        let c0c = out.iter().find(|c| c.record_id == rid("0C")).unwrap();
+        assert!(c0c.cosine.is_none());
+    }
+
+    #[test]
+    fn three_leg_high_confidence_outranks_low_confidence_at_same_rank() {
+        // Two graph-only candidates at graph_rank 1, differing only by
+        // edge confidence. Higher confidence must rank higher.
+        let docs: HashMap<RecordId, Vec<f32>> = HashMap::new();
+        let inputs_high = HybridSearchInputs {
+            keyword: vec![],
+            semantic: vec![],
+            graph: vec![super::super::graph::GraphCandidate {
+                record_id: rid("0A"),
+                edge_confidence_score: 1.0,
+                graph_rank: 1,
+            }],
+            query_vector: vec![1.0_f32, 0.0],
+            doc_vectors: docs.clone(),
+        };
+        let inputs_low = HybridSearchInputs {
+            keyword: vec![],
+            semantic: vec![],
+            graph: vec![super::super::graph::GraphCandidate {
+                record_id: rid("0B"),
+                edge_confidence_score: 0.3,
+                graph_rank: 1,
+            }],
+            query_vector: vec![1.0_f32, 0.0],
+            doc_vectors: docs,
+        };
+        let out_high = hybrid_search(&inputs_high, HybridSearchParams::default());
+        let out_low = hybrid_search(&inputs_low, HybridSearchParams::default());
+        assert!(out_high[0].rrf_score > out_low[0].rrf_score);
     }
 }

--- a/crates/cairn-core/src/search/rrf.rs
+++ b/crates/cairn-core/src/search/rrf.rs
@@ -24,6 +24,90 @@ pub struct RrfCandidate {
     pub rrf_score: f64,
 }
 
+/// One element of an explicit-rank input list to [`rrf_fusion_weighted`].
+///
+/// Unlike [`ScoredCandidate`] (rank inferred from list position), this
+/// carries `rank` and `weight` per candidate. Used by the graph leg where
+/// the SQL output order is the rank and the connecting-edge confidence
+/// is the weight, surviving hydration which may re-order results by id.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RankedCandidate {
+    /// Record id.
+    pub record_id: RecordId,
+    /// 1-based rank in the source list.
+    pub rank: usize,
+    /// Confidence weight in `[0.0, 1.0]`. Used to compute
+    /// `effective_rank = rank / max(weight, floor)`.
+    pub weight: f32,
+}
+
+/// One leg of [`rrf_fusion_weighted`].
+///
+/// `ListPosition` is the legacy shape (rank inferred from index, no
+/// weighting). `Explicit` carries per-candidate rank and weight, and the
+/// per-leg `floor` clamps weight from below to keep `effective_rank`
+/// finite at zero confidence.
+#[derive(Debug, Clone)]
+pub enum Leg {
+    /// Rank inferred from slice index. Equivalent to a single input of
+    /// [`rrf_fusion`].
+    ListPosition(Vec<ScoredCandidate>),
+    /// Rank carried per-candidate; confidence penalty applied with `floor`.
+    Explicit(Vec<RankedCandidate>, f32),
+}
+
+/// Confidence-weighted Reciprocal Rank Fusion.
+///
+/// Behaves identically to [`rrf_fusion`] for [`Leg::ListPosition`] legs
+/// (proven by the `list_position_matches_legacy_fusion` test). For
+/// [`Leg::Explicit`] legs each contribution is `1.0 / (k +
+/// rank/max(weight, floor))`, so a low-confidence neighbor at rank 1
+/// contributes less than a high-confidence one at the same rank, but
+/// always contributes more than a list of equal length and rank with no
+/// confidence penalty would.
+#[must_use]
+pub fn rrf_fusion_weighted(legs: &[Leg], k: usize) -> Vec<RrfCandidate> {
+    use std::collections::HashMap;
+    let mut acc: HashMap<RecordId, f64> = HashMap::new();
+    #[allow(clippy::cast_precision_loss)]
+    let kf = k as f64;
+    for leg in legs {
+        match leg {
+            Leg::ListPosition(list) => {
+                for (i, c) in list.iter().enumerate() {
+                    #[allow(clippy::cast_precision_loss)]
+                    let r = (i + 1) as f64;
+                    *acc.entry(c.record_id.clone()).or_insert(0.0) += 1.0 / (kf + r);
+                }
+            }
+            Leg::Explicit(list, floor) => {
+                let f = f64::from((*floor).max(1e-6));
+                for c in list {
+                    #[allow(clippy::cast_precision_loss)]
+                    let raw_rank = c.rank as f64;
+                    let weight = f64::from(c.weight).max(f);
+                    let effective = raw_rank / weight;
+                    *acc.entry(c.record_id.clone()).or_insert(0.0) += 1.0 / (kf + effective);
+                }
+            }
+        }
+    }
+    let mut out: Vec<RrfCandidate> = acc
+        .into_iter()
+        .map(|(record_id, rrf_score)| RrfCandidate {
+            record_id,
+            rrf_score,
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        b.rrf_score
+            .partial_cmp(&a.rrf_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.record_id.as_str().cmp(b.record_id.as_str()))
+    });
+    out
+}
+
 /// Reciprocal Rank Fusion over `inputs`.
 ///
 /// Each input list must be pre-sorted descending by its own score.
@@ -129,6 +213,56 @@ mod tests {
                 .map(|c| c.record_id.as_str().to_owned())
                 .collect::<Vec<_>>(),
         );
+    }
+
+    #[test]
+    fn weighted_extracted_outranks_inferred_at_same_rank() {
+        let extracted = vec![RankedCandidate {
+            record_id: rid("0A"),
+            rank: 1,
+            weight: 1.0,
+        }];
+        let inferred = vec![RankedCandidate {
+            record_id: rid("0B"),
+            rank: 1,
+            weight: 0.6,
+        }];
+        let out = rrf_fusion_weighted(
+            &[
+                Leg::Explicit(extracted, 1e-3),
+                Leg::Explicit(inferred, 1e-3),
+            ],
+            60,
+        );
+        assert_eq!(out[0].record_id, rid("0A"));
+    }
+
+    #[test]
+    fn list_position_matches_legacy_fusion() {
+        let list = vec![
+            ScoredCandidate {
+                record_id: rid("0A"),
+                score: 1.0,
+            },
+            ScoredCandidate {
+                record_id: rid("0B"),
+                score: 0.5,
+            },
+        ];
+        let legacy = rrf_fusion(std::slice::from_ref(&list), 60);
+        let weighted = rrf_fusion_weighted(&[Leg::ListPosition(list)], 60);
+        assert_eq!(legacy, weighted);
+    }
+
+    #[test]
+    fn confidence_floor_prevents_div_by_zero() {
+        let zero_conf = vec![RankedCandidate {
+            record_id: rid("0A"),
+            rank: 1,
+            weight: 0.0,
+        }];
+        let out = rrf_fusion_weighted(&[Leg::Explicit(zero_conf, 1e-3)], 60);
+        assert!(out[0].rrf_score.is_finite());
     }
 
     #[test]

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -56,6 +56,13 @@ pub struct SearchOutcome {
     /// `candidates`. Populated iff `request.explain` was true and the
     /// `policy_trace` capability was advertised.
     pub explain: Option<Vec<ScoreExplain>>,
+    /// Hybrid-only: legs that ran in degraded mode (capability missing,
+    /// SQL error, deadline, etc.). Empty for keyword/semantic and for
+    /// fully successful hybrid runs. Surface code (CLI, MCP, SDK) may
+    /// thread this through to operators or callers; v1 verb dispatch
+    /// surfaces it here so partial-result signaling is not silently
+    /// dropped between the store and the wire surface. Issue #191.
+    pub degraded_legs: Vec<crate::search::DegradedLeg>,
 }
 
 /// Errors raised by the dispatcher.
@@ -149,7 +156,7 @@ pub async fn run(
         request.visibility_allowlist.clone()
     };
 
-    let (candidates, explain) = match request.mode {
+    let (candidates, explain, degraded_legs) = match request.mode {
         SearchMode::Keyword => {
             let args = KeywordSearchArgs {
                 query: request.query.clone(),
@@ -161,7 +168,7 @@ pub async fn run(
                 with_explain: request.explain,
             };
             let page = store.search_keyword(&args).await?;
-            (page.candidates, page.explain)
+            (page.candidates, page.explain, Vec::new())
         }
         SearchMode::Semantic => {
             let args = SemanticSearchArgs {
@@ -174,7 +181,7 @@ pub async fn run(
                 with_explain: request.explain,
             };
             let page = store.search_semantic(&args).await?;
-            (page.candidates, page.explain)
+            (page.candidates, page.explain, Vec::new())
         }
         SearchMode::Hybrid => {
             let args = HybridSearchArgs {
@@ -191,7 +198,7 @@ pub async fn run(
                 confidence_floor: 1e-3,
             };
             let page = store.search_hybrid(&args).await?;
-            (page.candidates, page.explain)
+            (page.candidates, page.explain, page.degraded_legs)
         }
     };
 
@@ -204,6 +211,7 @@ pub async fn run(
     Ok(SearchOutcome {
         candidates,
         explain,
+        degraded_legs,
     })
 }
 

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -13,6 +13,7 @@ use crate::config::{CairnConfig, CapabilitySet};
 use crate::contract::memory_store::{
     HybridSearchArgs, KeywordSearchArgs, MemoryStore, SearchCandidate, SemanticSearchArgs,
 };
+use crate::domain::ScopeTuple;
 use crate::domain::taxonomy::MemoryVisibility;
 use crate::search::{ScoreExplain, token_budget_trim};
 
@@ -153,6 +154,7 @@ pub async fn run(
             let args = KeywordSearchArgs {
                 query: request.query.clone(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: visibility,
                 limit: request.limit,
                 cursor: None,
@@ -165,6 +167,7 @@ pub async fn run(
             let args = SemanticSearchArgs {
                 query: request.query.clone(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: visibility,
                 limit: request.limit,
                 model_label: request.model_label.clone(),
@@ -177,6 +180,7 @@ pub async fn run(
             let args = HybridSearchArgs {
                 query: request.query.clone(),
                 filter: None,
+                auth_scope: ScopeTuple::default(),
                 visibility_allowlist: visibility,
                 limit: request.limit,
                 model_label: request.model_label.clone(),
@@ -184,6 +188,7 @@ pub async fn run(
                 rrf_k: config.search.rrf_k,
                 rerank_topk: config.search.rerank_topk,
                 with_explain: request.explain,
+                confidence_floor: 1e-3,
             };
             let page = store.search_hybrid(&args).await?;
             (page.candidates, page.explain)
@@ -344,6 +349,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: true,
+                graph_search: false,
             },
             last_hybrid: Mutex::new(None),
         };
@@ -394,6 +400,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: true,
+                graph_search: false,
             },
             last_hybrid: Mutex::new(None),
         };
@@ -436,6 +443,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: true,
+                graph_search: false,
             },
             last_hybrid: Mutex::new(None),
         };
@@ -468,6 +476,7 @@ mod tests {
                 graph_edges: false,
                 transactions: true,
                 per_record_consent_model: true,
+                graph_search: false,
             },
             last_hybrid: Mutex::new(None),
         };
@@ -533,6 +542,7 @@ mod tests {
                     graph_edges: false,
                     transactions: true,
                     per_record_consent_model: true,
+                    graph_search: false,
                 };
                 &CAPS
             }

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -236,13 +236,14 @@ mod tests {
 
     /// Stub store that records which leg was called.
     ///
-    /// `last_hybrid` captures the `(blend, rrf_k, rerank_topk)` args from the
+    /// `last_hybrid` captures the
+    /// `(blend, rrf_k, rerank_topk, graph_confidence_min)` args from the
     /// most recent `search_hybrid` call so tests can assert config knobs
     /// flow through correctly.
     struct CallRecorder {
         calls: Mutex<Vec<&'static str>>,
         capabilities: MemoryStoreCapabilities,
-        last_hybrid: Mutex<Option<(f32, usize, usize)>>,
+        last_hybrid: Mutex<Option<(f32, usize, usize, f32)>>,
     }
 
     #[async_trait::async_trait]
@@ -318,8 +319,12 @@ mod tests {
             args: &HybridSearchArgs<'_>,
         ) -> Result<HybridSearchPage, StoreError> {
             self.calls.lock().expect("mutex").push("hybrid");
-            *self.last_hybrid.lock().expect("mutex") =
-                Some((args.blend, args.rrf_k, args.rerank_topk));
+            *self.last_hybrid.lock().expect("mutex") = Some((
+                args.blend,
+                args.rrf_k,
+                args.rerank_topk,
+                args.graph_confidence_min,
+            ));
             Ok(HybridSearchPage {
                 candidates: vec![],
                 explain: None,
@@ -785,6 +790,7 @@ mod tests {
         config.search.rerank_blend = 0.42;
         config.search.rrf_k = 99;
         config.search.rerank_topk = 33;
+        config.search.graph_confidence_min = 0.7;
         run(
             &store,
             &config,
@@ -797,6 +803,11 @@ mod tests {
         assert!((captured.0 - 0.42).abs() < 1e-6, "blend mismatch");
         assert_eq!(captured.1, 99, "rrf_k mismatch");
         assert_eq!(captured.2, 33, "rerank_topk mismatch");
+        assert!(
+            (captured.3 - 0.7).abs() < 1e-6,
+            "graph_confidence_min mismatch: got {}",
+            captured.3,
+        );
     }
 
     // M4-C: token_budget_trim is invoked — oversized candidates are trimmed.

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -430,6 +430,292 @@ mod tests {
         assert_eq!(store.calls.lock().expect("mutex").as_slice(), &["hybrid"]);
     }
 
+    #[allow(
+        clippy::too_many_lines,
+        reason = "stub MemoryStore impl is unavoidably wide"
+    )]
+    #[tokio::test]
+    async fn hybrid_propagates_degraded_legs_through_search_outcome() {
+        use crate::search::{DegradationReason, DegradedLeg, GraphSource};
+
+        struct DegradedHybridStore;
+
+        #[async_trait::async_trait]
+        impl MemoryStore for DegradedHybridStore {
+            fn name(&self) -> &'static str {
+                "degraded"
+            }
+            fn capabilities(&self) -> &MemoryStoreCapabilities {
+                static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                    fts: true,
+                    vector: true,
+                    graph_edges: false,
+                    transactions: true,
+                    per_record_consent_model: true,
+                    graph_search: false,
+                };
+                &CAPS
+            }
+            fn supported_contract_versions(&self) -> crate::contract::version::VersionRange {
+                use crate::contract::memory_store::CONTRACT_VERSION;
+                use crate::contract::version::ContractVersion;
+                crate::contract::version::VersionRange::new(
+                    CONTRACT_VERSION,
+                    ContractVersion::new(CONTRACT_VERSION.major, CONTRACT_VERSION.minor + 1, 0),
+                )
+            }
+            async fn upsert(
+                &self,
+                _r: &crate::domain::record::MemoryRecord,
+            ) -> Result<crate::contract::memory_store::UpsertOutcome, StoreError> {
+                unimplemented!()
+            }
+            async fn get(
+                &self,
+                _id: &crate::domain::RecordId,
+            ) -> Result<Option<crate::domain::record::MemoryRecord>, StoreError> {
+                Ok(None)
+            }
+            async fn list(
+                &self,
+                _args: &crate::contract::memory_store::ListArgs,
+            ) -> Result<crate::contract::memory_store::ListPage, StoreError> {
+                unimplemented!()
+            }
+            async fn tombstone(
+                &self,
+                _id: &crate::domain::RecordId,
+                _reason: crate::contract::memory_store::TombstoneReason,
+            ) -> Result<(), StoreError> {
+                unimplemented!()
+            }
+            async fn versions(
+                &self,
+                _t: &crate::domain::TargetId,
+            ) -> Result<Vec<crate::contract::memory_store::RecordVersion>, StoreError> {
+                Ok(vec![])
+            }
+            async fn put_edge(
+                &self,
+                _e: &crate::contract::memory_store::Edge,
+            ) -> Result<(), StoreError> {
+                unimplemented!()
+            }
+            async fn remove_edge(
+                &self,
+                _k: &crate::contract::memory_store::EdgeKey,
+            ) -> Result<bool, StoreError> {
+                Ok(false)
+            }
+            async fn neighbours(
+                &self,
+                _id: &crate::domain::RecordId,
+                _d: crate::contract::memory_store::EdgeDir,
+            ) -> Result<Vec<crate::contract::memory_store::Edge>, StoreError> {
+                Ok(vec![])
+            }
+            async fn search_keyword(
+                &self,
+                _args: &KeywordSearchArgs<'_>,
+            ) -> Result<KeywordSearchPage, StoreError> {
+                Ok(KeywordSearchPage {
+                    candidates: vec![],
+                    next_cursor: None,
+                    explain: None,
+                })
+            }
+            async fn search_semantic(
+                &self,
+                _args: &SemanticSearchArgs<'_>,
+            ) -> Result<SemanticSearchPage, StoreError> {
+                Ok(SemanticSearchPage {
+                    candidates: vec![],
+                    explain: None,
+                })
+            }
+            async fn search_hybrid(
+                &self,
+                _args: &HybridSearchArgs<'_>,
+            ) -> Result<HybridSearchPage, StoreError> {
+                Ok(HybridSearchPage {
+                    candidates: vec![],
+                    explain: None,
+                    degraded_legs: vec![DegradedLeg::Graph {
+                        reason: DegradationReason::CapabilityUnavailable,
+                        source: GraphSource::All,
+                    }],
+                })
+            }
+        }
+
+        let config = CairnConfig::default();
+        let outcome = run(
+            &DegradedHybridStore,
+            &config,
+            &caps(true, true, true),
+            req(SearchMode::Hybrid),
+        )
+        .await
+        .expect("hybrid run");
+        assert_eq!(
+            outcome.degraded_legs.len(),
+            1,
+            "hybrid must propagate store's degraded_legs through SearchOutcome"
+        );
+    }
+
+    #[tokio::test]
+    async fn keyword_outcome_has_empty_degraded_legs() {
+        let store = CallRecorder {
+            calls: Mutex::new(vec![]),
+            capabilities: MemoryStoreCapabilities::default(),
+            last_hybrid: Mutex::new(None),
+        };
+        let config = CairnConfig::default();
+        let outcome = run(
+            &store,
+            &config,
+            &caps(true, false, false),
+            req(SearchMode::Keyword),
+        )
+        .await
+        .expect("ok");
+        assert!(
+            outcome.degraded_legs.is_empty(),
+            "keyword leg never reports degraded_legs"
+        );
+    }
+
+    #[allow(
+        clippy::too_many_lines,
+        reason = "stub MemoryStore impl is unavoidably wide"
+    )]
+    #[tokio::test]
+    async fn auth_scope_threaded_into_keyword_args() {
+        use std::sync::Mutex as StdMutex;
+
+        struct ScopeRecorder {
+            captured: StdMutex<Option<ScopeTuple>>,
+        }
+        #[async_trait::async_trait]
+        impl MemoryStore for ScopeRecorder {
+            fn name(&self) -> &'static str {
+                "scope-recorder"
+            }
+            fn capabilities(&self) -> &MemoryStoreCapabilities {
+                static CAPS: MemoryStoreCapabilities = MemoryStoreCapabilities {
+                    fts: true,
+                    vector: false,
+                    graph_edges: false,
+                    transactions: true,
+                    per_record_consent_model: true,
+                    graph_search: false,
+                };
+                &CAPS
+            }
+            fn supported_contract_versions(&self) -> crate::contract::version::VersionRange {
+                use crate::contract::memory_store::CONTRACT_VERSION;
+                use crate::contract::version::ContractVersion;
+                crate::contract::version::VersionRange::new(
+                    CONTRACT_VERSION,
+                    ContractVersion::new(CONTRACT_VERSION.major, CONTRACT_VERSION.minor + 1, 0),
+                )
+            }
+            async fn upsert(
+                &self,
+                _r: &crate::domain::record::MemoryRecord,
+            ) -> Result<crate::contract::memory_store::UpsertOutcome, StoreError> {
+                unimplemented!()
+            }
+            async fn get(
+                &self,
+                _id: &crate::domain::RecordId,
+            ) -> Result<Option<crate::domain::record::MemoryRecord>, StoreError> {
+                Ok(None)
+            }
+            async fn list(
+                &self,
+                _args: &crate::contract::memory_store::ListArgs,
+            ) -> Result<crate::contract::memory_store::ListPage, StoreError> {
+                unimplemented!()
+            }
+            async fn tombstone(
+                &self,
+                _id: &crate::domain::RecordId,
+                _reason: crate::contract::memory_store::TombstoneReason,
+            ) -> Result<(), StoreError> {
+                unimplemented!()
+            }
+            async fn versions(
+                &self,
+                _t: &crate::domain::TargetId,
+            ) -> Result<Vec<crate::contract::memory_store::RecordVersion>, StoreError> {
+                Ok(vec![])
+            }
+            async fn put_edge(
+                &self,
+                _e: &crate::contract::memory_store::Edge,
+            ) -> Result<(), StoreError> {
+                unimplemented!()
+            }
+            async fn remove_edge(
+                &self,
+                _k: &crate::contract::memory_store::EdgeKey,
+            ) -> Result<bool, StoreError> {
+                Ok(false)
+            }
+            async fn neighbours(
+                &self,
+                _id: &crate::domain::RecordId,
+                _d: crate::contract::memory_store::EdgeDir,
+            ) -> Result<Vec<crate::contract::memory_store::Edge>, StoreError> {
+                Ok(vec![])
+            }
+            async fn search_keyword(
+                &self,
+                args: &KeywordSearchArgs<'_>,
+            ) -> Result<KeywordSearchPage, StoreError> {
+                *self.captured.lock().expect("mutex") = Some(args.auth_scope.clone());
+                Ok(KeywordSearchPage {
+                    candidates: vec![],
+                    next_cursor: None,
+                    explain: None,
+                })
+            }
+            async fn search_semantic(
+                &self,
+                _args: &SemanticSearchArgs<'_>,
+            ) -> Result<SemanticSearchPage, StoreError> {
+                unimplemented!()
+            }
+            async fn search_hybrid(
+                &self,
+                _args: &HybridSearchArgs<'_>,
+            ) -> Result<HybridSearchPage, StoreError> {
+                unimplemented!()
+            }
+        }
+
+        let store = ScopeRecorder {
+            captured: StdMutex::new(None),
+        };
+        let mut request = req(SearchMode::Keyword);
+        request.auth_scope = ScopeTuple {
+            tenant: Some("acme".into()),
+            ..Default::default()
+        };
+        let config = CairnConfig::default();
+        run(&store, &config, &caps(true, false, false), request)
+            .await
+            .expect("ok");
+        let captured = store.captured.lock().expect("mutex").clone();
+        assert_eq!(
+            captured.expect("captured").tenant.as_deref(),
+            Some("acme"),
+            "verb dispatcher must thread request.auth_scope into the leg's args"
+        );
+    }
+
     #[tokio::test]
     async fn empty_query_rejected() {
         let store = CallRecorder {

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -200,6 +200,7 @@ pub async fn run(
                 rerank_topk: config.search.rerank_topk,
                 with_explain: request.explain,
                 confidence_floor: 1e-3,
+                graph_confidence_min: config.search.graph_confidence_min,
             };
             let page = store.search_hybrid(&args).await?;
             (page.candidates, page.explain, page.degraded_legs)

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -40,6 +40,10 @@ pub struct SearchRequest {
     pub limit: usize,
     /// Visibility allowlist; empty = no narrowing.
     pub visibility_allowlist: Vec<MemoryVisibility>,
+    /// Authorization scope tuple. Threaded into every search SQL path
+    /// (keyword, semantic, graph, graph-only hydration). Issue #191.
+    /// Use [`ScopeTuple::default`] when no narrowing is required.
+    pub auth_scope: ScopeTuple,
     /// Active embedding model label (for semantic + hybrid).
     pub model_label: String,
     /// `true` → request explain block from the store and surface it.
@@ -161,7 +165,7 @@ pub async fn run(
             let args = KeywordSearchArgs {
                 query: request.query.clone(),
                 filter: None,
-                auth_scope: ScopeTuple::default(),
+                auth_scope: request.auth_scope.clone(),
                 visibility_allowlist: visibility,
                 limit: request.limit,
                 cursor: None,
@@ -174,7 +178,7 @@ pub async fn run(
             let args = SemanticSearchArgs {
                 query: request.query.clone(),
                 filter: None,
-                auth_scope: ScopeTuple::default(),
+                auth_scope: request.auth_scope.clone(),
                 visibility_allowlist: visibility,
                 limit: request.limit,
                 model_label: request.model_label.clone(),
@@ -187,7 +191,7 @@ pub async fn run(
             let args = HybridSearchArgs {
                 query: request.query.clone(),
                 filter: None,
-                auth_scope: ScopeTuple::default(),
+                auth_scope: request.auth_scope.clone(),
                 visibility_allowlist: visibility,
                 limit: request.limit,
                 model_label: request.model_label.clone(),
@@ -343,6 +347,7 @@ mod tests {
             mode,
             limit: 10,
             visibility_allowlist: vec![],
+            auth_scope: ScopeTuple::default(),
             model_label: "MiniLM-L6-v2".to_owned(),
             explain: false,
         }

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -310,6 +310,7 @@ mod tests {
             Ok(HybridSearchPage {
                 candidates: vec![],
                 explain: None,
+                degraded_legs: vec![],
             })
         }
     }

--- a/crates/cairn-core/tests/conformance_tier1.rs
+++ b/crates/cairn-core/tests/conformance_tier1.rs
@@ -27,12 +27,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 
 [features]
@@ -58,11 +58,13 @@ impl MemoryStore for StubStore {
             graph_edges: false,
             transactions: false,
             per_record_consent_model: false,
+
+            graph_search: false,
         };
         &CAPS
     }
     fn supported_contract_versions(&self) -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
     }
     async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
         Err("stub: upsert not implemented".into())

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -50,11 +50,13 @@ mod compatible_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
         }
         async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
             Err("stub: upsert not implemented".into())
@@ -94,7 +96,7 @@ mod compatible_plugin {
     impl MemoryStorePlugin for FakeStore {
         const NAME: &'static str = "fake-compat";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     register_plugin!(MemoryStore, FakeStore, "fake-compat");
@@ -118,6 +120,8 @@ mod future_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -223,12 +227,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 "#;
 
@@ -247,11 +251,13 @@ patch = 0
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0))
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
         }
         async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
             Err("stub: upsert not implemented".into())
@@ -291,7 +297,7 @@ patch = 0
     impl MemoryStorePlugin for FakeStore {
         const NAME: &'static str = "fake-with-manifest";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     register_plugin!(MemoryStore, FakeStore, "fake-with-manifest", MANIFEST_TOML);
@@ -328,6 +334,8 @@ mod incompatible_factory_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -404,6 +412,8 @@ mod config_driven_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -448,7 +458,7 @@ mod config_driven_plugin {
     impl MemoryStorePlugin for PathStore {
         const NAME: &'static str = "path-store";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     register_plugin_with!(
@@ -477,6 +487,8 @@ mod name_mismatch_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -521,7 +533,7 @@ mod name_mismatch_plugin {
     impl MemoryStorePlugin for BadNameStore {
         const NAME: &'static str = "actual-name";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     // NAME const = "actual-name" but macro literal = "wrong-name"
@@ -817,6 +829,8 @@ mod factory_error_plugin {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+
+                graph_search: false,
             };
             &CAPS
         }
@@ -861,7 +875,7 @@ mod factory_error_plugin {
     impl MemoryStorePlugin for FailingStore {
         const NAME: &'static str = "failing-store";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 5, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
     }
 
     register_plugin_with!(

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -144,6 +144,33 @@
           "type": "array",
           "description": "Optional per-candidate score-component explanations. Present only when args.explain is true (which itself requires the cairn.mcp.v1.policy_trace capability).",
           "items": { "$ref": "#/$defs/ScoreExplain" }
+        },
+        "degraded_legs": {
+          "type": "array",
+          "description": "Per-leg degradation entries when one or more search legs (semantic, graph, or graph seed sources) failed or were unavailable. Empty/absent when every requested leg contributed. Lets callers distinguish a low-recall result from a partial-failure result without inspecting server logs.",
+          "items": { "$ref": "#/$defs/DegradedLegEntry" }
+        }
+      }
+    },
+    "DegradedLegEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["leg", "reason"],
+      "properties": {
+        "leg": {
+          "type": "string",
+          "enum": ["semantic", "graph"],
+          "description": "Which hybrid leg degraded."
+        },
+        "reason": {
+          "type": "string",
+          "enum": ["sql_error", "capability_unavailable", "timeout"],
+          "description": "Why the leg degraded."
+        },
+        "source": {
+          "type": "string",
+          "enum": ["all", "auth_keyword_seed", "auth_semantic_seed"],
+          "description": "Graph-leg only: which seed source was in flight when the leg degraded. Absent for non-graph legs."
         }
       }
     },

--- a/crates/cairn-mcp/src/generated/schemas/verbs/search.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/search.input.json
@@ -63,6 +63,13 @@
     "Data": {
       "additionalProperties": false,
       "properties": {
+        "degraded_legs": {
+          "description": "Per-leg degradation entries when one or more search legs (semantic, graph, or graph seed sources) failed or were unavailable. Empty/absent when every requested leg contributed. Lets callers distinguish a low-recall result from a partial-failure result without inspecting server logs.",
+          "items": {
+            "$ref": "#/$defs/DegradedLegEntry"
+          },
+          "type": "array"
+        },
         "excluded": {
           "description": "Per-record exclusions; present only when args.explain is true.",
           "items": {
@@ -89,6 +96,42 @@
       },
       "required": [
         "hits"
+      ],
+      "type": "object"
+    },
+    "DegradedLegEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "leg": {
+          "description": "Which hybrid leg degraded.",
+          "enum": [
+            "semantic",
+            "graph"
+          ],
+          "type": "string"
+        },
+        "reason": {
+          "description": "Why the leg degraded.",
+          "enum": [
+            "sql_error",
+            "capability_unavailable",
+            "timeout"
+          ],
+          "type": "string"
+        },
+        "source": {
+          "description": "Graph-leg only: which seed source was in flight when the leg degraded. Absent for non-graph legs.",
+          "enum": [
+            "all",
+            "auth_keyword_seed",
+            "auth_semantic_seed"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "leg",
+        "reason"
       ],
       "type": "object"
     },

--- a/crates/cairn-mcp/src/generated/schemas/verbs/search.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/search.json
@@ -63,6 +63,13 @@
     "Data": {
       "additionalProperties": false,
       "properties": {
+        "degraded_legs": {
+          "description": "Per-leg degradation entries when one or more search legs (semantic, graph, or graph seed sources) failed or were unavailable. Empty/absent when every requested leg contributed. Lets callers distinguish a low-recall result from a partial-failure result without inspecting server logs.",
+          "items": {
+            "$ref": "#/$defs/DegradedLegEntry"
+          },
+          "type": "array"
+        },
         "excluded": {
           "description": "Per-record exclusions; present only when args.explain is true.",
           "items": {
@@ -89,6 +96,42 @@
       },
       "required": [
         "hits"
+      ],
+      "type": "object"
+    },
+    "DegradedLegEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "leg": {
+          "description": "Which hybrid leg degraded.",
+          "enum": [
+            "semantic",
+            "graph"
+          ],
+          "type": "string"
+        },
+        "reason": {
+          "description": "Why the leg degraded.",
+          "enum": [
+            "sql_error",
+            "capability_unavailable",
+            "timeout"
+          ],
+          "type": "string"
+        },
+        "source": {
+          "description": "Graph-leg only: which seed source was in flight when the leg degraded. Absent for non-graph legs.",
+          "enum": [
+            "all",
+            "auth_keyword_seed",
+            "auth_semantic_seed"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "leg",
+        "reason"
       ],
       "type": "object"
     },

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -540,12 +540,17 @@ async fn handle_search(
     caps.hybrid_search = caps.hybrid_search && store_caps.fts && store_caps.vector;
 
     let limit = args.limit.map_or(10, |l| usize::try_from(l).unwrap_or(10));
+    // Map the IDL `args.scope` into the dispatcher's auth_scope so MCP
+    // callers narrow reads by tenant/workspace/user/agent. Without this
+    // the MCP surface ran every search with `ScopeTuple::default()` —
+    // i.e. no auth narrowing — even when the caller supplied a scope.
+    let auth_scope = scope_filter_to_tuple(args.scope.as_ref());
     let request = cairn_core::verbs::search::SearchRequest {
         query: args.query.clone(),
         mode,
         limit,
         visibility_allowlist: vec![],
-        auth_scope: cairn_core::domain::ScopeTuple::default(),
+        auth_scope,
         model_label: config.search.embedding_model.as_str().to_owned(),
         explain: args.explain.unwrap_or(false),
     };
@@ -643,6 +648,32 @@ pub fn dispatch_stub(verb: &str) -> CallToolResult {
         "cairn {verb}: not yet implemented in this P0 scaffold. \
          Verb dispatch lands in a follow-up PR; no memory operation was performed."
     ))])
+}
+
+/// Map an IDL `ScopeFilter` to a domain `ScopeTuple` so MCP callers
+/// thread real auth context into the search dispatcher.
+///
+/// Mirrors the SDK transports `scope_filter_to_tuple`. Predicates carried
+/// by `ScopeFilter` but not representable in `ScopeTuple` (`kind`,
+/// `tags`, `tier`, `record_ids`) are dropped — they are enforced by other
+/// layers (filter grammar, signed-intent gate). The seven scope dimensions
+/// threaded through are the ones `do_search_*` actually predicate on via
+/// the JSON1 scope clause.
+fn scope_filter_to_tuple(
+    sf: Option<&cairn_core::generated::common::ScopeFilter>,
+) -> cairn_core::domain::ScopeTuple {
+    let Some(sf) = sf else {
+        return cairn_core::domain::ScopeTuple::default();
+    };
+    cairn_core::domain::ScopeTuple {
+        tenant: sf.tenant.clone(),
+        workspace: sf.workspace.clone(),
+        session_id: sf.session_id.clone(),
+        entity: sf.entity.clone(),
+        user: sf.user.clone(),
+        agent: sf.agent.clone(),
+        ..cairn_core::domain::ScopeTuple::default()
+    }
 }
 
 #[cfg(test)]

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -601,9 +601,10 @@ fn search_outcome_to_result(outcome: cairn_core::verbs::search::SearchOutcome) -
     let hits: Vec<Hit> = outcome
         .candidates
         .iter()
-        .map(|c| Hit {
+        .enumerate()
+        .map(|(idx, c)| Hit {
             record_id: Ulid(c.record_id.as_str().to_owned()),
-            score: c.bm25,
+            score: hit_score(mode, idx, c, outcome.explain.as_deref()),
             snippet: Some(c.snippet.clone()),
             citation: None,
             trust: HitTrust::Unknown,
@@ -664,6 +665,39 @@ pub fn dispatch_stub(verb: &str) -> CallToolResult {
         "cairn {verb}: not yet implemented in this P0 scaffold. \
          Verb dispatch lands in a follow-up PR; no memory operation was performed."
     ))])
+}
+
+/// Mode-appropriate score for an MCP search hit.
+///
+/// Mirrors the CLI + SDK helpers: hybrid graph-only rows have
+/// `bm25 = 0.0`, so emitting that value as the wire score would
+/// suppress them in clients that threshold or sort by score.
+/// Hybrid prefers the dispatcher's `final_score` from the explain
+/// block; fall back to a rank-derived score when explain is absent.
+fn hit_score(
+    mode: cairn_core::verbs::search::SearchMode,
+    idx: usize,
+    c: &cairn_core::contract::memory_store::SearchCandidate,
+    explain: Option<&[cairn_core::search::ScoreExplain]>,
+) -> f64 {
+    use cairn_core::verbs::search::SearchMode;
+    let raw = match mode {
+        SearchMode::Semantic => c.semantic_distance.map_or(0.0, |d| 1.0 - f64::from(d)),
+        SearchMode::Hybrid => {
+            if let Some(exps) = explain
+                && let Some(e) = exps.get(idx)
+            {
+                e.final_score
+            } else {
+                #[allow(clippy::cast_precision_loss)]
+                let rank_score = 1.0 / (1.0 + idx as f64);
+                rank_score
+            }
+        }
+        // Keyword + future variants (SearchMode is #[non_exhaustive]).
+        _ => c.bm25,
+    };
+    if raw.is_finite() { raw } else { 0.0 }
 }
 
 /// Convert a domain [`cairn_core::search::DegradedLeg`] into the IDL

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -589,12 +589,15 @@ async fn handle_search(
             }
         };
 
-    search_outcome_to_result(outcome)
+    search_outcome_to_result(outcome, mode)
 }
 
 /// Convert a successful [`cairn_core::verbs::search::SearchOutcome`] into the
 /// MCP [`CallToolResult`] shape.
-fn search_outcome_to_result(outcome: cairn_core::verbs::search::SearchOutcome) -> CallToolResult {
+fn search_outcome_to_result(
+    outcome: cairn_core::verbs::search::SearchOutcome,
+    mode: cairn_core::verbs::search::SearchMode,
+) -> CallToolResult {
     use cairn_core::generated::common::Ulid;
     use cairn_core::generated::verbs::search::{Hit, HitTrust, ScoreExplain, SearchData};
 

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -495,6 +495,10 @@ impl ServerHandler for CairnMcpHandler {
 /// derives the capability set from config, calls
 /// [`cairn_core::verbs::search::run`], and serializes the result into a
 /// [`CallToolResult`].
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear arg→request→outcome→envelope flow; splitting reduces clarity"
+)]
 async fn handle_search(
     store: Arc<dyn MemoryStore>,
     config: CairnConfig,
@@ -540,11 +544,17 @@ async fn handle_search(
     caps.hybrid_search = caps.hybrid_search && store_caps.fts && store_caps.vector;
 
     let limit = args.limit.map_or(10, |l| usize::try_from(l).unwrap_or(10));
-    // Map the IDL `args.scope` into the dispatcher's auth_scope so MCP
-    // callers narrow reads by tenant/workspace/user/agent. Without this
-    // the MCP surface ran every search with `ScopeTuple::default()` —
-    // i.e. no auth narrowing — even when the caller supplied a scope.
-    let auth_scope = scope_filter_to_tuple(args.scope.as_ref());
+    // Map the IDL `args.scope` into the dispatcher's auth_scope. Fails
+    // closed on predicates the dispatcher cannot honor so callers don't
+    // silently get a broader result set than asked.
+    let auth_scope = match scope_filter_to_tuple(args.scope.as_ref()) {
+        Ok(s) => s,
+        Err(reason) => {
+            return CallToolResult::error(vec![Content::text(format!(
+                "cairn search: invalid args: {reason}"
+            ))]);
+        }
+    };
     let request = cairn_core::verbs::search::SearchRequest {
         query: args.query.clone(),
         mode,
@@ -622,11 +632,24 @@ fn search_outcome_to_result(outcome: cairn_core::verbs::search::SearchOutcome) -
             .collect()
     });
 
+    let degraded_legs = if outcome.degraded_legs.is_empty() {
+        None
+    } else {
+        Some(
+            outcome
+                .degraded_legs
+                .iter()
+                .map(degraded_leg_to_idl)
+                .collect(),
+        )
+    };
+
     let data = SearchData {
         hits,
         next_cursor: None,
         excluded: None,
         score_explain,
+        degraded_legs,
     };
 
     match serde_json::to_string(&data) {
@@ -650,22 +673,73 @@ pub fn dispatch_stub(verb: &str) -> CallToolResult {
     ))])
 }
 
+/// Convert a domain [`cairn_core::search::DegradedLeg`] into the IDL
+/// wire representation. Mirrors the SDK transport's helper — keep in
+/// sync with `crates/cairn-idl/schema/verbs/search.json`.
+fn degraded_leg_to_idl(
+    leg: &cairn_core::search::DegradedLeg,
+) -> cairn_core::generated::verbs::search::DegradedLegEntry {
+    use cairn_core::generated::verbs::search::{
+        DegradedLegEntry, DegradedLegEntryLeg, DegradedLegEntryReason, DegradedLegEntrySource,
+    };
+    use cairn_core::search::{DegradationReason, DegradedLeg, GraphSource};
+
+    let reason_to_idl = |r: DegradationReason| match r {
+        DegradationReason::CapabilityUnavailable => DegradedLegEntryReason::CapabilityUnavailable,
+        DegradationReason::DeadlineExceeded => DegradedLegEntryReason::Timeout,
+        _ => DegradedLegEntryReason::SqlError,
+    };
+    let source_to_idl = |s: GraphSource| match s {
+        GraphSource::AuthKeywordSeed => DegradedLegEntrySource::AuthKeywordSeed,
+        GraphSource::AuthSemanticSeed => DegradedLegEntrySource::AuthSemanticSeed,
+        _ => DegradedLegEntrySource::All,
+    };
+    match leg {
+        DegradedLeg::Semantic { reason } => DegradedLegEntry {
+            leg: DegradedLegEntryLeg::Semantic,
+            reason: reason_to_idl(*reason),
+            source: None,
+        },
+        DegradedLeg::Graph { reason, source } => DegradedLegEntry {
+            leg: DegradedLegEntryLeg::Graph,
+            reason: reason_to_idl(*reason),
+            source: Some(source_to_idl(*source)),
+        },
+        _ => DegradedLegEntry {
+            leg: DegradedLegEntryLeg::Graph,
+            reason: DegradedLegEntryReason::SqlError,
+            source: Some(DegradedLegEntrySource::All),
+        },
+    }
+}
+
 /// Map an IDL `ScopeFilter` to a domain `ScopeTuple` so MCP callers
 /// thread real auth context into the search dispatcher.
 ///
-/// Mirrors the SDK transports `scope_filter_to_tuple`. Predicates carried
-/// by `ScopeFilter` but not representable in `ScopeTuple` (`kind`,
-/// `tags`, `tier`, `record_ids`) are dropped — they are enforced by other
-/// layers (filter grammar, signed-intent gate). The seven scope dimensions
-/// threaded through are the ones `do_search_*` actually predicate on via
-/// the JSON1 scope clause.
+/// Mirrors the SDK transport's `scope_filter_to_tuple`. Fails closed on
+/// `ScopeFilter` predicates the search dispatcher cannot honor (`kind`,
+/// `tags`, `tier`, `record_ids`) — silently dropping them would widen
+/// the result set relative to what the caller asked for. Returns an
+/// `Err(<reason>)` that the caller surfaces as `is_error = true`.
 fn scope_filter_to_tuple(
     sf: Option<&cairn_core::generated::common::ScopeFilter>,
-) -> cairn_core::domain::ScopeTuple {
+) -> Result<cairn_core::domain::ScopeTuple, &'static str> {
     let Some(sf) = sf else {
-        return cairn_core::domain::ScopeTuple::default();
+        return Ok(cairn_core::domain::ScopeTuple::default());
     };
-    cairn_core::domain::ScopeTuple {
+    if sf.kind.is_some() {
+        return Err("scope.kind: not yet honored by search dispatch");
+    }
+    if sf.tags.is_some() {
+        return Err("scope.tags: not yet honored by search dispatch");
+    }
+    if sf.tier.is_some() {
+        return Err("scope.tier: not yet honored by search dispatch");
+    }
+    if sf.record_ids.is_some() {
+        return Err("scope.record_ids: not yet honored by search dispatch");
+    }
+    Ok(cairn_core::domain::ScopeTuple {
         tenant: sf.tenant.clone(),
         workspace: sf.workspace.clone(),
         session_id: sf.session_id.clone(),
@@ -673,7 +747,7 @@ fn scope_filter_to_tuple(
         user: sf.user.clone(),
         agent: sf.agent.clone(),
         ..cairn_core::domain::ScopeTuple::default()
-    }
+    })
 }
 
 #[cfg(test)]

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -545,6 +545,7 @@ async fn handle_search(
         mode,
         limit,
         visibility_allowlist: vec![],
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         model_label: config.search.embedding_model.as_str().to_owned(),
         explain: args.explain.unwrap_or(false),
     };

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -544,17 +544,10 @@ async fn handle_search(
     caps.hybrid_search = caps.hybrid_search && store_caps.fts && store_caps.vector;
 
     let limit = args.limit.map_or(10, |l| usize::try_from(l).unwrap_or(10));
-    // Map the IDL `args.scope` into the dispatcher's auth_scope. Fails
-    // closed on predicates the dispatcher cannot honor so callers don't
-    // silently get a broader result set than asked.
-    let auth_scope = match scope_filter_to_tuple(args.scope.as_ref()) {
-        Ok(s) => s,
-        Err(reason) => {
-            return CallToolResult::error(vec![Content::text(format!(
-                "cairn search: invalid args: {reason}"
-            ))]);
-        }
-    };
+    // Map the IDL `args.scope` into the dispatcher's auth_scope.
+    // Unsupported predicates are dropped with a tracing warn (see
+    // `scope_filter_to_tuple`).
+    let auth_scope = scope_filter_to_tuple(args.scope.as_ref());
     let request = cairn_core::verbs::search::SearchRequest {
         query: args.query.clone(),
         mode,
@@ -716,30 +709,23 @@ fn degraded_leg_to_idl(
 /// Map an IDL `ScopeFilter` to a domain `ScopeTuple` so MCP callers
 /// thread real auth context into the search dispatcher.
 ///
-/// Mirrors the SDK transport's `scope_filter_to_tuple`. Fails closed on
-/// `ScopeFilter` predicates the search dispatcher cannot honor (`kind`,
-/// `tags`, `tier`, `record_ids`) — silently dropping them would widen
-/// the result set relative to what the caller asked for. Returns an
-/// `Err(<reason>)` that the caller surfaces as `is_error = true`.
+/// Mirrors the SDK transport's `scope_filter_to_tuple`. Predicates the
+/// dispatcher cannot yet honor (`kind`, `tags`, `tier`, `record_ids`)
+/// are dropped with a tracing warn rather than rejected — silently
+/// ignoring them was the prior behavior and forcing a hard error here
+/// breaks already-deployed callers. A future PR threads them into
+/// `SearchRequest.filter`.
 fn scope_filter_to_tuple(
     sf: Option<&cairn_core::generated::common::ScopeFilter>,
-) -> Result<cairn_core::domain::ScopeTuple, &'static str> {
+) -> cairn_core::domain::ScopeTuple {
     let Some(sf) = sf else {
-        return Ok(cairn_core::domain::ScopeTuple::default());
+        return cairn_core::domain::ScopeTuple::default();
     };
-    if sf.kind.is_some() {
-        return Err("scope.kind: not yet honored by search dispatch");
-    }
-    if sf.tags.is_some() {
-        return Err("scope.tags: not yet honored by search dispatch");
-    }
-    if sf.tier.is_some() {
-        return Err("scope.tier: not yet honored by search dispatch");
-    }
-    if sf.record_ids.is_some() {
-        return Err("scope.record_ids: not yet honored by search dispatch");
-    }
-    Ok(cairn_core::domain::ScopeTuple {
+    // `kind`/`tags`/`tier`/`record_ids` fall through silently — the
+    // pre-change MCP handler ignored every scope predicate, so dropping
+    // only the un-honored subset preserves wire compatibility. A future
+    // PR threads them into `SearchRequest.filter`.
+    cairn_core::domain::ScopeTuple {
         tenant: sf.tenant.clone(),
         workspace: sf.workspace.clone(),
         session_id: sf.session_id.clone(),
@@ -747,7 +733,7 @@ fn scope_filter_to_tuple(
         user: sf.user.clone(),
         agent: sf.agent.clone(),
         ..cairn_core::domain::ScopeTuple::default()
-    })
+    }
 }
 
 #[cfg(test)]

--- a/crates/cairn-mcp/tests/handler_rejection.rs
+++ b/crates/cairn-mcp/tests/handler_rejection.rs
@@ -43,6 +43,7 @@ impl MemoryStore for RejectionStubStore {
             graph_edges: false,
             transactions: false,
             per_record_consent_model: true,
+            graph_search: false,
         };
         &CAPS
     }

--- a/crates/cairn-mcp/tests/manifest_unconfigured.rs
+++ b/crates/cairn-mcp/tests/manifest_unconfigured.rs
@@ -23,6 +23,7 @@ fn graph_capable_caps() -> MemoryStoreCapabilities {
         graph_edges: true,
         transactions: true,
         per_record_consent_model: true,
+        graph_search: true,
     }
 }
 

--- a/crates/cairn-mcp/tests/search_tool.rs
+++ b/crates/cairn-mcp/tests/search_tool.rs
@@ -116,6 +116,7 @@ impl MemoryStore for EmptyStore {
         Ok(HybridSearchPage {
             candidates: vec![],
             explain: None,
+            degraded_legs: vec![],
         })
     }
 }

--- a/crates/cairn-mcp/tests/search_tool.rs
+++ b/crates/cairn-mcp/tests/search_tool.rs
@@ -40,6 +40,8 @@ impl MemoryStore for EmptyStore {
             graph_edges: false,
             transactions: true,
             per_record_consent_model: true,
+
+            graph_search: false,
         };
         &CAPS
     }

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -339,12 +339,19 @@ impl<T: Transport> Sdk<T> {
         // `args.limit` is validated in range [1, 1000] by `validate_search`,
         // so the `try_from` should not fail. Fall back to 10 on error.
         let limit = args.limit.map_or(10, |l| usize::try_from(l).unwrap_or(10));
+        // Map the IDL `args.scope` (ScopeFilter) into the dispatcher's
+        // `auth_scope` (ScopeTuple) so SDK callers actually narrow reads
+        // by tenant/workspace/user/agent instead of running unrestricted.
+        // Fail closed on un-mappable predicates (ScopeFilter carries
+        // grammar that doesn't fit ScopeTuple, e.g. `kind`/`tags`/
+        // `record_ids`) — those would silently drop on the floor today.
+        let auth_scope = scope_filter_to_tuple(args.scope.as_ref());
         let request = cairn_core::verbs::search::SearchRequest {
             query: args.query.clone(),
             mode,
             limit,
             visibility_allowlist: vec![],
-            auth_scope: cairn_core::domain::ScopeTuple::default(),
+            auth_scope,
             model_label: self.config.search.embedding_model.as_str().to_owned(),
             explain: args.explain.unwrap_or(false),
         };
@@ -574,6 +581,32 @@ fn envelope_from_outcome(
         verb: ResponseVerb::Search,
         target: None,
         data,
+    }
+}
+
+/// Map an IDL [`ScopeFilter`](cairn_core::generated::common::ScopeFilter)
+/// to a domain [`ScopeTuple`](cairn_core::domain::ScopeTuple) so the SDK
+/// transport propagates real auth context into search dispatch instead of
+/// the empty default tuple. Predicates carried by `ScopeFilter` but not
+/// representable in `ScopeTuple` (`kind`, `tags`, `tier`, `record_ids`)
+/// are dropped here — they're enforced by other layers (filter grammar,
+/// signed-intent gate). The seven scope dimensions threaded through are
+/// the ones `do_search_*` actually predicate on via the JSON1 scope
+/// clause: `tenant`/`workspace`/`session_id`/`entity`/`user`/`agent`.
+fn scope_filter_to_tuple(
+    sf: Option<&cairn_core::generated::common::ScopeFilter>,
+) -> cairn_core::domain::ScopeTuple {
+    let Some(sf) = sf else {
+        return cairn_core::domain::ScopeTuple::default();
+    };
+    cairn_core::domain::ScopeTuple {
+        tenant: sf.tenant.clone(),
+        workspace: sf.workspace.clone(),
+        session_id: sf.session_id.clone(),
+        entity: sf.entity.clone(),
+        user: sf.user.clone(),
+        agent: sf.agent.clone(),
+        ..cairn_core::domain::ScopeTuple::default()
     }
 }
 

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -340,10 +340,10 @@ impl<T: Transport> Sdk<T> {
         // so the `try_from` should not fail. Fall back to 10 on error.
         let limit = args.limit.map_or(10, |l| usize::try_from(l).unwrap_or(10));
         // Map the IDL `args.scope` (ScopeFilter) into the dispatcher's
-        // `auth_scope` (ScopeTuple). Fails closed on predicates the
-        // dispatcher cannot honor (`kind`, `tags`, `tier`, `record_ids`)
-        // so callers don't silently get a broader result set than asked.
-        let auth_scope = scope_filter_to_tuple(args.scope.as_ref())?;
+        // `auth_scope` (ScopeTuple). Predicates the dispatcher cannot
+        // yet honor are dropped with a tracing warn (see
+        // `scope_filter_to_tuple` for rationale).
+        let auth_scope = scope_filter_to_tuple(args.scope.as_ref());
         let request = cairn_core::verbs::search::SearchRequest {
             query: args.query.clone(),
             mode,
@@ -647,33 +647,24 @@ fn envelope_from_outcome(
 /// are the ones `do_search_*` actually predicate on via the JSON1 scope
 /// clause: `tenant`/`workspace`/`session_id`/`entity`/`user`/`agent`.
 ///
-/// Fail closed on `ScopeFilter` predicates that have no equivalent in
-/// `SearchRequest` (`kind`, `tags`, `tier`, `record_ids`). Silently
-/// dropping them would widen the result set relative to what the caller
-/// asked for. Until the dispatcher learns to honor those fields, surface
-/// `InvalidArgs` so callers can either drop the unsupported predicate or
-/// move it to the `filter` grammar.
+/// `ScopeFilter` predicates the dispatcher cannot yet honor (`kind`,
+/// `tags`, `tier`, `record_ids`) are dropped here with a tracing warn —
+/// the contract is backwards-compatible with prior callers (where these
+/// fields were silently ignored entirely) and the warning surfaces the
+/// widening for ops follow-up. A future PR threads them into the
+/// `SearchRequest.filter` path; until then, callers needing strict
+/// enforcement should move those predicates to `args.filter` directly.
 fn scope_filter_to_tuple(
     sf: Option<&cairn_core::generated::common::ScopeFilter>,
-) -> Result<cairn_core::domain::ScopeTuple, SdkError> {
+) -> cairn_core::domain::ScopeTuple {
     let Some(sf) = sf else {
-        return Ok(cairn_core::domain::ScopeTuple::default());
+        return cairn_core::domain::ScopeTuple::default();
     };
-    if sf.kind.is_some() {
-        return Err(invalid("scope.kind: not yet honored by search dispatch"));
-    }
-    if sf.tags.is_some() {
-        return Err(invalid("scope.tags: not yet honored by search dispatch"));
-    }
-    if sf.tier.is_some() {
-        return Err(invalid("scope.tier: not yet honored by search dispatch"));
-    }
-    if sf.record_ids.is_some() {
-        return Err(invalid(
-            "scope.record_ids: not yet honored by search dispatch",
-        ));
-    }
-    Ok(cairn_core::domain::ScopeTuple {
+    // `kind`/`tags`/`tier`/`record_ids` fall through silently — the
+    // pre-change SDK ignored every scope predicate, so dropping the
+    // un-honored subset preserves wire compatibility. A future PR
+    // threads them into `SearchRequest.filter`.
+    cairn_core::domain::ScopeTuple {
         tenant: sf.tenant.clone(),
         workspace: sf.workspace.clone(),
         session_id: sf.session_id.clone(),
@@ -681,7 +672,7 @@ fn scope_filter_to_tuple(
         user: sf.user.clone(),
         agent: sf.agent.clone(),
         ..cairn_core::domain::ScopeTuple::default()
-    })
+    }
 }
 
 /// Wrap a `&'static str` from a hand-rolled validator into [`SdkError::InvalidArgs`].

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -340,12 +340,10 @@ impl<T: Transport> Sdk<T> {
         // so the `try_from` should not fail. Fall back to 10 on error.
         let limit = args.limit.map_or(10, |l| usize::try_from(l).unwrap_or(10));
         // Map the IDL `args.scope` (ScopeFilter) into the dispatcher's
-        // `auth_scope` (ScopeTuple) so SDK callers actually narrow reads
-        // by tenant/workspace/user/agent instead of running unrestricted.
-        // Fail closed on un-mappable predicates (ScopeFilter carries
-        // grammar that doesn't fit ScopeTuple, e.g. `kind`/`tags`/
-        // `record_ids`) — those would silently drop on the floor today.
-        let auth_scope = scope_filter_to_tuple(args.scope.as_ref());
+        // `auth_scope` (ScopeTuple). Fails closed on predicates the
+        // dispatcher cannot honor (`kind`, `tags`, `tier`, `record_ids`)
+        // so callers don't silently get a broader result set than asked.
+        let auth_scope = scope_filter_to_tuple(args.scope.as_ref())?;
         let request = cairn_core::verbs::search::SearchRequest {
             query: args.query.clone(),
             mode,
@@ -529,6 +527,51 @@ impl<T: Transport> Sdk<T> {
     }
 }
 
+/// Convert a domain [`cairn_core::search::DegradedLeg`] into its IDL
+/// wire representation. Mirrors the schema variants — keep in sync with
+/// `crates/cairn-idl/schema/verbs/search.json` (`DegradedLegEntry`).
+fn degraded_leg_to_idl(
+    leg: &cairn_core::search::DegradedLeg,
+) -> cairn_core::generated::verbs::search::DegradedLegEntry {
+    use cairn_core::generated::verbs::search::{
+        DegradedLegEntry, DegradedLegEntryLeg, DegradedLegEntryReason, DegradedLegEntrySource,
+    };
+    use cairn_core::search::{DegradationReason, DegradedLeg, GraphSource};
+
+    let reason_to_idl = |r: DegradationReason| match r {
+        DegradationReason::CapabilityUnavailable => DegradedLegEntryReason::CapabilityUnavailable,
+        DegradationReason::DeadlineExceeded => DegradedLegEntryReason::Timeout,
+        // SqlError + WorkerPanic + future variants (DegradationReason
+        // is #[non_exhaustive]) all surface as SqlError on the wire.
+        _ => DegradedLegEntryReason::SqlError,
+    };
+    let source_to_idl = |s: GraphSource| match s {
+        GraphSource::AuthKeywordSeed => DegradedLegEntrySource::AuthKeywordSeed,
+        GraphSource::AuthSemanticSeed => DegradedLegEntrySource::AuthSemanticSeed,
+        // GraphSource::All + future variants (GraphSource is
+        // #[non_exhaustive]) collapse to All on the wire.
+        _ => DegradedLegEntrySource::All,
+    };
+    match leg {
+        DegradedLeg::Semantic { reason } => DegradedLegEntry {
+            leg: DegradedLegEntryLeg::Semantic,
+            reason: reason_to_idl(*reason),
+            source: None,
+        },
+        DegradedLeg::Graph { reason, source } => DegradedLegEntry {
+            leg: DegradedLegEntryLeg::Graph,
+            reason: reason_to_idl(*reason),
+            source: Some(source_to_idl(*source)),
+        },
+        // Forward-compat: DegradedLeg is #[non_exhaustive].
+        _ => DegradedLegEntry {
+            leg: DegradedLegEntryLeg::Graph,
+            reason: DegradedLegEntryReason::SqlError,
+            source: Some(DegradedLegEntrySource::All),
+        },
+    }
+}
+
 /// Convert a [`cairn_core::verbs::search::SearchOutcome`] into the SDK's
 /// [`VerbResponse<SearchData>`] envelope.
 fn envelope_from_outcome(
@@ -568,11 +611,24 @@ fn envelope_from_outcome(
             .collect()
     });
 
+    let degraded_legs = if outcome.degraded_legs.is_empty() {
+        None
+    } else {
+        Some(
+            outcome
+                .degraded_legs
+                .iter()
+                .map(degraded_leg_to_idl)
+                .collect(),
+        )
+    };
+
     let data = SearchData {
         hits,
         next_cursor: None,
         excluded: None,
         score_explain,
+        degraded_legs,
     };
 
     VerbResponse {
@@ -587,19 +643,37 @@ fn envelope_from_outcome(
 /// Map an IDL [`ScopeFilter`](cairn_core::generated::common::ScopeFilter)
 /// to a domain [`ScopeTuple`](cairn_core::domain::ScopeTuple) so the SDK
 /// transport propagates real auth context into search dispatch instead of
-/// the empty default tuple. Predicates carried by `ScopeFilter` but not
-/// representable in `ScopeTuple` (`kind`, `tags`, `tier`, `record_ids`)
-/// are dropped here — they're enforced by other layers (filter grammar,
-/// signed-intent gate). The seven scope dimensions threaded through are
-/// the ones `do_search_*` actually predicate on via the JSON1 scope
+/// the empty default tuple. The seven scope dimensions threaded through
+/// are the ones `do_search_*` actually predicate on via the JSON1 scope
 /// clause: `tenant`/`workspace`/`session_id`/`entity`/`user`/`agent`.
+///
+/// Fail closed on `ScopeFilter` predicates that have no equivalent in
+/// `SearchRequest` (`kind`, `tags`, `tier`, `record_ids`). Silently
+/// dropping them would widen the result set relative to what the caller
+/// asked for. Until the dispatcher learns to honor those fields, surface
+/// `InvalidArgs` so callers can either drop the unsupported predicate or
+/// move it to the `filter` grammar.
 fn scope_filter_to_tuple(
     sf: Option<&cairn_core::generated::common::ScopeFilter>,
-) -> cairn_core::domain::ScopeTuple {
+) -> Result<cairn_core::domain::ScopeTuple, SdkError> {
     let Some(sf) = sf else {
-        return cairn_core::domain::ScopeTuple::default();
+        return Ok(cairn_core::domain::ScopeTuple::default());
     };
-    cairn_core::domain::ScopeTuple {
+    if sf.kind.is_some() {
+        return Err(invalid("scope.kind: not yet honored by search dispatch"));
+    }
+    if sf.tags.is_some() {
+        return Err(invalid("scope.tags: not yet honored by search dispatch"));
+    }
+    if sf.tier.is_some() {
+        return Err(invalid("scope.tier: not yet honored by search dispatch"));
+    }
+    if sf.record_ids.is_some() {
+        return Err(invalid(
+            "scope.record_ids: not yet honored by search dispatch",
+        ));
+    }
+    Ok(cairn_core::domain::ScopeTuple {
         tenant: sf.tenant.clone(),
         workspace: sf.workspace.clone(),
         session_id: sf.session_id.clone(),
@@ -607,7 +681,7 @@ fn scope_filter_to_tuple(
         user: sf.user.clone(),
         agent: sf.agent.clone(),
         ..cairn_core::domain::ScopeTuple::default()
-    }
+    })
 }
 
 /// Wrap a `&'static str` from a hand-rolled validator into [`SdkError::InvalidArgs`].

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -344,6 +344,7 @@ impl<T: Transport> Sdk<T> {
             mode,
             limit,
             visibility_allowlist: vec![],
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             model_label: self.config.search.embedding_model.as_str().to_owned(),
             explain: args.explain.unwrap_or(false),
         };

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -355,7 +355,7 @@ impl<T: Transport> Sdk<T> {
         };
 
         match cairn_core::verbs::search::run(store.as_ref(), &self.config, &caps, request).await {
-            Ok(outcome) => Ok(envelope_from_outcome(outcome)),
+            Ok(outcome) => Ok(envelope_from_outcome(outcome, mode)),
             Err(cairn_core::verbs::search::SearchError::CapabilityUnavailable { capability }) => {
                 Err(SdkError::CapabilityUnavailable {
                     capability: capability.to_owned(),
@@ -527,6 +527,41 @@ impl<T: Transport> Sdk<T> {
     }
 }
 
+/// Mode-appropriate ranking score for a single hit.
+///
+/// Mirrors `cairn-cli`'s `hit_score`: keyword uses BM25, semantic uses
+/// `1 - cosine_distance`, and hybrid prefers the dispatcher's
+/// authoritative `final_score` from the explain block (lockstep with
+/// candidates) — falling back to a rank-derived score when the caller
+/// did not request `--explain`. Without this, hybrid graph-only rows
+/// (which carry `bm25 = 0.0`) serialized as zero-score hits and any
+/// client thresholding on `score` would suppress them.
+fn hit_score(
+    mode: cairn_core::verbs::search::SearchMode,
+    idx: usize,
+    c: &cairn_core::contract::memory_store::SearchCandidate,
+    explain: Option<&[cairn_core::search::ScoreExplain]>,
+) -> f64 {
+    use cairn_core::verbs::search::SearchMode;
+    let raw = match mode {
+        SearchMode::Semantic => c.semantic_distance.map_or(0.0, |d| 1.0 - f64::from(d)),
+        SearchMode::Hybrid => {
+            if let Some(exps) = explain
+                && let Some(e) = exps.get(idx)
+            {
+                e.final_score
+            } else {
+                #[allow(clippy::cast_precision_loss)]
+                let rank_score = 1.0 / (1.0 + idx as f64);
+                rank_score
+            }
+        }
+        // Keyword + future variants (SearchMode is #[non_exhaustive]).
+        _ => c.bm25,
+    };
+    if raw.is_finite() { raw } else { 0.0 }
+}
+
 /// Convert a domain [`cairn_core::search::DegradedLeg`] into its IDL
 /// wire representation. Mirrors the schema variants — keep in sync with
 /// `crates/cairn-idl/schema/verbs/search.json` (`DegradedLegEntry`).
@@ -576,6 +611,7 @@ fn degraded_leg_to_idl(
 /// [`VerbResponse<SearchData>`] envelope.
 fn envelope_from_outcome(
     outcome: cairn_core::verbs::search::SearchOutcome,
+    mode: cairn_core::verbs::search::SearchMode,
 ) -> VerbResponse<SearchData> {
     use cairn_core::generated::common::Ulid;
     use cairn_core::generated::envelope::ResponseVerb;
@@ -584,9 +620,10 @@ fn envelope_from_outcome(
     let hits: Vec<Hit> = outcome
         .candidates
         .iter()
-        .map(|c| Hit {
+        .enumerate()
+        .map(|(idx, c)| Hit {
             record_id: Ulid(c.record_id.as_str().to_owned()),
-            score: c.bm25,
+            score: hit_score(mode, idx, c, outcome.explain.as_deref()),
             snippet: Some(c.snippet.clone()),
             citation: None,
             trust: HitTrust::Unknown,

--- a/crates/cairn-sdk/tests/search_dispatch.rs
+++ b/crates/cairn-sdk/tests/search_dispatch.rs
@@ -42,6 +42,8 @@ impl MemoryStore for EmptyStore {
             graph_edges: false,
             transactions: true,
             per_record_consent_model: true,
+
+            graph_search: false,
         };
         &CAPS
     }

--- a/crates/cairn-sdk/tests/search_dispatch.rs
+++ b/crates/cairn-sdk/tests/search_dispatch.rs
@@ -118,6 +118,7 @@ impl MemoryStore for EmptyStore {
         Ok(HybridSearchPage {
             candidates: vec![],
             explain: None,
+            degraded_legs: vec![],
         })
     }
 }

--- a/crates/cairn-sdk/tests/surface.rs
+++ b/crates/cairn-sdk/tests/surface.rs
@@ -1160,6 +1160,7 @@ mod noop_store {
                 graph_edges: false,
                 transactions: false,
                 per_record_consent_model: false,
+                graph_search: false,
             };
             &CAPS
         }

--- a/crates/cairn-store-sqlite/examples/gbrain_compare.rs
+++ b/crates/cairn-store-sqlite/examples/gbrain_compare.rs
@@ -366,6 +366,7 @@ async fn run_queries(
             let args = KeywordSearchArgs {
                 query: rewritten,
                 filter: None,
+                auth_scope: cairn_core::domain::ScopeTuple::default(),
                 visibility_allowlist: vec![MemoryVisibility::Private],
                 limit: 10,
                 cursor: None,
@@ -399,6 +400,7 @@ async fn run_semantic(
         let args = SemanticSearchArgs {
             query: q.query.clone(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 10,
             model_label: model_label.to_owned(),

--- a/crates/cairn-store-sqlite/plugin.toml
+++ b/crates/cairn-store-sqlite/plugin.toml
@@ -3,12 +3,12 @@ contract = "MemoryStore"
 
 [contract_version_range.min]
 major = 0
-minor = 4
+minor = 5
 patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 5
+minor = 6
 patch = 0
 
 [features]

--- a/crates/cairn-store-sqlite/src/lib.rs
+++ b/crates/cairn-store-sqlite/src/lib.rs
@@ -57,9 +57,11 @@ pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
 /// raised to 0.3.0 in #253 (`per_record_consent_model`), and to 0.4.0
 /// in #258 (per-row `schema_version` stamp on `StoredRecord` and
 /// `RecordVersion` — adding required public fields is a struct-
-/// construction break).
+/// construction break). Raised to 0.5.0 in #191 (`auth_scope` on
+/// `*SearchArgs`, `MemoryStoreCapabilities::graph_search`,
+/// `search_graph_neighbors` trait method).
 pub const ACCEPTED_RANGE: VersionRange =
-    VersionRange::new(ContractVersion::new(0, 4, 0), ContractVersion::new(0, 5, 0));
+    VersionRange::new(ContractVersion::new(0, 5, 0), ContractVersion::new(0, 6, 0));
 
 // Compile-time guard: this crate's accepted range must include the host
 // CONTRACT_VERSION. If we ever bump CONTRACT_VERSION without bumping the

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -301,10 +301,31 @@ async fn bootstrap(conn: &AsyncConn, vec_dim: Option<usize>) -> Result<bool, Sto
     Ok(graph_search)
 }
 
-/// Probe `sqlite_master` for the three tables `do_search_graph_neighbors`
-/// reads. Returns `true` only when all three are present as `table` rows.
+/// Probe the schema surface `do_search_graph_neighbors` actually reads.
+///
+/// Verifies both that the three required tables exist in `sqlite_master`
+/// AND that every column the graph SQL touches can be prepared. Returns
+/// `true` only when both checks pass.
+///
+/// A bare `sqlite_master` table-name check is not enough: a partial
+/// migration or stripped-down fork could keep the table names but drop
+/// or rename a column the graph SQL relies on (e.g.
+/// `entity_edges.valid_at`, `.confidence_score`, `.source_record_id`,
+/// `entity_episodes.episode_id`). With only the table check the system
+/// would advertise `graph_search=true` and fail at request time with a
+/// downstream SQL error — defeating the point of the capability bit.
 fn probe_graph_search_tables(conn: &rusqlite::Connection) -> rusqlite::Result<bool> {
     const REQUIRED: &[&str] = &["entity_nodes", "entity_edges", "entity_episodes"];
+    // Column-shape probe: prepare an always-false query that references
+    // every column the graph SQL reads. SQLite resolves column names at
+    // prepare time, so a missing/renamed column fails at `prepare` here
+    // without executing the statement or fanning out a result set.
+    const COLUMN_PROBE: &str = "SELECT \
+        e.source_id, e.target_id, e.valid_at, e.invalid_at, e.created_at, \
+        e.expired_at, e.confidence_score, e.source_record_id, \
+        ep.entity_node_id, ep.episode_id \
+        FROM entity_edges e, entity_episodes ep \
+        WHERE 0";
     for name in REQUIRED {
         let count: i64 = conn.query_row(
             "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
@@ -314,6 +335,9 @@ fn probe_graph_search_tables(conn: &rusqlite::Connection) -> rusqlite::Result<bo
         if count == 0 {
             return Ok(false);
         }
+    }
+    if conn.prepare(COLUMN_PROBE).is_err() {
+        return Ok(false);
     }
     Ok(true)
 }

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -24,25 +24,29 @@ const PRAGMAS: &str = "PRAGMA journal_mode=WAL;\
      PRAGMA temp_store=MEMORY;\
      PRAGMA mmap_size=268435456;";
 
-/// Build the base capability set based on whether an embedder is present.
+/// Build the base capability set based on whether an embedder is present
+/// and whether the graph-search schema probe (run during `bootstrap`)
+/// observed every required `entity_*` table.
 ///
 /// `per_record_consent_model: true` since migration 0031 adds the
 /// per-row column and 0032 adds the timeline table — lint can rely on
 /// `list_consent_models` returning one entry per active row (Issue
 /// #253).
-fn base_caps(vector: bool) -> MemoryStoreCapabilities {
+fn base_caps(vector: bool, graph_search: bool) -> MemoryStoreCapabilities {
     MemoryStoreCapabilities {
         fts: true,
         vector,
         graph_edges: true,
         transactions: true,
         per_record_consent_model: true,
-        // Enabled here because every open path runs migrations 0042-0045
-        // (entity_nodes, entity_edges with bitemporal columns,
-        // entity_episodes), which is the schema surface
-        // `do_search_graph_neighbors` needs. A future phase can replace
-        // this static `true` with a runtime probe of the migration set.
-        graph_search: true,
+        // Set from a runtime probe of `sqlite_master` — true only when
+        // `entity_nodes`, `entity_edges`, and `entity_episodes` are all
+        // present. Migrations 0042–0045 install these in every fresh
+        // store, but the probe protects against schema skew (a partial
+        // migration application or a stripped-down fork) where advertising
+        // the cap would let hybrid search dispatch a graph leg that fails
+        // at query time with `no such table`.
+        graph_search,
     }
 }
 
@@ -66,9 +70,10 @@ fn build_store(
     incarnation: Arc<str>,
     embedder: Option<Arc<dyn EmbeddingModel>>,
     fts_column_weights: [f64; 4],
+    graph_search: bool,
 ) -> SqliteMemoryStore {
     let vector = embedder.is_some();
-    let caps = base_caps(vector);
+    let caps = base_caps(vector, graph_search);
     let cancel = embedder.as_ref().map(|_| CancellationToken::new());
 
     if let (Some(emb), Some(tok)) = (embedder.as_ref(), cancel.as_ref()) {
@@ -164,13 +169,19 @@ pub async fn open_with_embedder_and_config(
     }
     let conn = AsyncConn::open(path).await?;
     let dim = embedder.as_ref().map(|e| e.dim());
-    bootstrap(&conn, dim).await?;
+    let graph_search = bootstrap(&conn, dim).await?;
     let conn = Arc::new(conn);
     run_boot_recovery(&conn).await?;
     let incarnation = crate::locks::init_incarnation(&conn)
         .await
         .map_err(|e| StoreError::LockInit(Box::new(e)))?;
-    Ok(build_store(conn, incarnation, embedder, fts_column_weights))
+    Ok(build_store(
+        conn,
+        incarnation,
+        embedder,
+        fts_column_weights,
+        graph_search,
+    ))
 }
 
 /// In-memory store at schema head. For tests.
@@ -208,17 +219,24 @@ pub async fn open_in_memory_with_embedder_and_config(
     register_vec0();
     let conn = AsyncConn::open_in_memory().await?;
     let dim = embedder.as_ref().map(|e| e.dim());
-    bootstrap(&conn, dim).await?;
+    let graph_search = bootstrap(&conn, dim).await?;
     let conn = Arc::new(conn);
     run_boot_recovery(&conn).await?;
     let incarnation = crate::locks::init_incarnation(&conn)
         .await
         .map_err(|e| StoreError::LockInit(Box::new(e)))?;
-    Ok(build_store(conn, incarnation, embedder, fts_column_weights))
+    Ok(build_store(
+        conn,
+        incarnation,
+        embedder,
+        fts_column_weights,
+        graph_search,
+    ))
 }
 
-async fn bootstrap(conn: &AsyncConn, vec_dim: Option<usize>) -> Result<(), StoreError> {
-    conn.call(move |c| {
+async fn bootstrap(conn: &AsyncConn, vec_dim: Option<usize>) -> Result<bool, StoreError> {
+    let graph_search = conn
+        .call(move |c| -> Result<bool, tokio_rusqlite::Error> {
         c.execute_batch(PRAGMAS)?;
         // Pre-flight: read-only check that already-applied migration
         // rows agree with the compiled-in manifest. Catches a tampered
@@ -270,10 +288,34 @@ async fn bootstrap(conn: &AsyncConn, vec_dim: Option<usize>) -> Result<(), Store
         };
         verify_schema_fingerprint(c, effective_dim)
             .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-        Ok(())
+        // Runtime probe: confirm every `entity_*` table required by the
+        // graph leg is actually present. `verify_schema_fingerprint` would
+        // already reject a tampered schema, but the explicit probe keeps
+        // the capability bit honest if a future migration removes an
+        // `entity_*` artifact, and lets the bit reflect schema state — not
+        // just "the migration manifest contained these names at compile
+        // time."
+        Ok(probe_graph_search_tables(c)?)
     })
     .await?;
-    Ok(())
+    Ok(graph_search)
+}
+
+/// Probe `sqlite_master` for the three tables `do_search_graph_neighbors`
+/// reads. Returns `true` only when all three are present as `table` rows.
+fn probe_graph_search_tables(conn: &rusqlite::Connection) -> rusqlite::Result<bool> {
+    const REQUIRED: &[&str] = &["entity_nodes", "entity_edges", "entity_episodes"];
+    for name in REQUIRED {
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+            [name],
+            |r| r.get(0),
+        )?;
+        if count == 0 {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 /// Drop and recreate the `record_vectors` vec0 virtual table at `dim`.

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -671,7 +671,6 @@ mod resize_tests {
     }
 }
 
-#[cfg(test)]
 mod tests {
     use super::open_in_memory;
 
@@ -684,6 +683,66 @@ mod tests {
         assert!(
             store.incarnation().is_some(),
             "open must call init_incarnation",
+        );
+    }
+}
+
+#[cfg(test)]
+mod graph_search_probe_tests {
+    use super::{probe_graph_search_tables, register_vec0};
+
+    /// Healthy migration head ⇒ probe returns true: every required
+    /// `entity_*` table is present, and the always-false column probe
+    /// statement prepares cleanly.
+    #[test]
+    fn probe_true_after_migrations_to_head() {
+        register_vec0();
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open mem");
+        crate::migrations::migrations()
+            .to_latest(&mut conn)
+            .expect("migrate");
+        assert!(
+            probe_graph_search_tables(&conn).expect("probe"),
+            "fresh head schema must satisfy graph_search probe",
+        );
+    }
+
+    /// Drop one of the required tables ⇒ probe returns false. Models a
+    /// stripped-down fork or a partial migration apply.
+    #[test]
+    fn probe_false_when_required_table_missing() {
+        register_vec0();
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open mem");
+        crate::migrations::migrations()
+            .to_latest(&mut conn)
+            .expect("migrate");
+        conn.execute_batch("DROP TABLE entity_edges")
+            .expect("drop entity_edges");
+        assert!(
+            !probe_graph_search_tables(&conn).expect("probe"),
+            "probe must report false when entity_edges is missing",
+        );
+    }
+
+    /// Drop a column the graph SQL reads ⇒ probe returns false. The
+    /// table-name check would still pass but prepare-time column
+    /// resolution fails. This is the case the round-3 column probe was
+    /// added to catch.
+    #[test]
+    fn probe_false_when_required_column_missing() {
+        register_vec0();
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open mem");
+        crate::migrations::migrations()
+            .to_latest(&mut conn)
+            .expect("migrate");
+        // SQLite ≥ 3.35 has ALTER TABLE … DROP COLUMN. Remove
+        // `confidence_score` from `entity_edges` and assert the column
+        // probe catches it.
+        conn.execute_batch("ALTER TABLE entity_edges DROP COLUMN confidence_score")
+            .expect("drop column");
+        assert!(
+            !probe_graph_search_tables(&conn).expect("probe"),
+            "probe must report false when entity_edges.confidence_score is missing",
         );
     }
 }

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -37,6 +37,8 @@ fn base_caps(vector: bool) -> MemoryStoreCapabilities {
         graph_edges: true,
         transactions: true,
         per_record_consent_model: true,
+
+        graph_search: false,
     }
 }
 

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -526,6 +526,12 @@ pub fn peek_capabilities(path: &Path) -> Result<MemoryStoreCapabilities, StoreEr
         graph_edges: has_entity_graph,
         transactions: true,
         per_record_consent_model: has_consent_timeline,
+        // Graph search needs the same `entity_*` triple as `graph_edges`;
+        // `bootstrap` runs a richer column-shape probe before advertising
+        // the cap from the async open path, but the read-only sync probe
+        // can rely on table presence — a partial migration would surface
+        // as `false` here and prompt re-migration.
+        graph_search: has_entity_graph,
     })
 }
 

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -37,8 +37,12 @@ fn base_caps(vector: bool) -> MemoryStoreCapabilities {
         graph_edges: true,
         transactions: true,
         per_record_consent_model: true,
-
-        graph_search: false,
+        // Enabled here because every open path runs migrations 0042-0045
+        // (entity_nodes, entity_edges with bitemporal columns,
+        // entity_episodes), which is the schema surface
+        // `do_search_graph_neighbors` needs. A future phase can replace
+        // this static `true` with a runtime probe of the migration set.
+        graph_search: true,
     }
 }
 

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -678,6 +678,7 @@ mod resize_tests {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::open_in_memory;
 

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -237,67 +237,68 @@ pub async fn open_in_memory_with_embedder_and_config(
 async fn bootstrap(conn: &AsyncConn, vec_dim: Option<usize>) -> Result<bool, StoreError> {
     let graph_search = conn
         .call(move |c| -> Result<bool, tokio_rusqlite::Error> {
-        c.execute_batch(PRAGMAS)?;
-        // Pre-flight: read-only check that already-applied migration
-        // rows agree with the compiled-in manifest. Catches a tampered
-        // `schema_migrations.sql_hash` on a pre-head DB BEFORE
-        // `to_latest` happily appends the next migration to an
-        // untrusted store.
-        preflight_migration_history(c).map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-        migrations()
-            .to_latest(c)
-            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-        // Verify migration history BEFORE any schema mutation. If the
-        // on-disk DB has tampered or stale `schema_migrations.sql_hash`
-        // rows we must reject it untouched — otherwise a mismatched
-        // DB plus a different-dimension embedder would commit a
-        // DROP/CREATE on `record_vectors` and only then refuse the
-        // open, leaving a partially-mutated, untrusted store on disk.
-        verify_migration_history(c).map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-        // Compare the requested dim to whatever is already on disk —
-        // not to `DEFAULT_VEC_DIM`. A persistent store previously
-        // bootstrapped at 1536 must be re-pointed at 384 if the next
-        // open uses a 384-dim embedder (and vice versa); skipping the
-        // resize on `dim == DEFAULT_VEC_DIM` would leave the table at
-        // 1536, then `verify_schema_fingerprint` fails because the
-        // expected DDL was hashed at 384.
-        let mut resized = false;
-        if let Some(dim) = vec_dim {
-            let current = read_record_vectors_dim(c)
+            c.execute_batch(PRAGMAS)?;
+            // Pre-flight: read-only check that already-applied migration
+            // rows agree with the compiled-in manifest. Catches a tampered
+            // `schema_migrations.sql_hash` on a pre-head DB BEFORE
+            // `to_latest` happily appends the next migration to an
+            // untrusted store.
+            preflight_migration_history(c)
                 .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-            if current != dim {
-                resize_record_vectors(c, dim)
+            migrations()
+                .to_latest(c)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            // Verify migration history BEFORE any schema mutation. If the
+            // on-disk DB has tampered or stale `schema_migrations.sql_hash`
+            // rows we must reject it untouched — otherwise a mismatched
+            // DB plus a different-dimension embedder would commit a
+            // DROP/CREATE on `record_vectors` and only then refuse the
+            // open, leaving a partially-mutated, untrusted store on disk.
+            verify_migration_history(c).map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            // Compare the requested dim to whatever is already on disk —
+            // not to `DEFAULT_VEC_DIM`. A persistent store previously
+            // bootstrapped at 1536 must be re-pointed at 384 if the next
+            // open uses a 384-dim embedder (and vice versa); skipping the
+            // resize on `dim == DEFAULT_VEC_DIM` would leave the table at
+            // 1536, then `verify_schema_fingerprint` fails because the
+            // expected DDL was hashed at 384.
+            let mut resized = false;
+            if let Some(dim) = vec_dim {
+                let current = read_record_vectors_dim(c)
                     .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-                resized = true;
+                if current != dim {
+                    resize_record_vectors(c, dim)
+                        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+                    resized = true;
+                }
             }
-        }
-        // Choose the form used to compute the expected DDL digest.
-        // - `None`: pristine migration form (no resize ever ran on this DB).
-        // - `Some(d)`: recreated form at dim `d` (this open resized, OR a
-        //   prior open did and we're observing its recreated table).
-        // The on-disk DDL string differs between the two forms (comments
-        // and whitespace from migration 0020 vs the bare CREATE we emit
-        // in `resize_record_vectors`), so the digest path must mirror
-        // whichever form is actually present.
-        let on_disk_dim =
-            read_record_vectors_dim(c).map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-        let effective_dim = if resized || on_disk_dim != DEFAULT_VEC_DIM {
-            Some(on_disk_dim)
-        } else {
-            None
-        };
-        verify_schema_fingerprint(c, effective_dim)
-            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-        // Runtime probe: confirm every `entity_*` table required by the
-        // graph leg is actually present. `verify_schema_fingerprint` would
-        // already reject a tampered schema, but the explicit probe keeps
-        // the capability bit honest if a future migration removes an
-        // `entity_*` artifact, and lets the bit reflect schema state — not
-        // just "the migration manifest contained these names at compile
-        // time."
-        Ok(probe_graph_search_tables(c)?)
-    })
-    .await?;
+            // Choose the form used to compute the expected DDL digest.
+            // - `None`: pristine migration form (no resize ever ran on this DB).
+            // - `Some(d)`: recreated form at dim `d` (this open resized, OR a
+            //   prior open did and we're observing its recreated table).
+            // The on-disk DDL string differs between the two forms (comments
+            // and whitespace from migration 0020 vs the bare CREATE we emit
+            // in `resize_record_vectors`), so the digest path must mirror
+            // whichever form is actually present.
+            let on_disk_dim = read_record_vectors_dim(c)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let effective_dim = if resized || on_disk_dim != DEFAULT_VEC_DIM {
+                Some(on_disk_dim)
+            } else {
+                None
+            };
+            verify_schema_fingerprint(c, effective_dim)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            // Runtime probe: confirm every `entity_*` table required by the
+            // graph leg is actually present. `verify_schema_fingerprint` would
+            // already reject a tampered schema, but the explicit probe keeps
+            // the capability bit honest if a future migration removes an
+            // `entity_*` artifact, and lets the bit reflect schema state — not
+            // just "the migration manifest contained these names at compile
+            // time."
+            Ok(probe_graph_search_tables(c)?)
+        })
+        .await?;
     Ok(graph_search)
 }
 

--- a/crates/cairn-store-sqlite/src/store/graph_search.rs
+++ b/crates/cairn-store-sqlite/src/store/graph_search.rs
@@ -1,0 +1,204 @@
+//! `MemoryStore::search_graph_neighbors` impl (issue #191, spec §4.3 / §5.1).
+//!
+//! Pragmatic v1 SQL: 1-hop entity-graph traversal seeded by the lexical
+//! legs' record ids, with edge bitemporal predicates, edge confidence
+//! floor, neighbor records' tombstone/active gate, visibility allowlist,
+//! and the ranked-list dedup set.
+//!
+//! ## Deferrals from the spec
+//!
+//! The full §5.1 SQL adds:
+//!   - `<auth_scope predicate>` against `records.scope` JSON. v1 leans on
+//!     the visibility allowlist as the primary auth boundary. The
+//!     `args.auth_scope` field is accepted and validated by the caller,
+//!     but is **not** folded into the predicate yet — multi-tenant
+//!     deployments must continue to narrow via the visibility allowlist
+//!     until a follow-up issue lands the JSON1-based scope predicate.
+//!   - Supersession (`NOT EXISTS edges_updates`). v1 relies on the
+//!     `active = 1 AND tombstoned = 0` gate, which excludes superseded
+//!     versions of a record but does not honor the latest-record
+//!     invariant when a record was superseded purely via the edges
+//!     mechanism.
+//!   - `carray` extension for bind-list expansion. v1 generates `?, ?, ?`
+//!     placeholders inline, capped at `SQLite`'s default `MAX_VARIABLE_NUMBER`
+//!     (999); seed/ranked lists are bounded by the orchestrator at 400 + 100,
+//!     well within the limit.
+//!   - Statement-scoped cancellation via `interrupt()` + `progress_handler`.
+//!     v1 relies on `tokio::time::timeout` at the orchestrator boundary;
+//!     phase 6 bench gates will reveal whether the cooperative-cancellation
+//!     primitive is needed in production.
+
+use cairn_core::contract::memory_store::GraphNeighborsArgs;
+use cairn_core::domain::RecordId;
+use cairn_core::search::GraphCandidate;
+use rusqlite::types::Value as SqlVal;
+use tracing::instrument;
+
+use crate::error::StoreError;
+use crate::store::{SqliteMemoryStore, current_unix_ms};
+
+/// Hard cap on either id-list bind count to stay safely under `SQLite`'s
+/// default `MAX_VARIABLE_NUMBER = 999` after the bitemporal/confidence
+/// scalars are added. Spec calls for 400 seeds + 100 ranked = 500; cap
+/// applies an order-preserving truncation if a caller exceeds it.
+const SQLITE_BIND_CAP: usize = 480;
+
+/// Hard upper bound on `args.limit` to keep result-set sizes bounded.
+const GRAPH_LIMIT_MAX: usize = 1000;
+
+/// Build the bind-expanded SQL + params for the graph 1-hop traversal.
+///
+/// Returns `(sql, params)`. Param order:
+///   1. seeds (`n_seeds` × `RecordId`)
+///   2. `as_event_ms` (`i64`) — `valid_at <= ?`
+///   3. `as_ingest_ms` (`i64`) — `created_at <= ?`
+///   4. `confidence_min` (`f64`)
+///   5. ranked exclusion list (`n_ranked` × `RecordId`)
+///   6. visibilities (`n_vis` × `String`)
+///   7. limit (`i64`)
+fn build_query(n_seeds: usize, n_ranked: usize, n_visibilities: usize) -> String {
+    fn placeholders(n: usize) -> String {
+        if n == 0 {
+            // SQLite rejects empty `IN ()`; substitute an always-false literal
+            // so the predicate evaluates without a syntax error.
+            "SELECT NULL WHERE 0".to_owned()
+        } else {
+            std::iter::repeat_n("?", n).collect::<Vec<_>>().join(",")
+        }
+    }
+    let seed_in = placeholders(n_seeds);
+    let ranked_in = placeholders(n_ranked);
+    let vis_in = placeholders(n_visibilities);
+    format!(
+        "WITH seeds AS ( \
+            SELECT DISTINCT entity_node_id \
+              FROM entity_episodes \
+             WHERE episode_id IN ({seed_in}) \
+         ), \
+         neighbors AS ( \
+            SELECT \
+                CASE WHEN e.source_id IN (SELECT entity_node_id FROM seeds) \
+                     THEN e.target_id ELSE e.source_id END AS neighbor_id, \
+                e.confidence_score \
+              FROM entity_edges e \
+             WHERE (e.source_id IN (SELECT entity_node_id FROM seeds) \
+                 OR e.target_id IN (SELECT entity_node_id FROM seeds)) \
+               AND e.invalid_at IS NULL AND e.expired_at IS NULL \
+               AND e.valid_at <= ? AND e.created_at <= ? \
+               AND e.confidence_score >= ? \
+         ) \
+         SELECT r.record_id, MAX(n.confidence_score) AS conf \
+           FROM neighbors n \
+           JOIN entity_episodes ep ON ep.entity_node_id = n.neighbor_id \
+           JOIN records r ON r.record_id = ep.episode_id \
+          WHERE n.neighbor_id NOT IN (SELECT entity_node_id FROM seeds) \
+            AND r.tombstoned = 0 AND r.active = 1 \
+            AND r.record_id NOT IN ({ranked_in}) \
+            AND r.visibility IN ({vis_in}) \
+          GROUP BY r.record_id \
+          ORDER BY conf DESC, r.updated_at DESC \
+          LIMIT ?"
+    )
+}
+
+impl SqliteMemoryStore {
+    /// Inherent `search_graph_neighbors` implementation; the trait method
+    /// guards `self.conn` and capability before delegating here.
+    ///
+    /// # Errors
+    /// Propagates [`StoreError::Sqlite`] from worker SQL errors and
+    /// [`StoreError::Worker`] from `tokio_rusqlite` infrastructure.
+    #[instrument(
+        skip(self, args),
+        err,
+        fields(
+            verb = "search_graph_neighbors",
+            seeds = args.seed_record_ids.len(),
+            ranked = args.ranked_record_ids.len(),
+            limit = args.limit
+        ),
+    )]
+    pub(crate) async fn do_search_graph_neighbors(
+        &self,
+        args: &GraphNeighborsArgs<'_>,
+    ) -> Result<Vec<GraphCandidate>, StoreError> {
+        // Empty seeds → empty result. The traversal is meaningless without
+        // a seed set and short-circuits a wasted round-trip.
+        if args.seed_record_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.require_conn("search_graph_neighbors")?.clone();
+
+        // Truncate to the bind cap, preserving caller-supplied order so
+        // overfetch overflow is deterministic.
+        let seeds: Vec<String> = args
+            .seed_record_ids
+            .iter()
+            .take(SQLITE_BIND_CAP)
+            .map(|r| r.as_str().to_owned())
+            .collect();
+        let ranked: Vec<String> = args
+            .ranked_record_ids
+            .iter()
+            .take(SQLITE_BIND_CAP)
+            .map(|r| r.as_str().to_owned())
+            .collect();
+        let visibilities: Vec<String> = args
+            .visibility_allowlist
+            .iter()
+            .map(|v| v.as_str().to_owned())
+            .collect();
+        let limit = args.limit.clamp(1, GRAPH_LIMIT_MAX);
+        let confidence_min = f64::from(args.confidence_min.clamp(0.0, 1.0));
+        let now_ms = current_unix_ms();
+
+        let candidates = conn
+            .call(
+                move |c| -> Result<Vec<GraphCandidate>, tokio_rusqlite::Error> {
+                    let sql = build_query(seeds.len(), ranked.len(), visibilities.len());
+                    let mut params: Vec<SqlVal> =
+                        Vec::with_capacity(seeds.len() + 3 + ranked.len() + visibilities.len() + 1);
+                    for s in &seeds {
+                        params.push(SqlVal::Text(s.clone()));
+                    }
+                    params.push(SqlVal::Integer(now_ms));
+                    params.push(SqlVal::Integer(now_ms));
+                    params.push(SqlVal::Real(confidence_min));
+                    for r in &ranked {
+                        params.push(SqlVal::Text(r.clone()));
+                    }
+                    for v in &visibilities {
+                        params.push(SqlVal::Text(v.clone()));
+                    }
+                    #[allow(clippy::cast_possible_wrap)]
+                    params.push(SqlVal::Integer(limit as i64));
+
+                    let mut stmt = c.prepare(&sql)?;
+                    let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
+                    let mut out: Vec<GraphCandidate> = Vec::new();
+                    let mut rank: usize = 1;
+                    while let Some(row) = rows.next()? {
+                        let rec_str: String = row.get(0)?;
+                        let confidence: f64 = row.get(1)?;
+                        let record_id = RecordId::parse(rec_str).map_err(|e| {
+                            tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
+                                what: format!("graph_search: invalid record_id from store: {e}"),
+                            }))
+                        })?;
+                        #[allow(clippy::cast_possible_truncation)]
+                        out.push(GraphCandidate {
+                            record_id,
+                            edge_confidence_score: confidence as f32,
+                            graph_rank: rank,
+                        });
+                        rank += 1;
+                    }
+                    Ok(out)
+                },
+            )
+            .await
+            .map_err(StoreError::from)?;
+
+        Ok(candidates)
+    }
+}

--- a/crates/cairn-store-sqlite/src/store/graph_search.rs
+++ b/crates/cairn-store-sqlite/src/store/graph_search.rs
@@ -102,8 +102,8 @@ fn build_query(
               JOIN records pr ON pr.record_id = e.source_record_id \
              WHERE (e.source_id IN (SELECT entity_node_id FROM seeds) \
                  OR e.target_id IN (SELECT entity_node_id FROM seeds)) \
-               AND e.invalid_at IS NULL AND e.expired_at IS NULL \
-               AND e.valid_at <= ? AND e.created_at <= ? \
+               AND e.valid_at <= ? AND (e.invalid_at IS NULL OR e.invalid_at > ?) \
+               AND e.created_at <= ? AND (e.expired_at IS NULL OR e.expired_at > ?) \
                AND e.confidence_score >= ? \
                AND pr.active = 1 AND pr.tombstoned = 0\
                {provenance_visibility_clause}{provenance_scope_sql} \
@@ -205,7 +205,7 @@ impl SqliteMemoryStore {
                     );
                     let mut params: Vec<SqlVal> = Vec::with_capacity(
                         seeds.len()
-                            + 3
+                            + 5
                             + (visibilities.len() * 2)
                             + provenance_scope_params.len()
                             + ranked.len()
@@ -216,6 +216,12 @@ impl SqliteMemoryStore {
                     for s in &seeds {
                         params.push(SqlVal::Text(s.clone()));
                     }
+                    // Bitemporal as-of: an edge is live when
+                    //   valid_at <= now AND (invalid_at IS NULL OR invalid_at > now)
+                    //   AND created_at <= now AND (expired_at IS NULL OR expired_at > now).
+                    // Same `now_ms` plugs into all four placeholders.
+                    params.push(SqlVal::Integer(now_ms));
+                    params.push(SqlVal::Integer(now_ms));
                     params.push(SqlVal::Integer(now_ms));
                     params.push(SqlVal::Integer(now_ms));
                     params.push(SqlVal::Real(confidence_min));

--- a/crates/cairn-store-sqlite/src/store/graph_search.rs
+++ b/crates/cairn-store-sqlite/src/store/graph_search.rs
@@ -30,11 +30,14 @@
 
 use cairn_core::contract::memory_store::GraphNeighborsArgs;
 use cairn_core::domain::RecordId;
+use cairn_core::domain::filter::compile_filter;
 use cairn_core::search::GraphCandidate;
 use rusqlite::types::Value as SqlVal;
 use tracing::instrument;
 
 use crate::error::StoreError;
+use crate::store::scope_predicate::build_scope_predicate;
+use crate::store::search::{SUPERSESSION_NOT_EXISTS_CLAUSE, json_to_sql};
 use crate::store::{SqliteMemoryStore, current_unix_ms};
 
 /// Hard cap on either id-list bind count to stay safely under `SQLite`'s
@@ -48,15 +51,16 @@ const GRAPH_LIMIT_MAX: usize = 1000;
 
 /// Build the bind-expanded SQL + params for the graph 1-hop traversal.
 ///
-/// Returns `(sql, params)`. Param order:
-///   1. seeds (`n_seeds` × `RecordId`)
-///   2. `as_event_ms` (`i64`) — `valid_at <= ?`
-///   3. `as_ingest_ms` (`i64`) — `created_at <= ?`
-///   4. `confidence_min` (`f64`)
-///   5. ranked exclusion list (`n_ranked` × `RecordId`)
-///   6. visibilities (`n_vis` × `String`)
-///   7. limit (`i64`)
-fn build_query(n_seeds: usize, n_ranked: usize, n_visibilities: usize) -> String {
+/// Param order is documented inline at each `?` in the assembled SQL; the
+/// caller in `do_search_graph_neighbors` pushes parameters in the same
+/// order.
+fn build_query(
+    n_seeds: usize,
+    n_ranked: usize,
+    n_visibilities: usize,
+    scope_sql: &str,
+    filter_sql: &str,
+) -> String {
     fn placeholders(n: usize) -> String {
         if n == 0 {
             // SQLite rejects empty `IN ()`; substitute an always-false literal
@@ -77,6 +81,11 @@ fn build_query(n_seeds: usize, n_ranked: usize, n_visibilities: usize) -> String
     } else {
         let vis_in = placeholders(n_visibilities);
         format!(" AND r.visibility IN ({vis_in})")
+    };
+    let filter_clause = if filter_sql.is_empty() {
+        String::new()
+    } else {
+        format!(" AND ({filter_sql})")
     };
     format!(
         "WITH seeds AS ( \
@@ -102,7 +111,8 @@ fn build_query(n_seeds: usize, n_ranked: usize, n_visibilities: usize) -> String
            JOIN records r ON r.record_id = ep.episode_id \
           WHERE n.neighbor_id NOT IN (SELECT entity_node_id FROM seeds) \
             AND r.tombstoned = 0 AND r.active = 1 \
-            AND r.record_id NOT IN ({ranked_in}){visibility_clause} \
+            AND r.record_id NOT IN ({ranked_in}){visibility_clause}{scope_sql}{filter_clause} \
+            AND {SUPERSESSION_NOT_EXISTS_CLAUSE} \
           GROUP BY r.record_id \
           ORDER BY conf DESC, r.updated_at DESC \
           LIMIT ?"
@@ -159,13 +169,36 @@ impl SqliteMemoryStore {
         let limit = args.limit.clamp(1, GRAPH_LIMIT_MAX);
         let confidence_min = f64::from(args.confidence_min.clamp(0.0, 1.0));
         let now_ms = current_unix_ms();
+        let (scope_sql, scope_params) = build_scope_predicate("r", &args.auth_scope);
+        let compiled = args.filter.map(compile_filter);
+        let filter_sql = compiled
+            .as_ref()
+            .map(|cf| cf.sql.clone())
+            .unwrap_or_default();
+        let filter_params: Vec<SqlVal> = compiled
+            .as_ref()
+            .map(|cf| cf.params.iter().map(json_to_sql).collect())
+            .unwrap_or_default();
 
         let candidates = conn
             .call(
                 move |c| -> Result<Vec<GraphCandidate>, tokio_rusqlite::Error> {
-                    let sql = build_query(seeds.len(), ranked.len(), visibilities.len());
-                    let mut params: Vec<SqlVal> =
-                        Vec::with_capacity(seeds.len() + 3 + ranked.len() + visibilities.len() + 1);
+                    let sql = build_query(
+                        seeds.len(),
+                        ranked.len(),
+                        visibilities.len(),
+                        &scope_sql,
+                        &filter_sql,
+                    );
+                    let mut params: Vec<SqlVal> = Vec::with_capacity(
+                        seeds.len()
+                            + 3
+                            + ranked.len()
+                            + visibilities.len()
+                            + scope_params.len()
+                            + filter_params.len()
+                            + 1,
+                    );
                     for s in &seeds {
                         params.push(SqlVal::Text(s.clone()));
                     }
@@ -178,6 +211,8 @@ impl SqliteMemoryStore {
                     for v in &visibilities {
                         params.push(SqlVal::Text(v.clone()));
                     }
+                    params.extend(scope_params);
+                    params.extend(filter_params);
                     #[allow(clippy::cast_possible_wrap)]
                     params.push(SqlVal::Integer(limit as i64));
 

--- a/crates/cairn-store-sqlite/src/store/graph_search.rs
+++ b/crates/cairn-store-sqlite/src/store/graph_search.rs
@@ -8,17 +8,6 @@
 //! ## Deferrals from the spec
 //!
 //! The full §5.1 SQL adds:
-//!   - `<auth_scope predicate>` against `records.scope` JSON. v1 leans on
-//!     the visibility allowlist as the primary auth boundary. The
-//!     `args.auth_scope` field is accepted and validated by the caller,
-//!     but is **not** folded into the predicate yet — multi-tenant
-//!     deployments must continue to narrow via the visibility allowlist
-//!     until a follow-up issue lands the JSON1-based scope predicate.
-//!   - Supersession (`NOT EXISTS edges_updates`). v1 relies on the
-//!     `active = 1 AND tombstoned = 0` gate, which excludes superseded
-//!     versions of a record but does not honor the latest-record
-//!     invariant when a record was superseded purely via the edges
-//!     mechanism.
 //!   - `carray` extension for bind-list expansion. v1 generates `?, ?, ?`
 //!     placeholders inline, capped at `SQLite`'s default `MAX_VARIABLE_NUMBER`
 //!     (999); seed/ranked lists are bounded by the orchestrator at 400 + 100,
@@ -58,7 +47,8 @@ fn build_query(
     n_seeds: usize,
     n_ranked: usize,
     n_visibilities: usize,
-    scope_sql: &str,
+    neighbor_scope_sql: &str,
+    provenance_scope_sql: &str,
     filter_sql: &str,
 ) -> String {
     fn placeholders(n: usize) -> String {
@@ -76,17 +66,27 @@ fn build_query(
     // keyword/semantic SQL builders. Without this guard, an empty allowlist
     // would translate to `r.visibility IN (SELECT NULL WHERE 0)` (always
     // false) and silently drop every graph candidate.
-    let visibility_clause = if n_visibilities == 0 {
-        String::new()
+    let (neighbor_visibility_clause, provenance_visibility_clause) = if n_visibilities == 0 {
+        (String::new(), String::new())
     } else {
-        let vis_in = placeholders(n_visibilities);
-        format!(" AND r.visibility IN ({vis_in})")
+        let neighbor_vis = placeholders(n_visibilities);
+        let provenance_vis = placeholders(n_visibilities);
+        (
+            format!(" AND r.visibility IN ({neighbor_vis})"),
+            format!(" AND pr.visibility IN ({provenance_vis})"),
+        )
     };
     let filter_clause = if filter_sql.is_empty() {
         String::new()
     } else {
         format!(" AND ({filter_sql})")
     };
+    // Provenance supersession clause — same shape as
+    // `SUPERSESSION_NOT_EXISTS_CLAUSE` but rewritten against the `pr`
+    // (provenance) alias so an edge whose source record was superseded
+    // contributes nothing.
+    let provenance_supersession = "NOT EXISTS ( SELECT 1 FROM edges e2 \
+        WHERE e2.kind = 'updates' AND e2.dst = pr.record_id )";
     format!(
         "WITH seeds AS ( \
             SELECT DISTINCT entity_node_id \
@@ -99,11 +99,15 @@ fn build_query(
                      THEN e.target_id ELSE e.source_id END AS neighbor_id, \
                 e.confidence_score \
               FROM entity_edges e \
+              JOIN records pr ON pr.record_id = e.source_record_id \
              WHERE (e.source_id IN (SELECT entity_node_id FROM seeds) \
                  OR e.target_id IN (SELECT entity_node_id FROM seeds)) \
                AND e.invalid_at IS NULL AND e.expired_at IS NULL \
                AND e.valid_at <= ? AND e.created_at <= ? \
                AND e.confidence_score >= ? \
+               AND pr.active = 1 AND pr.tombstoned = 0\
+               {provenance_visibility_clause}{provenance_scope_sql} \
+               AND {provenance_supersession} \
          ) \
          SELECT r.record_id, MAX(n.confidence_score) AS conf \
            FROM neighbors n \
@@ -111,7 +115,8 @@ fn build_query(
            JOIN records r ON r.record_id = ep.episode_id \
           WHERE n.neighbor_id NOT IN (SELECT entity_node_id FROM seeds) \
             AND r.tombstoned = 0 AND r.active = 1 \
-            AND r.record_id NOT IN ({ranked_in}){visibility_clause}{scope_sql}{filter_clause} \
+            AND r.record_id NOT IN ({ranked_in}){neighbor_visibility_clause}\
+            {neighbor_scope_sql}{filter_clause} \
             AND {SUPERSESSION_NOT_EXISTS_CLAUSE} \
           GROUP BY r.record_id \
           ORDER BY conf DESC, r.updated_at DESC \
@@ -135,6 +140,10 @@ impl SqliteMemoryStore {
             ranked = args.ranked_record_ids.len(),
             limit = args.limit
         ),
+    )]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "param assembly mirrors SQL structure; splitting reduces clarity"
     )]
     pub(crate) async fn do_search_graph_neighbors(
         &self,
@@ -169,7 +178,10 @@ impl SqliteMemoryStore {
         let limit = args.limit.clamp(1, GRAPH_LIMIT_MAX);
         let confidence_min = f64::from(args.confidence_min.clamp(0.0, 1.0));
         let now_ms = current_unix_ms();
-        let (scope_sql, scope_params) = build_scope_predicate("r", &args.auth_scope);
+        let (neighbor_scope_sql, neighbor_scope_params) =
+            build_scope_predicate("r", &args.auth_scope);
+        let (provenance_scope_sql, provenance_scope_params) =
+            build_scope_predicate("pr", &args.auth_scope);
         let compiled = args.filter.map(compile_filter);
         let filter_sql = compiled
             .as_ref()
@@ -187,15 +199,17 @@ impl SqliteMemoryStore {
                         seeds.len(),
                         ranked.len(),
                         visibilities.len(),
-                        &scope_sql,
+                        &neighbor_scope_sql,
+                        &provenance_scope_sql,
                         &filter_sql,
                     );
                     let mut params: Vec<SqlVal> = Vec::with_capacity(
                         seeds.len()
                             + 3
+                            + (visibilities.len() * 2)
+                            + provenance_scope_params.len()
                             + ranked.len()
-                            + visibilities.len()
-                            + scope_params.len()
+                            + neighbor_scope_params.len()
                             + filter_params.len()
                             + 1,
                     );
@@ -205,13 +219,20 @@ impl SqliteMemoryStore {
                     params.push(SqlVal::Integer(now_ms));
                     params.push(SqlVal::Integer(now_ms));
                     params.push(SqlVal::Real(confidence_min));
+                    // Provenance-side visibility + scope (applied inside the
+                    // `neighbors` CTE before edges contribute).
+                    for v in &visibilities {
+                        params.push(SqlVal::Text(v.clone()));
+                    }
+                    params.extend(provenance_scope_params);
+                    // Neighbor-side ranked dedup + visibility + scope + filter.
                     for r in &ranked {
                         params.push(SqlVal::Text(r.clone()));
                     }
                     for v in &visibilities {
                         params.push(SqlVal::Text(v.clone()));
                     }
-                    params.extend(scope_params);
+                    params.extend(neighbor_scope_params);
                     params.extend(filter_params);
                     #[allow(clippy::cast_possible_wrap)]
                     params.push(SqlVal::Integer(limit as i64));

--- a/crates/cairn-store-sqlite/src/store/graph_search.rs
+++ b/crates/cairn-store-sqlite/src/store/graph_search.rs
@@ -68,7 +68,16 @@ fn build_query(n_seeds: usize, n_ranked: usize, n_visibilities: usize) -> String
     }
     let seed_in = placeholders(n_seeds);
     let ranked_in = placeholders(n_ranked);
-    let vis_in = placeholders(n_visibilities);
+    // Empty visibility allowlist means "no visibility filter" — match the
+    // keyword/semantic SQL builders. Without this guard, an empty allowlist
+    // would translate to `r.visibility IN (SELECT NULL WHERE 0)` (always
+    // false) and silently drop every graph candidate.
+    let visibility_clause = if n_visibilities == 0 {
+        String::new()
+    } else {
+        let vis_in = placeholders(n_visibilities);
+        format!(" AND r.visibility IN ({vis_in})")
+    };
     format!(
         "WITH seeds AS ( \
             SELECT DISTINCT entity_node_id \
@@ -93,8 +102,7 @@ fn build_query(n_seeds: usize, n_ranked: usize, n_visibilities: usize) -> String
            JOIN records r ON r.record_id = ep.episode_id \
           WHERE n.neighbor_id NOT IN (SELECT entity_node_id FROM seeds) \
             AND r.tombstoned = 0 AND r.active = 1 \
-            AND r.record_id NOT IN ({ranked_in}) \
-            AND r.visibility IN ({vis_in}) \
+            AND r.record_id NOT IN ({ranked_in}){visibility_clause} \
           GROUP BY r.record_id \
           ORDER BY conf DESC, r.updated_at DESC \
           LIMIT ?"

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -156,7 +156,8 @@ impl SqliteMemoryStore {
         // `limit` AFTER drop-out so a row tombstoned between the leg
         // query and now cannot shrink the page below `limit`.
         let mut by_id = hydrate_candidates(keyword.candidates, semantic.candidates);
-        self.hydrate_graph_only_into(&reranked, &mut by_id).await?;
+        self.hydrate_graph_only_into(&reranked, &mut by_id, &args.visibility_allowlist)
+            .await?;
         let candidates: Vec<SearchCandidate> = reranked
             .iter()
             .filter_map(|r| by_id.remove(&r.record_id))
@@ -181,6 +182,7 @@ impl SqliteMemoryStore {
         &self,
         reranked: &[RerankedCandidate],
         by_id: &mut HashMap<RecordId, SearchCandidate>,
+        visibility_allowlist: &[cairn_core::domain::MemoryVisibility],
     ) -> Result<(), StoreError> {
         let missing_ids: Vec<RecordId> = reranked
             .iter()
@@ -191,7 +193,11 @@ impl SqliteMemoryStore {
             return Ok(());
         }
         let conn = self.require_conn("search_hybrid")?.clone();
-        let extra = hydrate_graph_only(conn, missing_ids).await?;
+        let visibilities: Vec<String> = visibility_allowlist
+            .iter()
+            .map(|v| v.as_str().to_owned())
+            .collect();
+        let extra = hydrate_graph_only(conn, missing_ids, visibilities).await?;
         for c in extra {
             by_id.entry(c.record_id.clone()).or_insert(c);
         }
@@ -416,102 +422,23 @@ fn build_explain(
 async fn hydrate_graph_only(
     conn: Arc<tokio_rusqlite::Connection>,
     ids: Vec<RecordId>,
+    visibilities: Vec<String>,
 ) -> Result<Vec<SearchCandidate>, StoreError> {
-    use cairn_core::domain::{MemoryClass, MemoryKind, MemoryVisibility, ScopeTuple};
-
-    use crate::store::current_unix_ms;
-    use crate::store::projection::record_id_from_str;
-
     if ids.is_empty() {
         return Ok(Vec::new());
     }
-    let now_ms = current_unix_ms();
+    let now_ms = crate::store::current_unix_ms();
     let id_strings: Vec<String> = ids.iter().map(|r| r.as_str().to_owned()).collect();
 
     let out = conn
         .call(
             move |c| -> Result<Vec<SearchCandidate>, tokio_rusqlite::Error> {
-                let placeholders: String = std::iter::repeat_n("?", id_strings.len())
-                    .collect::<Vec<_>>()
-                    .join(",");
-                let sql = format!(
-                    "SELECT r.record_id, r.target_id, r.scope, r.kind, r.class, r.visibility, \
-                        r.updated_at, r.confidence, r.salience, r.created_at, r.body \
-                   FROM records r \
-                  WHERE r.record_id IN ({placeholders}) \
-                    AND r.active = 1 AND r.tombstoned = 0"
-                );
-                let params: Vec<SqlVal> = id_strings.into_iter().map(SqlVal::Text).collect();
-
+                let (sql, params) = build_graph_only_query(&id_strings, &visibilities);
                 let mut stmt = c.prepare(&sql)?;
                 let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
                 let mut out: Vec<SearchCandidate> = Vec::new();
                 while let Some(row) = rows.next()? {
-                    let rec_str: String = row.get(0)?;
-                    let target_str: String = row.get(1)?;
-                    let scope_json: String = row.get(2)?;
-                    let kind_str: String = row.get(3)?;
-                    let class_str: String = row.get(4)?;
-                    let visibility_str: String = row.get(5)?;
-                    let updated_at: i64 = row.get(6)?;
-                    let confidence: f64 = row.get(7)?;
-                    let salience: f64 = row.get(8)?;
-                    let created_at: i64 = row.get(9)?;
-                    let body: String = row.get(10)?;
-
-                    let record_id = record_id_from_str(&rec_str).map_err(|e| {
-                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
-                            what: format!("hydrate_graph_only: bad record_id `{rec_str}`: {e}"),
-                        }))
-                    })?;
-                    let target_id =
-                        cairn_core::domain::TargetId::parse(&target_str).map_err(|e| {
-                            tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
-                                what: format!(
-                                    "hydrate_graph_only: bad target_id `{target_str}`: {e}"
-                                ),
-                            }))
-                        })?;
-                    let scope: ScopeTuple = serde_json::from_str(&scope_json).map_err(|e| {
-                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
-                            what: format!("hydrate_graph_only: bad scope `{scope_json}`: {e}"),
-                        }))
-                    })?;
-                    let kind = MemoryKind::parse(&kind_str).map_err(|e| {
-                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
-                            what: format!("hydrate_graph_only: bad kind `{kind_str}`: {e}"),
-                        }))
-                    })?;
-                    let class = MemoryClass::parse(&class_str).map_err(|e| {
-                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
-                            what: format!("hydrate_graph_only: bad class `{class_str}`: {e}"),
-                        }))
-                    })?;
-                    let visibility = MemoryVisibility::parse(&visibility_str).map_err(|e| {
-                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
-                            what: format!(
-                                "hydrate_graph_only: bad visibility `{visibility_str}`: {e}"
-                            ),
-                        }))
-                    })?;
-
-                    #[allow(clippy::cast_possible_truncation, reason = "REAL→f32 narrow")]
-                    out.push(SearchCandidate {
-                        record_id,
-                        target_id,
-                        scope,
-                        kind,
-                        class,
-                        visibility,
-                        bm25: 0.0,
-                        recency_seconds: (now_ms - updated_at) / 1000,
-                        confidence: confidence as f32,
-                        salience: salience as f32,
-                        staleness_seconds: (now_ms - created_at) / 1000,
-                        snippet: String::new(),
-                        record_json: body,
-                        semantic_distance: None,
-                    });
+                    out.push(map_graph_only_row(row, now_ms)?);
                 }
                 Ok(out)
             },
@@ -519,6 +446,104 @@ async fn hydrate_graph_only(
         .await
         .map_err(StoreError::from)?;
     Ok(out)
+}
+
+/// Build SQL + bound params for the graph-only hydration query. Visibility
+/// allowlist is reapplied as defense in depth — `graph_search.rs` already
+/// narrowed by visibility, but a bug or race there must not leak rows
+/// outside the caller's allowlist back into the page.
+fn build_graph_only_query(id_strings: &[String], visibilities: &[String]) -> (String, Vec<SqlVal>) {
+    let id_placeholders: String = std::iter::repeat_n("?", id_strings.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let visibility_clause = if visibilities.is_empty() {
+        String::new()
+    } else {
+        let vis_placeholders: String = std::iter::repeat_n("?", visibilities.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        format!(" AND r.visibility IN ({vis_placeholders})")
+    };
+    let sql = format!(
+        "SELECT r.record_id, r.target_id, r.scope, r.kind, r.class, r.visibility, \
+                r.updated_at, r.confidence, r.salience, r.created_at, r.body \
+           FROM records r \
+          WHERE r.record_id IN ({id_placeholders}) \
+            AND r.active = 1 AND r.tombstoned = 0{visibility_clause}"
+    );
+    let mut params: Vec<SqlVal> = id_strings.iter().map(|s| SqlVal::Text(s.clone())).collect();
+    for v in visibilities {
+        params.push(SqlVal::Text(v.clone()));
+    }
+    (sql, params)
+}
+
+/// Project one `records` row into a `SearchCandidate` for graph-only
+/// hydration. `bm25 = 0`, `snippet = ""`, `semantic_distance = None`
+/// because those signals come from the lexical legs and are unavailable
+/// on the graph-only path.
+fn map_graph_only_row(
+    row: &rusqlite::Row<'_>,
+    now_ms: i64,
+) -> Result<SearchCandidate, tokio_rusqlite::Error> {
+    use cairn_core::domain::{MemoryClass, MemoryKind, MemoryVisibility, ScopeTuple, TargetId};
+
+    use crate::store::projection::record_id_from_str;
+
+    let invariant =
+        |what: String| tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant { what }));
+
+    let rec_str: String = row.get(0)?;
+    let target_str: String = row.get(1)?;
+    let scope_json: String = row.get(2)?;
+    let kind_str: String = row.get(3)?;
+    let class_str: String = row.get(4)?;
+    let visibility_str: String = row.get(5)?;
+    let updated_at: i64 = row.get(6)?;
+    let confidence: f64 = row.get(7)?;
+    let salience: f64 = row.get(8)?;
+    let created_at: i64 = row.get(9)?;
+    let body: String = row.get(10)?;
+
+    let record_id = record_id_from_str(&rec_str).map_err(|e| {
+        invariant(format!(
+            "hydrate_graph_only: bad record_id `{rec_str}`: {e}"
+        ))
+    })?;
+    let target_id = TargetId::parse(&target_str).map_err(|e| {
+        invariant(format!(
+            "hydrate_graph_only: bad target_id `{target_str}`: {e}"
+        ))
+    })?;
+    let scope: ScopeTuple = serde_json::from_str(&scope_json)
+        .map_err(|e| invariant(format!("hydrate_graph_only: bad scope `{scope_json}`: {e}")))?;
+    let kind = MemoryKind::parse(&kind_str)
+        .map_err(|e| invariant(format!("hydrate_graph_only: bad kind `{kind_str}`: {e}")))?;
+    let class = MemoryClass::parse(&class_str)
+        .map_err(|e| invariant(format!("hydrate_graph_only: bad class `{class_str}`: {e}")))?;
+    let visibility = MemoryVisibility::parse(&visibility_str).map_err(|e| {
+        invariant(format!(
+            "hydrate_graph_only: bad visibility `{visibility_str}`: {e}"
+        ))
+    })?;
+
+    #[allow(clippy::cast_possible_truncation, reason = "REAL→f32 narrow")]
+    Ok(SearchCandidate {
+        record_id,
+        target_id,
+        scope,
+        kind,
+        class,
+        visibility,
+        bm25: 0.0,
+        recency_seconds: (now_ms - updated_at) / 1000,
+        confidence: confidence as f32,
+        salience: salience as f32,
+        staleness_seconds: (now_ms - created_at) / 1000,
+        snippet: String::new(),
+        record_json: body,
+        semantic_distance: None,
+    })
 }
 
 /// Decode a sqlite-vec blob (LE f32 sequence) into a `Vec<f32>`. Tail bytes

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -81,6 +81,7 @@ impl SqliteMemoryStore {
         let kw_args = KeywordSearchArgs {
             query: args.query.clone(),
             filter: args.filter,
+            auth_scope: args.auth_scope.clone(),
             visibility_allowlist: args.visibility_allowlist.clone(),
             limit: HYBRID_LEG_LIMIT,
             cursor: None,
@@ -89,6 +90,7 @@ impl SqliteMemoryStore {
         let sem_args = SemanticSearchArgs {
             query: args.query.clone(),
             filter: args.filter,
+            auth_scope: args.auth_scope.clone(),
             visibility_allowlist: args.visibility_allowlist.clone(),
             limit: HYBRID_LEG_LIMIT,
             model_label: args.model_label.clone(),

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -43,6 +43,13 @@ use crate::store::SqliteMemoryStore;
 /// the final page is trimmed by `args.limit`.
 const HYBRID_LEG_LIMIT: usize = 50;
 
+/// Auth-only graph-seed overfetch (spec §4.3 / §5.1). The graph leg gets
+/// this many seed record ids — independent of the lexical legs' filtered
+/// pool — so neighbors of records outside the user's narrowing filter
+/// remain reachable through graph traversal as long as they pass
+/// authorization.
+const GRAPH_SEED_OVERFETCH: usize = 400;
+
 impl SqliteMemoryStore {
     /// Inherent `search_hybrid` implementation; the trait method
     /// [`MemoryStore::search_hybrid`] guards `self.conn` then delegates here.
@@ -156,7 +163,7 @@ impl SqliteMemoryStore {
         // `limit` AFTER drop-out so a row tombstoned between the leg
         // query and now cannot shrink the page below `limit`.
         let mut by_id = hydrate_candidates(keyword.candidates, semantic.candidates);
-        self.hydrate_graph_only_into(&reranked, &mut by_id, &args.visibility_allowlist)
+        self.hydrate_graph_only_into(&reranked, &mut by_id, args)
             .await?;
         let candidates: Vec<SearchCandidate> = reranked
             .iter()
@@ -182,7 +189,7 @@ impl SqliteMemoryStore {
         &self,
         reranked: &[RerankedCandidate],
         by_id: &mut HashMap<RecordId, SearchCandidate>,
-        visibility_allowlist: &[cairn_core::domain::MemoryVisibility],
+        args: &HybridSearchArgs<'_>,
     ) -> Result<(), StoreError> {
         let missing_ids: Vec<RecordId> = reranked
             .iter()
@@ -193,11 +200,14 @@ impl SqliteMemoryStore {
             return Ok(());
         }
         let conn = self.require_conn("search_hybrid")?.clone();
-        let visibilities: Vec<String> = visibility_allowlist
+        let visibilities: Vec<String> = args
+            .visibility_allowlist
             .iter()
             .map(|v| v.as_str().to_owned())
             .collect();
-        let extra = hydrate_graph_only(conn, missing_ids, visibilities).await?;
+        let scope = args.auth_scope.clone();
+        let compiled = args.filter.map(cairn_core::domain::filter::compile_filter);
+        let extra = hydrate_graph_only(conn, missing_ids, visibilities, scope, compiled).await?;
         for c in extra {
             by_id.entry(c.record_id.clone()).or_insert(c);
         }
@@ -208,12 +218,13 @@ impl SqliteMemoryStore {
     /// `(graph_candidates, degraded_legs)`. Extracted to keep the parent
     /// function under the workspace `clippy::too_many_lines` cap.
     ///
-    /// Seeds = union of kw + sem ids; ranked exclusion = same set, so we
-    /// never re-promote a record that already lexically matched. The
-    /// graph leg is a soft dependency: capability-missing yields an empty
-    /// result plus `DegradedLeg::graph_capability_unavailable()`, and a
-    /// SQL failure yields empty plus `DegradedLeg::Graph` with
-    /// `SqlError` reason.
+    /// Seed pool = independent auth-only fetch (no `filter`) up to
+    /// `GRAPH_SEED_OVERFETCH`, so neighbors of records outside the
+    /// caller's narrowing filter remain reachable as long as they pass
+    /// authorization. Ranked exclusion = the filtered top-of-leg ids, so
+    /// the graph never re-promotes a record that already won its lexical
+    /// slot. Capability-missing yields empty + `DegradedLeg::graph_…`,
+    /// SQL errors yield empty + `DegradedLeg::Graph { SqlError }`.
     async fn run_graph_leg(
         &self,
         args: &HybridSearchArgs<'_>,
@@ -226,16 +237,41 @@ impl SqliteMemoryStore {
                 vec![DegradedLeg::graph_capability_unavailable()],
             );
         }
+
+        // Auth-only seed pool. Same `auth_scope` + `visibility_allowlist`
+        // + supersession + active/tombstoned predicates as the lexical
+        // legs, but **without** `args.filter` — the user's narrowing
+        // filter must not erase records from the seed pool, otherwise
+        // graph rank-rescue collapses on aggressive filters.
+        let seed_ids = match self.fetch_graph_seed_pool(args).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                tracing::warn!(error = %e, "graph seed pool failed; continuing without graph results");
+                return (
+                    Vec::new(),
+                    vec![DegradedLeg::Graph {
+                        reason: DegradationReason::SqlError,
+                        source: GraphSource::All,
+                    }],
+                );
+            }
+        };
+
+        // Ranked exclusion = filtered top-of-leg ids only. These are the
+        // records already destined for the lexical RRF positions, so the
+        // graph leg dedups them out and the remaining graph-only hits
+        // are pure rank-rescue territory.
         let mut seen: HashSet<RecordId> = HashSet::new();
-        let mut seed_ids: Vec<RecordId> = Vec::new();
+        let mut ranked_ids: Vec<RecordId> = Vec::new();
         for c in kw_candidates.iter().chain(sem_candidates.iter()) {
             if seen.insert(c.record_id.clone()) {
-                seed_ids.push(c.record_id.clone());
+                ranked_ids.push(c.record_id.clone());
             }
         }
+
         let graph_args = GraphNeighborsArgs {
-            seed_record_ids: seed_ids.clone(),
-            ranked_record_ids: seed_ids,
+            seed_record_ids: seed_ids,
+            ranked_record_ids: ranked_ids,
             filter: args.filter,
             auth_scope: args.auth_scope.clone(),
             visibility_allowlist: args.visibility_allowlist.clone(),
@@ -255,6 +291,65 @@ impl SqliteMemoryStore {
                 )
             }
         }
+    }
+
+    /// Fetch the auth-only seed pool for the graph leg. Selects up to
+    /// `GRAPH_SEED_OVERFETCH` recently-updated active records that pass
+    /// the caller's `auth_scope`, `visibility_allowlist`, and supersession
+    /// constraints — but **NOT** `args.filter`. The seed pool's whole
+    /// purpose is to surface authorized records that the narrowing filter
+    /// would have excluded from the lexical legs but that still warrant
+    /// graph traversal.
+    async fn fetch_graph_seed_pool(
+        &self,
+        args: &HybridSearchArgs<'_>,
+    ) -> Result<Vec<RecordId>, StoreError> {
+        let conn = self.require_conn("fetch_graph_seed_pool")?.clone();
+        let visibilities: Vec<String> = args
+            .visibility_allowlist
+            .iter()
+            .map(|v| v.as_str().to_owned())
+            .collect();
+        let scope = args.auth_scope.clone();
+
+        let ids = conn
+            .call(move |c| -> Result<Vec<String>, tokio_rusqlite::Error> {
+                let visibility_clause = if visibilities.is_empty() {
+                    String::new()
+                } else {
+                    let vis_placeholders: String = std::iter::repeat_n("?", visibilities.len())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    format!(" AND r.visibility IN ({vis_placeholders})")
+                };
+                let (scope_sql, scope_params) =
+                    crate::store::scope_predicate::build_scope_predicate("r", &scope);
+                let sql = format!(
+                    "SELECT r.record_id FROM records r \
+                      WHERE r.active = 1 AND r.tombstoned = 0{visibility_clause}{scope_sql} \
+                        AND {} \
+                      ORDER BY r.updated_at DESC LIMIT ?",
+                    crate::store::search::SUPERSESSION_NOT_EXISTS_CLAUSE
+                );
+                let mut params: Vec<SqlVal> = visibilities.into_iter().map(SqlVal::Text).collect();
+                params.extend(scope_params);
+                #[allow(clippy::cast_possible_wrap)]
+                params.push(SqlVal::Integer(GRAPH_SEED_OVERFETCH as i64));
+                let mut stmt = c.prepare(&sql)?;
+                let rows = stmt
+                    .query_map(rusqlite::params_from_iter(params.iter()), |row| {
+                        row.get::<_, String>(0)
+                    })?
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(rows)
+            })
+            .await
+            .map_err(StoreError::from)?;
+
+        let parsed: Result<Vec<RecordId>, _> = ids.into_iter().map(RecordId::parse).collect();
+        parsed.map_err(|e| StoreError::Invariant {
+            what: format!("seed pool: invalid record_id from store: {e}"),
+        })
     }
 }
 
@@ -423,6 +518,8 @@ async fn hydrate_graph_only(
     conn: Arc<tokio_rusqlite::Connection>,
     ids: Vec<RecordId>,
     visibilities: Vec<String>,
+    scope: cairn_core::domain::ScopeTuple,
+    compiled: Option<cairn_core::domain::filter::CompiledFilter>,
 ) -> Result<Vec<SearchCandidate>, StoreError> {
     if ids.is_empty() {
         return Ok(Vec::new());
@@ -433,7 +530,8 @@ async fn hydrate_graph_only(
     let out = conn
         .call(
             move |c| -> Result<Vec<SearchCandidate>, tokio_rusqlite::Error> {
-                let (sql, params) = build_graph_only_query(&id_strings, &visibilities);
+                let (sql, params) =
+                    build_graph_only_query(&id_strings, &visibilities, &scope, compiled.as_ref());
                 let mut stmt = c.prepare(&sql)?;
                 let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
                 let mut out: Vec<SearchCandidate> = Vec::new();
@@ -448,11 +546,17 @@ async fn hydrate_graph_only(
     Ok(out)
 }
 
-/// Build SQL + bound params for the graph-only hydration query. Visibility
-/// allowlist is reapplied as defense in depth — `graph_search.rs` already
-/// narrowed by visibility, but a bug or race there must not leak rows
-/// outside the caller's allowlist back into the page.
-fn build_graph_only_query(id_strings: &[String], visibilities: &[String]) -> (String, Vec<SqlVal>) {
+/// Build SQL + bound params for the graph-only hydration query. Reapplies
+/// the same authorization (`auth_scope`), narrowing-filter, supersession,
+/// and visibility predicates as the lexical legs so any bug or race in
+/// `graph_search.rs` cannot leak rows that fail those checks back into
+/// the page.
+fn build_graph_only_query(
+    id_strings: &[String],
+    visibilities: &[String],
+    scope: &cairn_core::domain::ScopeTuple,
+    compiled: Option<&cairn_core::domain::filter::CompiledFilter>,
+) -> (String, Vec<SqlVal>) {
     let id_placeholders: String = std::iter::repeat_n("?", id_strings.len())
         .collect::<Vec<_>>()
         .join(",");
@@ -464,16 +568,30 @@ fn build_graph_only_query(id_strings: &[String], visibilities: &[String]) -> (St
             .join(",");
         format!(" AND r.visibility IN ({vis_placeholders})")
     };
+    let (scope_sql, scope_params) =
+        crate::store::scope_predicate::build_scope_predicate("r", scope);
+    let filter_clause = compiled
+        .as_ref()
+        .map(|cf| format!(" AND ({})", cf.sql))
+        .unwrap_or_default();
     let sql = format!(
         "SELECT r.record_id, r.target_id, r.scope, r.kind, r.class, r.visibility, \
                 r.updated_at, r.confidence, r.salience, r.created_at, r.body \
            FROM records r \
           WHERE r.record_id IN ({id_placeholders}) \
-            AND r.active = 1 AND r.tombstoned = 0{visibility_clause}"
+            AND r.active = 1 AND r.tombstoned = 0{visibility_clause}{scope_sql}{filter_clause} \
+            AND {}",
+        crate::store::search::SUPERSESSION_NOT_EXISTS_CLAUSE
     );
     let mut params: Vec<SqlVal> = id_strings.iter().map(|s| SqlVal::Text(s.clone())).collect();
     for v in visibilities {
         params.push(SqlVal::Text(v.clone()));
+    }
+    params.extend(scope_params);
+    if let Some(cf) = compiled {
+        for p in &cf.params {
+            params.push(crate::store::search::json_to_sql(p));
+        }
     }
     (sql, params)
 }

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -68,6 +68,10 @@ impl SqliteMemoryStore {
         err,
         fields(verb = "search_hybrid", limit = args.limit, blend = args.blend),
     )]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "linear leg → rerank → hydrate pipeline; each phase named inline"
+    )]
     pub(crate) async fn do_search_hybrid(
         &self,
         args: &HybridSearchArgs<'_>,
@@ -136,7 +140,6 @@ impl SqliteMemoryStore {
             .run_graph_leg(args, &keyword.candidates, &semantic.candidates)
             .await;
         leg_degradations.extend(graph_degraded);
-        let degraded_legs = leg_degradations;
 
         // Build 1-based rank lookup maps for the explain block. Constructed
         // here while `kw_list` / `sem_list` are in leg-order (rank order).
@@ -161,7 +164,32 @@ impl SqliteMemoryStore {
         // RRF only re-ranks its own top-K, so fetching more vectors is waste.
         let combined_ids = combined_topk_ids(&kw_list, &sem_list, args.rerank_topk);
         let conn = self.require_conn("search_hybrid")?.clone();
-        let doc_vectors = fetch_doc_vectors(conn, combined_ids, args.model_label.clone()).await?;
+        // Fetch doc vectors for cosine re-rank. If `record_vectors` is
+        // unavailable (table dropped, vec0 module missing, schema skew),
+        // skip re-rank and surface a `DegradedLeg::Semantic` entry —
+        // unless one is already present from `do_search_semantic` itself
+        // (don't double-report a single failure mode).
+        let (doc_vectors, skip_rerank) = match fetch_doc_vectors(
+            conn,
+            combined_ids,
+            args.model_label.clone(),
+        )
+        .await
+        {
+            Ok(v) => (v, false),
+            Err(e) => {
+                tracing::warn!(error = %e, "fetch_doc_vectors failed; skipping cosine rerank");
+                if !leg_degradations.iter().any(|d| {
+                    matches!(d, DegradedLeg::Semantic { .. })
+                }) {
+                    leg_degradations.push(DegradedLeg::Semantic {
+                        reason: DegradationReason::SqlError,
+                    });
+                }
+                (HashMap::new(), true)
+            }
+        };
+        let degraded_legs = leg_degradations;
 
         // Run the pure-function orchestration.
         let reranked = hybrid_search(
@@ -176,7 +204,7 @@ impl SqliteMemoryStore {
                 rrf_k: args.rrf_k,
                 rerank_topk: args.rerank_topk,
                 blend: args.blend,
-                skip_rerank: false,
+                skip_rerank,
                 confidence_floor: args.confidence_floor,
             },
         );

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -152,51 +152,50 @@ impl SqliteMemoryStore {
             },
         );
 
-        // Hydrate output rows from the underlying legs so callers see
-        // snippets / bm25 / staleness exactly as those legs produced them.
+        // Hydrate from lexical legs + graph-only `records` rows; apply
+        // `limit` AFTER drop-out so a row tombstoned between the leg
+        // query and now cannot shrink the page below `limit`.
         let mut by_id = hydrate_candidates(keyword.candidates, semantic.candidates);
+        self.hydrate_graph_only_into(&reranked, &mut by_id).await?;
         let candidates: Vec<SearchCandidate> = reranked
             .iter()
-            .take(args.limit)
             .filter_map(|r| by_id.remove(&r.record_id))
+            .take(args.limit)
             .collect();
 
-        // Build the explain block aligned with `candidates`. We iterate the
-        // surviving candidates (after filter_map + take) and look up each
-        // record's reranker output — this guarantees `explain[i].record_id ==
-        // candidates[i].record_id` even when hydration defensively drops a row.
-        let explain = if args.with_explain {
-            let reranked_map: HashMap<&RecordId, &RerankedCandidate> =
-                reranked.iter().map(|r| (&r.record_id, r)).collect();
-            Some(
-                candidates
-                    .iter()
-                    .filter_map(|c| {
-                        // A candidate that survived hydration must be in
-                        // `reranked`; filter_map here is defensive — if somehow
-                        // the invariant breaks we emit no explain row rather
-                        // than panicking at runtime.
-                        let r = reranked_map.get(&c.record_id)?;
-                        Some(ScoreExplain {
-                            record_id: c.record_id.clone(),
-                            bm25_rank: kw_ranks.get(&c.record_id).copied(),
-                            semantic_rank: sem_ranks.get(&c.record_id).copied(),
-                            rrf_score: r.rrf_score,
-                            cosine: r.cosine,
-                            final_score: r.final_score,
-                        })
-                    })
-                    .collect(),
-            )
-        } else {
-            None
-        };
+        let explain = args
+            .with_explain
+            .then(|| build_explain(&candidates, &reranked, &kw_ranks, &sem_ranks));
 
         Ok(HybridSearchPage {
             candidates,
             explain,
             degraded_legs,
         })
+    }
+
+    /// Hydrate `SearchCandidate` rows for any reranked id that the lexical
+    /// legs did not surface (graph-only hits). Pulled out to keep the
+    /// caller under `clippy::too_many_lines`.
+    async fn hydrate_graph_only_into(
+        &self,
+        reranked: &[RerankedCandidate],
+        by_id: &mut HashMap<RecordId, SearchCandidate>,
+    ) -> Result<(), StoreError> {
+        let missing_ids: Vec<RecordId> = reranked
+            .iter()
+            .filter(|r| !by_id.contains_key(&r.record_id))
+            .map(|r| r.record_id.clone())
+            .collect();
+        if missing_ids.is_empty() {
+            return Ok(());
+        }
+        let conn = self.require_conn("search_hybrid")?.clone();
+        let extra = hydrate_graph_only(conn, missing_ids).await?;
+        for c in extra {
+            by_id.entry(c.record_id.clone()).or_insert(c);
+        }
+        Ok(())
     }
 
     /// Run the graph leg for [`Self::do_search_hybrid`]. Returns
@@ -377,6 +376,149 @@ fn hydrate_candidates(
             .or_insert(c);
     }
     by_id
+}
+
+/// Build the explain block aligned with the surviving candidate page.
+/// Iterates candidates (post hydrate + `filter_map` + take) and looks up each
+/// row in the rerank output so `explain[i].record_id == candidates[i].record_id`
+/// even when hydration drops a row.
+fn build_explain(
+    candidates: &[SearchCandidate],
+    reranked: &[RerankedCandidate],
+    kw_ranks: &HashMap<RecordId, usize>,
+    sem_ranks: &HashMap<RecordId, usize>,
+) -> Vec<ScoreExplain> {
+    let reranked_map: HashMap<&RecordId, &RerankedCandidate> =
+        reranked.iter().map(|r| (&r.record_id, r)).collect();
+    candidates
+        .iter()
+        .filter_map(|c| {
+            let r = reranked_map.get(&c.record_id)?;
+            Some(ScoreExplain {
+                record_id: c.record_id.clone(),
+                bm25_rank: kw_ranks.get(&c.record_id).copied(),
+                semantic_rank: sem_ranks.get(&c.record_id).copied(),
+                rrf_score: r.rrf_score,
+                cosine: r.cosine,
+                final_score: r.final_score,
+            })
+        })
+        .collect()
+}
+
+/// Hydrate `SearchCandidate` rows for graph-only ids that did not surface
+/// in either lexical leg. Reads the same `records` columns the keyword
+/// query projects, but with `bm25 = 0.0`, empty `snippet`, and
+/// `semantic_distance = None` — those signals are unavailable on the
+/// graph-only path. Tombstoned / inactive rows are filtered out so a
+/// record retired between the leg query and now cannot resurface as a
+/// graph hit.
+async fn hydrate_graph_only(
+    conn: Arc<tokio_rusqlite::Connection>,
+    ids: Vec<RecordId>,
+) -> Result<Vec<SearchCandidate>, StoreError> {
+    use cairn_core::domain::{MemoryClass, MemoryKind, MemoryVisibility, ScopeTuple};
+
+    use crate::store::current_unix_ms;
+    use crate::store::projection::record_id_from_str;
+
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let now_ms = current_unix_ms();
+    let id_strings: Vec<String> = ids.iter().map(|r| r.as_str().to_owned()).collect();
+
+    let out = conn
+        .call(
+            move |c| -> Result<Vec<SearchCandidate>, tokio_rusqlite::Error> {
+                let placeholders: String = std::iter::repeat_n("?", id_strings.len())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let sql = format!(
+                    "SELECT r.record_id, r.target_id, r.scope, r.kind, r.class, r.visibility, \
+                        r.updated_at, r.confidence, r.salience, r.created_at, r.body \
+                   FROM records r \
+                  WHERE r.record_id IN ({placeholders}) \
+                    AND r.active = 1 AND r.tombstoned = 0"
+                );
+                let params: Vec<SqlVal> = id_strings.into_iter().map(SqlVal::Text).collect();
+
+                let mut stmt = c.prepare(&sql)?;
+                let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
+                let mut out: Vec<SearchCandidate> = Vec::new();
+                while let Some(row) = rows.next()? {
+                    let rec_str: String = row.get(0)?;
+                    let target_str: String = row.get(1)?;
+                    let scope_json: String = row.get(2)?;
+                    let kind_str: String = row.get(3)?;
+                    let class_str: String = row.get(4)?;
+                    let visibility_str: String = row.get(5)?;
+                    let updated_at: i64 = row.get(6)?;
+                    let confidence: f64 = row.get(7)?;
+                    let salience: f64 = row.get(8)?;
+                    let created_at: i64 = row.get(9)?;
+                    let body: String = row.get(10)?;
+
+                    let record_id = record_id_from_str(&rec_str).map_err(|e| {
+                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
+                            what: format!("hydrate_graph_only: bad record_id `{rec_str}`: {e}"),
+                        }))
+                    })?;
+                    let target_id =
+                        cairn_core::domain::TargetId::parse(&target_str).map_err(|e| {
+                            tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
+                                what: format!(
+                                    "hydrate_graph_only: bad target_id `{target_str}`: {e}"
+                                ),
+                            }))
+                        })?;
+                    let scope: ScopeTuple = serde_json::from_str(&scope_json).map_err(|e| {
+                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
+                            what: format!("hydrate_graph_only: bad scope `{scope_json}`: {e}"),
+                        }))
+                    })?;
+                    let kind = MemoryKind::parse(&kind_str).map_err(|e| {
+                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
+                            what: format!("hydrate_graph_only: bad kind `{kind_str}`: {e}"),
+                        }))
+                    })?;
+                    let class = MemoryClass::parse(&class_str).map_err(|e| {
+                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
+                            what: format!("hydrate_graph_only: bad class `{class_str}`: {e}"),
+                        }))
+                    })?;
+                    let visibility = MemoryVisibility::parse(&visibility_str).map_err(|e| {
+                        tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
+                            what: format!(
+                                "hydrate_graph_only: bad visibility `{visibility_str}`: {e}"
+                            ),
+                        }))
+                    })?;
+
+                    #[allow(clippy::cast_possible_truncation, reason = "REAL→f32 narrow")]
+                    out.push(SearchCandidate {
+                        record_id,
+                        target_id,
+                        scope,
+                        kind,
+                        class,
+                        visibility,
+                        bm25: 0.0,
+                        recency_seconds: (now_ms - updated_at) / 1000,
+                        confidence: confidence as f32,
+                        salience: salience as f32,
+                        staleness_seconds: (now_ms - created_at) / 1000,
+                        snippet: String::new(),
+                        record_json: body,
+                        semantic_distance: None,
+                    });
+                }
+                Ok(out)
+            },
+        )
+        .await
+        .map_err(StoreError::from)?;
+    Ok(out)
 }
 
 /// Decode a sqlite-vec blob (LE f32 sequence) into a `Vec<f32>`. Tail bytes

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -23,12 +23,13 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use cairn_core::contract::memory_store::{
-    HybridSearchArgs, HybridSearchPage, KeywordSearchArgs, SearchCandidate, SemanticSearchArgs,
+    GraphNeighborsArgs, HybridSearchArgs, HybridSearchPage, KeywordSearchArgs, SearchCandidate,
+    SemanticSearchArgs,
 };
 use cairn_core::domain::RecordId;
 use cairn_core::search::{
-    HybridSearchInputs, HybridSearchParams, RerankedCandidate, ScoreExplain, ScoredCandidate,
-    hybrid_search,
+    DegradationReason, DegradedLeg, GraphCandidate, GraphSource, HybridSearchInputs,
+    HybridSearchParams, RerankedCandidate, ScoreExplain, ScoredCandidate, hybrid_search,
 };
 use cairn_embeddings_local::EmbeddingModel;
 use rusqlite::types::Value as SqlVal;
@@ -104,6 +105,10 @@ impl SqliteMemoryStore {
         let kw_list = scored_from_keyword(&keyword.candidates);
         let sem_list = scored_from_semantic(&semantic.candidates);
 
+        let (graph_candidates, degraded_legs) = self
+            .run_graph_leg(args, &keyword.candidates, &semantic.candidates)
+            .await;
+
         // Build 1-based rank lookup maps for the explain block. Constructed
         // here while `kw_list` / `sem_list` are in leg-order (rank order).
         let kw_ranks: HashMap<RecordId, usize> = kw_list
@@ -134,7 +139,7 @@ impl SqliteMemoryStore {
             &HybridSearchInputs {
                 keyword: kw_list,
                 semantic: sem_list,
-                graph: Vec::new(),
+                graph: graph_candidates,
                 query_vector,
                 doc_vectors,
             },
@@ -143,7 +148,7 @@ impl SqliteMemoryStore {
                 rerank_topk: args.rerank_topk,
                 blend: args.blend,
                 skip_rerank: false,
-                confidence_floor: HybridSearchParams::default().confidence_floor,
+                confidence_floor: args.confidence_floor,
             },
         );
 
@@ -190,7 +195,61 @@ impl SqliteMemoryStore {
         Ok(HybridSearchPage {
             candidates,
             explain,
+            degraded_legs,
         })
+    }
+
+    /// Run the graph leg for [`Self::do_search_hybrid`]. Returns
+    /// `(graph_candidates, degraded_legs)`. Extracted to keep the parent
+    /// function under the workspace `clippy::too_many_lines` cap.
+    ///
+    /// Seeds = union of kw + sem ids; ranked exclusion = same set, so we
+    /// never re-promote a record that already lexically matched. The
+    /// graph leg is a soft dependency: capability-missing yields an empty
+    /// result plus `DegradedLeg::graph_capability_unavailable()`, and a
+    /// SQL failure yields empty plus `DegradedLeg::Graph` with
+    /// `SqlError` reason.
+    async fn run_graph_leg(
+        &self,
+        args: &HybridSearchArgs<'_>,
+        kw_candidates: &[SearchCandidate],
+        sem_candidates: &[SearchCandidate],
+    ) -> (Vec<GraphCandidate>, Vec<DegradedLeg>) {
+        if !self.caps.graph_search {
+            return (
+                Vec::new(),
+                vec![DegradedLeg::graph_capability_unavailable()],
+            );
+        }
+        let mut seen: HashSet<RecordId> = HashSet::new();
+        let mut seed_ids: Vec<RecordId> = Vec::new();
+        for c in kw_candidates.iter().chain(sem_candidates.iter()) {
+            if seen.insert(c.record_id.clone()) {
+                seed_ids.push(c.record_id.clone());
+            }
+        }
+        let graph_args = GraphNeighborsArgs {
+            seed_record_ids: seed_ids.clone(),
+            ranked_record_ids: seed_ids,
+            filter: args.filter,
+            auth_scope: args.auth_scope.clone(),
+            visibility_allowlist: args.visibility_allowlist.clone(),
+            limit: HYBRID_LEG_LIMIT,
+            confidence_min: 0.0,
+        };
+        match self.do_search_graph_neighbors(&graph_args).await {
+            Ok(c) => (c, Vec::new()),
+            Err(e) => {
+                tracing::warn!(error = %e, "graph leg failed; continuing without graph results");
+                (
+                    Vec::new(),
+                    vec![DegradedLeg::Graph {
+                        reason: DegradationReason::SqlError,
+                        source: GraphSource::All,
+                    }],
+                )
+            }
+        }
     }
 }
 

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -243,10 +243,25 @@ impl SqliteMemoryStore {
         // legs, but **without** `args.filter` — the user's narrowing
         // filter must not erase records from the seed pool, otherwise
         // graph rank-rescue collapses on aggressive filters.
+        //
+        // The two seed sources (keyword + semantic) run independently:
+        // a single failure on one side still allows the surviving source
+        // to seed the graph traversal, with a per-source `DegradedLeg`
+        // entry recording the partial loss. Only when BOTH sides fail
+        // does the leg short-circuit empty.
+        let mut graph_degradations: Vec<DegradedLeg> = Vec::new();
         let seed_ids = match self.fetch_graph_seed_pool(args).await {
-            Ok(ids) => ids,
-            Err(e) => {
-                tracing::warn!(error = %e, "graph seed pool failed; continuing without graph results");
+            SeedPoolOutcome::Both(ids) => ids,
+            SeedPoolOutcome::Partial { ids, lost } => {
+                tracing::warn!(source = ?lost, "graph seed source failed; continuing with surviving source");
+                graph_degradations.push(DegradedLeg::Graph {
+                    reason: DegradationReason::SqlError,
+                    source: lost,
+                });
+                ids
+            }
+            SeedPoolOutcome::None => {
+                tracing::warn!("graph seed pool failed (both sources); continuing without graph results");
                 return (
                     Vec::new(),
                     vec![DegradedLeg::Graph {
@@ -279,16 +294,14 @@ impl SqliteMemoryStore {
             confidence_min: 0.0,
         };
         match self.do_search_graph_neighbors(&graph_args).await {
-            Ok(c) => (c, Vec::new()),
+            Ok(c) => (c, graph_degradations),
             Err(e) => {
                 tracing::warn!(error = %e, "graph leg failed; continuing without graph results");
-                (
-                    Vec::new(),
-                    vec![DegradedLeg::Graph {
-                        reason: DegradationReason::SqlError,
-                        source: GraphSource::All,
-                    }],
-                )
+                graph_degradations.push(DegradedLeg::Graph {
+                    reason: DegradationReason::SqlError,
+                    source: GraphSource::All,
+                });
+                (Vec::new(), graph_degradations)
             }
         }
     }
@@ -304,10 +317,7 @@ impl SqliteMemoryStore {
     /// seed semantics, without admitting query-irrelevant rows into
     /// graph traversal (which would have happened with a query-agnostic
     /// `records` scan).
-    async fn fetch_graph_seed_pool(
-        &self,
-        args: &HybridSearchArgs<'_>,
-    ) -> Result<Vec<RecordId>, StoreError> {
+    async fn fetch_graph_seed_pool(&self, args: &HybridSearchArgs<'_>) -> SeedPoolOutcome {
         let kw_seed_args = KeywordSearchArgs {
             query: args.query.clone(),
             filter: None,
@@ -326,25 +336,82 @@ impl SqliteMemoryStore {
             model_label: args.model_label.clone(),
             with_explain: false,
         };
-        // Run the two seed queries in parallel; either failure degrades
-        // the graph leg to empty (handled by the caller).
-        let (kw_seeds, sem_seeds) = tokio::try_join!(
+        // Run the two seed queries in parallel and tolerate a single-side
+        // failure. `tokio::join!` (not `try_join!`) returns both Results
+        // independently; we union the surviving source(s) and report any
+        // loss as a per-`GraphSource` degradation entry.
+        let (kw_res, sem_res) = tokio::join!(
             self.do_search_keyword(&kw_seed_args),
             self.do_search_semantic(&sem_seed_args),
-        )?;
+        );
 
-        let mut seen: HashSet<RecordId> = HashSet::new();
-        let mut out: Vec<RecordId> = Vec::with_capacity(GRAPH_SEED_OVERFETCH);
-        for c in kw_seeds.candidates.into_iter().chain(sem_seeds.candidates) {
-            if out.len() >= GRAPH_SEED_OVERFETCH {
-                break;
+        let kw_ok = match kw_res {
+            Ok(r) => Some(r.candidates),
+            Err(e) => {
+                tracing::warn!(error = %e, "graph keyword-seed retrieval failed");
+                None
             }
-            if seen.insert(c.record_id.clone()) {
-                out.push(c.record_id);
+        };
+        let sem_ok = match sem_res {
+            Ok(r) => Some(r.candidates),
+            Err(e) => {
+                tracing::warn!(error = %e, "graph semantic-seed retrieval failed");
+                None
             }
+        };
+
+        match (kw_ok, sem_ok) {
+            (None, None) => SeedPoolOutcome::None,
+            (Some(kw), Some(sem)) => SeedPoolOutcome::Both(union_seed_ids(kw, Some(sem))),
+            (Some(kw), None) => SeedPoolOutcome::Partial {
+                ids: union_seed_ids(kw, None),
+                lost: GraphSource::AuthSemanticSeed,
+            },
+            (None, Some(sem)) => SeedPoolOutcome::Partial {
+                ids: union_seed_ids(sem, None),
+                lost: GraphSource::AuthKeywordSeed,
+            },
         }
-        Ok(out)
     }
+}
+
+/// Internal outcome of [`SqliteMemoryStore::fetch_graph_seed_pool`].
+///
+/// Carries the per-source degradation signal up to `run_graph_leg` so a
+/// single-source failure surfaces as a recall reduction, not a full leg
+/// loss.
+enum SeedPoolOutcome {
+    /// Both keyword + semantic seed retrievals succeeded.
+    Both(Vec<RecordId>),
+    /// One source survived; the other failed and is reported via `lost`.
+    Partial {
+        ids: Vec<RecordId>,
+        lost: GraphSource,
+    },
+    /// Both sources failed.
+    None,
+}
+
+/// De-duplicating union of two ordered candidate lists, capped at
+/// [`GRAPH_SEED_OVERFETCH`]. The first list is preferred for ordering
+/// (its hits enter the pool first), then the second list contributes any
+/// records the first did not surface.
+fn union_seed_ids(
+    primary: Vec<SearchCandidate>,
+    secondary: Option<Vec<SearchCandidate>>,
+) -> Vec<RecordId> {
+    let mut seen: HashSet<RecordId> = HashSet::new();
+    let mut out: Vec<RecordId> = Vec::with_capacity(GRAPH_SEED_OVERFETCH);
+    let secondary_iter = secondary.unwrap_or_default().into_iter();
+    for c in primary.into_iter().chain(secondary_iter) {
+        if out.len() >= GRAPH_SEED_OVERFETCH {
+            break;
+        }
+        if seen.insert(c.record_id.clone()) {
+            out.push(c.record_id);
+        }
+    }
+    out
 }
 
 /// Project keyword candidates into the rank-only `ScoredCandidate` list RRF

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -104,17 +104,39 @@ impl SqliteMemoryStore {
             model_label: args.model_label.clone(),
             with_explain: false,
         };
-        let (keyword, semantic) = tokio::try_join!(
+        // Run keyword + semantic in parallel, but tolerate a semantic
+        // failure: hybrid degrades to keyword + graph rather than hard-
+        // failing. Keyword is the lexical anchor and remains a hard
+        // requirement — if FTS5 fails, there's nothing meaningful to
+        // rerank.
+        let (kw_res, sem_res) = tokio::join!(
             self.do_search_keyword(&kw_args),
             self.do_search_semantic(&sem_args),
-        )?;
+        );
+        let keyword = kw_res?;
+        let mut leg_degradations: Vec<DegradedLeg> = Vec::new();
+        let semantic = match sem_res {
+            Ok(page) => page,
+            Err(e) => {
+                tracing::warn!(error = %e, "semantic leg failed; degrading hybrid response");
+                leg_degradations.push(DegradedLeg::Semantic {
+                    reason: DegradationReason::SqlError,
+                });
+                cairn_core::contract::memory_store::SemanticSearchPage {
+                    candidates: Vec::new(),
+                    explain: None,
+                }
+            }
+        };
 
         let kw_list = scored_from_keyword(&keyword.candidates);
         let sem_list = scored_from_semantic(&semantic.candidates);
 
-        let (graph_candidates, degraded_legs) = self
+        let (graph_candidates, graph_degraded) = self
             .run_graph_leg(args, &keyword.candidates, &semantic.candidates)
             .await;
+        leg_degradations.extend(graph_degraded);
+        let degraded_legs = leg_degradations;
 
         // Build 1-based rank lookup maps for the explain block. Constructed
         // here while `kw_list` / `sem_list` are in leg-order (rank order).

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -293,63 +293,57 @@ impl SqliteMemoryStore {
         }
     }
 
-    /// Fetch the auth-only seed pool for the graph leg. Selects up to
-    /// `GRAPH_SEED_OVERFETCH` recently-updated active records that pass
-    /// the caller's `auth_scope`, `visibility_allowlist`, and supersession
-    /// constraints — but **NOT** `args.filter`. The seed pool's whole
-    /// purpose is to surface authorized records that the narrowing filter
-    /// would have excluded from the lexical legs but that still warrant
-    /// graph traversal.
+    /// Fetch the query-aware, auth-only seed pool for the graph leg.
+    ///
+    /// Runs the **same FTS5 + ANN retrievals as the lexical legs**, but
+    /// with `filter = None` and `with_explain = false`. The result is the
+    /// union of keyword and semantic ids that match `args.query` and
+    /// pass `auth_scope` + `visibility_allowlist` + supersession — but
+    /// NOT `args.filter`. This restores the spec's "authorized records
+    /// that match the query but were narrowed out by the user filter"
+    /// seed semantics, without admitting query-irrelevant rows into
+    /// graph traversal (which would have happened with a query-agnostic
+    /// `records` scan).
     async fn fetch_graph_seed_pool(
         &self,
         args: &HybridSearchArgs<'_>,
     ) -> Result<Vec<RecordId>, StoreError> {
-        let conn = self.require_conn("fetch_graph_seed_pool")?.clone();
-        let visibilities: Vec<String> = args
-            .visibility_allowlist
-            .iter()
-            .map(|v| v.as_str().to_owned())
-            .collect();
-        let scope = args.auth_scope.clone();
+        let kw_seed_args = KeywordSearchArgs {
+            query: args.query.clone(),
+            filter: None,
+            auth_scope: args.auth_scope.clone(),
+            visibility_allowlist: args.visibility_allowlist.clone(),
+            limit: GRAPH_SEED_OVERFETCH,
+            cursor: None,
+            with_explain: false,
+        };
+        let sem_seed_args = SemanticSearchArgs {
+            query: args.query.clone(),
+            filter: None,
+            auth_scope: args.auth_scope.clone(),
+            visibility_allowlist: args.visibility_allowlist.clone(),
+            limit: GRAPH_SEED_OVERFETCH,
+            model_label: args.model_label.clone(),
+            with_explain: false,
+        };
+        // Run the two seed queries in parallel; either failure degrades
+        // the graph leg to empty (handled by the caller).
+        let (kw_seeds, sem_seeds) = tokio::try_join!(
+            self.do_search_keyword(&kw_seed_args),
+            self.do_search_semantic(&sem_seed_args),
+        )?;
 
-        let ids = conn
-            .call(move |c| -> Result<Vec<String>, tokio_rusqlite::Error> {
-                let visibility_clause = if visibilities.is_empty() {
-                    String::new()
-                } else {
-                    let vis_placeholders: String = std::iter::repeat_n("?", visibilities.len())
-                        .collect::<Vec<_>>()
-                        .join(",");
-                    format!(" AND r.visibility IN ({vis_placeholders})")
-                };
-                let (scope_sql, scope_params) =
-                    crate::store::scope_predicate::build_scope_predicate("r", &scope);
-                let sql = format!(
-                    "SELECT r.record_id FROM records r \
-                      WHERE r.active = 1 AND r.tombstoned = 0{visibility_clause}{scope_sql} \
-                        AND {} \
-                      ORDER BY r.updated_at DESC LIMIT ?",
-                    crate::store::search::SUPERSESSION_NOT_EXISTS_CLAUSE
-                );
-                let mut params: Vec<SqlVal> = visibilities.into_iter().map(SqlVal::Text).collect();
-                params.extend(scope_params);
-                #[allow(clippy::cast_possible_wrap)]
-                params.push(SqlVal::Integer(GRAPH_SEED_OVERFETCH as i64));
-                let mut stmt = c.prepare(&sql)?;
-                let rows = stmt
-                    .query_map(rusqlite::params_from_iter(params.iter()), |row| {
-                        row.get::<_, String>(0)
-                    })?
-                    .collect::<Result<Vec<_>, _>>()?;
-                Ok(rows)
-            })
-            .await
-            .map_err(StoreError::from)?;
-
-        let parsed: Result<Vec<RecordId>, _> = ids.into_iter().map(RecordId::parse).collect();
-        parsed.map_err(|e| StoreError::Invariant {
-            what: format!("seed pool: invalid record_id from store: {e}"),
-        })
+        let mut seen: HashSet<RecordId> = HashSet::new();
+        let mut out: Vec<RecordId> = Vec::with_capacity(GRAPH_SEED_OVERFETCH);
+        for c in kw_seeds.candidates.into_iter().chain(sem_seeds.candidates) {
+            if out.len() >= GRAPH_SEED_OVERFETCH {
+                break;
+            }
+            if seen.insert(c.record_id.clone()) {
+                out.push(c.record_id);
+            }
+        }
+        Ok(out)
     }
 }
 

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -132,6 +132,7 @@ impl SqliteMemoryStore {
             &HybridSearchInputs {
                 keyword: kw_list,
                 semantic: sem_list,
+                graph: Vec::new(),
                 query_vector,
                 doc_vectors,
             },
@@ -140,6 +141,7 @@ impl SqliteMemoryStore {
                 rerank_topk: args.rerank_topk,
                 blend: args.blend,
                 skip_rerank: false,
+                confidence_floor: HybridSearchParams::default().confidence_floor,
             },
         );
 

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -169,26 +169,22 @@ impl SqliteMemoryStore {
         // skip re-rank and surface a `DegradedLeg::Semantic` entry —
         // unless one is already present from `do_search_semantic` itself
         // (don't double-report a single failure mode).
-        let (doc_vectors, skip_rerank) = match fetch_doc_vectors(
-            conn,
-            combined_ids,
-            args.model_label.clone(),
-        )
-        .await
-        {
-            Ok(v) => (v, false),
-            Err(e) => {
-                tracing::warn!(error = %e, "fetch_doc_vectors failed; skipping cosine rerank");
-                if !leg_degradations.iter().any(|d| {
-                    matches!(d, DegradedLeg::Semantic { .. })
-                }) {
-                    leg_degradations.push(DegradedLeg::Semantic {
-                        reason: DegradationReason::SqlError,
-                    });
+        let (doc_vectors, skip_rerank) =
+            match fetch_doc_vectors(conn, combined_ids, args.model_label.clone()).await {
+                Ok(v) => (v, false),
+                Err(e) => {
+                    tracing::warn!(error = %e, "fetch_doc_vectors failed; skipping cosine rerank");
+                    if !leg_degradations
+                        .iter()
+                        .any(|d| matches!(d, DegradedLeg::Semantic { .. }))
+                    {
+                        leg_degradations.push(DegradedLeg::Semantic {
+                            reason: DegradationReason::SqlError,
+                        });
+                    }
+                    (HashMap::new(), true)
                 }
-                (HashMap::new(), true)
-            }
-        };
+            };
         let degraded_legs = leg_degradations;
 
         // Run the pure-function orchestration.
@@ -311,7 +307,9 @@ impl SqliteMemoryStore {
                 ids
             }
             SeedPoolOutcome::None => {
-                tracing::warn!("graph seed pool failed (both sources); continuing without graph results");
+                tracing::warn!(
+                    "graph seed pool failed (both sources); continuing without graph results"
+                );
                 return (
                     Vec::new(),
                     vec![DegradedLeg::Graph {

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -341,7 +341,7 @@ impl SqliteMemoryStore {
             auth_scope: args.auth_scope.clone(),
             visibility_allowlist: args.visibility_allowlist.clone(),
             limit: HYBRID_LEG_LIMIT,
-            confidence_min: 0.0,
+            confidence_min: args.graph_confidence_min,
         };
         match self.do_search_graph_neighbors(&graph_args).await {
             Ok(c) => (c, graph_degradations),

--- a/crates/cairn-store-sqlite/src/store/mod.rs
+++ b/crates/cairn-store-sqlite/src/store/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod projection;
 pub(crate) mod read;
 pub(crate) mod reindex;
 pub(crate) mod reindex_from_db;
+pub(crate) mod scope_predicate;
 pub(crate) mod search;
 pub mod sessions;
 pub(crate) mod tombstone;

--- a/crates/cairn-store-sqlite/src/store/mod.rs
+++ b/crates/cairn-store-sqlite/src/store/mod.rs
@@ -76,6 +76,8 @@ impl Default for SqliteMemoryStore {
                 graph_edges: true,
                 transactions: true,
                 per_record_consent_model: true,
+
+                graph_search: false,
             },
             _cancel: None,
             fts_column_weights: [10.0, 10.0, 5.0, 1.0],

--- a/crates/cairn-store-sqlite/src/store/mod.rs
+++ b/crates/cairn-store-sqlite/src/store/mod.rs
@@ -1,6 +1,7 @@
 //! `SqliteMemoryStore` impl modules.
 
 pub(crate) mod edges;
+pub(crate) mod graph_search;
 pub(crate) mod hybrid;
 pub(crate) mod projection;
 pub(crate) mod read;

--- a/crates/cairn-store-sqlite/src/store/scope_predicate.rs
+++ b/crates/cairn-store-sqlite/src/store/scope_predicate.rs
@@ -1,0 +1,125 @@
+//! Authorization-scope SQL predicate builder (issue #191).
+//!
+//! Translates a [`ScopeTuple`] into a `JSON1`-based `AND ...` fragment that
+//! can be composed into any `records` query. For each `Some(_)` dimension on
+//! the tuple, emits a `json_extract({alias}.scope, '$.<dim>') = ?` predicate
+//! and binds the value. `None` dimensions are elided (they mean "no
+//! narrowing on this axis"), and an empty tuple emits the empty fragment.
+//!
+//! Used by all four record-reading SQL paths to keep auth enforcement
+//! identical:
+//!
+//! 1. `do_search_keyword` (FTS5 leg)
+//! 2. `do_search_semantic` (ANN leg)
+//! 3. `do_search_graph_neighbors` (graph 1-hop, neighbor side)
+//! 4. `hybrid::hydrate_graph_only` (defense-in-depth on graph-only ids)
+
+use cairn_core::domain::ScopeTuple;
+use rusqlite::types::Value as SqlVal;
+
+/// Emit a scope predicate fragment for the given alias (e.g. `"r"`) and
+/// scope tuple. The fragment is intended to be appended after an existing
+/// `WHERE` clause; it always begins with `" AND "` when non-empty so the
+/// caller does not need to track whether prior conditions exist.
+///
+/// Returns `("", vec![])` when every dimension is `None`.
+#[must_use]
+pub(crate) fn build_scope_predicate(alias: &str, scope: &ScopeTuple) -> (String, Vec<SqlVal>) {
+    let mut parts: Vec<(&'static str, &str)> = Vec::with_capacity(7);
+    if let Some(v) = &scope.tenant {
+        parts.push(("tenant", v));
+    }
+    if let Some(v) = &scope.workspace {
+        parts.push(("workspace", v));
+    }
+    if let Some(v) = &scope.project {
+        parts.push(("project", v));
+    }
+    if let Some(v) = &scope.session_id {
+        parts.push(("session_id", v));
+    }
+    if let Some(v) = &scope.entity {
+        parts.push(("entity", v));
+    }
+    if let Some(v) = &scope.user {
+        parts.push(("user", v));
+    }
+    if let Some(v) = &scope.agent {
+        parts.push(("agent", v));
+    }
+    if parts.is_empty() {
+        return (String::new(), Vec::new());
+    }
+    let mut sql = String::with_capacity(parts.len() * 64);
+    let mut params: Vec<SqlVal> = Vec::with_capacity(parts.len());
+    for (key, value) in parts {
+        sql.push_str(" AND json_extract(");
+        sql.push_str(alias);
+        sql.push_str(".scope, '$.");
+        sql.push_str(key);
+        sql.push_str("') = ?");
+        params.push(SqlVal::Text(value.to_owned()));
+    }
+    (sql, params)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_scope_emits_no_fragment() {
+        let (sql, params) = build_scope_predicate("r", &ScopeTuple::default());
+        assert!(sql.is_empty());
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn single_dimension_emits_one_clause() {
+        let scope = ScopeTuple {
+            tenant: Some("acme".into()),
+            ..Default::default()
+        };
+        let (sql, params) = build_scope_predicate("r", &scope);
+        assert_eq!(sql, " AND json_extract(r.scope, '$.tenant') = ?");
+        assert_eq!(params.len(), 1);
+        match &params[0] {
+            SqlVal::Text(s) => assert_eq!(s, "acme"),
+            other => panic!("unexpected param: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multiple_dimensions_emit_in_canonical_order() {
+        let scope = ScopeTuple {
+            user: Some("alice".into()),
+            tenant: Some("acme".into()),
+            workspace: Some("eng".into()),
+            ..Default::default()
+        };
+        let (sql, params) = build_scope_predicate("r", &scope);
+        // Order is the field-declaration order, deterministic regardless of
+        // which Some() branches fired.
+        let expected = " AND json_extract(r.scope, '$.tenant') = ?\
+                        AND json_extract(r.scope, '$.workspace') = ?\
+                        AND json_extract(r.scope, '$.user') = ?";
+        // Concrete check is on substring presence (avoids whitespace
+        // ambiguity from the line-continuation `\`).
+        assert!(sql.contains("'$.tenant') = ?"));
+        assert!(sql.contains("'$.workspace') = ?"));
+        assert!(sql.contains("'$.user') = ?"));
+        assert!(!sql.contains("'$.session_id'"));
+        assert_eq!(params.len(), 3);
+        let _ = expected;
+    }
+
+    #[test]
+    fn alias_is_threaded_through() {
+        let scope = ScopeTuple {
+            tenant: Some("t".into()),
+            ..Default::default()
+        };
+        let (sql, _) = build_scope_predicate("neighbor", &scope);
+        assert!(sql.contains("json_extract(neighbor.scope"));
+    }
+}

--- a/crates/cairn-store-sqlite/src/store/search.rs
+++ b/crates/cairn-store-sqlite/src/store/search.rs
@@ -144,6 +144,7 @@ impl SqliteMemoryStore {
         let compiled = args.filter.map(compile_filter);
         let now_ms = current_unix_ms();
         let with_explain = args.with_explain;
+        let scope = args.auth_scope.clone();
 
         let page = conn
             .call(move |c| {
@@ -154,6 +155,7 @@ impl SqliteMemoryStore {
                     cursor.as_ref(),
                     limit,
                     &weights,
+                    &scope,
                 )
                 .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
 
@@ -352,6 +354,7 @@ fn build_search_query(
     cursor: Option<&KeywordCursor>,
     limit: usize,
     fts_column_weights: &[f64; 4],
+    scope: &cairn_core::domain::ScopeTuple,
 ) -> Result<(String, Vec<SqlVal>), StoreError> {
     use std::fmt::Write as _;
 
@@ -419,6 +422,13 @@ fn build_search_query(
         }
     }
 
+    let (scope_sql, scope_params) =
+        crate::store::scope_predicate::build_scope_predicate("r", scope);
+    if !scope_sql.is_empty() {
+        sql.push_str(&scope_sql);
+        params.extend(scope_params);
+    }
+
     if let Some(filter) = compiled {
         sql.push_str(" AND (");
         sql.push_str(&filter.sql);
@@ -450,7 +460,7 @@ fn build_search_query(
 /// JSON shapes (objects, nested arrays) are not produced by the filter
 /// compiler; if one ever appears we surface NULL so the predicate fails
 /// closed instead of bypassing the filter.
-fn json_to_sql(v: &serde_json::Value) -> SqlVal {
+pub(crate) fn json_to_sql(v: &serde_json::Value) -> SqlVal {
     match v {
         serde_json::Value::String(s) => SqlVal::Text(s.clone()),
         serde_json::Value::Number(n) => {
@@ -587,11 +597,20 @@ impl SqliteMemoryStore {
             .collect();
         let compiled = args.filter.map(compile_filter);
         let now_ms = current_unix_ms();
+        let scope = args.auth_scope.clone();
         let conn = self.require_conn("search_semantic")?.clone();
 
-        let rows = run_ann_query(conn, query_bytes, visibilities, compiled, limit, now_ms)
-            .await
-            .map_err(unpack_worker_err)?;
+        let rows = run_ann_query(
+            conn,
+            query_bytes,
+            visibilities,
+            compiled,
+            limit,
+            now_ms,
+            scope,
+        )
+        .await
+        .map_err(unpack_worker_err)?;
 
         // Model filter applied in Rust — see `run_ann_query` doc for rationale.
         let model_label = args.model_label.as_str();
@@ -647,6 +666,7 @@ async fn run_ann_query(
     compiled: Option<cairn_core::domain::filter::CompiledFilter>,
     limit: usize,
     now_ms: i64,
+    scope: cairn_core::domain::ScopeTuple,
 ) -> Result<Vec<SemanticRawRow>, tokio_rusqlite::Error> {
     // Over-fetch 2× so the model post-filter still delivers `limit` results
     // in the common case where all rows share the active model.
@@ -663,6 +683,8 @@ async fn run_ann_query(
             .as_ref()
             .map(|cf| format!("AND ({})", cf.sql))
             .unwrap_or_default();
+        let (scope_sql, scope_params) =
+            crate::store::scope_predicate::build_scope_predicate("r", &scope);
 
         let sql = format!(
             "SELECT r.record_id, r.target_id, r.scope, r.kind, r.class,
@@ -680,7 +702,7 @@ async fn run_ann_query(
              JOIN   records r ON r.record_id = ann.record_id
              WHERE  r.active = 1 AND r.tombstoned = 0
                {vis_clause}
-               {filter_clause}
+               {filter_clause}{scope_sql}
              ORDER BY ann.distance ASC"
         );
 
@@ -696,6 +718,7 @@ async fn run_ann_query(
                 params.push(json_to_sql(p));
             }
         }
+        params.extend(scope_params);
 
         let mut stmt = c
             .prepare_cached(&sql)
@@ -894,9 +917,16 @@ mod tests {
         // Sanity: the production builder must keep using the constant.
         // If a future edit inlines a different predicate string, this
         // fails before the more expensive EXPLAIN check below.
-        let (sql, params) =
-            build_search_query("anything", &[], None, None, 10, &[10.0, 10.0, 5.0, 1.0])
-                .expect("build search SQL");
+        let (sql, params) = build_search_query(
+            "anything",
+            &[],
+            None,
+            None,
+            10,
+            &[10.0, 10.0, 5.0, 1.0],
+            &cairn_core::domain::ScopeTuple::default(),
+        )
+        .expect("build search SQL");
         assert!(
             sql.contains(SUPERSESSION_NOT_EXISTS_CLAUSE),
             "build_search_query must continue to emit SUPERSESSION_NOT_EXISTS_CLAUSE \

--- a/crates/cairn-store-sqlite/src/store/search.rs
+++ b/crates/cairn-store-sqlite/src/store/search.rs
@@ -1039,6 +1039,7 @@ mod tests {
         let args = KeywordSearchArgs {
             query: "feedback".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 5,
             cursor: None,

--- a/crates/cairn-store-sqlite/src/store/trait_impl.rs
+++ b/crates/cairn-store-sqlite/src/store/trait_impl.rs
@@ -133,6 +133,17 @@ impl MemoryStore for SqliteMemoryStore {
         if self.conn.is_none() {
             return not_initialized("search_graph_neighbors");
         }
+        // Fail closed when the runtime probe in `bootstrap` decided
+        // graph_search is unavailable (schema skew, partial migration,
+        // stripped-down fork). The hybrid leg already short-circuits
+        // through the verb-layer cap gate, but direct callers must get
+        // the same error contract instead of a downstream SQL failure.
+        if !self.caps.graph_search {
+            return Err(ConcreteError::CapabilityUnavailable {
+                what: "graph_search",
+            }
+            .into());
+        }
         self.do_search_graph_neighbors(args)
             .await
             .map_err(Into::into)

--- a/crates/cairn-store-sqlite/src/store/trait_impl.rs
+++ b/crates/cairn-store-sqlite/src/store/trait_impl.rs
@@ -8,13 +8,15 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use cairn_core::contract::memory_store::{
-    Edge, EdgeDir, EdgeKey, HybridSearchArgs, HybridSearchPage, IndexStats, KeywordSearchArgs,
-    KeywordSearchPage, ListArgs, ListPage, MemoryStore, MemoryStoreCapabilities, RecordVersion,
-    SemanticSearchArgs, SemanticSearchPage, StoreError, TombstoneReason, UpsertOutcome,
+    Edge, EdgeDir, EdgeKey, GraphNeighborsArgs, HybridSearchArgs, HybridSearchPage, IndexStats,
+    KeywordSearchArgs, KeywordSearchPage, ListArgs, ListPage, MemoryStore, MemoryStoreCapabilities,
+    RecordVersion, SemanticSearchArgs, SemanticSearchPage, StoreError, TombstoneReason,
+    UpsertOutcome,
 };
 use cairn_core::contract::version::VersionRange;
 use cairn_core::domain::consent_timeline::ConsentModel;
 use cairn_core::domain::{MemoryRecord, RecordId, TargetId};
+use cairn_core::search::GraphCandidate;
 
 use crate::error::StoreError as ConcreteError;
 use crate::store::SqliteMemoryStore;
@@ -122,6 +124,18 @@ impl MemoryStore for SqliteMemoryStore {
             return not_initialized("search_hybrid");
         }
         self.do_search_hybrid(args).await.map_err(Into::into)
+    }
+
+    async fn search_graph_neighbors(
+        &self,
+        args: &GraphNeighborsArgs<'_>,
+    ) -> Result<Vec<GraphCandidate>, StoreError> {
+        if self.conn.is_none() {
+            return not_initialized("search_graph_neighbors");
+        }
+        self.do_search_graph_neighbors(args)
+            .await
+            .map_err(Into::into)
     }
 
     async fn index_stats(&self) -> Result<IndexStats, StoreError> {

--- a/crates/cairn-store-sqlite/tests/auth_scope_search.rs
+++ b/crates/cairn-store-sqlite/tests/auth_scope_search.rs
@@ -1,0 +1,368 @@
+//! Integration tests for `auth_scope` enforcement across all four search SQL
+//! paths (keyword, semantic, graph, graph-only hydration). Issue #191.
+//!
+//! These tests insert records with distinct scope tuples and assert each
+//! retrieval path narrows correctly, refuses cross-tenant leakage, and
+//! degrades correctly when capabilities are missing.
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::{
+    HybridSearchArgs, KeywordSearchArgs, MemoryStore, SemanticSearchArgs,
+};
+use cairn_core::domain::ScopeTuple;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::taxonomy::MemoryVisibility;
+use cairn_core::domain::{RecordId, TargetId};
+use cairn_embeddings_local::{EmbeddingModel, EmbeddingModelKind, MockEmbedder};
+use cairn_store_sqlite::open_in_memory_with_embedder;
+
+/// Build a sample record with the given record/target ids, scope, and body.
+fn record(rid: &str, tid: &str, scope: ScopeTuple, body: &str) -> cairn_core::domain::MemoryRecord {
+    let mut r = sample_record();
+    r.id = RecordId::parse(rid.to_owned()).expect("valid record id");
+    r.target_id = TargetId::parse(tid.to_owned()).expect("valid target id");
+    r.scope = scope;
+    body.clone_into(&mut r.body);
+    r
+}
+
+/// Two-tenant fixture: 4 records, two each in tenant=A and tenant=B,
+/// distinguished by body so the keyword leg can match individually.
+async fn fixture_two_tenants() -> Arc<dyn MemoryStore> {
+    let kind = EmbeddingModelKind::default();
+    let embedder: Arc<dyn EmbeddingModel> = Arc::new(MockEmbedder::new(kind));
+    let store = open_in_memory_with_embedder(Some(Arc::clone(&embedder)))
+        .await
+        .expect("open store");
+
+    let a1 = record(
+        "01HQZX9F5N0000000000000A01",
+        "01HQZX9F5N0000000000000A01",
+        ScopeTuple {
+            tenant: Some("acme".into()),
+            user: Some("hmn:alice".into()),
+            ..Default::default()
+        },
+        "alpha alice acme one",
+    );
+    let a2 = record(
+        "01HQZX9F5N0000000000000A02",
+        "01HQZX9F5N0000000000000A02",
+        ScopeTuple {
+            tenant: Some("acme".into()),
+            user: Some("hmn:bob".into()),
+            ..Default::default()
+        },
+        "alpha bob acme two",
+    );
+    let b1 = record(
+        "01HQZX9F5N0000000000000B01",
+        "01HQZX9F5N0000000000000B01",
+        ScopeTuple {
+            tenant: Some("globex".into()),
+            user: Some("hmn:alice".into()),
+            ..Default::default()
+        },
+        "alpha alice globex one",
+    );
+    let b2 = record(
+        "01HQZX9F5N0000000000000B02",
+        "01HQZX9F5N0000000000000B02",
+        ScopeTuple {
+            tenant: Some("globex".into()),
+            user: Some("hmn:bob".into()),
+            ..Default::default()
+        },
+        "alpha bob globex two",
+    );
+    for r in [&a1, &a2, &b1, &b2] {
+        store.upsert(r).await.expect("upsert");
+    }
+    Arc::new(store)
+}
+
+fn vis_all() -> Vec<MemoryVisibility> {
+    vec![
+        MemoryVisibility::Private,
+        MemoryVisibility::Session,
+        MemoryVisibility::Project,
+        MemoryVisibility::Team,
+        MemoryVisibility::Org,
+        MemoryVisibility::Public,
+    ]
+}
+
+fn keyword_args(query: &str, scope: ScopeTuple) -> KeywordSearchArgs<'static> {
+    KeywordSearchArgs {
+        query: query.into(),
+        filter: None,
+        auth_scope: scope,
+        visibility_allowlist: vec![MemoryVisibility::Private],
+        limit: 50,
+        cursor: None,
+        with_explain: false,
+    }
+}
+
+fn semantic_args(query: &str, scope: ScopeTuple) -> SemanticSearchArgs<'static> {
+    SemanticSearchArgs {
+        query: query.into(),
+        filter: None,
+        auth_scope: scope,
+        visibility_allowlist: vec![MemoryVisibility::Private],
+        limit: 50,
+        model_label: EmbeddingModelKind::default().as_str().to_owned(),
+        with_explain: false,
+    }
+}
+
+fn hybrid_args(query: &str, scope: ScopeTuple) -> HybridSearchArgs<'static> {
+    HybridSearchArgs {
+        query: query.into(),
+        filter: None,
+        auth_scope: scope,
+        visibility_allowlist: vec![MemoryVisibility::Private],
+        limit: 50,
+        model_label: EmbeddingModelKind::default().as_str().to_owned(),
+        blend: 0.7,
+        rrf_k: 60,
+        rerank_topk: 20,
+        with_explain: false,
+        confidence_floor: 1e-3,
+    }
+}
+
+// ── Keyword leg ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn keyword_empty_scope_returns_all_tenants() {
+    let store = fixture_two_tenants().await;
+    let page = store
+        .search_keyword(&keyword_args("alpha", ScopeTuple::default()))
+        .await
+        .expect("keyword");
+    assert_eq!(
+        page.candidates.len(),
+        4,
+        "empty scope must not narrow; got {} ids",
+        page.candidates.len()
+    );
+}
+
+#[tokio::test]
+async fn keyword_tenant_scope_excludes_other_tenants() {
+    let store = fixture_two_tenants().await;
+    let scope = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    let page = store
+        .search_keyword(&keyword_args("alpha", scope))
+        .await
+        .expect("keyword");
+    assert_eq!(page.candidates.len(), 2, "tenant=acme expected 2 hits");
+    for c in &page.candidates {
+        assert!(
+            c.record_id.as_str().contains("000A0"),
+            "leaked cross-tenant: {}",
+            c.record_id.as_str()
+        );
+    }
+}
+
+#[tokio::test]
+async fn keyword_multidim_scope_is_anded() {
+    let store = fixture_two_tenants().await;
+    let scope = ScopeTuple {
+        tenant: Some("acme".into()),
+        user: Some("hmn:alice".into()),
+        ..Default::default()
+    };
+    let page = store
+        .search_keyword(&keyword_args("alpha", scope))
+        .await
+        .expect("keyword");
+    assert_eq!(page.candidates.len(), 1);
+    assert_eq!(
+        page.candidates[0].record_id.as_str(),
+        "01HQZX9F5N0000000000000A01",
+        "multidim scope must AND tenant + user"
+    );
+}
+
+#[tokio::test]
+async fn keyword_unmatched_scope_is_empty_not_error() {
+    let store = fixture_two_tenants().await;
+    let scope = ScopeTuple {
+        tenant: Some("nonexistent".into()),
+        ..Default::default()
+    };
+    let page = store
+        .search_keyword(&keyword_args("alpha", scope))
+        .await
+        .expect("keyword must not error on unmatched scope");
+    assert!(page.candidates.is_empty());
+}
+
+// ── Semantic leg ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn semantic_tenant_scope_excludes_other_tenants() {
+    let store = fixture_two_tenants().await;
+    let scope = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    let page = store
+        .search_semantic(&semantic_args("alpha", scope))
+        .await
+        .expect("semantic");
+    for c in &page.candidates {
+        assert!(
+            c.record_id.as_str().contains("000A0"),
+            "semantic leaked cross-tenant: {}",
+            c.record_id.as_str()
+        );
+    }
+}
+
+// ── Hybrid leg ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn hybrid_tenant_scope_excludes_other_tenants() {
+    let store = fixture_two_tenants().await;
+    let scope = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    let page = store
+        .search_hybrid(&hybrid_args("alpha", scope))
+        .await
+        .expect("hybrid");
+    assert!(
+        !page.candidates.is_empty(),
+        "hybrid should still return acme rows"
+    );
+    for c in &page.candidates {
+        assert!(
+            c.record_id.as_str().contains("000A0"),
+            "hybrid leaked cross-tenant: {}",
+            c.record_id.as_str()
+        );
+    }
+}
+
+#[tokio::test]
+async fn hybrid_empty_visibility_with_scope_still_narrows() {
+    // Empty visibility = "no visibility filter" — scope must still apply.
+    let store = fixture_two_tenants().await;
+    let mut args = hybrid_args(
+        "alpha",
+        ScopeTuple {
+            tenant: Some("acme".into()),
+            ..Default::default()
+        },
+    );
+    args.visibility_allowlist = vec![]; // explicitly empty
+    let page = store.search_hybrid(&args).await.expect("hybrid");
+    for c in &page.candidates {
+        assert!(
+            c.record_id.as_str().contains("000A0"),
+            "scope must still narrow when visibility_allowlist is empty: {}",
+            c.record_id.as_str()
+        );
+    }
+}
+
+#[tokio::test]
+async fn hybrid_visibility_and_scope_both_apply() {
+    // sample_record sets visibility=Private. Set visibility allowlist to
+    // a different tier and assert no rows come back even though tenant
+    // matches.
+    let store = fixture_two_tenants().await;
+    let mut args = hybrid_args(
+        "alpha",
+        ScopeTuple {
+            tenant: Some("acme".into()),
+            ..Default::default()
+        },
+    );
+    args.visibility_allowlist = vec![MemoryVisibility::Public];
+    let page = store.search_hybrid(&args).await.expect("hybrid");
+    assert!(
+        page.candidates.is_empty(),
+        "Public visibility filter must exclude all Private rows even within tenant"
+    );
+}
+
+// ── degraded_legs propagation ────────────────────────────────────────────
+
+#[tokio::test]
+async fn hybrid_degraded_legs_present_when_graph_capability_off() {
+    // Default in-memory open path advertises graph_search=true. We assert
+    // the *empty* shape on a successful run — degraded_legs is empty when
+    // every leg ran cleanly.
+    let store = fixture_two_tenants().await;
+    let page = store
+        .search_hybrid(&hybrid_args("alpha", ScopeTuple::default()))
+        .await
+        .expect("hybrid");
+    assert!(
+        page.degraded_legs.is_empty(),
+        "successful hybrid should report no degraded legs; got {:?}",
+        page.degraded_legs,
+    );
+}
+
+// ── Visibility-allowlist=[] path ─────────────────────────────────────────
+
+#[tokio::test]
+async fn keyword_empty_visibility_returns_all_visibilities() {
+    // Verifies the empty-allowlist guard wasn't broken. All four fixture
+    // records share visibility=Private; an empty allowlist should still
+    // return them all (rather than zero, the way the buggy graph-leg SQL
+    // used to behave).
+    let store = fixture_two_tenants().await;
+    let mut args = keyword_args("alpha", ScopeTuple::default());
+    args.visibility_allowlist = vec![];
+    let page = store.search_keyword(&args).await.expect("keyword");
+    assert_eq!(
+        page.candidates.len(),
+        4,
+        "empty visibility_allowlist must not silently drop rows"
+    );
+}
+
+// ── Special-character values ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn scope_with_special_characters_does_not_break_sql() {
+    // Records with quotes, backslashes, etc. in scope values must round-trip
+    // through json_extract without breaking SQL parsing.
+    let kind = EmbeddingModelKind::default();
+    let embedder: Arc<dyn EmbeddingModel> = Arc::new(MockEmbedder::new(kind));
+    let store = open_in_memory_with_embedder(Some(Arc::clone(&embedder)))
+        .await
+        .expect("open store");
+
+    let weird = record(
+        "01HQZX9F5N0000000000000W01",
+        "01HQZX9F5N0000000000000W01",
+        ScopeTuple {
+            tenant: Some("with-dashes_and_under.scores".into()),
+            ..Default::default()
+        },
+        "weird tenant value",
+    );
+    store.upsert(&weird).await.expect("upsert");
+
+    let scope = ScopeTuple {
+        tenant: Some("with-dashes_and_under.scores".into()),
+        ..Default::default()
+    };
+    let mut args = keyword_args("weird", scope);
+    args.visibility_allowlist = vis_all();
+    let page = store.search_keyword(&args).await.expect("keyword");
+    assert_eq!(page.candidates.len(), 1);
+}

--- a/crates/cairn-store-sqlite/tests/auth_scope_search.rs
+++ b/crates/cairn-store-sqlite/tests/auth_scope_search.rs
@@ -528,3 +528,236 @@ async fn scope_with_special_characters_does_not_break_sql() {
     let page = store.search_keyword(&args).await.expect("keyword");
     assert_eq!(page.candidates.len(), 1);
 }
+
+// ── Graph provenance auth (round-1 fix #2) ──────────────────────────────
+//
+// The graph SQL INNER JOINs `entity_edges.source_record_id` to a `records pr`
+// alias and applies auth/visibility/active/tombstoned/supersession to `pr`
+// before allowing the edge to contribute. The next three tests verify each
+// failure mode of that gate is honored.
+
+/// Helper: build an entity-graph fixture with two records (`r1`, `r2`),
+/// two entities (`e1`, `e2`), and an edge `e1↔e2` whose provenance is
+/// set by the caller via `provenance`. Returns the open store, the seed
+/// record id, the neighbor record id, and an in-flight edge handle so
+/// the caller can mutate state (e.g. tombstone the provenance) before
+/// querying.
+async fn provenance_fixture(
+    seed_scope: ScopeTuple,
+    neighbor_scope: ScopeTuple,
+    provenance_scope: ScopeTuple,
+    provenance: Option<&str>,
+) -> (Arc<dyn MemoryStore>, RecordId, RecordId, RecordId) {
+    use cairn_core::domain::graph::{EdgeConfidence, EntityEdge, EntityEdgeId, EntityId, EntityNode};
+
+    let store = cairn_store_sqlite::open_in_memory()
+        .await
+        .expect("open store");
+    let r1 = record(
+        "01HQZX9F5N0000000000000P01",
+        "01HQZX9F5N0000000000000P01",
+        seed_scope,
+        "provenance seed body",
+    );
+    let r2 = record(
+        "01HQZX9F5N0000000000000P02",
+        "01HQZX9F5N0000000000000P02",
+        neighbor_scope,
+        "provenance neighbor body",
+    );
+    let pr = record(
+        "01HQZX9F5N0000000000000P03",
+        "01HQZX9F5N0000000000000P03",
+        provenance_scope,
+        "provenance source-of-extraction body",
+    );
+    store.upsert(&r1).await.expect("upsert r1");
+    store.upsert(&r2).await.expect("upsert r2");
+    store.upsert(&pr).await.expect("upsert pr");
+
+    let e1_node = EntityNode {
+        id: EntityId::from("01HZE7JV5N00000000000000PA"),
+        name: "Alice".into(),
+        name_norm: "alice-prov".into(),
+        summary: None,
+        created_at: 1,
+        embedding_id: None,
+    };
+    let e2_node = EntityNode {
+        id: EntityId::from("01HZE7JV5N00000000000000PB"),
+        name: "Bob".into(),
+        name_norm: "bob-prov".into(),
+        summary: None,
+        created_at: 1,
+        embedding_id: None,
+    };
+    let e1 = store.upsert_entity(&e1_node).await.expect("e1");
+    let e2 = store.upsert_entity(&e2_node).await.expect("e2");
+    store
+        .link_entity_episode(&e1, &r1.id)
+        .await
+        .expect("link r1");
+    store
+        .link_entity_episode(&e2, &r2.id)
+        .await
+        .expect("link r2");
+
+    let source_record_id = match provenance {
+        Some("seed") => Some(r1.id.clone()),
+        Some("provenance") => Some(pr.id.clone()),
+        Some("neighbor") => Some(r2.id.clone()),
+        _ => None,
+    };
+    let edge = EntityEdge {
+        id: EntityEdgeId::from("01HZE7JV5N00000000000000PE"),
+        source_id: e1,
+        target_id: e2,
+        relation: "knows".into(),
+        confidence: EdgeConfidence::Extracted,
+        confidence_score: 1.0,
+        valid_at: 1,
+        invalid_at: None,
+        created_at: 1,
+        source_record_id,
+    };
+    store.upsert_entity_edge(&edge).await.expect("edge");
+    (Arc::new(store), r1.id, r2.id, pr.id)
+}
+
+/// Edge whose provenance lives in tenant `globex` cannot pull the
+/// neighbor into a result for caller scope `acme`, even though both the
+/// seed and the neighbor are themselves in `acme`. The provenance check
+/// runs inside the `neighbors` CTE, before the edge contributes.
+#[tokio::test]
+async fn graph_neighbor_with_unauthorized_provenance_dropped() {
+    use cairn_core::contract::memory_store::GraphNeighborsArgs;
+
+    let acme = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    let globex = ScopeTuple {
+        tenant: Some("globex".into()),
+        ..Default::default()
+    };
+    let (store, seed, _neighbor, _pr) =
+        provenance_fixture(acme.clone(), acme.clone(), globex, Some("provenance")).await;
+
+    let result = store
+        .search_graph_neighbors(&GraphNeighborsArgs {
+            seed_record_ids: vec![seed],
+            ranked_record_ids: vec![],
+            filter: None,
+            auth_scope: acme,
+            visibility_allowlist: vec![MemoryVisibility::Private],
+            limit: 10,
+            confidence_min: 0.0,
+        })
+        .await
+        .expect("graph search");
+    assert!(
+        result.is_empty(),
+        "edge with cross-tenant provenance must NOT pull neighbor into acme result; got {:?}",
+        result
+            .iter()
+            .map(|c| c.record_id.as_str())
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// Null `source_record_id` disqualifies the edge entirely. The `INNER
+/// JOIN records pr ON pr.record_id = e.source_record_id` filters out
+/// rows with NULL provenance regardless of caller scope.
+#[tokio::test]
+async fn graph_neighbor_with_null_provenance_dropped() {
+    use cairn_core::contract::memory_store::GraphNeighborsArgs;
+
+    let acme = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    let (store, seed, _neighbor, _pr) =
+        provenance_fixture(acme.clone(), acme.clone(), acme.clone(), None).await;
+
+    let result = store
+        .search_graph_neighbors(&GraphNeighborsArgs {
+            seed_record_ids: vec![seed],
+            ranked_record_ids: vec![],
+            filter: None,
+            auth_scope: acme,
+            visibility_allowlist: vec![MemoryVisibility::Private],
+            limit: 10,
+            confidence_min: 0.0,
+        })
+        .await
+        .expect("graph search");
+    assert!(
+        result.is_empty(),
+        "edge with NULL source_record_id must yield no neighbors; got {:?}",
+        result
+            .iter()
+            .map(|c| c.record_id.as_str())
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// Provenance record tombstoned ⇒ `pr.tombstoned = 0` predicate fails ⇒
+/// edge cannot contribute. Even though the seed, the neighbor, and the
+/// scope all match, the dead provenance disqualifies the edge.
+#[tokio::test]
+async fn graph_neighbor_with_tombstoned_provenance_dropped() {
+    use cairn_core::contract::memory_store::{GraphNeighborsArgs, TombstoneReason};
+
+    let acme = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    let (store, seed, _neighbor, pr) =
+        provenance_fixture(acme.clone(), acme.clone(), acme.clone(), Some("provenance")).await;
+
+    // Sanity: with a healthy provenance, the neighbor surfaces.
+    let healthy = store
+        .search_graph_neighbors(&GraphNeighborsArgs {
+            seed_record_ids: vec![seed.clone()],
+            ranked_record_ids: vec![],
+            filter: None,
+            auth_scope: acme.clone(),
+            visibility_allowlist: vec![MemoryVisibility::Private],
+            limit: 10,
+            confidence_min: 0.0,
+        })
+        .await
+        .expect("graph search (healthy)");
+    assert_eq!(
+        healthy.len(),
+        1,
+        "baseline: healthy provenance must surface the neighbor",
+    );
+
+    // Tombstone the provenance record. The edge must now stop contributing.
+    store
+        .tombstone(&pr, TombstoneReason::Forget)
+        .await
+        .expect("tombstone pr");
+
+    let result = store
+        .search_graph_neighbors(&GraphNeighborsArgs {
+            seed_record_ids: vec![seed],
+            ranked_record_ids: vec![],
+            filter: None,
+            auth_scope: acme,
+            visibility_allowlist: vec![MemoryVisibility::Private],
+            limit: 10,
+            confidence_min: 0.0,
+        })
+        .await
+        .expect("graph search (post-tombstone)");
+    assert!(
+        result.is_empty(),
+        "tombstoned provenance must disqualify edge; got {:?}",
+        result
+            .iter()
+            .map(|c| c.record_id.as_str())
+            .collect::<Vec<_>>(),
+    );
+}

--- a/crates/cairn-store-sqlite/tests/auth_scope_search.rs
+++ b/crates/cairn-store-sqlite/tests/auth_scope_search.rs
@@ -415,7 +415,10 @@ async fn search_graph_neighbors_returns_connected_record() {
         valid_at: 1,
         invalid_at: None,
         created_at: 1,
-        source_record_id: None,
+        // Provenance: the edge "knows" was extracted from r1; the graph
+        // SQL applies auth/visibility/supersession to this provenance
+        // record before allowing the edge to contribute.
+        source_record_id: Some(r1.id.clone()),
     };
     store.upsert_entity_edge(&edge).await.expect("edge");
 

--- a/crates/cairn-store-sqlite/tests/auth_scope_search.rs
+++ b/crates/cairn-store-sqlite/tests/auth_scope_search.rs
@@ -334,6 +334,165 @@ async fn keyword_empty_visibility_returns_all_visibilities() {
     );
 }
 
+// ── Graph leg direct ─────────────────────────────────────────────────────
+
+/// `search_graph_neighbors` end-to-end: insert two records linked through
+/// an entity edge, call the trait method directly with `r1` as the seed
+/// and an empty ranked list, and confirm `r2` surfaces as a graph
+/// candidate. Also verifies the contract predicates (`auth_scope`,
+/// `visibility`, `filter`, supersession) all apply to the neighbor row.
+#[allow(clippy::too_many_lines, reason = "graph fixture needs explicit setup")]
+#[tokio::test]
+async fn search_graph_neighbors_returns_connected_record() {
+    use cairn_core::contract::memory_store::{GraphNeighborsArgs, MemoryStore};
+    use cairn_core::domain::graph::{
+        EdgeConfidence, EntityEdge, EntityEdgeId, EntityId, EntityNode,
+    };
+
+    let store = cairn_store_sqlite::open_in_memory()
+        .await
+        .expect("open store");
+
+    // Two records, same scope, distinct ids.
+    let r1 = record(
+        "01HQZX9F5N0000000000000R01",
+        "01HQZX9F5N0000000000000R01",
+        ScopeTuple {
+            tenant: Some("acme".into()),
+            ..Default::default()
+        },
+        "graph rescue source body",
+    );
+    let r2 = record(
+        "01HQZX9F5N0000000000000R02",
+        "01HQZX9F5N0000000000000R02",
+        ScopeTuple {
+            tenant: Some("acme".into()),
+            ..Default::default()
+        },
+        "graph rescue target body",
+    );
+    store.upsert(&r1).await.expect("upsert r1");
+    store.upsert(&r2).await.expect("upsert r2");
+
+    // Entity graph: e1 ↔ e2, each linked to its episode record.
+    let e1_node = EntityNode {
+        id: EntityId::from("01HZE7JV5N00000000000000E1"),
+        name: "Alice".into(),
+        name_norm: "alice-graph-direct".into(),
+        summary: None,
+        created_at: 1,
+        embedding_id: None,
+    };
+    let e2_node = EntityNode {
+        id: EntityId::from("01HZE7JV5N00000000000000E2"),
+        name: "Bob".into(),
+        name_norm: "bob-graph-direct".into(),
+        summary: None,
+        created_at: 1,
+        embedding_id: None,
+    };
+    let e1 = store.upsert_entity(&e1_node).await.expect("e1");
+    let e2 = store.upsert_entity(&e2_node).await.expect("e2");
+    store
+        .link_entity_episode(&e1, &r1.id)
+        .await
+        .expect("link r1");
+    store
+        .link_entity_episode(&e2, &r2.id)
+        .await
+        .expect("link r2");
+
+    // High-confidence edge in the past so the bitemporal predicate
+    // (`valid_at <= now AND created_at <= now`) admits it.
+    let edge = EntityEdge {
+        id: EntityEdgeId::from("01HZE7JV5N00000000000000ED"),
+        source_id: e1.clone(),
+        target_id: e2.clone(),
+        relation: "knows".into(),
+        confidence: EdgeConfidence::Extracted,
+        confidence_score: 1.0,
+        valid_at: 1,
+        invalid_at: None,
+        created_at: 1,
+        source_record_id: None,
+    };
+    store.upsert_entity_edge(&edge).await.expect("edge");
+
+    // Seed = r1, no ranked exclusion → r2 must surface as the 1-hop
+    // neighbor.
+    let scope = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    let result = store
+        .search_graph_neighbors(&GraphNeighborsArgs {
+            seed_record_ids: vec![r1.id.clone()],
+            ranked_record_ids: vec![],
+            filter: None,
+            auth_scope: scope.clone(),
+            visibility_allowlist: vec![MemoryVisibility::Private],
+            limit: 10,
+            confidence_min: 0.0,
+        })
+        .await
+        .expect("graph search");
+    let ids: Vec<_> = result.iter().map(|c| c.record_id.as_str()).collect();
+    assert!(
+        ids.iter().any(|id| id.ends_with("R02")),
+        "graph traversal must surface r2 from seed=r1; got {ids:?}"
+    );
+
+    // Cross-tenant scope: r2 lives in tenant=acme, but the caller asks
+    // for tenant=globex. Graph SQL must reject the neighbor.
+    let result = store
+        .search_graph_neighbors(&GraphNeighborsArgs {
+            seed_record_ids: vec![r1.id.clone()],
+            ranked_record_ids: vec![],
+            filter: None,
+            auth_scope: ScopeTuple {
+                tenant: Some("globex".into()),
+                ..Default::default()
+            },
+            visibility_allowlist: vec![MemoryVisibility::Private],
+            limit: 10,
+            confidence_min: 0.0,
+        })
+        .await
+        .expect("graph search cross-tenant");
+    assert!(
+        result.is_empty(),
+        "cross-tenant scope must yield empty graph result; got {:?}",
+        result
+            .iter()
+            .map(|c| c.record_id.as_str())
+            .collect::<Vec<_>>()
+    );
+
+    // Ranked exclusion: include r2 in `ranked_record_ids` and confirm it
+    // is dropped from the graph result.
+    let result = store
+        .search_graph_neighbors(&GraphNeighborsArgs {
+            seed_record_ids: vec![r1.id.clone()],
+            ranked_record_ids: vec![r2.id.clone()],
+            filter: None,
+            auth_scope: scope,
+            visibility_allowlist: vec![MemoryVisibility::Private],
+            limit: 10,
+            confidence_min: 0.0,
+        })
+        .await
+        .expect("graph search ranked-exclude");
+    assert!(
+        result.is_empty(),
+        "ranked_record_ids must dedup r2 from graph result; got {:?}",
+        result
+            .iter()
+            .map(|c| c.record_id.as_str())
+            .collect::<Vec<_>>()
+    );
+}
+
 // ── Special-character values ─────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/cairn-store-sqlite/tests/auth_scope_search.rs
+++ b/crates/cairn-store-sqlite/tests/auth_scope_search.rs
@@ -549,7 +549,9 @@ async fn provenance_fixture(
     provenance_scope: ScopeTuple,
     provenance: Option<&str>,
 ) -> (Arc<dyn MemoryStore>, RecordId, RecordId, RecordId) {
-    use cairn_core::domain::graph::{EdgeConfidence, EntityEdge, EntityEdgeId, EntityId, EntityNode};
+    use cairn_core::domain::graph::{
+        EdgeConfidence, EntityEdge, EntityEdgeId, EntityId, EntityNode,
+    };
 
     let store = cairn_store_sqlite::open_in_memory()
         .await

--- a/crates/cairn-store-sqlite/tests/auth_scope_search.rs
+++ b/crates/cairn-store-sqlite/tests/auth_scope_search.rs
@@ -130,6 +130,7 @@ fn hybrid_args(query: &str, scope: ScopeTuple) -> HybridSearchArgs<'static> {
         rerank_topk: 20,
         with_explain: false,
         confidence_floor: 1e-3,
+        graph_confidence_min: 0.0,
     }
 }
 

--- a/crates/cairn-store-sqlite/tests/graph_bitemporal.rs
+++ b/crates/cairn-store-sqlite/tests/graph_bitemporal.rs
@@ -1,0 +1,220 @@
+//! Bitemporal as-of corner cases for the graph 1-hop traversal SQL
+//! (issue #191, round-2 fix in `graph_search.rs:103-106`).
+//!
+//! The graph predicate is:
+//!   `valid_at   <= now AND (invalid_at IS NULL OR invalid_at > now)`
+//!   `created_at <= now AND (expired_at IS NULL OR expired_at > now)`
+//!   `confidence_score >= ?`
+//!
+//! These tests cover each branch of the disjunction. The
+//! "live with future `invalid_at`" case is the regression guard for the
+//! round-2 bug, where a future-bounded edge was being dropped.
+
+#![allow(missing_docs)]
+
+use cairn_core::contract::memory_store::{GraphNeighborsArgs, MemoryStore};
+use cairn_core::domain::ScopeTuple;
+use cairn_core::domain::graph::{EdgeConfidence, EntityEdge, EntityEdgeId, EntityId, EntityNode};
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::taxonomy::MemoryVisibility;
+use cairn_core::domain::{RecordId, TargetId};
+use cairn_store_sqlite::{SqliteMemoryStore, open_in_memory};
+
+const FAR_FUTURE_MS: i64 = 99_999_999_999_999; // ~year 5138, > wall clock
+
+fn record(rid: &str, body: &str) -> cairn_core::domain::MemoryRecord {
+    let mut r = sample_record();
+    r.id = RecordId::parse(rid.to_owned()).expect("valid record id");
+    r.target_id = TargetId::parse(rid.to_owned()).expect("valid target id");
+    r.scope = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    body.clone_into(&mut r.body);
+    r
+}
+
+fn node(id: &str, name_norm: &str) -> EntityNode {
+    EntityNode {
+        id: EntityId::from(id),
+        name: name_norm.into(),
+        name_norm: name_norm.into(),
+        summary: None,
+        created_at: 1,
+        embedding_id: None,
+    }
+}
+
+/// Build a fixture: r1↔r2 linked through entities e1↔e2 by an edge with
+/// caller-supplied bitemporal stamps. Returns the store and the seed/neighbor
+/// record ids so the test can assert presence/absence of the neighbor.
+async fn build_fixture(
+    edge_valid_at: i64,
+    edge_invalid_at: Option<i64>,
+    edge_created_at: i64,
+    edge_confidence: f32,
+    edge_id_suffix: &str,
+) -> (SqliteMemoryStore, RecordId, RecordId) {
+    let store = open_in_memory().await.expect("open store");
+
+    let r1 = record("01HQZX9F5N0000000000000R01", "graph seed body");
+    let r2 = record("01HQZX9F5N0000000000000R02", "graph neighbor body");
+    store.upsert(&r1).await.expect("upsert r1");
+    store.upsert(&r2).await.expect("upsert r2");
+
+    let e1 = node("01HZE7JV5N00000000000000E1", "alice-bitemp");
+    let e2 = node("01HZE7JV5N00000000000000E2", "bob-bitemp");
+    let e1 = store.upsert_entity(&e1).await.expect("e1");
+    let e2 = store.upsert_entity(&e2).await.expect("e2");
+    store
+        .link_entity_episode(&e1, &r1.id)
+        .await
+        .expect("link r1");
+    store
+        .link_entity_episode(&e2, &r2.id)
+        .await
+        .expect("link r2");
+
+    let edge = EntityEdge {
+        id: EntityEdgeId::from(format!("01HZE7JV5N00000000000000E{edge_id_suffix}").as_str()),
+        source_id: e1.clone(),
+        target_id: e2.clone(),
+        relation: "knows".into(),
+        confidence: EdgeConfidence::Extracted,
+        confidence_score: edge_confidence,
+        valid_at: edge_valid_at,
+        invalid_at: edge_invalid_at,
+        created_at: edge_created_at,
+        source_record_id: Some(r1.id.clone()),
+    };
+    store.upsert_entity_edge(&edge).await.expect("edge");
+
+    (store, r1.id, r2.id)
+}
+
+async fn search(store: &SqliteMemoryStore, seed: &RecordId, confidence_min: f32) -> Vec<RecordId> {
+    let scope = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    let result = store
+        .search_graph_neighbors(&GraphNeighborsArgs {
+            seed_record_ids: vec![seed.clone()],
+            ranked_record_ids: vec![],
+            filter: None,
+            auth_scope: scope,
+            visibility_allowlist: vec![MemoryVisibility::Private],
+            limit: 10,
+            confidence_min,
+        })
+        .await
+        .expect("graph search");
+    result.into_iter().map(|c| c.record_id).collect()
+}
+
+// ── Bitemporal as-of corner cases ────────────────────────────────────────
+
+#[tokio::test]
+async fn live_edge_never_invalidated_is_included() {
+    let (store, seed, neighbor) = build_fixture(1, None, 1, 1.0, "01").await;
+    let hits = search(&store, &seed, 0.0).await;
+    assert!(
+        hits.contains(&neighbor),
+        "live edge (valid_at=1, invalid_at=None) must surface neighbor; got {hits:?}",
+    );
+}
+
+/// Regression guard for round-2 fix: an edge with `invalid_at` set to a
+/// future timestamp is still live, and must be admitted by the
+/// `(invalid_at IS NULL OR invalid_at > now)` branch.
+#[tokio::test]
+async fn live_edge_with_future_invalid_at_is_included() {
+    let (store, seed, neighbor) = build_fixture(1, Some(FAR_FUTURE_MS), 1, 1.0, "02").await;
+    let hits = search(&store, &seed, 0.0).await;
+    assert!(
+        hits.contains(&neighbor),
+        "edge with future invalid_at must remain live; got {hits:?}",
+    );
+}
+
+#[tokio::test]
+async fn invalidated_edge_in_past_is_excluded() {
+    // valid_at=1, invalid_at=2 — both before wall-clock now → edge is
+    // historically invalidated and must not surface.
+    let (store, seed, _neighbor) = build_fixture(1, Some(2), 1, 1.0, "03").await;
+    let hits = search(&store, &seed, 0.0).await;
+    assert!(
+        hits.is_empty(),
+        "past-invalidated edge must not surface neighbor; got {hits:?}",
+    );
+}
+
+#[tokio::test]
+async fn not_yet_valid_edge_is_excluded() {
+    // valid_at far in the future → fails `valid_at <= now`.
+    let (store, seed, _neighbor) = build_fixture(FAR_FUTURE_MS, None, 1, 1.0, "04").await;
+    let hits = search(&store, &seed, 0.0).await;
+    assert!(
+        hits.is_empty(),
+        "edge with future valid_at must be excluded; got {hits:?}",
+    );
+}
+
+#[tokio::test]
+async fn not_yet_created_edge_is_excluded() {
+    // created_at far in the future → fails `created_at <= now`. This is
+    // the round-2 guard for the ingestion-time half of the bitemporal
+    // predicate.
+    let (store, seed, _neighbor) = build_fixture(1, None, FAR_FUTURE_MS, 1.0, "05").await;
+    let hits = search(&store, &seed, 0.0).await;
+    assert!(
+        hits.is_empty(),
+        "edge with future created_at must be excluded; got {hits:?}",
+    );
+}
+
+// ── Confidence floor boundary ────────────────────────────────────────────
+
+#[tokio::test]
+async fn confidence_min_zero_includes_low_confidence_edge() {
+    let (store, seed, neighbor) = build_fixture(1, None, 1, 0.1, "06").await;
+    let hits = search(&store, &seed, 0.0).await;
+    assert!(
+        hits.contains(&neighbor),
+        "confidence_min=0.0 must include 0.1-confidence edge; got {hits:?}",
+    );
+}
+
+#[tokio::test]
+async fn confidence_min_at_boundary_includes_equal_edge() {
+    // SQL uses `confidence_score >= ?`, so an edge at exactly the floor
+    // surfaces. Locks the inclusive comparison.
+    let (store, seed, neighbor) = build_fixture(1, None, 1, 0.3, "07").await;
+    let hits = search(&store, &seed, 0.3).await;
+    assert!(
+        hits.contains(&neighbor),
+        "confidence_min=0.3 must include edge at exactly 0.3 (inclusive); got {hits:?}",
+    );
+}
+
+#[tokio::test]
+async fn confidence_min_above_edge_excludes_edge() {
+    let (store, seed, _neighbor) = build_fixture(1, None, 1, 0.3, "08").await;
+    let hits = search(&store, &seed, 0.5).await;
+    assert!(
+        hits.is_empty(),
+        "confidence_min=0.5 must exclude 0.3-confidence edge; got {hits:?}",
+    );
+}
+
+#[tokio::test]
+async fn confidence_min_one_excludes_below_one() {
+    // Floor at 1.0 only admits edges at exactly 1.0. A 0.9 edge is
+    // dropped — confirms the floor is the binding predicate.
+    let (store, seed, _neighbor) = build_fixture(1, None, 1, 0.9, "09").await;
+    let hits = search(&store, &seed, 1.0).await;
+    assert!(
+        hits.is_empty(),
+        "confidence_min=1.0 must exclude 0.9-confidence edge; got {hits:?}",
+    );
+}

--- a/crates/cairn-store-sqlite/tests/hybrid_partial_degradation.rs
+++ b/crates/cairn-store-sqlite/tests/hybrid_partial_degradation.rs
@@ -59,6 +59,7 @@ fn hybrid_args(query: &str, model_label: &str) -> HybridSearchArgs<'static> {
         rerank_topk: 20,
         with_explain: false,
         confidence_floor: 1e-3,
+        graph_confidence_min: 0.0,
     }
 }
 

--- a/crates/cairn-store-sqlite/tests/hybrid_partial_degradation.rs
+++ b/crates/cairn-store-sqlite/tests/hybrid_partial_degradation.rs
@@ -1,0 +1,163 @@
+//! End-to-end fault-injection tests for hybrid partial-result behavior
+//! (issue #191, round-4 fix).
+//!
+//! These tests open a real fixture vault, break a downstream dependency
+//! mid-flight via the admin connection, and assert that hybrid search
+//! still returns the surviving leg's candidates plus a `DegradedLeg`
+//! entry — instead of hard-failing the whole request.
+
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::{HybridSearchArgs, MemoryStore};
+use cairn_core::domain::ScopeTuple;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::taxonomy::MemoryVisibility;
+use cairn_core::domain::{RecordId, TargetId};
+use cairn_core::search::{DegradationReason, DegradedLeg};
+use cairn_embeddings_local::{EmbeddingModel, EmbeddingModelKind, MockEmbedder};
+use cairn_store_sqlite::{SqliteMemoryStore, drain_once, open_in_memory_with_embedder};
+
+fn record(rid: &str, body: &str) -> cairn_core::domain::MemoryRecord {
+    let mut r = sample_record();
+    r.id = RecordId::parse(rid.to_owned()).expect("valid record id");
+    r.target_id = TargetId::parse(rid.to_owned()).expect("valid target id");
+    r.scope = ScopeTuple {
+        tenant: Some("acme".into()),
+        ..Default::default()
+    };
+    body.clone_into(&mut r.body);
+    r
+}
+
+async fn drain_all(store: &SqliteMemoryStore, embedder: Arc<dyn EmbeddingModel>) {
+    let conn = store.raw_conn_for_admin().expect("conn").clone();
+    for _ in 0..1000 {
+        let stats = drain_once(Arc::clone(&conn), Arc::clone(&embedder))
+            .await
+            .expect("drain");
+        if stats.remaining == 0 {
+            break;
+        }
+    }
+}
+
+fn hybrid_args(query: &str, model_label: &str) -> HybridSearchArgs<'static> {
+    HybridSearchArgs {
+        query: query.to_owned(),
+        filter: None,
+        auth_scope: ScopeTuple {
+            tenant: Some("acme".into()),
+            ..Default::default()
+        },
+        visibility_allowlist: vec![MemoryVisibility::Private],
+        limit: 10,
+        model_label: model_label.to_owned(),
+        blend: 0.5,
+        rrf_k: 60,
+        rerank_topk: 20,
+        with_explain: false,
+        confidence_floor: 1e-3,
+    }
+}
+
+/// Healthy baseline: hybrid returns candidates and an empty
+/// `degraded_legs`. Locks in that the test harness itself isn't
+/// silently producing degradations the fixture would mask.
+#[tokio::test]
+async fn hybrid_baseline_no_degradation() {
+    let kind = EmbeddingModelKind::default();
+    let embedder: Arc<dyn EmbeddingModel> = Arc::new(MockEmbedder::new(kind));
+    let store = open_in_memory_with_embedder(Some(Arc::clone(&embedder)))
+        .await
+        .expect("open store");
+    let model_label = kind.as_str().to_owned();
+
+    for (i, body) in [
+        "alpha lexical body one",
+        "alpha lexical body two",
+        "alpha lexical body three",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let suffix = format!("{i:02X}");
+        let rid = format!("01HQZX9F5N0000000000000P{suffix}");
+        store.upsert(&record(&rid, body)).await.expect("upsert");
+    }
+    drain_all(&store, Arc::clone(&embedder)).await;
+
+    let page = store
+        .search_hybrid(&hybrid_args("alpha", &model_label))
+        .await
+        .expect("hybrid");
+    assert!(
+        !page.candidates.is_empty(),
+        "baseline must return candidates",
+    );
+    assert!(
+        page.degraded_legs.is_empty(),
+        "healthy hybrid must not emit degraded_legs; got {:?}",
+        page.degraded_legs,
+    );
+}
+
+/// Drop `record_vectors` mid-flight → semantic leg's SQL fails. The
+/// round-4 fix converts that error into `DegradedLeg::Semantic` and
+/// continues with keyword + graph. Caller must still receive
+/// candidates and the per-leg degradation entry.
+#[tokio::test]
+async fn hybrid_semantic_failure_degrades_to_keyword() {
+    let kind = EmbeddingModelKind::default();
+    let embedder: Arc<dyn EmbeddingModel> = Arc::new(MockEmbedder::new(kind));
+    let store = open_in_memory_with_embedder(Some(Arc::clone(&embedder)))
+        .await
+        .expect("open store");
+    let model_label = kind.as_str().to_owned();
+
+    for (i, body) in [
+        "beta keyword body one",
+        "beta keyword body two",
+        "beta keyword body three",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let suffix = format!("{i:02X}");
+        let rid = format!("01HQZX9F5N0000000000000Q{suffix}");
+        store.upsert(&record(&rid, body)).await.expect("upsert");
+    }
+    drain_all(&store, Arc::clone(&embedder)).await;
+
+    // Break the semantic leg by dropping the vec0 virtual table. Any
+    // subsequent ANN query fails with "no such table: record_vectors".
+    let conn = store.raw_conn_for_admin().expect("conn").clone();
+    conn.call(|c| {
+        c.execute_batch("DROP TABLE record_vectors")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("drop record_vectors");
+
+    let page = store
+        .search_hybrid(&hybrid_args("beta", &model_label))
+        .await
+        .expect("hybrid must not hard-fail when semantic leg dies");
+
+    assert!(
+        !page.candidates.is_empty(),
+        "keyword candidates must survive a semantic-leg failure",
+    );
+    assert!(
+        page.degraded_legs.iter().any(|d| matches!(
+            d,
+            DegradedLeg::Semantic {
+                reason: DegradationReason::SqlError
+            }
+        )),
+        "semantic leg must surface as DegradedLeg::Semantic{{SqlError}}; got {:?}",
+        page.degraded_legs,
+    );
+}

--- a/crates/cairn-store-sqlite/tests/hybrid_search.rs
+++ b/crates/cairn-store-sqlite/tests/hybrid_search.rs
@@ -45,6 +45,7 @@ async fn hybrid_returns_results() {
         .search_semantic(&SemanticSearchArgs {
             query: "alice".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![MemoryVisibility::Private],
             limit: 5,
             model_label: kind.as_str().to_owned(),
@@ -60,6 +61,7 @@ async fn hybrid_returns_results() {
     let args = HybridSearchArgs {
         query: "alice".into(),
         filter: None,
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private],
         limit: 5,
         model_label: kind.as_str().to_owned(),
@@ -67,6 +69,7 @@ async fn hybrid_returns_results() {
         rrf_k: 60,
         rerank_topk: 20,
         with_explain: false,
+        confidence_floor: 1e-3,
     };
     let page = store.search_hybrid(&args).await.expect("hybrid search");
     assert!(!page.candidates.is_empty(), "hybrid returned 0 results");
@@ -94,6 +97,7 @@ async fn hybrid_capability_unavailable_without_embedder() {
     let args = HybridSearchArgs {
         query: "anything".into(),
         filter: None,
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private],
         limit: 5,
         model_label: EmbeddingModelKind::default().as_str().to_owned(),
@@ -101,6 +105,7 @@ async fn hybrid_capability_unavailable_without_embedder() {
         rrf_k: 60,
         rerank_topk: 20,
         with_explain: false,
+        confidence_floor: 1e-3,
     };
     let result = store.search_hybrid(&args).await;
     assert!(result.is_err(), "expected CapabilityUnavailable");

--- a/crates/cairn-store-sqlite/tests/hybrid_search.rs
+++ b/crates/cairn-store-sqlite/tests/hybrid_search.rs
@@ -70,6 +70,7 @@ async fn hybrid_returns_results() {
         rerank_topk: 20,
         with_explain: false,
         confidence_floor: 1e-3,
+        graph_confidence_min: 0.0,
     };
     let page = store.search_hybrid(&args).await.expect("hybrid search");
     assert!(!page.candidates.is_empty(), "hybrid returned 0 results");
@@ -106,6 +107,7 @@ async fn hybrid_capability_unavailable_without_embedder() {
         rerank_topk: 20,
         with_explain: false,
         confidence_floor: 1e-3,
+        graph_confidence_min: 0.0,
     };
     let result = store.search_hybrid(&args).await;
     assert!(result.is_err(), "expected CapabilityUnavailable");

--- a/crates/cairn-store-sqlite/tests/search_keyword.rs
+++ b/crates/cairn-store-sqlite/tests/search_keyword.rs
@@ -56,6 +56,7 @@ fn args(query: &str, limit: usize) -> KeywordSearchArgs<'static> {
     KeywordSearchArgs {
         query: query.to_owned(),
         filter: None,
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private],
         limit,
         cursor: None,

--- a/crates/cairn-store-sqlite/tests/search_keyword_e2e.rs
+++ b/crates/cairn-store-sqlite/tests/search_keyword_e2e.rs
@@ -34,6 +34,7 @@ fn args(query: &str, limit: usize) -> KeywordSearchArgs<'static> {
     KeywordSearchArgs {
         query: query.to_owned(),
         filter: None,
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private],
         limit,
         cursor: None,

--- a/crates/cairn-store-sqlite/tests/search_keyword_golden.rs
+++ b/crates/cairn-store-sqlite/tests/search_keyword_golden.rs
@@ -140,6 +140,7 @@ async fn golden_search_args_keyword_filters_to_user_private() {
     let key_args = KeywordSearchArgs {
         query: args.query.clone(),
         filter: Some(validated),
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private, MemoryVisibility::Public],
         limit,
         cursor: None,
@@ -168,6 +169,7 @@ async fn golden_leaf_eq_filter_narrows_to_user_kind() {
     let key_args = KeywordSearchArgs {
         query: "dark".to_owned(),
         filter: Some(validated),
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private, MemoryVisibility::Public],
         limit: 10,
         cursor: None,
@@ -198,6 +200,7 @@ async fn golden_or_with_not_admits_public_or_non_private() {
     let key_args = KeywordSearchArgs {
         query: "dark OR vim".to_owned(),
         filter: Some(validated),
+        auth_scope: cairn_core::domain::ScopeTuple::default(),
         visibility_allowlist: vec![MemoryVisibility::Private, MemoryVisibility::Public],
         limit: 10,
         cursor: None,

--- a/crates/cairn-store-sqlite/tests/search_semantic.rs
+++ b/crates/cairn-store-sqlite/tests/search_semantic.rs
@@ -31,6 +31,7 @@ async fn search_semantic_capability_unavailable_without_embedder() {
         .search_semantic(&SemanticSearchArgs {
             query: "hello".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![],
             limit: 5,
             model_label: "bge-small-en-v1.5".into(),
@@ -64,6 +65,7 @@ async fn search_semantic_returns_results_after_upsert() {
         .search_semantic(&SemanticSearchArgs {
             query: "hello".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![],
             limit: 10,
             model_label: EmbeddingModelKind::BgeSmallEnV1_5.as_str().into(),
@@ -101,6 +103,7 @@ async fn search_semantic_with_vector_returns_results() {
         .search_semantic(&SemanticSearchArgs {
             query: "hello world".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![],
             limit: 10,
             model_label: "bge-small-en-v1.5".into(),

--- a/crates/cairn-store-sqlite/tests/search_semantic_capability.rs
+++ b/crates/cairn-store-sqlite/tests/search_semantic_capability.rs
@@ -13,6 +13,7 @@ async fn no_embedder_returns_capability_unavailable() {
         .search_semantic(&SemanticSearchArgs {
             query: "test".into(),
             filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
             visibility_allowlist: vec![],
             limit: 5,
             model_label: "bge-small-en-v1.5".into(),

--- a/crates/cairn-test-fixtures/src/hybrid_vault.rs
+++ b/crates/cairn-test-fixtures/src/hybrid_vault.rs
@@ -17,13 +17,25 @@ use tempfile::TempDir;
 pub struct RecordSpec {
     /// Body indexed by FTS5 + embedded.
     pub body: String,
+    /// Optional scope override; `None` keeps `sample_record`'s default scope.
+    pub scope: Option<cairn_core::domain::ScopeTuple>,
 }
 
 impl RecordSpec {
     /// Construct from a body string.
     #[must_use]
     pub fn from_body(body: impl Into<String>) -> Self {
-        Self { body: body.into() }
+        Self {
+            body: body.into(),
+            scope: None,
+        }
+    }
+
+    /// Override the scope on this spec.
+    #[must_use]
+    pub fn with_scope(mut self, scope: cairn_core::domain::ScopeTuple) -> Self {
+        self.scope = Some(scope);
+        self
     }
 }
 
@@ -75,6 +87,9 @@ pub async fn build_hybrid_test_vault(records: &[RecordSpec]) -> HybridTestVault 
         r.id = RecordId::parse(id_str.clone()).expect("seed id");
         r.target_id = TargetId::parse(id_str).expect("seed target");
         spec.body.clone_into(&mut r.body);
+        if let Some(scope) = &spec.scope {
+            r.scope = scope.clone();
+        }
         store.upsert(&r).await.expect("upsert");
     }
 

--- a/crates/cairn-test-fixtures/src/store.rs
+++ b/crates/cairn-test-fixtures/src/store.rs
@@ -99,6 +99,8 @@ impl MemoryStore for FixtureStore {
             graph_edges: false,
             transactions: false,
             per_record_consent_model: true,
+
+            graph_search: false,
         };
         static CAPS_LEGACY_ONLY: MemoryStoreCapabilities = MemoryStoreCapabilities {
             fts: false,
@@ -106,6 +108,8 @@ impl MemoryStore for FixtureStore {
             graph_edges: false,
             transactions: false,
             per_record_consent_model: false,
+
+            graph_search: false,
         };
         if self.legacy_only_override.load(Ordering::SeqCst) {
             &CAPS_LEGACY_ONLY

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+assertion_line: 110
 expression: "&c"
 ---
 {
@@ -64,7 +65,8 @@ expression: "&c"
     ],
     "rrf_k": 60,
     "rerank_topk": 20,
-    "max_snippet_chars_per_page": 8000
+    "max_snippet_chars_per_page": 8000,
+    "graph_confidence_min": 0.3
   },
   "sensors": {
     "hooks": {

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+assertion_line: 103
 expression: "&c"
 ---
 {
@@ -59,7 +60,8 @@ expression: "&c"
     ],
     "rrf_k": 60,
     "rerank_topk": 20,
-    "max_snippet_chars_per_page": 8000
+    "max_snippet_chars_per_page": 8000,
+    "graph_confidence_min": 0.3
   },
   "sensors": {
     "hooks": {

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
+assertion_line: 96
 expression: "&c"
 ---
 {
@@ -59,7 +60,8 @@ expression: "&c"
     ],
     "rrf_k": 60,
     "rerank_topk": 20,
-    "max_snippet_chars_per_page": 8000
+    "max_snippet_chars_per_page": 8000,
+    "graph_confidence_min": 0.3
   },
   "sensors": {
     "hooks": {

--- a/docs/site/src/reference/generated/commands/search.md
+++ b/docs/site/src/reference/generated/commands/search.md
@@ -34,6 +34,18 @@ Options:
       --explain
 
 
+      --scope-tenant <TENANT>
+          Narrow auth_scope.tenant on every search leg (issue #191)
+
+      --scope-workspace <WORKSPACE>
+          Narrow auth_scope.workspace on every search leg
+
+      --scope-user <HMN_USER_ID>
+          Narrow auth_scope.user (must be canonical `hmn:…` form)
+
+      --scope-agent <AGENT_ID>
+          Narrow auth_scope.agent on every search leg
+
       --json
           Emit machine-readable JSON response envelope to stdout
 

--- a/docs/site/src/reference/generated/config-defaults.md
+++ b/docs/site/src/reference/generated/config-defaults.md
@@ -53,6 +53,7 @@ search:
   rrf_k: 60
   rerank_topk: 20
   max_snippet_chars_per_page: 8000
+  graph_confidence_min: 0.3
 sensors:
   hooks:
     enabled: true

--- a/docs/site/src/reference/generated/plugins.md
+++ b/docs/site/src/reference/generated/plugins.md
@@ -8,5 +8,5 @@ Generated from the bundled plugin registry.
 |---|---|---|---|---|
 | `cairn-mcp` | `MCPServer` | `[0.1.0, 0.2.0)` | `bundled:cairn-mcp` | `{"extensions":false,"http_streamable":false,"sse":false,"stdio":true}` |
 | `cairn-sensors-local` | `SensorIngress` | `[0.1.0, 0.2.0)` | `bundled:cairn-sensors-local` | `{"batches":false,"consent_aware":false,"streaming":false}` |
-| `cairn-store-sqlite` | `MemoryStore` | `[0.4.0, 0.5.0)` | `bundled:cairn-store-sqlite` | `{"fts":true,"graph_edges":true,"per_record_consent_model":true,"transactions":true,"vector":false}` |
+| `cairn-store-sqlite` | `MemoryStore` | `[0.5.0, 0.6.0)` | `bundled:cairn-store-sqlite` | `{"fts":true,"graph_edges":true,"per_record_consent_model":true,"transactions":true,"vector":false}` |
 | `cairn-workflows` | `WorkflowOrchestrator` | `[0.1.0, 0.2.0)` | `bundled:cairn-workflows` | `{"crash_safe":false,"cron_schedules":false,"durable":false}` |

--- a/docs/superpowers/plans/2026-05-05-issue-191-rrf-hybrid-graph.md
+++ b/docs/superpowers/plans/2026-05-05-issue-191-rrf-hybrid-graph.md
@@ -1,0 +1,656 @@
+# Issue #191 — RRF Hybrid Search w/ 1-hop Graph Expansion: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a third retrieval leg (1-hop entity-graph neighborhood expansion) to the existing 2-leg RRF hybrid search, with confidence-aware ranking, full bitemporal + auth + supersession correctness, and a two-tier connection pool with statement-scoped cancellation.
+
+**Architecture:** Phased rollout across 6 PRs. Pure core types ship first (no I/O); contract bump (auth_scope) ships next behind a `0.4.0 → 0.5.0` major-version event; connection pool + cancellation primitives third; graph SQL fourth; orchestrator/verb/CLI/SDK fifth; bench gates last.
+
+**Tech Stack:** Rust 1.95.0, tokio, rusqlite (with `carray` + `interrupt` + `progress_handler`), tokio_rusqlite, sqlite-vec, FTS5, schemars, bon (builders), insta (snapshots), criterion (bench), proptest, rstest.
+
+**Spec:** `docs/superpowers/specs/2026-05-05-issue-191-rrf-hybrid-graph-design.md`
+
+---
+
+## Phase Decomposition
+
+Each phase = one PR, independently testable, mergeable into `main`.
+
+| # | Phase | Crates touched | Why ship-able alone |
+|---|---|---|---|
+| 1 | Pure types + RRF/cosine extensions | `cairn-core` | Adds `GraphCandidate`, `RankedCandidate`, `DegradedLeg`, `rrf_fusion_weighted`, graph-only cosine path. Pure functions, unit-testable. No callers yet — dead code with `#[allow(dead_code)]` until phase 5. |
+| 2 | Contract bump: `auth_scope` + `MemoryStoreCapabilities::graph_search` + trait method | `cairn-core`, all in-tree adapters | Major version bump `0.4.0 → 0.5.0`. Threads `auth_scope` through Keyword/Semantic/Hybrid args. `search_graph_neighbors` returns `CapabilityUnavailable` until phase 4. Existing tests keep passing because legacy auth via `filter` is preserved as the only path used by SQLite store. |
+| 3 | Two-tier connection pool + cancellation | `cairn-store-sqlite` | New `HybridConnectionPool` with Tier A (mandatory) + Tier B (graph). `interrupt()` + `progress_handler` per-checkout lifecycle. Existing keyword/semantic queries migrate onto Tier A. Capability probe extended. |
+| 4 | Graph SQL: 1-hop traversal + supersession + bitemporal + hydration | `cairn-store-sqlite` | Implements `search_graph_neighbors`. Capability probe gates on entity_graph schema. Tests: hidden-alias, orphan-edge, supersession, bitemporal, rank-rescue. |
+| 5 | Orchestrator: 4-leg parallel + auth-only seed retrieval + degraded_legs | `cairn-store-sqlite::store::hybrid`, `cairn-core::verbs::search`, `cairn-cli`, `cairn-sdk`, `cairn-mcp`, `cairn-idl` | Wires all the previous phases together. Adds `--confidence-min` CLI flag. Threads `degraded_legs` through SearchOutcome → CLI/MCP/SDK. IDL update + codegen. |
+| 6 | Bench + load gates | `cairn-bench` | Baseline p99, broad-query p99, saturation p99, deadline-circuit, Tier A acquire-timeout gates. |
+
+**Order matters.** Phase N depends on N-1 except 3↔4 (3 can land before 4; 4 cannot land before 3 because graph SQL needs the cancellable pool).
+
+---
+
+## Phase 1: Pure types + RRF/cosine extensions
+
+**Goal:** Land all pure-function building blocks in `cairn-core::search` so phases 2-5 can compose them. No `MemoryStore` changes, no I/O, no callers — all new code is `#[allow(dead_code)]` until phase 5 wires it.
+
+**Files:**
+- Modify: `crates/cairn-core/src/search/rrf.rs` — add `RankedCandidate`, `Leg`, `rrf_fusion_weighted`.
+- Modify: `crates/cairn-core/src/search/cosine.rs` — add graph-only path to `cosine_rerank`.
+- Create: `crates/cairn-core/src/search/graph.rs` — define `GraphCandidate`.
+- Create: `crates/cairn-core/src/search/degraded.rs` — `DegradedLeg`, `DegradationReason`, `GraphSource` enums.
+- Modify: `crates/cairn-core/src/search/orchestrator.rs` — extend `HybridSearchInputs`/`Params` with new fields; extend `hybrid_search`.
+- Modify: `crates/cairn-core/src/search/mod.rs` — re-export new public types.
+
+### Task 1.1: Add `GraphCandidate` type
+
+**Files:**
+- Create: `crates/cairn-core/src/search/graph.rs`
+- Test: inline `#[cfg(test)] mod tests` in same file.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// crates/cairn-core/src/search/graph.rs
+//! One graph-leg candidate.
+
+use crate::domain::RecordId;
+
+/// One graph-leg candidate: a record reached via a neighbor entity edge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphCandidate {
+    pub record_id: RecordId,
+    /// Confidence score of the *connecting edge* in `[0.0, 1.0]`.
+    pub edge_confidence_score: f32,
+    /// 1-based rank in the graph leg's SQL output order. Carried
+    /// explicitly so RRF fusion does not infer rank from list position
+    /// after hydration shuffles ids. See spec §5.2.1.
+    pub graph_rank: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rid(suffix: &str) -> RecordId {
+        RecordId::parse(format!("01HQZX9F5N00000000000000{suffix}")).expect("valid id")
+    }
+
+    #[test]
+    fn construct_and_clone() {
+        let c = GraphCandidate {
+            record_id: rid("0A"),
+            edge_confidence_score: 0.85,
+            graph_rank: 3,
+        };
+        let c2 = c.clone();
+        assert_eq!(c, c2);
+    }
+}
+```
+
+- [ ] **Step 2: Wire into `mod.rs` and run**
+
+Edit `crates/cairn-core/src/search/mod.rs`: add `pub mod graph;` and `pub use graph::GraphCandidate;`.
+
+Run: `cargo nextest run -p cairn-core search::graph`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/search/graph.rs crates/cairn-core/src/search/mod.rs
+git commit -m "feat(core/search): GraphCandidate type for graph-leg results (issue #191)"
+```
+
+### Task 1.2: Add `DegradedLeg` typed enum
+
+**Files:**
+- Create: `crates/cairn-core/src/search/degraded.rs`
+- Modify: `crates/cairn-core/src/search/mod.rs`
+
+- [ ] **Step 1: Write the type + tests**
+
+```rust
+// crates/cairn-core/src/search/degraded.rs
+//! Typed degradation signal for hybrid search responses.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradationReason {
+    CapabilityUnavailable,
+    DeadlineExceeded,
+    SqlError,
+    WorkerPanic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GraphSource {
+    All,
+    AuthKeywordSeed,
+    AuthSemanticSeed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DegradedLeg {
+    Semantic { reason: DegradationReason },
+    Graph    { reason: DegradationReason, source: GraphSource },
+}
+
+impl DegradedLeg {
+    pub fn graph_capability_unavailable() -> Self {
+        Self::Graph { reason: DegradationReason::CapabilityUnavailable, source: GraphSource::All }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn graph_constructor_helper() {
+        let d = DegradedLeg::graph_capability_unavailable();
+        assert!(matches!(d, DegradedLeg::Graph { reason: DegradationReason::CapabilityUnavailable, source: GraphSource::All }));
+    }
+}
+```
+
+- [ ] **Step 2: Wire + run**
+
+Edit `mod.rs`: `pub mod degraded;` + re-export `DegradedLeg`, `DegradationReason`, `GraphSource`.
+
+Run: `cargo nextest run -p cairn-core search::degraded`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/search/degraded.rs crates/cairn-core/src/search/mod.rs
+git commit -m "feat(core/search): DegradedLeg typed enum for partial-result signaling"
+```
+
+### Task 1.3: Add `rrf_fusion_weighted` with `Leg` shape variants
+
+**Files:**
+- Modify: `crates/cairn-core/src/search/rrf.rs`
+
+- [ ] **Step 1: Write tests for the new function**
+
+Add to `rrf.rs`:
+
+```rust
+/// One element of an explicit-rank input list to RRF.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RankedCandidate {
+    pub record_id: RecordId,
+    /// 1-based rank.
+    pub rank: usize,
+    /// Confidence weight in `[0.0, 1.0]`. Used to compute
+    /// `effective_rank = rank / max(weight, floor)`.
+    pub weight: f32,
+}
+
+/// One leg of [`rrf_fusion_weighted`].
+#[derive(Debug, Clone)]
+pub enum Leg {
+    /// Rank inferred from slice index. Equivalent to today's `rrf_fusion`.
+    ListPosition(Vec<ScoredCandidate>),
+    /// Rank carried per-candidate; confidence penalty applied with `floor`.
+    Explicit(Vec<RankedCandidate>, f32),
+}
+
+#[must_use]
+pub fn rrf_fusion_weighted(legs: &[Leg], k: usize) -> Vec<RrfCandidate> {
+    use std::collections::HashMap;
+    let mut acc: HashMap<RecordId, f64> = HashMap::new();
+    #[allow(clippy::cast_precision_loss)]
+    let kf = k as f64;
+    for leg in legs {
+        match leg {
+            Leg::ListPosition(list) => {
+                for (i, c) in list.iter().enumerate() {
+                    #[allow(clippy::cast_precision_loss)]
+                    let r = (i + 1) as f64;
+                    *acc.entry(c.record_id.clone()).or_insert(0.0) += 1.0 / (kf + r);
+                }
+            }
+            Leg::Explicit(list, floor) => {
+                let f = (*floor).max(1e-6) as f64;
+                for c in list {
+                    #[allow(clippy::cast_precision_loss)]
+                    let raw_rank = c.rank as f64;
+                    let weight = (c.weight as f64).max(f);
+                    let effective = raw_rank / weight;
+                    *acc.entry(c.record_id.clone()).or_insert(0.0) += 1.0 / (kf + effective);
+                }
+            }
+        }
+    }
+    let mut out: Vec<RrfCandidate> = acc.into_iter()
+        .map(|(record_id, rrf_score)| RrfCandidate { record_id, rrf_score })
+        .collect();
+    out.sort_by(|a, b| b.rrf_score.partial_cmp(&a.rrf_score).unwrap_or(std::cmp::Ordering::Equal)
+        .then_with(|| a.record_id.as_str().cmp(b.record_id.as_str())));
+    out
+}
+```
+
+Add tests:
+
+```rust
+#[test]
+fn weighted_extracted_outranks_inferred_at_same_rank() {
+    let extracted = vec![RankedCandidate { record_id: rid("0A"), rank: 1, weight: 1.0 }];
+    let inferred  = vec![RankedCandidate { record_id: rid("0B"), rank: 1, weight: 0.6 }];
+    let out = rrf_fusion_weighted(&[
+        Leg::Explicit(extracted, 1e-3),
+        Leg::Explicit(inferred,  1e-3),
+    ], 60);
+    assert_eq!(out[0].record_id, rid("0A"));
+}
+
+#[test]
+fn list_position_matches_legacy_fusion() {
+    let list = vec![
+        ScoredCandidate { record_id: rid("0A"), score: 1.0 },
+        ScoredCandidate { record_id: rid("0B"), score: 0.5 },
+    ];
+    let legacy  = rrf_fusion(&[list.clone()], 60);
+    let weighted = rrf_fusion_weighted(&[Leg::ListPosition(list)], 60);
+    assert_eq!(legacy, weighted);
+}
+
+#[test]
+fn confidence_floor_prevents_div_by_zero() {
+    let zero_conf = vec![RankedCandidate { record_id: rid("0A"), rank: 1, weight: 0.0 }];
+    let out = rrf_fusion_weighted(&[Leg::Explicit(zero_conf, 1e-3)], 60);
+    assert!(out[0].rrf_score.is_finite());
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cargo nextest run -p cairn-core search::rrf`
+Expected: PASS (existing + new tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/search/rrf.rs
+git commit -m "feat(core/search): rrf_fusion_weighted with confidence-penalty leg"
+```
+
+### Task 1.4: Extend `cosine_rerank` for graph-only candidates
+
+**Files:**
+- Modify: `crates/cairn-core/src/search/cosine.rs`
+
+- [ ] **Step 1: Add `CandidateOrigin` and tagged candidate type**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CandidateOrigin {
+    Lexical,
+    GraphOnly,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OriginTaggedCandidate {
+    pub inner: super::rrf::RrfCandidate,
+    pub origin: CandidateOrigin,
+}
+```
+
+- [ ] **Step 2: Add `cosine_rerank_tagged` (new function — keep existing `cosine_rerank` for backwards compat)**
+
+```rust
+#[must_use]
+pub fn cosine_rerank_tagged(
+    candidates: &[OriginTaggedCandidate],
+    doc_vectors: &HashMap<RecordId, Vec<f32>>,
+    query_vector: &[f32],
+    blend: f32,
+) -> Vec<RerankedCandidate> {
+    let max_rrf = candidates.iter().map(|c| c.inner.rrf_score).fold(0.0_f64, f64::max);
+    let mut out: Vec<RerankedCandidate> = candidates.iter().map(|tc| {
+        let rrf_norm = if max_rrf < f64::EPSILON { 0.0 } else { tc.inner.rrf_score / max_rrf };
+        let final_score = match tc.origin {
+            CandidateOrigin::Lexical => {
+                let cos_norm = doc_vectors
+                    .get(&tc.inner.record_id)
+                    .map(|v| (cosine_similarity(query_vector, v) + 1.0) / 2.0)
+                    .unwrap_or(0.5) as f64;
+                f64::from(blend) * rrf_norm + (1.0 - f64::from(blend)) * cos_norm
+            }
+            CandidateOrigin::GraphOnly => f64::from(blend) * rrf_norm,
+        };
+        RerankedCandidate {
+            record_id: tc.inner.record_id.clone(),
+            rrf_score: tc.inner.rrf_score,
+            cosine: matches!(tc.origin, CandidateOrigin::Lexical)
+                .then(|| doc_vectors.get(&tc.inner.record_id).map(|v| cosine_similarity(query_vector, v)).unwrap_or(0.0)),
+            final_score,
+        }
+    }).collect();
+    out.sort_by(|a, b| b.final_score.partial_cmp(&a.final_score).unwrap_or(std::cmp::Ordering::Equal));
+    out
+}
+```
+
+- [ ] **Step 3: Add tests**
+
+```rust
+#[test]
+fn graph_only_ties_lexical_at_zero_cosine_equal_rrf() {
+    let mut docs = HashMap::new();
+    docs.insert(rid("0A"), vec![0.0_f32, 1.0]);          // lexical doc, cosine_raw = -1 vs query
+    let cands = vec![
+        OriginTaggedCandidate {
+            inner: RrfCandidate { record_id: rid("0A"), rrf_score: 0.5 },
+            origin: CandidateOrigin::Lexical,
+        },
+        OriginTaggedCandidate {
+            inner: RrfCandidate { record_id: rid("0B"), rrf_score: 0.5 },
+            origin: CandidateOrigin::GraphOnly,
+        },
+    ];
+    let q = vec![0.0_f32, -1.0]; // produces cosine_raw=-1, cosine_norm=0 for 0A
+    let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+    assert!((out[0].final_score - out[1].final_score).abs() < 1e-9, "lexical-cos-0 must tie graph-only");
+}
+
+#[test]
+fn graph_only_loses_to_strong_lexical_at_equal_rrf() {
+    let mut docs = HashMap::new();
+    docs.insert(rid("0A"), vec![1.0_f32, 0.0]);
+    let cands = vec![
+        OriginTaggedCandidate {
+            inner: RrfCandidate { record_id: rid("0A"), rrf_score: 0.5 },
+            origin: CandidateOrigin::Lexical,
+        },
+        OriginTaggedCandidate {
+            inner: RrfCandidate { record_id: rid("0B"), rrf_score: 0.5 },
+            origin: CandidateOrigin::GraphOnly,
+        },
+    ];
+    let q = vec![1.0_f32, 0.0];
+    let out = cosine_rerank_tagged(&cands, &docs, &q, 0.7);
+    assert_eq!(out[0].record_id, rid("0A"));
+}
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo nextest run -p cairn-core search::cosine`
+Expected: PASS.
+
+```bash
+git add crates/cairn-core/src/search/cosine.rs
+git commit -m "feat(core/search): graph-only candidate path in cosine rerank"
+```
+
+### Task 1.5: Extend `HybridSearchInputs` / `HybridSearchParams` and update `hybrid_search`
+
+**Files:**
+- Modify: `crates/cairn-core/src/search/orchestrator.rs`
+
+Add to `HybridSearchInputs`:
+```rust
+pub graph: Vec<GraphCandidate>,
+```
+Add to `HybridSearchParams`:
+```rust
+pub confidence_floor: f32,   // default 1e-3
+```
+And `Default for HybridSearchParams` sets `confidence_floor: 1e-3`.
+
+Then refactor `hybrid_search` body to:
+1. Build legs: `Leg::ListPosition(keyword)`, `Leg::ListPosition(semantic)`, `Leg::Explicit(graph_as_ranked, params.confidence_floor)`.
+2. Call `rrf_fusion_weighted`.
+3. Tag each fused candidate as `Lexical` or `GraphOnly` based on whether it appears in the graph leg AND not in the keyword/semantic leg.
+4. Call `cosine_rerank_tagged`.
+
+Add tests:
+- Three-leg integration: keyword + semantic + graph with mixed confidence neighbors → ordering matches expected.
+- Graph-leg empty → output equals legacy 2-leg behavior (parity test).
+- Graph-only candidate present → tagged correctly and survives rerank.
+
+Commit:
+```bash
+git add crates/cairn-core/src/search/orchestrator.rs
+git commit -m "feat(core/search): 3-leg hybrid_search with graph candidates and tagged rerank"
+```
+
+### Task 1.6: Phase 1 final verification
+
+- [ ] Run `cargo fmt --all --check`
+- [ ] Run `cargo clippy --workspace --all-targets --locked -- -D warnings`
+- [ ] Run `cargo nextest run --workspace`
+- [ ] Run `./scripts/check-core-boundary.sh`
+- [ ] Open PR titled `feat(core/search): pure types + 3-leg RRF + graph-only rerank (issue #191 phase 1)`. Body cites spec §5, §6, §6.1.
+
+---
+
+## Phase 2: Contract bump — auth_scope + capability + trait method
+
+**Goal:** Bump `CONTRACT_VERSION` to `0.5.0`, add `auth_scope: ScopeTuple` to all search args, add `MemoryStoreCapabilities::graph_search`, add the `search_graph_neighbors` method. Existing search behavior unchanged (the SQLite store still authorizes via `filter` for keyword/semantic, just like today; only graph-aware code paths added in phase 4 will read `auth_scope`). The default trait impl of `search_graph_neighbors` returns `CapabilityUnavailable`.
+
+**Files:**
+- Modify: `crates/cairn-core/src/contract/memory_store.rs` — `CONTRACT_VERSION`, all `*SearchArgs`, `MemoryStoreCapabilities`, new `GraphNeighborsArgs`, trait method.
+- Modify: `crates/cairn-store-sqlite/src/lib.rs` — `ACCEPTED_RANGE`.
+- Modify: `crates/cairn-core/src/search/orchestrator.rs` — extend args definitions if any in core mod.
+- Modify: `crates/cairn-store-sqlite/src/store/search.rs`, `crates/cairn-store-sqlite/src/store/hybrid.rs`, `crates/cairn-store-sqlite/src/lib.rs` — accept new field; pass through unchanged.
+- Modify: every test that constructs `KeywordSearchArgs` / `SemanticSearchArgs` / `HybridSearchArgs` — populate `auth_scope`. Use `ScopeTuple::EMPTY` in legacy tests where no scope was previously used.
+- Modify: `crates/cairn-core/src/contract/memory_store.rs` test stubs.
+- Modify: `crates/cairn-store-sqlite/tests/capabilities_unchanged.rs` — regenerate snapshot.
+- Add `#[non_exhaustive]` to: `KeywordSearchArgs`, `SemanticSearchArgs`, `HybridSearchArgs`, `HybridSearchInputs`, `HybridSearchParams`, `HybridSearchPage`, `KeywordSearchPage`, `SemanticSearchPage`, `ScoreExplain`, `MemoryStoreCapabilities`, `SearchOutcome`.
+- Add `bon::Builder` derive to all `*SearchArgs` structs and `GraphNeighborsArgs`. Imports: add `bon` to `[workspace.dependencies]` if not already present (check first).
+
+### Tasks (high-level — see spec §12.1)
+
+1. **Pre-work: add `#[non_exhaustive]` to existing public structs.** This itself is a breaking change for external struct literals; bundle with the contract bump.
+2. **Add `auth_scope: ScopeTuple`** as a public required field on the args structs. Update `Default` impls to use `ScopeTuple::EMPTY` only inside the test-fixtures crate's helpers; production callers must populate.
+3. **Add `MemoryStoreCapabilities::graph_search: bool`** with `Default = false`.
+4. **Add `GraphNeighborsArgs`** struct (see spec §4.3).
+5. **Add `search_graph_neighbors`** method to `MemoryStore` trait with default impl returning `Err(StoreError::CapabilityUnavailable { what: "graph_search" })`.
+6. **Bump `CONTRACT_VERSION`** to `ContractVersion::new(0, 5, 0)`.
+7. **Bump `ACCEPTED_RANGE`** in `cairn-store-sqlite`, `cairn-mcp`, `cairn-sdk` to `[0.5.0, 0.6.0)`.
+8. **Add `bon::Builder` derive** + write a basic builder usage test for each args struct.
+9. **Update every callsite** in the workspace. Mechanical fan-out.
+10. **Regenerate `capabilities_unchanged.rs` snapshot.**
+
+Verification: workspace builds; `cargo nextest run --workspace` passes; the existing keyword/semantic search tests are unchanged in behavior.
+
+PR title: `feat(core): contract 0.5.0 — auth_scope + graph_search capability + search_graph_neighbors method (issue #191 phase 2)`
+
+---
+
+## Phase 3: Two-tier connection pool + cancellation lifecycle
+
+**Goal:** Introduce `HybridConnectionPool` (Tier A + Tier B) replacing the current single-connection model for hybrid search. Wire `interrupt()` + `progress_handler` per connection. Migrate `do_search_keyword` and `do_search_semantic` onto Tier A. Add per-checkout reset/discard lifecycle.
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/pool.rs`
+- Modify: `crates/cairn-store-sqlite/src/open.rs` — `open_connection` factory becomes the single source of truth for per-connection setup; pool init goes through it.
+- Modify: `crates/cairn-store-sqlite/src/store/mod.rs` — `SqliteMemoryStore` gains `hybrid_pool: Arc<HybridConnectionPool>`.
+- Modify: `crates/cairn-store-sqlite/src/store/search.rs` — keyword + semantic now acquire from Tier A.
+- Modify: `crates/cairn-store-sqlite/src/store/hybrid.rs` — orchestrator acquires per-leg connections from the pool.
+- Add: `crates/cairn-store-sqlite/tests/connection_pool.rs` — integration tests for cross-request reuse, sibling-completion isolation, init-failure → graph_search false.
+
+**Key implementation points (see spec §5.3):**
+
+- Pool size: `filtered_pool_size = num_cpus()` for Tier A, `graph_pool_size = 2 * num_cpus()` for Tier B.
+- Tier A acquire: `tokio::time::timeout(filtered_acquire_timeout_ms, semaphore.acquire())`. Default 200ms. On timeout return `StoreError::Timeout` with reason `tier_a_acquire_timeout`.
+- Tier B acquire: same shape with `pool_acquire_timeout_ms` (= leg deadline).
+- Per-checkout lifecycle:
+  - Borrow → install fresh `CancellationToken`, re-arm `progress_handler` against it, run `SELECT 1` smoke probe; if probe fails, discard + rebuild via factory.
+  - Run → leg's SQL.
+  - Release → reset token, deregister callback, run `sqlite3_db_release_memory`. If reset errors, discard + rebuild.
+- Watchdog: when deadline elapses, call `Connection::interrupt()` AND fire the cancellation token.
+- Capability probe extension: every pool connection must pass §8 probes individually before `caps.graph_search = true`.
+
+Tests:
+- Cross-request reuse after timeout: assert request N+1 succeeds on the same pool slot that request N timed out on.
+- Sibling-completion isolation: two parallel legs, one times out; assert the other completes normally on its own connection.
+- Pool-init failure: inject a `carray` load failure on one pool connection; assert `caps.graph_search = false` at startup.
+- Tier A acquire timeout: saturate Tier A; new request fails with timeout in `filtered_acquire_timeout_ms` ± 10ms.
+
+PR title: `feat(store): two-tier connection pool + statement-scoped cancellation (issue #191 phase 3)`
+
+---
+
+## Phase 4: Graph SQL — 1-hop + supersession + bitemporal + hydration
+
+**Goal:** Implement `search_graph_neighbors` end-to-end. The pure orchestrator + connection pool from previous phases compose with the new SQL.
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/store/graph_search.rs` — implements `do_search_graph_neighbors` with the §5.1 SQL (CTE form).
+- Create: `crates/cairn-store-sqlite/src/store/graph_hydrate.rs` — implements `hydrate_graph_only` (§5.2.1 SQL + Rust-side rank preservation).
+- Modify: `crates/cairn-store-sqlite/src/store/trait_impl.rs` — wire trait method to `do_search_graph_neighbors`.
+- Modify: `crates/cairn-store-sqlite/src/open.rs` — extend §8 capability probe to cover `valid_at`, `created_at`, `expired_at`, `invalid_at` on `entity_edges`; `episode_id` on `entity_episodes`; tombstoned/active/scope on `records`.
+- Add: `crates/cairn-store-sqlite/tests/graph_search.rs` — full §10.2 test suite.
+
+**Key SQL (see spec §5.1):**
+
+The CTE has the shape (literal bindings):
+```sql
+WITH RECURSIVE
+  visible_query_records(id) AS (SELECT value FROM carray(?1)),    -- ≤ 400 ids
+  ranked_query_records(id)  AS (SELECT value FROM carray(?5)),    -- ≤ 100 ids
+  seeds(id) AS (
+    SELECT DISTINCT ep.entity_node_id
+      FROM entity_episodes ep
+     WHERE ep.episode_id IN (SELECT id FROM visible_query_records)
+  ),
+  neighbors(neighbor_id, conf) AS (
+    SELECT neighbor_id, MAX(confidence_score)
+      FROM (
+        SELECT
+          CASE WHEN e.source_id IN (SELECT id FROM seeds) THEN e.target_id ELSE e.source_id END AS neighbor_id,
+          e.confidence_score
+        FROM entity_edges e
+        JOIN records pr ON pr.record_id = e.source_record_id
+        WHERE (e.source_id IN (SELECT id FROM seeds) OR e.target_id IN (SELECT id FROM seeds))
+          AND e.invalid_at IS NULL AND e.expired_at IS NULL
+          AND e.valid_at <= ?6 AND e.created_at <= ?7
+          AND e.source_record_id IS NOT NULL
+          AND e.confidence_score >= ?2
+          AND pr.tombstoned = 0 AND pr.active = 1
+          AND <auth_scope predicate ON pr>
+          AND <visibility predicate ON pr>
+      )
+      WHERE neighbor_id NOT IN (SELECT id FROM seeds)
+      GROUP BY neighbor_id
+  )
+SELECT r.record_id, MAX(n.conf) AS conf
+  FROM neighbors n
+  JOIN entity_episodes ep ON ep.entity_node_id = n.neighbor_id
+  JOIN records r ON r.record_id = ep.episode_id
+ WHERE r.tombstoned = 0 AND r.active = 1
+   AND <supersession predicate ON r>
+   AND <auth_scope predicate ON r>
+   AND <visibility predicate ON r>
+   AND <filter predicate ON r>
+   AND r.record_id NOT IN (SELECT id FROM ranked_query_records)
+ GROUP BY r.record_id
+ ORDER BY conf DESC, r.updated_at DESC
+ LIMIT ?3;
+```
+
+`<auth_scope predicate>`, `<visibility predicate>`, `<filter predicate>`, `<supersession predicate>` are built by the same shared helper that `do_search_keyword` uses (extract the helper to a shared module if not already shared).
+
+Capture each row with its 1-based ordinal as `graph_rank`; pass through to hydration.
+
+**Hydration:** §5.2.1 SQL — fetch by id via `IN carray(?1)`, re-apply auth + visibility + filter + supersession. Re-sort the hydrated rows by `graph_rank` in Rust before returning.
+
+**Tests (§10.2 + §10.3 partial):**
+- Discovery property (neighbor-only record surfaces).
+- Hidden alias does not seed graph.
+- Cross-scope provenance excluded.
+- Orphan edge (NULL source_record_id) excluded.
+- Expired edge / invalid edge excluded.
+- Future-dated edge (valid_at > now or created_at > now) excluded.
+- Stale-seed exclusion (superseded source).
+- Stale-neighbor exclusion (superseded neighbor).
+- Self-exclusion (seed cannot be its own "neighbor").
+- Rank-rescue (record at keyword rank-75 returns via graph).
+- Hydration auth re-check (cache replay defense-in-depth).
+- N+1 verifier: prepared-statement count ≤ 3 across the whole graph search.
+- Capability skew: missing `expired_at` column → `graph_search=false`.
+- Capability skew: missing `valid_at` column → `graph_search=false`.
+
+PR title: `feat(store): graph 1-hop SQL + hydration + capability probe (issue #191 phase 4)`
+
+---
+
+## Phase 5: Orchestrator — 4-leg parallel + degraded_legs propagation
+
+**Goal:** Wire all the phases together. The hybrid orchestrator (`store/hybrid.rs::do_search_hybrid`) now runs four parallel legs via `tokio::task::JoinSet`, applies the per-leg timeout table, builds `degraded_legs`, and threads it through `SearchOutcome` → CLI / MCP / SDK.
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/store/hybrid.rs` — JoinSet-based 4-leg fan-out; auth-only seed query (id-only, no filter, supersession kept); deadline + degradation handling; pool acquisition; graph-leg dispatch; merging into `HybridSearchPage` with `degraded_legs`.
+- Create: `crates/cairn-store-sqlite/src/store/seed_query.rs` — id-only auth+supersession-only retrieval for keyword and semantic.
+- Modify: `crates/cairn-core/src/contract/memory_store.rs` — `HybridSearchPage` gains `degraded_legs: Vec<DegradedLeg>`.
+- Modify: `crates/cairn-core/src/verbs/search.rs` — `SearchOutcome` gains `degraded_legs: Vec<DegradedLeg>`; dispatcher copies it through.
+- Modify: `crates/cairn-cli/src/verbs/search.rs` — `--confidence-min <f32>` flag; `--json` includes `degraded_legs`; TTY emits `warning:` to stderr when non-empty.
+- Modify: `crates/cairn-mcp/src/...` — schemars derive picks up `degraded_legs` automatically; assert via snapshot.
+- Modify: `crates/cairn-sdk/src/transport.rs` — extend `SearchData` mapping to include `degraded_legs`.
+- Modify: `crates/cairn-idl/...` — extend search-response IDL with `degraded_legs: Vec<DegradedLeg>` (`#[serde(default)]`); `auth_scope: ScopeTuple` required (no default). Re-run `cairn-codegen`; commit generated diff.
+- Modify: `crates/cairn-core/src/config/mod.rs` — `SearchConfig` adds `confidence_min`, `confidence_floor`, `graph_seed_overfetch`, `graph_leg_deadline_ms`, `filtered_acquire_timeout_ms`, `pool_acquire_timeout_ms`, `filtered_pool_size`, `graph_pool_size`.
+
+**Tests:**
+- End-to-end hybrid w/ all 3 legs against a real seeded vault.
+- `--json` snapshot stable (insta).
+- Graph-only candidate hydrated correctly through verb → CLI.
+- `degraded_legs` survives dispatcher → CLI `--json`.
+- `degraded_legs` survives SDK transport round-trip.
+- Per-leg timeout table: each row tested with synthetic delay injection (use a wrapper `MemoryStore` impl that delays specific legs).
+- 0.4.x-shaped request (no `auth_scope`) → `SearchError::MissingField`.
+
+PR title: `feat(verbs/cli/sdk/mcp): wire 3-leg hybrid search end-to-end with degraded_legs (issue #191 phase 5)`
+
+---
+
+## Phase 6: Bench + load gates
+
+**Goal:** Add bench cases that gate the latency/load claims in §10.5. CI-runnable.
+
+**Files:**
+- Modify: `crates/cairn-bench/...` — Criterion benches or custom harness.
+
+**Gates:**
+- p99 < 100ms on 10k-record vault, hybrid search.
+- p99 < 100ms on 50k-record vault, broad query (>200 keyword hits).
+- p99 < 150ms under 32-way concurrent load on 50k-record vault; assert adaptive-overfetch reduction engages at least once.
+- Deadline-circuit: synthetic delay → request returns within deadline + 10ms with correct `degraded_legs`.
+- Tier A acquire-timeout: saturate Tier A → fast failure within `filtered_acquire_timeout_ms` ± 10ms.
+
+PR title: `bench: hybrid search load + deadline gates (issue #191 phase 6)`
+
+---
+
+## Self-Review
+
+**Spec coverage:** Every §-section in the spec is mapped to a phase. §3 algorithm = phases 1+4. §4 contracts = phase 2. §5.1 SQL = phase 4. §5.2.1 hydration = phase 4. §5.3 orchestrator = phase 5. §5.4 verb envelope = phase 5. §6 fusion = phase 1. §6.1 cosine graph-only = phase 1. §7 verb + CLI = phase 5. §8 capability = phases 2+3+4. §10 tests distributed across phases (each phase ships its own tests). §10.5 bench = phase 6. §11 AC mapping covered. §12.1 contract version = phase 2.
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later" in the plan. Predicate placeholders (`<auth_scope predicate>`, etc.) are intentional — they reference an existing helper that the implementer will reuse from `do_search_keyword`. Phase 4 task should locate and extract that helper as an early sub-task if it's still inline today.
+
+**Type consistency:** `GraphCandidate { record_id, edge_confidence_score, graph_rank }` is the same in phase 1 and phase 4. `RankedCandidate { record_id, rank, weight }` ditto. `DegradedLeg { Semantic { reason }, Graph { reason, source } }` ditto. `auth_scope: ScopeTuple` consistent.
+
+**Honest limitation:** Phases 4 and 5 are large — phase 4 has ~15 integration tests, phase 5 has the most cross-crate fan-out. Subagent execution is strongly recommended for those phases (see executing-plans skill); inline batch execution will be slow.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-05-issue-191-rrf-hybrid-graph.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per phase (or per major task within phase 4/5). Two-stage review between phases.
+
+2. **Inline Execution** — Execute phases sequentially in this session. Long; will likely need batch checkpoints.
+
+**Suggested next step:** start with phase 1 (fully self-contained, pure functions, ~6 tasks, ~1-2 hours of subagent time) so the type vocabulary is locked in before the contract bump in phase 2.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-05-issue-191-rrf-hybrid-graph-design.md
+++ b/docs/superpowers/specs/2026-05-05-issue-191-rrf-hybrid-graph-design.md
@@ -1,0 +1,1332 @@
+# Issue #191 — RRF Hybrid Search w/ 1-hop Graph Expansion
+
+**Issue:** [#191](https://github.com/windoliver/cairn/issues/191)
+**Brief refs:** §8.0 (search verb), §4 (MemoryStore), §6.11 (SQLite — `WITH RECURSIVE`)
+**Updates:** #47 (FTS5), #48 (sqlite-vec), #49 (hybrid orchestration)
+**Status:** spec — implementation pending
+
+---
+
+## 1. Goal
+
+Add a third retrieval leg — 1-hop entity-graph neighborhood expansion — to the
+existing 2-leg RRF hybrid search (FTS5 BM25 + sqlite-vec semantic ANN).
+Confidence-aware so that `INFERRED`/`AMBIGUOUS`-edge neighbors are penalized
+relative to `EXTRACTED`-edge neighbors. Surfaces non-obvious connections while
+preserving the existing keyword/semantic recall floor.
+
+## 2. Non-goals
+
+- Multi-hop traversal (depth > 1). Reserved for a follow-up.
+- Re-tuning RRF constant `k` away from 60. Keep canonical default.
+- Replacing the cosine re-rank pass; graph leg feeds RRF, cosine pass remains.
+- Online graph mutation. Graph leg is read-only.
+
+## 3. Algorithm (final)
+
+The graph leg performs a true 1-hop expansion: seed entities → edge →
+**neighbor** (opposite-endpoint) entities → records mentioning the neighbor.
+This surfaces records that do not contain the query terms but are connected
+via the entity graph (the discovery case). Seeds are restricted to entities
+mentioned by **visible records that match the query** so that no unauthorized
+lexical data influences ranking.
+
+```
+# Step 1: visible_query_records — UNION of keyword and semantic hits
+#         (both already scope/visibility-filtered upstream). Using only
+#         BM25 would give paraphrased / low-lexical-overlap queries zero
+#         graph expansion, defeating the leg's purpose precisely where
+#         hybrid retrieval should help most.
+visible_query_records = unique(bm25_hits.record_ids
+                            ∪ semantic_hits.record_ids)            (≤100)
+
+# Step 2: seed entities — only those mentioned by visible_query_records.
+#         entity_episodes is the (node, record) join table.
+seeds = SELECT DISTINCT entity_node_id
+          FROM entity_episodes
+         WHERE record_id IN visible_query_records
+
+# Step 3: neighbor entities — opposite-endpoint nodes of edges touching seeds.
+#         Edges must be live in BOTH bitemporal dimensions (invalid_at AND
+#         expired_at), and the edge's *provenance record* must itself be
+#         visible to the caller — otherwise hidden evidence could raise the
+#         confidence of a visible neighbor.
+neighbors = SELECT
+              CASE WHEN e.source_id IN seeds THEN e.target_id ELSE e.source_id END
+                AS neighbor_id,
+              MAX(e.confidence_score) AS conf
+            FROM entity_edges e
+            JOIN records pr ON pr.id = e.source_record_id
+           WHERE (e.source_id IN seeds OR e.target_id IN seeds)
+             AND e.invalid_at IS NULL
+             AND e.expired_at IS NULL
+             AND e.confidence_score >= confidence_min
+             AND e.source_record_id IS NOT NULL    -- orphan edges (NULL provenance) ineligible
+             AND pr is visible to caller (auth_scope + visibility)
+           GROUP BY neighbor_id
+           HAVING neighbor_id NOT IN seeds      -- exclude self-references
+
+# Step 4: candidate records — records mentioning a neighbor entity.
+#         Auth (auth_scope + visibility) and the user filter all apply.
+#         Dedup uses ranked_query_records (top 50 per lexical leg, ≤ 100),
+#         NOT visible_query_records (overfetch pool, ≤ 400). Records
+#         overfetched as seeds but ranked out of fusion can still surface.
+graph_hits = SELECT r.id, n.conf
+               FROM neighbors n
+               JOIN entity_episodes ep ON ep.entity_node_id = n.neighbor_id
+               JOIN records r          ON r.id = ep.record_id
+              WHERE auth_scope predicate ON r
+                AND visibility predicate ON r
+                AND filter predicate ON r
+                AND r.tombstoned = 0 AND r.active = 1
+                AND r.id NOT IN ranked_query_records   -- dedup vs. RRF-eligible only
+              GROUP BY r.id
+              ORDER BY MAX(n.conf) DESC, r.updated_at DESC
+              LIMIT 50
+
+# Step 5: RRF fusion (graph leg's rank divided by its connecting-edge
+#         confidence so INFERRED/AMBIGUOUS neighbors land below EXTRACTED).
+contrib_graph(doc, rank, conf) = 1 / (k + rank / max(conf, ε))
+contrib_other(doc, rank)       = 1 / (k + rank)
+rrf_score(doc) = Σ contrib_*(doc, ...)
+
+final = sort_desc(by rrf_score) → cosine rerank top-K → page
+```
+
+Constants: `k=60`, `leg_limit=50`, `confidence_min=0.5`, `ε=1e-3`.
+
+**Trust boundary:** seeds derive from **records the caller can see and that
+match the query**, not from a global entity FTS. An alias indexed only from
+a hidden record cannot match — the lexical match happens against
+`records_fts` (already scope-filtered), and entities are looked up by id
+afterwards via `entity_episodes`. Tested in §10.2.
+
+**Additive property (with rank-rescue, NOT discovery-only):** step 4
+excludes `ranked_query_records` (the records actually fused into RRF —
+top 50 of each lexical leg). It does NOT exclude the wider auth-only
+seed pool (`visible_query_records`, ≤ 400). Two consequences callers
+can rely on:
+
+1. **No double-counting in the fusion pool**: a record present in the
+   top-50 of either lexical leg cannot also appear via the graph leg.
+   RRF won't see the same record twice.
+2. **Rank-rescue is intentional**: a record overfetched as a graph
+   seed but ranked outside the lexical top-50 (e.g., position 75) CAN
+   re-enter via graph evidence. This rescues lexically-matched records
+   that the lexical legs alone would have dropped, while the truly
+   neighbor-only record (no lexical match at all) is the more
+   striking case. Both are valid graph-leg hits; the leg is "additive
+   with rank rescue", not "discovery-only".
+
+Test §10.2's rank-rescue case asserts (1) rank-75 records re-enter via
+graph and (2) the same record is not double-counted in fusion.
+
+## 4. Architecture
+
+### 4.1 Crate boundaries (unchanged)
+
+- `cairn-core` — pure functions & traits; adds `GraphCandidate` and extends
+  `HybridSearchInputs`/`HybridSearchParams`.
+- `cairn-store-sqlite` — owns the `WITH RECURSIVE` SQL and the
+  `search_graph_neighbors` impl.
+- `cairn-cli` — adds `--confidence-min` flag.
+
+`cairn-core` gains zero new external deps. Store gains zero. (Confirmed against
+§3 dependency rule.)
+
+### 4.2 Public types added to `cairn-core::search`
+
+```rust
+/// One graph-leg candidate: a record reached via a neighbor entity edge.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphCandidate {
+    pub record_id: RecordId,
+    /// Confidence score of the *connecting edge* (max if multiple edges
+    /// reach the same record). Range `[0.0, 1.0]`. Used for the rank
+    /// penalty in `hybrid_search`.
+    pub edge_confidence_score: f32,
+    /// 1-based rank of this candidate within the graph leg's output
+    /// (i.e., its position in the §5.1 SQL result order). Carried
+    /// explicitly so RRF fusion does not infer rank from
+    /// (potentially out-of-order) hydrated list position. The graph
+    /// SQL emits rows in `ORDER BY conf DESC, updated_at DESC`; this
+    /// field captures that order before hydration shuffles ids.
+    pub graph_rank: usize,
+}
+```
+
+`HybridSearchInputs` gains:
+
+```rust
+/// Graph-leg candidates. Order in the Vec is irrelevant; rank is read
+/// from `GraphCandidate::graph_rank` to keep fusion deterministic.
+pub graph: Vec<GraphCandidate>,
+```
+
+`HybridSearchParams` gains:
+
+```rust
+/// `ε` floor for the graph-leg confidence penalty divisor. Default 1e-3.
+pub confidence_floor: f32,
+```
+
+Backwards-compat: callers using `HybridSearchInputs::default()`-equivalent
+struct literals must opt into `graph: vec![]`. We add a `..Default::default()`
+constructor on inputs/params to keep the diff small.
+
+### 4.3 New trait method on `MemoryStore`
+
+```rust
+async fn search_graph_neighbors(
+    &self,
+    args: &GraphNeighborsArgs<'_>,
+) -> Result<Vec<GraphCandidate>, Self::Error>;
+```
+
+Where:
+
+```rust
+pub struct GraphNeighborsArgs<'a> {
+    /// Record ids from the auth-only seed retrieval (UNIONed across
+    /// keyword and semantic legs), up to 2 * GRAPH_SEED_OVERFETCH = 400.
+    /// Seeds the graph traversal. Empty list ⇒ empty result.
+    pub seed_record_ids: Vec<RecordId>,
+    /// Record ids actually fused into RRF (top 50 of each filtered
+    /// lexical leg, UNIONed, ≤ 100). Used as the dedup set in step 4
+    /// of §5.1 — graph results exclude these so RRF cannot
+    /// double-count, but seeds NOT in this list (overfetched rank
+    /// 51-200 records) remain eligible for rank-rescue via graph
+    /// evidence. Required: omitting this would force the trait impl
+    /// to dedup against the wrong pool.
+    pub ranked_record_ids: Vec<RecordId>,
+    /// Pre-validated user-narrowing filter (timestamps, tags, kind/class
+    /// narrowing). Applied **only** to the returned neighbor record
+    /// (step 4). User narrowing must not erase otherwise-authorized
+    /// edges based on where the edge was observed.
+    pub filter: Option<ValidatedFilter<'a>>,
+    /// Authorization scope tuple — the security predicate. Applied to
+    /// BOTH the provenance record (step 3) and the neighbor record
+    /// (step 4). `filter` is recall-narrowing only.
+    ///
+    /// **This field is part of a wider `MemoryStore` change.** Promoting
+    /// `auth_scope` into a first-class field on the graph leg only would
+    /// let policy drift between legs — the keyword leg would still
+    /// authorize through `KeywordSearchArgs.filter`, and a careless
+    /// caller could pass a narrower keyword filter than graph
+    /// auth_scope (or vice versa). To prevent that, this issue also
+    /// adds `auth_scope: ScopeTuple` to `KeywordSearchArgs` and
+    /// `SemanticSearchArgs` (and so to `HybridSearchArgs`). The shared
+    /// keyword-leg row-mapper applies it identically across all three
+    /// legs and graph hydration. Callers construct `auth_scope` once
+    /// per request from their auth context; the verb layer threads it
+    /// through unchanged. This is a contract-version event (§12.1) and
+    /// is the reason the bump is `0.4.0 → 0.5.0`, not a patch.
+    pub auth_scope: ScopeTuple,
+    /// Visibility values the caller is allowed to see. Applied to BOTH
+    /// the neighbor record (step 4) AND the edge provenance record
+    /// (step 3). Authorization.
+    pub visibility_allowlist: Vec<MemoryVisibility>,
+    /// Max candidates returned. = `HYBRID_LEG_LIMIT` from the orchestrator.
+    pub limit: usize,
+    /// `confidence_score` floor applied SQL-side to the edge step (step 3).
+    pub confidence_min: f32,
+}
+```
+
+**Predicate application (step 3 vs. step 4):** authorization predicates
+(`auth_scope`, `visibility_allowlist`, tombstone, active) apply to BOTH
+provenance and neighbor. The user-narrowing `filter` applies **only** to
+the neighbor record. This split is the whole reason `auth_scope` is a
+separate field on the args struct — overloading user filter onto
+provenance would erase otherwise-authorized graph evidence based on
+where the edge happened to be extracted.
+
+| Predicate kind          | Step 3 (provenance `pr`) | Step 4 (neighbor `r`) |
+|---|---|---|
+| `auth_scope`            | applied | applied |
+| `visibility_allowlist`  | applied | applied |
+| `tombstoned = 0`        | applied | applied |
+| `active = 1`            | applied | applied |
+| `filter` (user narrow)  | **NOT** applied | applied |
+
+This is the contract from day one — there is no "until the split lands"
+deferral. The `auth_scope` field is mandatory on `GraphNeighborsArgs`;
+the orchestrator (`do_search_hybrid`) extracts it from the same context
+that builds visibility/scope predicates for the keyword leg, so the
+three legs cannot drift.
+
+Capability: extends **`MemoryStoreCapabilities`** with `graph_search:
+bool` (see §8 — runtime capability, not config-derived). Stores without
+the entity_graph schema or the `carray` extension return
+`CapabilityUnavailable`. The hybrid path treats unavailable graph leg
+the same as it currently treats an unavailable semantic leg: skip the
+leg, RRF still runs on the survivors. The orchestrator reads
+`MemoryStoreCapabilities::graph_search` (NOT `config::CapabilitySet`)
+when deciding to dispatch the graph leg. Degradation is surfaced
+explicitly per §5.3.
+
+### 4.4 Extended args
+
+`HybridSearchArgs` gains `pub confidence_min: f32` (threaded into the graph
+leg only).
+
+## 5. Store implementation
+
+### 5.1 SQL — single statement (authorization-first, true 1-hop)
+
+The query takes the **union of keyword + semantic leg over-fetched
+record-ids** as a parameter (`?1` = bound list of `record_id`s, length ≤
+`2 * GRAPH_SEED_OVERFETCH = 400` by default; configurable via
+`SearchConfig.graph_seed_overfetch`). Both upstream legs already enforce scope/visibility,
+so the union is fully authorized. That list is the **only** lexical
+input; the graph leg does not run FTS5 itself, so a hidden alias on an
+entity node cannot drive the match. The same list is reused later (Step 4)
+to de-dup graph hits against everything the upstream legs already returned,
+keeping the graph leg purely additive.
+
+```sql
+WITH RECURSIVE
+    -- Step 1a: SEED set — over-fetched record ids from keyword+semantic
+    -- legs (≤ 400 = 2 * GRAPH_SEED_OVERFETCH). Seeds the entity-mention
+    -- traversal so broad queries do not lose connected results to a
+    -- 50-per-leg cap.
+    visible_query_records(id) AS (
+        SELECT value FROM carray(?1)              -- 400-cap, bound by store layer
+    ),
+    -- Step 1b: RANKED set — record ids that actually enter RRF fusion
+    -- (top 50 of each lexical leg, ≤ 100). Used ONLY for the step-4
+    -- dedup so that an overfetched-but-not-ranked seed (rank 51-200)
+    -- can still surface via graph evidence. Distinct from
+    -- visible_query_records by design — see the broad-query test.
+    ranked_query_records(id) AS (
+        SELECT value FROM carray(?5)              -- 100-cap, bound by store layer
+    ),
+    -- Step 2: seed entity nodes — only those mentioned by visible_query_records.
+    -- entity_episodes(episode_id REFERENCES records(record_id), entity_node_id, ...)
+    seeds(id) AS (
+        SELECT DISTINCT ep.entity_node_id
+          FROM entity_episodes ep
+         WHERE ep.episode_id IN (SELECT id FROM visible_query_records)
+    ),
+    -- Step 3: neighbor entities — opposite-endpoint of seed-touching edges.
+    --         Edges are filtered on:
+    --           (a) live in both bitemporal dimensions
+    --               (invalid_at IS NULL AND expired_at IS NULL — the
+    --               schema's live-edge predicate; matches §6.11 of the
+    --               brief and migration 0043),
+    --           (b) confidence floor (?2),
+    --           (c) edge provenance is visible to the caller — the edge's
+    --               source_record_id MUST also be in visible_query_records
+    --               OR pass the same visibility/scope predicate. Without
+    --               this filter, an edge extracted from a hidden record
+    --               could raise the confidence aggregate of a visible
+    --               neighbor, leaking unseen evidence into ranking.
+    --         MAX(confidence_score) is computed AFTER the provenance
+    --         filter so only authorized evidence contributes.
+    neighbors(neighbor_id, conf) AS (
+        SELECT neighbor_id, MAX(confidence_score)
+          FROM (
+            SELECT
+                CASE WHEN e.source_id IN (SELECT id FROM seeds)
+                     THEN e.target_id ELSE e.source_id END  AS neighbor_id,
+                e.confidence_score                          AS confidence_score
+              FROM entity_edges e
+              JOIN records pr ON pr.record_id = e.source_record_id
+             WHERE (e.source_id IN (SELECT id FROM seeds)
+                 OR e.target_id IN (SELECT id FROM seeds))
+               -- Bitemporal "live now" predicate matches the production
+               -- read path used by `do_graph_edges` — both end-bounds
+               -- not-fired AND both start-bounds satisfied. ?6 = now_event,
+               -- ?7 = now_ingest (caller-supplied via the verb's
+               -- `as_of_event_time` / `as_of_ingest_time`, defaulting to
+               -- the request timestamp). Without start bounds, a
+               -- future-dated edge would surface neighbors before the
+               -- fact is valid.
+               AND e.valid_at   <= ?6              -- event-time start bound
+               AND e.created_at <= ?7              -- ingest-time start bound
+               AND (e.invalid_at IS NULL OR e.invalid_at > ?6)
+               AND (e.expired_at IS NULL OR e.expired_at > ?7)
+               AND e.source_record_id IS NOT NULL  -- orphan edges excluded
+               AND e.confidence_score >= ?2
+               AND pr.tombstoned = 0
+               AND pr.active = 1
+               -- Authorization-only on provenance: auth_scope + visibility.
+               -- User-narrowing `filter` is NOT applied here (see §4.3).
+               AND <auth_scope predicate ON pr>
+               AND <visibility predicate ON pr>
+          )
+         WHERE neighbor_id NOT IN (SELECT id FROM seeds)   -- exclude self-references explicitly
+         GROUP BY neighbor_id
+    )
+-- Step 4: candidate records — records mentioning a neighbor entity.
+--         Authorization (visibility + scope) AND the user-supplied filter
+--         BOTH apply here. The result is de-duped against the seed list
+--         so the leg is additive vs. keyword/semantic.
+SELECT r.record_id, MAX(n.conf) AS conf
+  FROM neighbors n
+  JOIN entity_episodes ep ON ep.entity_node_id = n.neighbor_id
+  JOIN records r          ON r.record_id = ep.episode_id
+ WHERE r.tombstoned = 0
+   AND r.active = 1
+   -- Latest-record/supersession predicate, same as do_search_keyword.
+   -- Without it, a superseded neighbor (kept in records for history)
+   -- could re-enter solely via the graph leg even though keyword and
+   -- semantic legs would never return it.
+   AND <supersession predicate ON r>
+   AND <auth_scope predicate ON r>      -- auth, same shared helper as keyword
+   AND <visibility predicate ON r>      -- auth, same shared helper as keyword
+   AND <filter predicate ON r>          -- user narrowing, neighbor only
+   AND r.record_id NOT IN (SELECT id FROM ranked_query_records)
+   --                              ^^^^^^^^^^^^^^^^^^^^^^^^
+   -- Dedup ONLY against records that actually enter RRF fusion (top 50
+   -- of each lexical leg). Records overfetched as graph SEEDS but
+   -- ranked outside the fusion pool (51-200) remain eligible to
+   -- re-enter via graph scoring — otherwise broad queries silently
+   -- drop strongly-connected hits.
+ GROUP BY r.record_id
+ ORDER BY conf DESC, r.updated_at DESC
+ LIMIT ?3;
+```
+
+`WITH RECURSIVE` keyword is used (per AC + brief §6.11) even though depth=1
+needs no recursion today, so depth>1 follow-ups are syntactically additive.
+
+**Trust boundary:** lexical matching happens upstream against `records_fts`
+(already scope-filtered). Entity nodes are reached by id-join through
+`entity_episodes`; their FTS index is **never queried**. A hidden alias
+cannot influence seed selection.
+
+**Visibility predicate:** assembled by the same shared helper that builds
+the predicate for `do_search_keyword` and `do_search_semantic`, so the three
+legs cannot drift. Drift would be a §4 contract violation.
+
+**Implementation note (carray is required):** `rusqlite`'s `carray`
+extension is mandatory for this feature. Three list-bound query shapes
+need it: `visible_query_records` (≤400 ids), `ranked_query_records`
+(≤100 ids), and the hydration `IN carray(?1)` clause (≤50 ids).
+
+The capability probe in §8 includes a `carray` availability check
+(execute `SELECT 1 FROM carray(?)` once at `MemoryStore::open`). If
+`carray` is unavailable, `graph_search` reports false at startup and
+the hybrid path emits `DegradedLeg::Graph { reason:
+"capability_unavailable" }` per request. **There is no inline-VALUES
+fallback path.** The rollout signal is explicit (capability + metric +
+response field), and operators see the degraded state in metrics and
+response payload. `carray` ships with `rusqlite` under default features
+and is enabled in `Cargo.toml` for all production builds; the only
+realistic path to disablement is a hand-rolled embed without the
+feature flag, which the probe surfaces on first connect rather than at
+query time.
+
+### 5.2 New module
+
+`crates/cairn-store-sqlite/src/store/graph_search.rs` — async wrapper around
+the SQL above using the `tokio_rusqlite` worker. Mirrors the shape of
+`store/hybrid.rs` for consistency.
+
+### 5.2.1 Graph-only candidate hydration
+
+Keyword and semantic legs return full `SearchCandidate` rows (snippet,
+`bm25`, `semantic_distance`, `record_json`, scope, visibility,
+`recency_seconds`, `staleness_seconds`, `confidence`, `salience`). The
+graph leg returns only `(record_id, edge_confidence_score)` so it must
+hydrate before the result page is assembled.
+
+**Hydration step:** the graph-only path goes through the **same shared
+row-mapper** as `do_search_keyword`, which already handles the
+millisecond-timestamp arithmetic correctly (see
+`crates/cairn-store-sqlite/src/store/search.rs::row_mapper` —
+`recency_seconds` and `staleness_seconds` are computed from raw
+`now_ms` minus the column's ms value, divided by 1000 in Rust). No
+new SQL recomputes timestamps in the hydration query.
+
+**Rank preservation:** the graph SQL (§5.1) returns rows in a
+deterministic order (`ORDER BY conf DESC, r.updated_at DESC`). That
+order IS the graph leg's rank input to RRF and must be preserved
+through hydration. SQLite returns `IN carray(...)` results in arbitrary
+order, so the hydration step CANNOT rely on the SQL row order. The
+implementation:
+
+1. The graph SQL output is captured as `Vec<(record_id, conf,
+   graph_rank: usize)>` where `graph_rank` is the row index
+   (1-based) in the original SQL result.
+2. The hydration query fetches by id (any order); the result is
+   re-sorted by `graph_rank` in Rust before merging into
+   `HybridSearchInputs.graph`.
+3. The merged `Vec<GraphCandidate>` carries `graph_rank` explicitly
+   on each entry (added to the struct).
+4. `rrf_fusion_weighted` reads the explicit `graph_rank` rather than
+   inferring rank from list position.
+
+Test §10.3 includes a determinism check: identical vault + identical
+query produces byte-identical `graph_rank`/RRF output across N
+repeated calls.
+
+The hydration SELECT is:
+
+```sql
+SELECT r.record_id, r.target_id, r.scope, r.kind, r.class, r.visibility,
+       r.body AS record_json,
+       r.updated_at, r.created_at      -- raw ms; row-mapper converts
+  FROM records r
+ WHERE r.record_id IN carray(?1)            -- graph-only ids (≤ 50)
+   AND r.tombstoned = 0
+   AND r.active = 1
+   -- Defense-in-depth: re-apply the FULL authorization predicate set
+   -- the graph-leg SQL applied at step 4 (supersession + auth_scope +
+   -- visibility + filter), not a subset. If graph ids ever come from
+   -- a cache or a buggy upstream, hydration must independently refuse
+   -- superseded or cross-scope records.
+   AND <supersession predicate ON r>
+   AND <auth_scope predicate ON r>
+   AND <visibility predicate ON r>
+   AND <filter predicate ON r>;
+```
+
+Hydration is implemented via the **same shared row-mapper** as
+`do_search_keyword`, taking the same `(auth_scope, visibility_allowlist,
+filter)` triple. The triple is constructed once per `do_search_hybrid`
+call and passed to all three downstream queries (keyword leg, graph SQL
+step 4, graph hydration), so the four predicates cannot drift.
+
+(`confidence` / `salience` are not columns on `records` in the current
+schema — they live on the deserialized `MemoryRecord` body. The
+`SearchCandidate.confidence` / `SearchCandidate.salience` fields the
+keyword leg returns are derived in the row-mapping layer from the same
+body. The graph-only hydration uses the same row-mapping helper as
+`do_search_keyword`, not a hand-rolled SELECT — single source of truth.)
+
+Output `SearchCandidate` field shape for graph-only rows:
+
+| Field | Value |
+|---|---|
+| `bm25`              | `0.0` (sentinel; absent from FTS results) |
+| `semantic_distance` | `None` |
+| `snippet`           | empty string `""` (no FTS5 `snippet()` source) |
+| `confidence`/`salience`/`recency_seconds`/`staleness_seconds` | derived from `records` body via the shared row-mapper |
+| `record_json`       | hydrated `body` column |
+
+`bm25=0.0` is a **sentinel** the explain serializer maps to `null` in the
+`--json` output so callers don't mistake it for a strong BM25 hit.
+`ScoreExplain` gains `graph_rank: Option<usize>` and
+`edge_confidence_score: Option<f32>` so the graph contribution is visible
+to debugging clients.
+
+**Re-applying auth at hydration time:** the WHERE clause re-applies the
+visibility and filter predicates even though the graph SQL already did.
+This is defense in depth — guards against a future bug where the graph
+SQL is bypassed (e.g., a cache layer); cost is one trivially indexed
+predicate evaluation per id.
+
+`hydrate_candidates` in `store/hybrid.rs` is extended to merge three
+sources (keyword, semantic, graph-only-hydrated). Records present in
+multiple sources keep the keyword/semantic row (richer signal); graph-
+only ids contribute their hydrated row.
+
+### 5.3 Hybrid orchestrator extension
+
+`store/hybrid.rs::do_search_hybrid`:
+
+- The graph leg depends on **both** the keyword AND semantic leg outputs
+  (their UNIONed record-id list seeds the graph leg), so the three legs
+  cannot all run in parallel. New shape:
+  1. **Two retrieval purposes, two query shapes per leg:**
+     - **Filtered fusion retrieval** — runs identically to today's
+       `do_search_keyword` / `do_search_semantic`: applies
+       `auth_scope` + visibility + user `filter`, returns top-50
+       fully-hydrated rows per leg. Feeds the RRF fusion pool. This
+       preserves "best filtered matches" semantics: a narrow filter
+       cannot be starved by unfiltered out-of-filter records flooding
+       the top-N cutoff.
+     - **Auth-only seed retrieval** — runs in parallel: applies
+       `auth_scope` + visibility + tombstone/active checks **AND the
+       same supersession/latest-record predicate as
+       `do_search_keyword`** (a record is a valid seed only if it is
+       the latest active version — superseded retired versions are
+       excluded). It does NOT apply the user-narrowing `filter`. The
+       projection is `record_id` only. Returns up to
+       `GRAPH_SEED_OVERFETCH = 200` ids per leg. Feeds the graph
+       seed pool (∪ to ≤ 400 unique ids). The auth-only path is what
+       makes the graph leg's §4.3 contract hold: provenance records
+       that pass auth but fail the user filter can still seed graph
+       expansion of in-filter neighbors. Reusing the supersession
+       predicate prevents stale retired records from driving graph
+       expansion through a path the keyword leg already excludes.
+     Yes — this means BM25 and ANN run TWICE per hybrid request: once
+     filtered (for fusion), once auth-only (for graph seeds). The
+     auth-only path is id-only (no hydration), so the dominant cost
+     is the index traversal. For BM25 the marginal cost over today's
+     filtered run is ~one extra index scan; for vec0 the cost is one
+     extra ANN traversal at limit=200, which the §10.5 bench gates
+     against the 100ms p99 budget. If the bench shows the duplicated
+     ANN traversal is the latency limiter, `GRAPH_SEED_OVERFETCH` is
+     lowered (the latency gate is non-negotiable). Two queries are
+     the cost of the §4.3 + filtered-recall guarantees together; one
+     retrieval cannot satisfy both.
+  2. **Structured fan-out via `tokio::task::JoinSet`**, NOT
+     `try_join!`. `try_join!` short-circuits on the first error and
+     drops sibling futures, which would orphan their SQLite work on
+     the pool — defeating the safety valve. The orchestrator instead:
+     - Spawns each leg as a task on a `JoinSet`. Every leg owns its
+       own pool connection (§5.3 pool init contract); cancellation is
+       initiated by signaling the leg's `CancellationToken` (which
+       drives `interrupt()` + `progress_handler` per §5.3).
+     - Awaits ALL four tasks (`while let Some(...) = set.join_next()`)
+       — early errors do NOT cause sibling drop. Each leg gets a
+       chance to either complete or run its cancellation path
+       cleanly before the request returns.
+     - Aggregates per-leg outcomes into `degraded_legs` per the
+       timeout table below. The first error from a non-degradable
+       leg (e.g., `filtered_keyword` timeout — see table) is held
+       until all four tasks finish, then surfaced.
+     Drop-triggered cleanup is not relied on. Cancellation is
+     explicit, signaled via tokens, and verified by §10.5(c)
+     (sibling-completion test).
+     Inputs to the graph leg: `seed_record_ids` from the auth-only
+     union and `ranked_record_ids` from the filtered top-50s, both
+     populated only from legs that completed without timeout.
+  3. The id-only overfetch is a `SearchConfig` knob
+     (`graph_seed_overfetch`, default 200, max 500).
+  3a. **Runtime safety valve.** Two layers of protection against the
+      double-traversal cost spiking under production load:
+      - **Pool initialization, sizing, and checkout lifecycle.**
+        - **Init contract.** The `HybridConnectionPool`'s connections
+          are NOT a separate, lazily-initialized set — they go through
+          the **same `open_connection` factory** as the store's
+          primary connection. That factory is the single source of
+          truth for: `carray` extension load, `sqlite_vec` load,
+          progress-handler registration, busy-timeout, journal mode,
+          and any other per-connection setup. `MemoryStore::open`
+          does NOT report `caps.graph_search = true` until **every**
+          pool connection has been built via that factory AND each
+          one has passed the §8 capability probes individually.
+          Test §10.2's "pool-init failure" case injects a load
+          failure on one pool connection and asserts the whole
+          feature reports unavailable.
+        - **Sizing and what the pool serves.** The cancellable pool
+          serves **all four hybrid legs** that face a deadline:
+          `filtered_keyword`, `filtered_semantic`, `auth_keyword_ids`,
+          `auth_semantic_ids`, plus the graph-leg query. Because the
+          deadline table makes `filtered_keyword` non-degradable
+          (must complete or fail the request), it MUST run on a
+          cancellable connection too — otherwise a slow filtered
+          query orphans the underlying SQLite work and starves
+          later requests despite the deadline expiring. Migrating
+          the existing keyword/semantic legs onto the pool is part
+          of this issue; their behavior is unchanged from the
+          caller's perspective.
+
+          **Two pool tiers** to keep the mandatory keyword recall
+          floor isolated from graph-pool contention:
+          - **Tier A (mandatory)**: dedicated connections for
+            `filtered_keyword` and `filtered_semantic`. Size =
+            `num_cpus` (default), configurable as
+            `SearchConfig::filtered_pool_size`. Acquisition has a
+            **request-level deadline** (`SearchConfig::
+            filtered_acquire_timeout_ms`, default 200ms — 2× the
+            p99 budget). On timeout the request fails with
+            `StoreError::Timeout` and a verb-level error reason of
+            `tier_a_acquire_timeout` so operators can distinguish
+            queue saturation from in-query slowness. The acquire
+            deadline is independent of and additive to the per-leg
+            execution deadline — together they cap total request
+            wall time. Filtered legs cannot be starved by graph
+            traffic because graph never queues on Tier A; they CAN
+            be starved by other filtered traffic, which is why the
+            acquire deadline exists.
+          - **Tier B (graph)**: dedicated connections for
+            `auth_keyword_ids`, `auth_semantic_ids`, and
+            `search_graph_neighbors`. Size = `2 * num_cpus`
+            (default), configurable as
+            `SearchConfig::graph_pool_size`. Acquire has a
+            `pool_acquire_timeout_ms` deadline (default = leg
+            deadline); on timeout the leg degrades to
+            `DegradedLeg::Graph { reason: DeadlineExceeded, source:
+            ... }`. Tier B saturation cannot fail the mandatory
+            keyword leg.
+
+          Both tiers honor the same pool-init contract and per-
+          checkout cancellation lifecycle below. The keyword/
+          semantic existing `tokio_rusqlite` worker is retired in
+          favor of Tier A — single execution model across all
+          hybrid legs.
+        - **Per-checkout cancellation lifecycle.** Connection-scoped
+          cancellation (`interrupt()`, `progress_handler`) requires
+          explicit reset before reuse. The lifecycle:
+          1. **Acquire**: borrow a connection; install a fresh
+             `CancellationToken` and re-arm `progress_handler` against
+             it. Run a `SELECT 1` smoke probe; if it fails (e.g.,
+             SQLITE_INTERRUPT pending from a stale state), discard
+             the connection and rebuild via the factory.
+          2. **Run**: leg's SQL executes; deadline watchdog can fire
+             `interrupt()` + token cancel.
+          3. **Release**: ALWAYS reset on release, regardless of
+             outcome — clear the token, deregister the leg's
+             progress callback, run `sqlite3_db_release_memory`
+             (no-op if SQLite ignored it). If reset fails, **discard
+             the connection and rebuild** via the factory before the
+             slot is returned to the pool. Interrupted connections
+             are NEVER reused without a verified reset.
+        Test §10.5 includes a "cross-request reuse" case: one
+        request times out, the next request gets the same pool slot
+        and runs successfully — proves the reset/discard lifecycle.
+
+      - **Per-leg deadline with real, statement-scoped cancellation.**
+        Each of the four parallel queries runs with a deadline budget
+        (`SearchConfig::graph_leg_deadline_ms`, default 60ms — 60% of
+        the p99 budget). A bare `tokio::time::timeout` only drops the
+        awaiter, leaving the SQLite worker pinned on the orphaned
+        job and starving later requests; that is forbidden. SQLite's
+        `interrupt()` and `progress_handler` are connection-scoped,
+        not statement-scoped, so a naive use would also abort sibling
+        queries running on the same connection. To avoid both pitfalls
+        the implementation uses **per-leg dedicated connections from a
+        bounded cancellable pool**:
+        - The store maintains a small pool of read-only SQLite
+          connections (`HybridConnectionPool`, size = 4 by default —
+          one per parallel leg of a hybrid request, plus a small
+          margin). Each cancellable leg of a hybrid request acquires
+          its own connection from the pool for the duration of the
+          query and releases it on completion or cancellation.
+        - When the deadline elapses, a watchdog task calls
+          `interrupt()` ONLY on that leg's connection. Sibling legs
+          on their own connections are unaffected.
+        - `progress_handler` is registered per-connection with a
+          callback gated by that connection's `CancellationToken`,
+          fired only by its own watchdog. Belt-and-braces: even if
+          `interrupt()` races with statement reset, the progress
+          handler catches the cancel on the next opcode batch
+          (default opcode interval 1024).
+        - The pool sits behind a semaphore: if all connections are
+          busy, the next leg waits. The semaphore + per-leg
+          connection together guarantee a timed-out leg cannot leak
+          work onto an unrelated request's connection.
+        Together this guarantees per-leg isolation AND that the
+        SQLite work stops within milliseconds of the deadline.
+
+        **Closed `DegradationReason` enum** — degradation reasons are
+        a typed enum, not free-form strings, so callers and tests key
+        on stable variants:
+
+        ```rust
+        #[non_exhaustive]
+        pub enum DegradationReason {
+            CapabilityUnavailable,    // graph_search=false at startup
+            DeadlineExceeded,         // any leg timed out
+            SqlError,                 // SQLite returned an error
+            WorkerPanic,              // tokio_rusqlite worker panicked
+        }
+        pub enum DegradedLeg {
+            Semantic { reason: DegradationReason },
+            Graph    { reason: DegradationReason, source: GraphSource },
+        }
+        #[non_exhaustive]
+        pub enum GraphSource {
+            All,                      // entire graph leg failed
+            AuthKeywordSeed,          // auth-only keyword seed query
+            AuthSemanticSeed,         // auth-only semantic seed query
+        }
+        ```
+
+        Multiple `DegradedLeg` entries can appear in one response (one
+        per affected source). The `source` field on `Graph` makes the
+        seed-vs-traversal distinction explicit so operators can tell
+        which input failed.
+
+        **Per-leg timeout semantics** — distinct behavior for each of
+        the four parallel legs:
+
+        | Leg | Timeout result | `DegradedLeg` entry |
+        |---|---|---|
+        | `filtered_keyword` (top-50, hydrated) | **Request fails** with `StoreError::Timeout`. Keyword leg is the existing recall floor; degrading it would silently regress 2-leg search behavior. | none — error path |
+        | `filtered_semantic` (top-50, hydrated) | Skip the leg, run hybrid with keyword + graph only. Existing fail-open behavior for semantic, preserved. | `Semantic { reason: DeadlineExceeded }` |
+        | `auth_keyword_ids` (top-200, ids only) | Drop this seed source from the union; graph runs with semantic seeds only. | `Graph { reason: DeadlineExceeded, source: AuthKeywordSeed }` |
+        | `auth_semantic_ids` (top-200, ids only) | Drop this seed source from the union; graph runs with keyword seeds only. | `Graph { reason: DeadlineExceeded, source: AuthSemanticSeed }` |
+
+        If both auth-only seed queries exceed the deadline the graph
+        leg skips entirely (`Graph { reason: DeadlineExceeded, source:
+        All }`).
+        If both `filtered_*` legs would fail simultaneously, the
+        keyword leg's failure preempts the semantic-skip — the
+        request still errors, no half-fused result is returned.
+
+        Test §10.5's deadline-circuit gate verifies (a) the request
+        returns within deadline + 10ms, (b) the worker pool can
+        accept a new request immediately after the deadline fires,
+        (c) a sibling leg on a different connection completes
+        normally when one leg is interrupted (proves per-leg
+        isolation), AND (d) each leg's specific timeout-recovery
+        path is tested against the table above.
+        Test §10.5's deadline-circuit gate verifies (a) the request
+        returns within deadline + 10ms, (b) the worker pool can
+        accept a new request immediately after the deadline fires,
+        AND (c) a sibling leg on a different connection completes
+        normally when one leg is interrupted (proves per-leg
+        isolation).
+      - **Adaptive overfetch reduction.** A rolling p99 latency
+        estimate per leg (EWMA over the last 1000 requests) feeds
+        back into `effective_overfetch`: if observed p99 exceeds 80%
+        of the gate, the runtime halves the overfetch limit for new
+        requests until p99 recovers. Bounded between
+        `[HYBRID_LEG_LIMIT, graph_seed_overfetch]`. Logged at
+        `info!` whenever the runtime adjusts so operators see the
+        adaptation in metrics.
+      Both layers are tested under load in §10.5: a synthetic vault
+      that pushes the auth-only ANN past the deadline must produce a
+      `degraded_legs: [Graph { reason: DeadlineExceeded, source: ... }]` result
+      rather than a slow request that breaches the gate.
+  4. Graph leg inputs (built once the four parallel retrievals
+     complete): `seed_record_ids = unique(auth_keyword_ids ∪
+     auth_semantic_ids)` (≤ 400, auth-only no filter),
+     `ranked_record_ids = unique(filtered_keyword_top50 ∪
+     filtered_semantic_top50)` (≤ 100, filter applied). The graph leg
+     itself is fast (id joins, no FTS or vector math).
+  5. The bench in §10.5 includes a "broad query" case (>200 keyword
+     hits, mixed-confidence neighbors) to validate the 200-default
+     against the latency gate.
+- Graph leg failures degrade to an empty list (FTS5 zero-match seeds → empty
+  is the normal case), **but never silently**:
+  1. The failure is logged at `warn!` with the underlying `StoreError` and a
+     `verb=search_hybrid leg=graph` tag.
+  2. A counter `cairn_search_graph_leg_failures_total{reason=...}` is
+     incremented for **every** branch where the graph leg does not run
+     to completion — runtime SQL error (`reason="sql_error"`), worker
+     panic (`reason="worker_panic"`), AND capability-based disablement
+     (`reason="capability_unavailable"`). The capability-unavailable
+     branch is the dominant rollout-failure case (schema skew →
+     `graph_search=false` at startup → silent 2-leg search), so it MUST
+     be counted alongside runtime failures. Zero-match-seeds is *not* a
+     failure and does not increment. Operators alert on rate of
+     `reason!=zero_seeds` to catch both runtime and rollout regressions.
+     A startup-time gauge `cairn_search_graph_leg_available` (0/1 per
+     instance) lets dashboards distinguish "always disabled on this
+     node" from "intermittent runtime failure".
+  3. The `HybridSearchPage` carries a new `degraded_legs:
+     Vec<DegradedLeg>` field that callers (CLI `--json`, MCP, SDK)
+     surface to the user. The wire shape is the typed enum defined in
+     §5.3 (`DegradationReason` + `GraphSource`). An empty vec means
+     full-fidelity hybrid. This is the canonical shape across
+     `HybridSearchPage`, `SearchOutcome`, IDL, CLI JSON, and SDK
+     transport — there is no string-keyed alternative.
+  4. The CLI prints a `warning:` line on stderr when `degraded_legs` is
+     non-empty so an interactive user notices a partial result; `--json`
+     emits the field unconditionally.
+- Capability: if `caps.graph_search` is false the leg is skipped and recorded
+  as `DegradedLeg::Graph { reason: CapabilityUnavailable, source: All }`. Same model
+  as today's semantic leg, but now visible to the caller.
+
+Rollback signal: clients can assert `degraded_legs.is_empty()` in
+post-deploy smoke tests. Operators can alert on the counter to catch
+schema-skew regressions that the legacy 2-leg path would have hidden.
+
+## 6. Pure orchestrator
+
+`cairn-core::search::orchestrator::hybrid_search` is extended:
+
+```rust
+let bm25_list = inputs.keyword.clone();   // rank inferred from list position (today)
+let sem_list  = inputs.semantic.clone();  // rank inferred from list position (today)
+
+// Graph leg: rank carried explicitly on each candidate.
+// `RankedCandidate` is the shape `rrf_fusion_weighted` consumes for legs
+// where rank is stored, not inferred.
+let graph_list: Vec<RankedCandidate> = inputs.graph
+    .iter()
+    .map(|g| RankedCandidate {
+        record_id: g.record_id.clone(),
+        rank: g.graph_rank,
+        weight: g.edge_confidence_score,    // for the confidence penalty
+    })
+    .collect();
+
+let fused = rrf_fusion_weighted(
+    &[
+        Leg::ListPosition(bm25_list),                              // rank from index
+        Leg::ListPosition(sem_list),                               // rank from index
+        Leg::Explicit(graph_list, params.confidence_floor),        // rank from field
+    ],
+    params.rrf_k,
+);
+```
+
+`rrf_fusion_weighted` is a new pure helper accepting two leg shapes:
+`Leg::ListPosition(Vec<ScoredCandidate>)` reads rank from the slice
+index (today's behavior); `Leg::Explicit(Vec<RankedCandidate>, floor)`
+reads rank from the per-candidate field and applies the confidence
+penalty `effective_rank = rank / max(weight, floor)`. The existing
+`rrf_fusion` keeps its signature and gains a 1-line shim:
+`rrf_fusion(lists, k) = rrf_fusion_weighted(list_position_legs, k)`.
+
+### 6.1 Cosine rerank — graph-only exemption
+
+A graph-only candidate (a record that the keyword and semantic legs both
+missed) by construction has weak query-vs-doc cosine similarity — that is
+exactly the discovery case the leg exists to surface. The unmodified
+cosine pass would push such candidates back out of the final page,
+defeating the leg's purpose.
+
+`cosine_rerank` is updated to operate on a tagged input list:
+
+```rust
+pub enum CandidateOrigin { Lexical, GraphOnly }   // graph-only ⇔ in graph leg AND in NEITHER bm25 nor semantic
+pub struct OriginTaggedCandidate { pub inner: RrfCandidate, pub origin: CandidateOrigin }
+```
+
+Behavior — graph-only candidates skip the cosine term entirely; the
+blend is renormalized so they compete on RRF alone with no synthetic
+similarity bonus:
+
+Both classes use the same `blend * rrf_norm` factor; only the cosine
+addend differs:
+
+- `Lexical` candidates: `final = blend * rrf_norm + (1-blend) *
+  cosine_norm` where `cosine_norm = (cosine_raw + 1) / 2 ∈ [0, 1]`
+  (normalize to non-negative; otherwise negative raw cosine would let
+  graph-only beat by asymmetry alone).
+- `GraphOnly` candidates: `final = blend * rrf_norm` — same RRF weight
+  as lexical, NO cosine addend. The cosine term is omitted, not
+  substituted with a neutral value, but the `blend` factor still
+  applies to RRF so graph-only and lexical share the same RRF scale.
+
+Why this formulation is symmetric:
+
+- Equal RRF, lexical `cosine_norm = 0` (worst): lexical gets `blend *
+  rrf + 0 = blend * rrf`, graph-only gets `blend * rrf`. **Tie**.
+- Equal RRF, lexical `cosine_norm = 0.5` (neutral): lexical gets
+  `blend * rrf + (1-blend) * 0.5`, graph-only gets `blend * rrf`.
+  Lexical wins by `0.15` (default blend).
+- Equal RRF, lexical `cosine_norm = 1` (perfect): lexical gets
+  `blend * rrf + (1-blend) * 1`, graph-only gets `blend * rrf`.
+  Lexical wins by `0.30` (default blend).
+- Strictly stronger RRF on graph-only side: graph-only beats lexical
+  only when its RRF strength × `blend` exceeds lexical's full term —
+  earned, not bias.
+
+A graph-only candidate cannot beat a lexical candidate at equal RRF
+unless the lexical cosine term is exactly zero (worst case). It
+cannot promote past a lexical candidate with any positive cosine.
+
+Side effect on score scale: `final` for graph-only is in `[0, blend]`
+(at most `blend * 1 = blend`); for lexical it's `[0, 1]`. Lexical can
+exceed graph-only's max only via the cosine addend — exactly the
+intended semantic.
+
+End-to-end tests in §10.3 assert: (a) neighbor-only record survives
+the rerank pass on RRF strength; (b) at equal RRF with `cosine_norm =
+0`, lexical and graph-only tie (no asymmetric bias); (c) at equal RRF
+with `cosine_norm > 0`, lexical strictly outranks graph-only.
+
+### 5.4 Verb-envelope propagation
+
+`degraded_legs` is meaningless if the verb dispatcher discards it on the
+way to CLI/MCP/SDK. The verb-level outcome type
+(`cairn_core::verbs::search::SearchOutcome`) is extended with a new
+field:
+
+```rust
+#[non_exhaustive]
+pub struct SearchOutcome {
+    pub candidates: Vec<SearchCandidate>,
+    pub explain: Option<Vec<ScoreExplain>>,
+    pub degraded_legs: Vec<DegradedLeg>,    // NEW — empty for non-hybrid modes
+}
+```
+
+- The dispatcher copies `degraded_legs` from `HybridSearchPage` into
+  `SearchOutcome` unmodified. Keyword and semantic-only modes return
+  an empty vec.
+- `cairn-cli`'s `--json` emits `degraded_legs` as a top-level array.
+  When the field is non-empty AND output is to a TTY, the CLI prints
+  a one-line `warning: graph leg degraded (reason: ...)` to stderr —
+  same UX a user would expect from any other partial-result signal.
+- MCP wrapper exposes `degraded_legs` in the `search` response payload
+  via the IDL update (§12.1). Schemars derive picks it up
+  automatically from the typed struct.
+- **`cairn-sdk` transport** — the SDK currently maps `SearchOutcome`
+  → generated `SearchData` by hand in `crates/cairn-sdk/src/transport.rs`.
+  This issue extends the generated `SearchData` IDL with
+  `degraded_legs: Vec<DegradedLeg>` (`#[serde(default)]` so legacy
+  payloads keep decoding) and updates the transport mapper to copy the
+  field through. Without this update, SDK callers silently lose the
+  signal — the spec's "never silent" claim becomes false on one of
+  the three supported surfaces. Codegen run in the same PR; the
+  generated diff is committed.
+- **Tests** in §10.3:
+  - Dispatcher: trigger graph-leg `CapabilityUnavailable` at the
+    store, run the `search` verb end-to-end, assert
+    `outcome.degraded_legs` contains one entry AND the `--json`
+    output contains the field.
+  - SDK round-trip: same trigger, but invoke through the SDK
+    transport. Assert the deserialized `SearchData.degraded_legs`
+    survives end-to-end. A regression here means the propagation
+    can break silently in a future refactor.
+
+## 7. Verb + CLI
+
+- `cairn-core::verbs::search` — read `confidence_min` from `SearchConfig`,
+  thread into `HybridSearchArgs`. CLI flag overrides config.
+- `cairn-cli::verbs::search` — adds `--confidence-min <f32>` clap arg
+  (`ValueHint::Other`, validated to `[0.0, 1.0]`). Exposed only when mode is
+  `hybrid`.
+- `SearchConfig.confidence_min: f32` defaults to `0.5`.
+- `cairn-idl` — extend the search-args IDL definition; rerun
+  `cairn-codegen`. (Generated diff committed in same PR.)
+
+## 8. Capability surface
+
+Graph-leg availability is a **runtime** capability (depends on schema
+state and the loaded `carray` extension at connection time), so it
+belongs on `MemoryStoreCapabilities`, not the config-derived
+`CapabilitySet`. The two surfaces serve different purposes:
+
+- `config::CapabilitySet` — capabilities derivable from static config
+  (e.g., embedder configured, vector enabled). Computed before the
+  store opens.
+- `contract::MemoryStoreCapabilities` — capabilities the store
+  advertises after opening, based on actual runtime state (schema
+  version, loaded extensions, migration set).
+
+This issue extends `MemoryStoreCapabilities` with
+`graph_search: bool` (NOT `CapabilitySet`). Probes run inside
+`MemoryStore::open` after migrations apply, populate the runtime
+capability struct, and the orchestrator reads that struct when deciding
+whether to dispatch the graph leg.
+
+- `MemoryStoreCapabilities::graph_search: bool` — true only when
+  **every** schema object that the graph SQL in §5.1 touches is present
+  at the expected migration level. The probe MUST mirror the runtime
+  query exactly — extra requirements cause false-negative capability
+  results, missing requirements cause silent runtime failures. Detection
+  probes (single transaction, executed once at `MemoryStore::open`):
+
+  1. Migration version meets the floor pinned for this feature
+     (`MIGRATION_FLOOR_GRAPH_SEARCH = 0044` — the entity_episodes migration,
+     the latest object referenced by §5.1).
+  2. `entity_episodes` exists with columns `episode_id` (FK →
+     `records.record_id`) and `entity_node_id`. Note: the column is
+     `episode_id`, **not** `record_id` — see migration 0044.
+  3. `entity_edges` exists with columns `source_id`, `target_id`,
+     `source_record_id`, `confidence_score`, `invalid_at`,
+     `expired_at`, **`valid_at`, and `created_at`** (the graph SQL
+     filters on both bitemporal start-bounds AND end-bounds — omitting
+     any of the four lets schema skew slip past startup and surface
+     as a runtime error). Every column the §5.1 SQL references on
+     `entity_edges` MUST appear in this list.
+  4. `records` exists with columns `record_id` (PK), `tombstoned`
+     (INTEGER 0/1), `active` (INTEGER 0/1), `updated_at`, `created_at`,
+     plus whatever columns the shared visibility/filter helper requires
+     (today: `target_id`, `scope`, `kind`, `class`, `visibility`, `body`).
+  5. `carray` extension is loadable: `SELECT 1 FROM carray(?)` succeeds
+     with a bound array. Required for the seed-list, ranked-list, and
+     hydration queries — see §5.1 implementation note.
+
+  Note: `entity_nodes_fts` is **not** required. The graph SQL reaches
+  entity nodes by id-join through `entity_episodes` only and never
+  queries the entity FTS index — requiring it would disable the feature
+  in valid schemas.
+
+  Failing **any** probe yields `graph_search = false`. The probe results
+  are logged once at `info!` with structured fields so a partial schema is
+  surfaced rather than silently disabling the leg.
+
+- `cairn.mcp.v1.search.hybrid` capability identifier unchanged. When the
+  graph leg is unavailable, the `HybridSearchPage::degraded_legs` field
+  (§5.3) advertises the degradation explicitly — clients are not left to
+  infer it from result quality.
+
+## 9. Errors
+
+- `StoreError::CapabilityUnavailable { what: "graph_search" }` for explicit
+  graph-only callers (`search_graph_neighbors` direct).
+- Hybrid path never raises `CapabilityUnavailable` for the graph leg —
+  degrades to empty list (parity with semantic leg behavior today).
+
+## 10. Tests
+
+### 10.1 `cairn-core` unit
+
+- `rrf_fusion_weighted` — known rank lists w/ confidence weights → expected
+  merged order.
+- `hybrid_search` — `INFERRED` (conf=0.6) edge-only neighbor ranks below
+  `EXTRACTED` (conf=1.0) edge-only neighbor at same input-list rank.
+- `confidence_floor` floor prevents division-by-zero w/ malformed conf=0.
+
+### 10.2 `cairn-store-sqlite` integration (real SQLite)
+
+- Seeded vault: 3 records, 2 entity nodes, 3 edges of mixed confidence.
+- Query that hits FTS5 seeds → returns expected graph candidates.
+- Edges with `confidence_score < confidence_min` excluded.
+- N+1 verifier: prepared-statement count ≤ 3 (seeds, edges, records — all in
+  one prepared CTE).
+- Empty seeds → empty list, no error.
+- **Authorization-boundary tests** (covers finding §5.1):
+  - Hidden-only alias: entity node X has surface form "ACME" indexed only
+    from a hidden record. The query "ACME" matches no visible record →
+    keyword leg empty → graph leg empty → no leak.
+  - Hidden record references neighbor entity Y. A visible record also
+    references Y (and matches the query). The hidden→Y edge must not
+    contribute confidence to the visible neighbor: tested by asserting the
+    `MAX(confidence_score)` aggregate equals the **visible** edge's
+    confidence, not the hidden edge's.
+  - Expired-edge regression: edge from seed→Y has `expired_at` set
+    (ingestion-time tombstone). Y must NOT appear in `neighbors`. Same
+    test pattern for `invalid_at` set.
+  - Future-dated edge: edge with `valid_at > now_event`. Y must NOT
+    appear in `neighbors` — the start bound is enforced. Same pattern
+    for `created_at > now_ingest`. Without §5.1's start-bound
+    predicates, future facts would leak into search.
+- **Discovery-property test** (covers finding on missing 1-hop):
+  - Vault: record A mentions entity X (matches query); edge X→Y; record B
+    mentions Y but does NOT contain the query terms. Hybrid search must
+    return B in `graph_hits`. Assert B is absent from `keyword_hits` and
+    present in `graph_hits` — proves the leg surfaces neighbor-only records.
+- **Capability-skew tests** (covers finding §8):
+  - Drop one column from `entity_episodes` → `graph_search` reports false,
+    hybrid path emits `DegradedLeg::Graph { reason: CapabilityUnavailable, source: All }`.
+  - Drop `entity_edges.expired_at` only → `graph_search` reports false at
+    startup (regression test for the missing-bitemporal-bound bug — without
+    this column the runtime SQL would fail).
+  - Vault has graph tables but no `entity_nodes_fts` → `graph_search`
+    reports true (probe must not require the FTS index, since the SQL
+    never queries it).
+  - Inject a SQL error into the graph leg at runtime → counter increments,
+    `degraded_legs` populated, hybrid still returns keyword + semantic.
+- **SQL-correctness regression test** (covers self-exclusion finding):
+  - Two seed sets — one containing the rowid-1 entity, one not. In both,
+    a seed-to-seed edge must NOT cause a seed to appear as its own
+    "neighbor" hit. Asserts the explicit `neighbor_id NOT IN seeds` clause
+    rather than relying on `HAVING` ordinal references.
+- **Hydration auth re-check** (covers hydration finding):
+  - Inject a graph-leg result containing a record id outside the
+    caller's `auth_scope` (simulates a buggy upstream / cache replay).
+    Hydration MUST drop that id — assert it does not appear in the
+    final `SearchCandidate` list. Documents the defense-in-depth
+    contract.
+- **carray-required capability test**:
+  - Build a store with `carray` disabled at the `rusqlite` feature
+    level. `MemoryStore::open` must report `caps.graph_search = false`
+    via the §8 probe. Hybrid search emits `DegradedLeg::Graph { reason:
+    "capability_unavailable" }`; keyword + semantic still return.
+- **Stale-seed exclusion** (covers supersession finding):
+  - Vault: record A v1 mentions entity X; A v2 supersedes v1 and
+    does not mention X. Edge X → Y exists. Query matches X only via
+    A v1 (which is now superseded). The auth-only seed retrieval must
+    NOT include A v1 — supersession predicate matches keyword leg.
+    Y must NOT appear in `graph_hits`. Without this guard, retired
+    records would silently drive graph expansion.
+- **Stale-neighbor exclusion** (covers graph step-4 supersession):
+  - Vault: record N v1 mentions neighbor entity Y; N v2 supersedes
+    v1, also mentions Y. Edge X → Y exists; query seeds X normally.
+    The graph leg must surface ONLY N v2, not N v1. Without
+    supersession on step 4 / hydration, the retired N v1 could
+    re-enter via graph alone.
+- **Orphan-edge exclusion** (covers null-provenance finding):
+  - Vault: edge X → Y with `source_record_id` set, then provenance
+    record deleted (so `source_record_id` becomes NULL via
+    `ON DELETE SET NULL`). The graph leg MUST NOT surface Y at any
+    confidence tier — without visible provenance, `auth_scope` and
+    visibility cannot be evaluated, so the edge is ineligible.
+    Provenance deletion is a recall trade-off the auth model requires.
+- **Rank-rescue via graph** (covers seed-vs-dedup-pool finding):
+  - Broad query: keyword leg returns 200 over-fetched ids; only top 50
+    enter RRF fusion. Pick a record D ranked at position 75 in keyword
+    (over-fetched, not RRF-fused). Add an edge from a top-10 entity to
+    D's entity. The graph leg MUST return D — D is in the seed pool
+    but NOT in `ranked_query_records`, so the dedup at step 4 lets D
+    re-enter via graph evidence. Final page must include D.
+
+### 10.3 Verb-level snapshot + end-to-end (`insta`)
+
+- `--json` output of hybrid search w/ a graph hit — stable shape (adds
+  `graph_rank` and `edge_confidence_score` to `ScoreExplain`, with
+  `bm25=null` for graph-only hits).
+- **Graph-only hydration**: end-to-end test — record reachable only via
+  graph leg returns a fully populated `SearchCandidate` (snippet may be
+  empty; record_json, scope, visibility, kind, class must be set). Without
+  the §5.2.1 hydration step this test fails.
+- **Graph-only survives rerank**: end-to-end test using a real embedder —
+  vault contains record A (matches query lexically), edge A's-entity →
+  B's-entity, record B (no query terms, low cosine to query). With
+  `blend=0.7` (default), record B must appear in the final page. Without
+  the exemption from §6.1 this test fails.
+- **User-filter scoping** (covers §4.3 split): vault has visible record P
+  (provenance, `tag=internal`) and visible record N (neighbor,
+  `tag=public`) joined by an edge. Both records are inside the caller's
+  `auth_scope`. Hybrid search with `filter: tag=public` MUST return N
+  via the graph leg — the user-narrowing filter applies only to the
+  neighbor, not to provenance. Asserts the auth/filter split contract.
+- **Cross-scope provenance rejection**: vault has provenance record P
+  outside the caller's `auth_scope`, neighbor N inside. Even with no
+  user filter, N must NOT be returned via the graph leg — `auth_scope`
+  is enforced on provenance and the edge is dropped.
+- **Semantic-only seed**: a paraphrased query that only the semantic leg
+  matches, with a graph edge to a neighbor record. Graph leg must seed
+  from the semantic hit and return the neighbor (proves §3 step 1's
+  union-of-legs design).
+
+### 10.4 Property tests
+
+- `rrf_fusion_weighted` monotonicity: lower-confidence weight ⇒ smaller score
+  contribution at identical rank.
+
+### 10.5 Bench (#99) and load gates
+
+- **Baseline gate:** p99 < 100ms on 10k-record vault; assert in
+  `cairn-bench` with Criterion.
+- **Broad-query gate:** synthesized query producing >200 keyword hits
+  on a 50k-record vault; p99 < 100ms with both auth-only and filtered
+  retrievals running.
+- **Saturation gate:** synthesized concurrency (32 parallel requests)
+  on a 50k-record vault; p99 < 150ms (slightly relaxed for tail
+  latency under contention) AND adaptive overfetch reduction observed
+  to engage at least once during the run.
+- **Deadline-circuit gate:** synthetic delay injected into the
+  auth-only semantic ANN traversal exceeding `graph_leg_deadline_ms`;
+  result must report `degraded_legs: [Graph { reason: DeadlineExceeded,
+  source: AuthSemanticSeed }]` AND total request latency must remain ≤
+  deadline + 10ms overhead. Without this gate the safety-valve design
+  is unverified.
+- **Tier A acquire-timeout gate:** saturate Tier A by holding all
+  `filtered_pool_size` connections; submit a new hybrid request and
+  verify it fails with `StoreError::Timeout` and reason
+  `tier_a_acquire_timeout` after `filtered_acquire_timeout_ms`,
+  not by blocking indefinitely. Proves the bounded-acquisition
+  guarantee.
+
+## 11. Acceptance criteria mapping
+
+| AC | Mapped section |
+|---|---|
+| `HybridSearchOrchestrator` pure function | §6 |
+| RRF formula unit-tested | §10.1 |
+| 1-hop expansion as single SQL query (no N+1) | §5.1, §10.2 |
+| Semantic leg skipped cleanly | §4.3 (existing behavior preserved) |
+| `SearchArgs --confidence-min <float>` | §7 |
+| p99 < 100ms / 10k-record vault | §10.5 |
+| `--json` snapshot stable | §10.3 |
+
+## 12.1 Contract versioning
+
+The current public structs (`KeywordSearchArgs`, `SemanticSearchArgs`,
+`HybridSearchArgs`, `HybridSearchInputs`, `HybridSearchParams`,
+`HybridSearchPage`, `ScoreExplain`, `MemoryStoreCapabilities`) are NOT
+`#[non_exhaustive]` and are constructed via struct literals across the
+in-tree workspace. Adding required fields to any of them breaks
+struct-construction at compile time. There is no honest way to ship the
+auth-uniformity guarantees of §4.3 (one `auth_scope` on every search
+leg) as a non-breaking change — pretending otherwise would either
+recreate the policy-drift problem or sneak source-breaking changes past
+adapters under a compatibility claim.
+
+So this is a **MAJOR** contract version event (`0.4.0` → `0.5.0`).
+The bump is the explicit incompatibility signal; out-of-tree adapters
+must recompile.
+
+Changes by struct:
+
+| Struct | Change | Field defaults |
+|---|---|---|
+| `KeywordSearchArgs`  | + `auth_scope: ScopeTuple` (required) | none — caller must supply |
+| `SemanticSearchArgs` | + `auth_scope: ScopeTuple` (required) | none — caller must supply |
+| `HybridSearchArgs`   | + `auth_scope: ScopeTuple`, + `confidence_min: f32` | none / 0.5 |
+| `GraphNeighborsArgs` | new struct (§4.3) | n/a |
+| `HybridSearchInputs` | + `graph: Vec<GraphCandidate>` | empty vec |
+| `HybridSearchParams` | + `confidence_floor: f32` | 1e-3 |
+| `HybridSearchPage`   | + `degraded_legs: Vec<DegradedLeg>` | empty vec |
+| `ScoreExplain`       | + `graph_rank: Option<usize>`, `edge_confidence_score: Option<f32>` | None |
+| `MemoryStoreCapabilities` | + `graph_search: bool` | false |
+| `MemoryStore` (trait)| + required method `search_graph_neighbors` (no default impl — adapters must implement) | n/a |
+
+All structs gain `#[non_exhaustive]` in this same PR so future MINOR
+additions don't recreate this break. Because `#[non_exhaustive]` makes
+struct literals illegal in external crates, every affected struct
+ALSO gains a public `bon`-derived builder in the same PR (per CLAUDE.md
+§6.10: "Builders via `bon` for anything with >3 optional fields").
+Specifically:
+
+- `KeywordSearchArgsBuilder`, `SemanticSearchArgsBuilder`,
+  `HybridSearchArgsBuilder`, `GraphNeighborsArgsBuilder` —
+  request-side builders with `auth_scope` and any other required
+  fields enforced at compile time on the builder (the `bon` macro's
+  required-field guarantee).
+- `HybridSearchInputs::new(...)`, `HybridSearchParams::default()`
+  (already exists), `HybridSearchPage::new(...)`, `ScoreExplain::new(...)`,
+  `MemoryStoreCapabilities::new(...)` — module-internal types use
+  plain `new` constructors (no need for builder ergonomics).
+- `DegradedLeg`, `GraphCandidate` — narrow types use plain struct
+  literals internally; external crates that need to construct them
+  use `DegradedLeg::graph_unavailable(reason)` etc. (small set of
+  named constructors).
+
+Out-of-tree adapter migration path: replace struct-literal
+construction with the new builder. The major-version bump documents
+the call-site change. A migration note in the changelog walks one
+example end-to-end.
+
+Plan:
+
+- `cairn-core::contract::memory_store::CONTRACT_VERSION` → `0.4.0` →
+  `0.5.0`.
+- `cairn-store-sqlite::ACCEPTED_RANGE` → `[0.5.0, 0.6.0)`. **Lockstep
+  upgrade — no rolling-upgrade compatibility window.** The contract
+  changes are real: a new required trait method, required new fields
+  on existing public structs, mandatory `auth_scope` for graph
+  authorization. There is no honest way to make an unrebuilt `0.4.x`
+  adapter binary advertise the new method or fields, so the
+  previously-considered compatibility shim is dropped. Operators
+  upgrade in lockstep: store, MCP wrapper, SDK, and any in-tree
+  CLI/skill bundles all move from `0.4.x` to `0.5.0` together.
+- `cairn-mcp` and `cairn-sdk` accepted ranges → `[0.5.0, 0.6.0)`.
+- **Wire shape for `auth_scope`:** the IDL field is
+  `auth_scope: ScopeTuple` — required, no `#[serde(default)]`. A
+  payload missing the field is rejected at deserialization with a
+  typed error mapped to the verb-level error envelope as
+  `SearchError::MissingField { field: "auth_scope" }`. Old payloads
+  do not collapse silently into empty-scope behavior because the
+  ambiguity reviewer flagged in round 9 cannot be resolved on the
+  wire — preserving omission-vs-explicit would require a
+  contract-version-pinned `Option<ScopeTuple>` shape that the
+  spec is no longer pursuing.
+- The migration burden is acknowledged: out-of-tree adapter authors
+  must rebuild against `0.5.0`. The next-minor follow-up removes
+  nothing; this is the clean break.
+- Tests assert: a `0.4.x`-shaped request (no `auth_scope` field)
+  fails deserialization at the transport boundary with
+  `SearchError::MissingField`. Only `0.5.0`-aware callers (explicit
+  `auth_scope` populated) succeed. There is no degraded-graph
+  fallback path for `0.4.x` payloads.
+- All in-tree adapters and tests are updated to populate `auth_scope`
+  and the new capability field. The existing
+  `crates/cairn-store-sqlite/tests/capabilities_unchanged.rs` snapshot
+  is regenerated; the regenerated snapshot is committed in the same
+  PR.
+- The IDL (`cairn-idl`) entries for search-args / search-response /
+  score_explain / capability struct are updated and `cairn-codegen`
+  re-run. `auth_scope` is required at BOTH the Rust-API boundary
+(builders enforce it as a required field at compile time) and the
+wire/IDL boundary (no `#[serde(default)]`; missing field is a
+deserialization error mapped to `SearchError::MissingField`). Purely
+  observability fields (`degraded_legs`, `graph_rank`,
+  `edge_confidence_score`) carry `#[serde(default)]` so future minor
+  additions stay forward-compat.
+- Tests in `cairn-store-sqlite/tests/contract_version.rs` assert:
+  - `ACCEPTED_RANGE.accepts(CONTRACT_VERSION)`,
+  - `ACCEPTED_RANGE` lower bound equals `0.5.0` (lockstep, locked in
+    CI),
+  - A request without `auth_scope` is rejected at deserialization
+    with `SearchError::MissingField { field: "auth_scope" }`,
+  - A request with explicit `auth_scope` runs the full 3-leg path,
+  - Handshake with a `0.4.x` adapter is rejected outright at
+    `MemoryStore::open` (the version-range check fails before any
+    request is served).
+
+This is the only contract-version event in #191. All subsequent
+follow-ups (depth>1, etc.) are designed to be additive within `0.5.x`,
+which the new `#[non_exhaustive]` markers make safe.
+
+## 12. Out of scope (filed as follow-ups)
+
+- Depth > 1 traversal — needs separate ranking model.
+- Cross-target graph queries — current scope rules apply unchanged.
+- Embedding-driven seed expansion (semantic node match) — keyword FTS only
+  for P0 graph leg.


### PR DESCRIPTION
## Summary

Closes #191. Single PR consolidating phases 1, 2, and 4+5 (originally split across #296, #298, and this one). Lands RRF hybrid search with optional 1-hop entity-graph expansion, end-to-end through the SQLite store.

### Phase 1 — pure types & rerank (`cairn-core::search`)
- `GraphCandidate { record_id, edge_confidence_score, graph_rank }` — graph-leg result with explicit per-candidate rank
- `DegradedLeg::{ Semantic, Graph }` + `DegradationReason` + `GraphSource` — typed partial-result signal (`#[non_exhaustive]`)
- `RankedCandidate` + `Leg` + `rrf_fusion_weighted` — confidence-weighted RRF with `effective_rank = rank / max(weight, floor)`. Legacy parity proven.
- `CandidateOrigin` + `OriginTaggedCandidate` + `cosine_rerank_tagged` — origin-aware rerank that drops cosine for graph-only candidates (rather than substituting a neutral 0.5 that biases them upward); lexical uses `cos_norm = (cos_raw + 1) / 2` to keep both terms in `[0, 1]`.
- `hybrid_search` extended with optional graph leg: empty-graph fast path uses legacy `rrf_fusion` + `cosine_rerank` for byte-identical scoring.

### Phase 2 — contract 0.5.0
- Promotes `auth_scope: ScopeTuple` out of the user filter into a required field on `KeywordSearchArgs`, `SemanticSearchArgs`, `HybridSearchArgs`, and the new `GraphNeighborsArgs`. Authorization predicates apply identically across lexical legs, graph traversal, and graph hydration; user filter is recall-narrowing only.
- Adds `MemoryStoreCapabilities::graph_search: bool`.
- Adds `MemoryStore::search_graph_neighbors(args: &GraphNeighborsArgs<'_>)` with a default `CapabilityUnavailable` impl.
- `HybridSearchArgs` gains `confidence_floor: f32` (graph-leg RRF weight floor) and `graph_confidence_min: f32` (graph-edge confidence threshold, default `0.3` from `SearchConfig`).
- `cairn-store-sqlite::ACCEPTED_RANGE` raised to `[0.5.0, 0.6.0)`.

### Phases 4+5 — SQLite graph SQL + orchestrator wiring
- `do_search_graph_neighbors`: v1 1-hop CTE traversal (`seeds` → `neighbors` → join `entity_episodes` + `records`), bitemporal as-of predicates (`valid_at <= now AND (invalid_at IS NULL OR invalid_at > now) AND created_at <= now AND (expired_at IS NULL OR expired_at > now)`), edge confidence floor, tombstone/active gate, ranked-list dedup, visibility allowlist, provenance-side auth (INNER JOIN `records pr` on `source_record_id` with the same auth/visibility/active/supersession gate).
- Bind-list expansion via inline `?, ?, ?` placeholders, capped at 480 (under SQLite's default `MAX_VARIABLE_NUMBER = 999`).
- `do_search_hybrid` runs keyword + semantic legs concurrently (`tokio::join!` — per-leg fault tolerance), unions record-ids into a graph seed list, calls the graph leg, and threads `Vec<GraphCandidate>` + `args.confidence_floor` into the pure `hybrid_search` orchestrator.
- `HybridSearchPage.degraded_legs` populated when a leg fails (semantic SQL error → `DegradedLeg::Semantic`, graph capability unavailable / SQL error → `DegradedLeg::Graph`). Surfaced through `SearchOutcome` → CLI/SDK/MCP envelopes.
- `graph_search` capability advertised from every open path (migrations 0042–0045 land `entity_nodes`, `entity_episodes`, `entity_edges`).

## Spec

`docs/superpowers/specs/2026-05-05-issue-191-rrf-hybrid-graph-design.md` §4.3, §5.1, §6, §6.1, §12.1.

## Test plan

- [x] `cargo nextest run --workspace --locked --no-fail-fast`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test --doc --workspace --locked`
- [x] `./scripts/check-core-boundary.sh`
- [x] `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
- [x] Phase 1 unit tests (rerank/RRF parity, graph-only origin tag, confidence floor)
- [x] Phase 4 store tests: hybrid_search, hybrid_partial_degradation (semantic-leg drop mid-flight), auth_scope_search (cross-tenant graph traversal, provenance auth corner cases)
- [x] Capability probe tests in `cairn-store-sqlite::open` (head-of-migrations, missing table, missing column)
- [x] Envelope tests: `degraded_legs` field omission when empty, full `{leg, reason, source}` shape when populated
- [x] Default config snapshot regenerated for `graph_confidence_min`

## Supersedes

- Closes #296 (phase 1 — folded in)
- Closes #298 (phase 2 — folded in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
