### PR TITLE
feat(profile): AutoUserProfile synthesizer + typed DataProfile (issue #81)

### DIFF
--- a/crates/cairn-core/src/generated/schemas/verbs/retrieve.json
+++ b/crates/cairn-core/src/generated/schemas/verbs/retrieve.json
@@ -366,10 +366,13 @@
     },
     "DataProfile": {
       "additionalProperties": false,
+      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static`, `is_static = 1`) and current state (`dynamic`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1. Wire field names match the brief's `{static, dynamic, updated_at}` notation; the Rust binding emits them via the `r#static` raw identifier.",
       "properties": {
-        "profile": {
-          "description": "Free-form profile payload — typed in a later increment once the profile taxonomy lands.",
-          "type": "object"
+        "dynamic": {
+          "$ref": "#/$defs/ProfileHalf"
+        },
+        "static": {
+          "$ref": "#/$defs/ProfileHalf"
         },
         "subject": {
           "additionalProperties": false,
@@ -396,11 +399,20 @@
             }
           },
           "type": "object"
+        },
+        "updated_at": {
+          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty. Validator accept set matches `cairn_core::domain::Rfc3339Timestamp::parse` (excluding leap-seconds), so any wire-accepted value also parses domain-side without a second gauntlet.",
+          "format": "date-time",
+          "maxLength": 64,
+          "minLength": 20,
+          "type": "string"
         }
       },
       "required": [
         "subject",
-        "profile"
+        "static",
+        "dynamic",
+        "updated_at"
       ],
       "type": "object"
     },
@@ -495,6 +507,117 @@
         "session_id",
         "turn_id",
         "turn"
+      ],
+      "type": "object"
+    },
+    "KeyFacts": {
+      "additionalProperties": false,
+      "description": "Seven structured fact buckets (brief §7.1). Each bucket is an array of ProfileLine — empty arrays are valid and required so a consumer can rely on every key being present.",
+      "properties": {
+        "addressed_issues": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "current_issues": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "known_entities": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "preferences": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "recurring_issues": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "software": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "devices",
+        "software",
+        "preferences",
+        "current_issues",
+        "addressed_issues",
+        "recurring_issues",
+        "known_entities"
+      ],
+      "type": "object"
+    },
+    "ProfileHalf": {
+      "additionalProperties": false,
+      "description": "One half of an AutoUserProfile (brief §7.1). `summary` and `historical_summary` are the rolling DreamWorkflow narratives — they remain empty strings at P0 and are populated by the P1 ConsolidationWorkflow. `key_facts` is the P0 deliverable: structured per-facet ProfileLine arrays.",
+      "properties": {
+        "historical_summary": {
+          "type": "string"
+        },
+        "key_facts": {
+          "$ref": "#/$defs/KeyFacts"
+        },
+        "summary": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "historical_summary",
+        "key_facts"
+      ],
+      "type": "object"
+    },
+    "ProfileLine": {
+      "additionalProperties": false,
+      "description": "One profile fact with its evidence trail. `evidence` is the list of source records that contributed; record-level forget removes them from the input set, so re-synthesizing the profile drops the line.",
+      "properties": {
+        "confidence": {
+          "description": "Confidence in [0, 1]. Records with confidence < 0.3 (ConfidenceBand::Uncertain) are excluded from the profile.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "evidence": {
+          "description": "Source-record ULIDs whose bodies contributed to this line. Always non-empty.",
+          "items": {
+            "$ref": "../common/primitives.json#/$defs/Ulid"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "value": {
+          "description": "Canonical short statement of the fact (e.g., 'prefers terse explanations', 'M2 MacBook Pro').",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "confidence",
+        "evidence"
       ],
       "type": "object"
     },

--- a/crates/cairn-core/src/generated/verbs/retrieve.rs
+++ b/crates/cairn-core/src/generated/verbs/retrieve.rs
@@ -97,7 +97,7 @@ pub struct DataProfile {
     #[serde(rename = "static")]
     pub r#static: ProfileHalf,
     pub subject: DataProfileSubject,
-    /// RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty.
+    /// RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty. Validator accept set matches `cairn_core::domain::Rfc3339Timestamp::parse` (excluding leap-seconds), so any wire-accepted value also parses domain-side without a second gauntlet.
     pub updated_at: String,
 }
 
@@ -108,28 +108,57 @@ struct RawDataProfile {
     #[serde(rename = "static")]
     r#static: ProfileHalf,
     subject: DataProfileSubject,
-    /// RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty.
+    /// RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty. Validator accept set matches `cairn_core::domain::Rfc3339Timestamp::parse` (excluding leap-seconds), so any wire-accepted value also parses domain-side without a second gauntlet.
     updated_at: String,
 }
 
 impl ::core::convert::TryFrom<RawDataProfile> for DataProfile {
     type Error = &'static str;
     fn try_from(raw: RawDataProfile) -> Result<Self, Self::Error> {
-        if raw.updated_at.len() < 20 {
-            return Err("updated_at: must be RFC3339 date-time with at least 20 chars");
-        }
+        if !(20..=64).contains(&raw.updated_at.len()) { return Err("updated_at: RFC3339 date-time must be 20..=64 chars"); }
         if !raw.updated_at.is_ascii() {
             return Err("updated_at: RFC3339 date-time must be ASCII");
         }
         {
             let bytes = raw.updated_at.as_bytes();
-            if bytes[4] != b'-' || bytes[7] != b'-' || !matches!(bytes[10], b'T' | b't') || bytes[13] != b':' || bytes[16] != b':' {
-                return Err("updated_at: RFC3339 date-time anchors must be `-`/`T`/`:` at positions 4/7/10/13/16");
+            if !bytes[..4].iter().all(u8::is_ascii_digit) || bytes[4] != b'-' || !bytes[5..7].iter().all(u8::is_ascii_digit) || bytes[7] != b'-' || !bytes[8..10].iter().all(u8::is_ascii_digit) {
+                return Err("updated_at: date must be YYYY-MM-DD");
             }
-            let last = bytes[bytes.len() - 1];
-            if !matches!(last, b'Z' | b'z') && !matches!(bytes.get(bytes.len() - 6), Some(b'+' | b'-')) {
-                return Err("updated_at: RFC3339 date-time must end with `Z` or `+/-HH:MM` offset");
+            let mm = (bytes[5] - b'0') * 10 + (bytes[6] - b'0');
+            let dd = (bytes[8] - b'0') * 10 + (bytes[9] - b'0');
+            if !(1..=12).contains(&mm) { return Err("updated_at: month out of range"); }
+            if !(1..=31).contains(&dd) { return Err("updated_at: day out of range"); }
+            if !matches!(bytes[10], b'T' | b't') { return Err("updated_at: expected `T` between date and time"); }
+            if !bytes[11..13].iter().all(u8::is_ascii_digit) || bytes[13] != b':' || !bytes[14..16].iter().all(u8::is_ascii_digit) || bytes[16] != b':' || !bytes[17..19].iter().all(u8::is_ascii_digit) {
+                return Err("updated_at: time must be HH:MM:SS");
             }
+            let hh = (bytes[11] - b'0') * 10 + (bytes[12] - b'0');
+            let mi = (bytes[14] - b'0') * 10 + (bytes[15] - b'0');
+            let ss = (bytes[17] - b'0') * 10 + (bytes[18] - b'0');
+            if hh > 23 { return Err("updated_at: hour out of range"); }
+            if mi > 59 { return Err("updated_at: minute out of range"); }
+            if ss > 59 { return Err("updated_at: second out of range"); }
+            let mut idx = 19usize;
+            if idx < bytes.len() && bytes[idx] == b'.' {
+                idx += 1;
+                let frac_start = idx;
+                while idx < bytes.len() && bytes[idx].is_ascii_digit() { idx += 1; }
+                if idx == frac_start { return Err("updated_at: fractional must have >=1 digit after `.`"); }
+            }
+            if idx < bytes.len() && matches!(bytes[idx], b'Z' | b'z') { idx += 1; }
+            else if idx + 6 == bytes.len() && matches!(bytes[idx], b'+' | b'-') {
+                let off = &bytes[idx + 1..];
+                if !off[..2].iter().all(u8::is_ascii_digit) || off[2] != b':' || !off[3..5].iter().all(u8::is_ascii_digit) {
+                    return Err("updated_at: offset must be `+/-HH:MM` digits");
+                }
+                let oh = (off[0] - b'0') * 10 + (off[1] - b'0');
+                let om = (off[3] - b'0') * 10 + (off[4] - b'0');
+                if oh > 23 { return Err("updated_at: offset hour out of range"); }
+                if om > 59 { return Err("updated_at: offset minute out of range"); }
+                idx = bytes.len();
+            }
+            else { return Err("updated_at: must end with `Z` or `+/-HH:MM` offset"); }
+            if idx != bytes.len() { return Err("updated_at: trailing data after zone"); }
         }
         Ok(Self {
             dynamic: raw.dynamic,

--- a/crates/cairn-core/src/generated/verbs/retrieve.rs
+++ b/crates/cairn-core/src/generated/verbs/retrieve.rs
@@ -68,6 +68,12 @@ impl ::core::convert::TryFrom<RawDataProfileSubject> for DataProfileSubject {
     type Error = &'static str;
     fn try_from(raw: RawDataProfileSubject) -> Result<Self, Self::Error> {
         if !(raw.user.is_some() || raw.agent.is_some()) { return Err("at least one of [user, agent] is required"); }
+        if let Some(s) = &raw.user {
+            if s.is_empty() { return Err("user: must not be empty"); }
+        }
+        if let Some(s) = &raw.agent {
+            if s.is_empty() { return Err("agent: must not be empty"); }
+        }
         Ok(Self {
             agent: raw.agent,
             user: raw.user,
@@ -83,15 +89,63 @@ impl<'de> ::serde::Deserialize<'de> for DataProfileSubject {
     }
 }
 
-/// Typed AutoUserProfile (brief §7.1) split into permanent traits (`static_section`, `is_static = 1`) and current state (`dynamic_section`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Typed AutoUserProfile (brief §7.1) split into permanent traits (`static`, `is_static = 1`) and current state (`dynamic`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1. Wire field names match the brief's `{static, dynamic, updated_at}` notation; the Rust binding emits them via the `r#static` raw identifier.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataProfile {
-    pub dynamic_section: ProfileHalf,
-    pub static_section: ProfileHalf,
+    pub dynamic: ProfileHalf,
+    #[serde(rename = "static")]
+    pub r#static: ProfileHalf,
     pub subject: DataProfileSubject,
     /// RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty.
     pub updated_at: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawDataProfile {
+    dynamic: ProfileHalf,
+    #[serde(rename = "static")]
+    r#static: ProfileHalf,
+    subject: DataProfileSubject,
+    /// RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty.
+    updated_at: String,
+}
+
+impl ::core::convert::TryFrom<RawDataProfile> for DataProfile {
+    type Error = &'static str;
+    fn try_from(raw: RawDataProfile) -> Result<Self, Self::Error> {
+        if raw.updated_at.len() < 20 {
+            return Err("updated_at: must be RFC3339 date-time with at least 20 chars");
+        }
+        if !raw.updated_at.is_ascii() {
+            return Err("updated_at: RFC3339 date-time must be ASCII");
+        }
+        {
+            let bytes = raw.updated_at.as_bytes();
+            if bytes[4] != b'-' || bytes[7] != b'-' || !matches!(bytes[10], b'T' | b't') || bytes[13] != b':' || bytes[16] != b':' {
+                return Err("updated_at: RFC3339 date-time anchors must be `-`/`T`/`:` at positions 4/7/10/13/16");
+            }
+            let last = bytes[bytes.len() - 1];
+            if !matches!(last, b'Z' | b'z') && !matches!(bytes.get(bytes.len() - 6), Some(b'+' | b'-')) {
+                return Err("updated_at: RFC3339 date-time must end with `Z` or `+/-HH:MM` offset");
+            }
+        }
+        Ok(Self {
+            dynamic: raw.dynamic,
+            r#static: raw.r#static,
+            subject: raw.subject,
+            updated_at: raw.updated_at,
+        })
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for DataProfile {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: ::serde::Deserializer<'de> {
+        let raw = RawDataProfile::deserialize(deserializer)?;
+        Self::try_from(raw).map_err(::serde::de::Error::custom)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/crates/cairn-core/src/generated/verbs/retrieve.rs
+++ b/crates/cairn-core/src/generated/verbs/retrieve.rs
@@ -124,10 +124,19 @@ impl ::core::convert::TryFrom<RawDataProfile> for DataProfile {
             if !bytes[..4].iter().all(u8::is_ascii_digit) || bytes[4] != b'-' || !bytes[5..7].iter().all(u8::is_ascii_digit) || bytes[7] != b'-' || !bytes[8..10].iter().all(u8::is_ascii_digit) {
                 return Err("updated_at: date must be YYYY-MM-DD");
             }
+            let yyyy: u16 = (u16::from(bytes[0] - b'0')) * 1000 + (u16::from(bytes[1] - b'0')) * 100 + (u16::from(bytes[2] - b'0')) * 10 + u16::from(bytes[3] - b'0');
             let mm = (bytes[5] - b'0') * 10 + (bytes[6] - b'0');
             let dd = (bytes[8] - b'0') * 10 + (bytes[9] - b'0');
             if !(1..=12).contains(&mm) { return Err("updated_at: month out of range"); }
-            if !(1..=31).contains(&dd) { return Err("updated_at: day out of range"); }
+            let leap = yyyy.is_multiple_of(4) && (!yyyy.is_multiple_of(100) || yyyy.is_multiple_of(400));
+            let max_day: u8 = match mm {
+                1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+                4 | 6 | 9 | 11 => 30,
+                2 if leap => 29,
+                2 => 28,
+                _ => 0,
+            };
+            if dd < 1 || dd > max_day { return Err("updated_at: day out of range for month"); }
             if !matches!(bytes[10], b'T' | b't') { return Err("updated_at: expected `T` between date and time"); }
             if !bytes[11..13].iter().all(u8::is_ascii_digit) || bytes[13] != b':' || !bytes[14..16].iter().all(u8::is_ascii_digit) || bytes[16] != b':' || !bytes[17..19].iter().all(u8::is_ascii_digit) {
                 return Err("updated_at: time must be HH:MM:SS");
@@ -144,6 +153,7 @@ impl ::core::convert::TryFrom<RawDataProfile> for DataProfile {
                 let frac_start = idx;
                 while idx < bytes.len() && bytes[idx].is_ascii_digit() { idx += 1; }
                 if idx == frac_start { return Err("updated_at: fractional must have >=1 digit after `.`"); }
+                if idx - frac_start > 9 { return Err("updated_at: fractional must be <= 9 digits (ns precision)"); }
             }
             if idx < bytes.len() && matches!(bytes[idx], b'Z' | b'z') { idx += 1; }
             else if idx + 6 == bytes.len() && matches!(bytes[idx], b'+' | b'-') {

--- a/crates/cairn-core/src/generated/verbs/retrieve.rs
+++ b/crates/cairn-core/src/generated/verbs/retrieve.rs
@@ -83,12 +83,15 @@ impl<'de> ::serde::Deserialize<'de> for DataProfileSubject {
     }
 }
 
+/// Typed AutoUserProfile (brief §7.1) split into permanent traits (`static_section`, `is_static = 1`) and current state (`dynamic_section`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataProfile {
-    /// Free-form profile payload — typed in a later increment once the profile taxonomy lands.
-    pub profile: serde_json::Value,
+    pub dynamic_section: ProfileHalf,
+    pub static_section: ProfileHalf,
     pub subject: DataProfileSubject,
+    /// RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty.
+    pub updated_at: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -215,6 +218,81 @@ impl<'de> ::serde::Deserialize<'de> for DataTurn {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: ::serde::Deserializer<'de> {
         let raw = RawDataTurn::deserialize(deserializer)?;
+        Self::try_from(raw).map_err(::serde::de::Error::custom)
+    }
+}
+
+/// Seven structured fact buckets (brief §7.1). Each bucket is an array of ProfileLine — empty arrays are valid and required so a consumer can rely on every key being present.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KeyFacts {
+    pub addressed_issues: Vec<ProfileLine>,
+    pub current_issues: Vec<ProfileLine>,
+    pub devices: Vec<ProfileLine>,
+    pub known_entities: Vec<ProfileLine>,
+    pub preferences: Vec<ProfileLine>,
+    pub recurring_issues: Vec<ProfileLine>,
+    pub software: Vec<ProfileLine>,
+}
+
+/// One half of an AutoUserProfile (brief §7.1). `summary` and `historical_summary` are the rolling DreamWorkflow narratives — they remain empty strings at P0 and are populated by the P1 ConsolidationWorkflow. `key_facts` is the P0 deliverable: structured per-facet ProfileLine arrays.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileHalf {
+    pub historical_summary: String,
+    pub key_facts: KeyFacts,
+    pub summary: String,
+}
+
+/// One profile fact with its evidence trail. `evidence` is the list of source records that contributed; record-level forget removes them from the input set, so re-synthesizing the profile drops the line.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileLine {
+    /// Confidence in [0, 1]. Records with confidence < 0.3 (ConfidenceBand::Uncertain) are excluded from the profile.
+    pub confidence: f64,
+    /// Source-record ULIDs whose bodies contributed to this line. Always non-empty.
+    pub evidence: Vec<crate::generated::common::Ulid>,
+    /// Canonical short statement of the fact (e.g., 'prefers terse explanations', 'M2 MacBook Pro').
+    pub value: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawProfileLine {
+    /// Confidence in [0, 1]. Records with confidence < 0.3 (ConfidenceBand::Uncertain) are excluded from the profile.
+    confidence: f64,
+    /// Source-record ULIDs whose bodies contributed to this line. Always non-empty.
+    evidence: Vec<crate::generated::common::Ulid>,
+    /// Canonical short statement of the fact (e.g., 'prefers terse explanations', 'M2 MacBook Pro').
+    value: String,
+}
+
+impl ::core::convert::TryFrom<RawProfileLine> for ProfileLine {
+    type Error = &'static str;
+    fn try_from(raw: RawProfileLine) -> Result<Self, Self::Error> {
+        if raw.value.is_empty() { return Err("value: must not be empty"); }
+        if !(0.0..=1.0).contains(&raw.confidence) || raw.confidence.is_nan() {
+            return Err("confidence: must be in [0, 1]");
+        }
+        if raw.evidence.is_empty() { return Err("evidence: must contain at least 1 item"); }
+        {
+            let mut seen = ::std::collections::BTreeSet::new();
+            for ulid in &raw.evidence {
+                if !seen.insert(ulid.0.clone()) { return Err("evidence: must be unique"); }
+            }
+        }
+        Ok(Self {
+            confidence: raw.confidence,
+            evidence: raw.evidence,
+            value: raw.value,
+        })
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for ProfileLine {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: ::serde::Deserializer<'de> {
+        let raw = RawProfileLine::deserialize(deserializer)?;
         Self::try_from(raw).map_err(::serde::de::Error::custom)
     }
 }

--- a/crates/cairn-core/src/pipeline/mod.rs
+++ b/crates/cairn-core/src/pipeline/mod.rs
@@ -40,6 +40,7 @@ pub mod extract;
 pub mod extraction_cache;
 pub mod filter;
 pub mod lint;
+pub mod profile;
 pub(crate) mod squash;
 pub mod turn;
 

--- a/crates/cairn-core/src/pipeline/profile/mod.rs
+++ b/crates/cairn-core/src/pipeline/profile/mod.rs
@@ -1,0 +1,37 @@
+//! `AutoUserProfile` synthesis (brief §7.1, issue #81).
+//!
+//! Pure functions that turn a slim projection of stored memory records
+//! into the typed `DataProfile` document returned by
+//! `retrieve --profile` (§8.0.c) and consumed by `assemble_hot` for the
+//! hot prefix (§7).
+//!
+//! The synthesizer never touches the store. Callers (CLI / SDK / MCP
+//! adapters wired in #82) project active, non-tombstoned records into
+//! [`ProfileSourceRecord`] values, hand them to [`synthesize()`], and
+//! emit the typed result.
+//!
+//! ## Why pure
+//!
+//! - **Repeatable** — the same inputs always produce the same profile.
+//!   The forget-propagation contract (§7.1, "Profile lines can be removed
+//!   by record-level forget of their source evidence") relies on
+//!   re-synthesizing from a smaller record set after a forget.
+//! - **Adapter-free** — `cairn-core` has no `SQLite` / vault dependency, so
+//!   this module sits inside the dep-boundary enforced by
+//!   `scripts/check-core-boundary.sh`.
+//!
+//! ## P0 vs P1
+//!
+//! Per brief §7.1, only the structural split (`static_section` /
+//! `dynamic_section`) and the `key_facts` aggregation are P0; the rolling
+//! `summary` / `historical_summary` narratives are produced by
+//! `DreamWorkflow` and remain empty strings here at P0.
+
+mod source;
+mod synthesize;
+
+#[cfg(test)]
+mod tests;
+
+pub use source::{KeyFactFacet, ProfileSourceRecord, ProfileSubject};
+pub use synthesize::{SynthesizeError, synthesize};

--- a/crates/cairn-core/src/pipeline/profile/mod.rs
+++ b/crates/cairn-core/src/pipeline/profile/mod.rs
@@ -22,10 +22,10 @@
 //!
 //! ## P0 vs P1
 //!
-//! Per brief §7.1, only the structural split (`static_section` /
-//! `dynamic_section`) and the `key_facts` aggregation are P0; the rolling
-//! `summary` / `historical_summary` narratives are produced by
-//! `DreamWorkflow` and remain empty strings here at P0.
+//! Per brief §7.1, only the structural split (the `static` / `dynamic`
+//! halves) and the `key_facts` aggregation are P0; the rolling `summary`
+//! / `historical_summary` narratives are produced by `DreamWorkflow` and
+//! remain empty strings here at P0.
 
 mod source;
 mod synthesize;

--- a/crates/cairn-core/src/pipeline/profile/source.rs
+++ b/crates/cairn-core/src/pipeline/profile/source.rs
@@ -55,7 +55,8 @@ pub struct ProfileSourceRecord {
     /// is built from these.
     pub record_id: RecordId,
     /// Static-vs-dynamic split per brief §3.0 / §7.1: records with
-    /// `is_static = 1` feed `static_section`; the rest feed `dynamic_section`.
+    /// `is_static = 1` feed the `static` half of the profile; the rest
+    /// feed the `dynamic` half.
     pub is_static: bool,
     /// Confidence scalar in `[0.0, 1.0]`. Records with confidence
     /// `< 0.3` (`ConfidenceBand::Uncertain`) are dropped before the

--- a/crates/cairn-core/src/pipeline/profile/source.rs
+++ b/crates/cairn-core/src/pipeline/profile/source.rs
@@ -1,0 +1,75 @@
+//! Slim projections fed into the [`super::synthesize()`] function.
+//!
+//! Adapter crates (`cairn-store-sqlite`, etc.) are responsible for
+//! producing these from active, non-tombstoned, consent-cleared records
+//! — the synthesizer treats whatever it is given as authoritative.
+
+use crate::domain::{RecordId, Rfc3339Timestamp};
+
+/// Seven `key_facts` buckets defined by brief §7.1.
+///
+/// The bucket assignment is the adapter's responsibility (decided from
+/// `kind`, `class`, tags, vault path, etc.); the synthesizer only routes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum KeyFactFacet {
+    /// Hardware the user works on (laptop, phone, desk monitor).
+    Devices,
+    /// Software / tools the user has standardized on.
+    Software,
+    /// Stable preferences (response style, naming, formatting).
+    Preferences,
+    /// Active blockers in progress (only fed from records observed on
+    /// ≥ 2 distinct days per the brief's evidence gate; the gate itself
+    /// is the adapter's responsibility).
+    CurrentIssues,
+    /// Resolved historical issues — kept for context, not as live work.
+    AddressedIssues,
+    /// Patterns the agent has seen repeat over time.
+    RecurringIssues,
+    /// Entities the user works with (employer, primary project, key
+    /// collaborators).
+    KnownEntities,
+}
+
+/// Subject of the synthesized profile. At least one of `user` / `agent`
+/// must be set — mirrors the IDL `DataProfileSubject` `anyOf` constraint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileSubject {
+    /// Stable user identifier (e.g., `hmn:alice`).
+    pub user: Option<String>,
+    /// Agent identifier when the profile is scoped to an agent variant.
+    pub agent: Option<String>,
+}
+
+/// One record's contribution to the profile.
+///
+/// The synthesizer never reads the underlying record body. Adapters
+/// derive [`Self::value`] from the body / frontmatter once and hand the
+/// canonical short statement here. This keeps the synthesizer free of
+/// markdown parsing and the body-reading constraints in §6.5.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProfileSourceRecord {
+    /// Stable record id used as the line's evidence pointer. The
+    /// `evidence` array on every emitted [`crate::generated::verbs::retrieve::ProfileLine`]
+    /// is built from these.
+    pub record_id: RecordId,
+    /// Static-vs-dynamic split per brief §3.0 / §7.1: records with
+    /// `is_static = 1` feed `static_section`; the rest feed `dynamic_section`.
+    pub is_static: bool,
+    /// Confidence scalar in `[0.0, 1.0]`. Records with confidence
+    /// `< 0.3` (`ConfidenceBand::Uncertain`) are dropped before the
+    /// fact-line merge step — the brief calls this "avoid profile updates
+    /// from low-confidence records."
+    pub confidence: f32,
+    /// Bucket the line lands in. The synthesizer routes by this field;
+    /// it never recomputes the facet.
+    pub facet: KeyFactFacet,
+    /// Canonical short statement (the line's `value`). Lines with the
+    /// same `(is_static, facet, value)` triple are merged: confidences
+    /// take the max, evidence sets union.
+    pub value: String,
+    /// Wall-clock instant the source record was last updated. Drives
+    /// `DataProfile.updated_at` (latest contributing record).
+    pub updated_at: Rfc3339Timestamp,
+}

--- a/crates/cairn-core/src/pipeline/profile/synthesize.rs
+++ b/crates/cairn-core/src/pipeline/profile/synthesize.rs
@@ -87,7 +87,7 @@ pub enum SynthesizeError {
 /// let now = Rfc3339Timestamp::parse("2026-04-22T14:00:01Z").unwrap();
 ///
 /// let profile = synthesize(&records, &subject, &now).unwrap();
-/// assert_eq!(profile.static_section.key_facts.preferences.len(), 1);
+/// assert_eq!(profile.r#static.key_facts.preferences.len(), 1);
 /// assert_eq!(profile.updated_at, "2026-04-22T14:00:00Z");
 /// ```
 pub fn synthesize(
@@ -123,8 +123,8 @@ pub fn synthesize(
 
     Ok(DataProfile {
         subject: subject_out,
-        static_section: build_half(&static_records),
-        dynamic_section: build_half(&dynamic_records),
+        r#static: build_half(&static_records),
+        dynamic: build_half(&dynamic_records),
         updated_at,
     })
 }

--- a/crates/cairn-core/src/pipeline/profile/synthesize.rs
+++ b/crates/cairn-core/src/pipeline/profile/synthesize.rs
@@ -63,6 +63,33 @@ pub enum SynthesizeError {
 /// Returns [`SynthesizeError::EmptySubject`] when neither `user` nor
 /// `agent` is set, or [`SynthesizeError::BlankSubjectField`] when a set
 /// field is empty.
+///
+/// # Example
+///
+/// ```
+/// use cairn_core::domain::{RecordId, Rfc3339Timestamp};
+/// use cairn_core::pipeline::profile::{
+///     synthesize, KeyFactFacet, ProfileSourceRecord, ProfileSubject,
+/// };
+///
+/// let records = vec![ProfileSourceRecord {
+///     record_id: RecordId::parse("01HQZX9F5N0000000000000000").unwrap(),
+///     is_static: true,
+///     confidence: 0.9,
+///     facet: KeyFactFacet::Preferences,
+///     value: "prefers terse explanations".to_owned(),
+///     updated_at: Rfc3339Timestamp::parse("2026-04-22T14:00:00Z").unwrap(),
+/// }];
+/// let subject = ProfileSubject {
+///     user: Some("hmn:alice".to_owned()),
+///     agent: None,
+/// };
+/// let now = Rfc3339Timestamp::parse("2026-04-22T14:00:01Z").unwrap();
+///
+/// let profile = synthesize(&records, &subject, &now).unwrap();
+/// assert_eq!(profile.static_section.key_facts.preferences.len(), 1);
+/// assert_eq!(profile.updated_at, "2026-04-22T14:00:00Z");
+/// ```
 pub fn synthesize(
     records: &[ProfileSourceRecord],
     subject: &ProfileSubject,
@@ -103,7 +130,14 @@ pub fn synthesize(
 }
 
 fn is_admissible(r: &ProfileSourceRecord) -> bool {
-    if r.confidence.is_nan() {
+    // NaN, < 0.0, > 1.0 are all out-of-contract: `MemoryRecord.validate`
+    // already rejects them upstream, but we re-check at the trust
+    // boundary. Without this gate a confidence of `1.5` would slip into
+    // the output and the generated `ProfileLine` deserializer (codegen
+    // emits `(0.0..=1.0).contains(&raw.confidence)`) would reject the
+    // wire round-trip, leaving the synthesizer producing data its own
+    // schema rejects.
+    if !(0.0..=1.0).contains(&r.confidence) || r.confidence.is_nan() {
         return false;
     }
     if r.confidence < CONFIDENCE_FLOOR {

--- a/crates/cairn-core/src/pipeline/profile/synthesize.rs
+++ b/crates/cairn-core/src/pipeline/profile/synthesize.rs
@@ -42,8 +42,10 @@ pub enum SynthesizeError {
     /// the synthesizer's output validator-symmetric with the schema.
     #[error("profile subject must specify at least one of `user` or `agent`")]
     EmptySubject,
-    /// Subject string was set but empty (post-trim). The IDL constrains
-    /// both fields to `minLength: 1`.
+    /// Subject string was set but empty. The IDL constrains both
+    /// fields to `minLength: 1`. Whitespace-only strings are not
+    /// trimmed at this layer — the caller is expected to normalize
+    /// before passing.
     #[error("profile subject `{field}` must not be empty")]
     BlankSubjectField {
         /// Which subject field was blank — `user` or `agent`.

--- a/crates/cairn-core/src/pipeline/profile/synthesize.rs
+++ b/crates/cairn-core/src/pipeline/profile/synthesize.rs
@@ -1,0 +1,190 @@
+//! `UserProfileSynthesizer` — pure function, brief §7.1.
+//!
+//! Walks a slice of [`super::ProfileSourceRecord`] projections and
+//! emits the typed [`crate::generated::verbs::retrieve::DataProfile`]
+//! used by `retrieve --profile` and the `assemble_hot` hot prefix.
+//!
+//! Filtering rules (P0):
+//! - records with `confidence < 0.3` (`ConfidenceBand::Uncertain`) are
+//!   dropped — see brief §6.4 + the issue's "low-confidence exclusion"
+//!   acceptance criterion;
+//! - the adapter is responsible for excluding `tombstoned` /
+//!   privacy-blocked / consent-declined records before calling in.
+//!
+//! Merge rules:
+//! - lines with the same `(is_static, facet, value)` triple coalesce;
+//!   the merged line keeps `max(confidence)` and the union of evidence
+//!   ULIDs (sorted, deduplicated).
+//!
+//! Ordering:
+//! - within each facet, lines emit in ascending `value` order so the
+//!   profile is bytewise-deterministic for fixed inputs (the
+//!   forget-propagation tests rely on this).
+
+use crate::domain::Rfc3339Timestamp;
+use crate::generated::common::Ulid;
+use crate::generated::verbs::retrieve::{
+    DataProfile, DataProfileSubject, KeyFacts, ProfileHalf, ProfileLine,
+};
+
+use super::source::{KeyFactFacet, ProfileSourceRecord, ProfileSubject};
+
+/// Confidence band threshold below which records are excluded — matches
+/// `ConfidenceBand::Uncertain` in `crate::domain::evidence`.
+const CONFIDENCE_FLOOR: f32 = 0.3;
+
+/// Errors returned by [`synthesize`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SynthesizeError {
+    /// Subject carried neither `user` nor `agent`. The IDL
+    /// `DataProfileSubject` requires at least one — failing here keeps
+    /// the synthesizer's output validator-symmetric with the schema.
+    #[error("profile subject must specify at least one of `user` or `agent`")]
+    EmptySubject,
+    /// Subject string was set but empty (post-trim). The IDL constrains
+    /// both fields to `minLength: 1`.
+    #[error("profile subject `{field}` must not be empty")]
+    BlankSubjectField {
+        /// Which subject field was blank — `user` or `agent`.
+        field: &'static str,
+    },
+}
+
+/// Pure-function profile materializer (brief §7.1).
+///
+/// `now` becomes `DataProfile.updated_at` when the input contributes
+/// no records; otherwise the synthesizer picks the chronologically
+/// latest [`ProfileSourceRecord::updated_at`] across the surviving
+/// inputs (post-confidence-filter).
+///
+/// # Errors
+///
+/// Returns [`SynthesizeError::EmptySubject`] when neither `user` nor
+/// `agent` is set, or [`SynthesizeError::BlankSubjectField`] when a set
+/// field is empty.
+pub fn synthesize(
+    records: &[ProfileSourceRecord],
+    subject: &ProfileSubject,
+    now: &Rfc3339Timestamp,
+) -> Result<DataProfile, SynthesizeError> {
+    let subject_out = build_subject(subject)?;
+
+    let mut static_records: Vec<&ProfileSourceRecord> = Vec::new();
+    let mut dynamic_records: Vec<&ProfileSourceRecord> = Vec::new();
+    let mut latest: Option<&Rfc3339Timestamp> = None;
+
+    for r in records {
+        if !is_admissible(r) {
+            continue;
+        }
+        if r.is_static {
+            static_records.push(r);
+        } else {
+            dynamic_records.push(r);
+        }
+        latest = Some(match latest {
+            None => &r.updated_at,
+            Some(prev) if prev.cmp_chronological(&r.updated_at) == std::cmp::Ordering::Less => {
+                &r.updated_at
+            }
+            Some(prev) => prev,
+        });
+    }
+
+    let updated_at = latest.unwrap_or(now).as_str().to_owned();
+
+    Ok(DataProfile {
+        subject: subject_out,
+        static_section: build_half(&static_records),
+        dynamic_section: build_half(&dynamic_records),
+        updated_at,
+    })
+}
+
+fn is_admissible(r: &ProfileSourceRecord) -> bool {
+    if r.confidence.is_nan() {
+        return false;
+    }
+    if r.confidence < CONFIDENCE_FLOOR {
+        return false;
+    }
+    if r.value.is_empty() {
+        return false;
+    }
+    true
+}
+
+fn build_subject(subject: &ProfileSubject) -> Result<DataProfileSubject, SynthesizeError> {
+    if subject.user.is_none() && subject.agent.is_none() {
+        return Err(SynthesizeError::EmptySubject);
+    }
+    if matches!(&subject.user, Some(s) if s.is_empty()) {
+        return Err(SynthesizeError::BlankSubjectField { field: "user" });
+    }
+    if matches!(&subject.agent, Some(s) if s.is_empty()) {
+        return Err(SynthesizeError::BlankSubjectField { field: "agent" });
+    }
+    Ok(DataProfileSubject {
+        user: subject.user.clone(),
+        agent: subject.agent.clone(),
+    })
+}
+
+fn build_half(records: &[&ProfileSourceRecord]) -> ProfileHalf {
+    ProfileHalf {
+        // Rolling DreamWorkflow narratives are P1; P0 emits empty bodies.
+        summary: String::new(),
+        historical_summary: String::new(),
+        key_facts: build_key_facts(records),
+    }
+}
+
+fn build_key_facts(records: &[&ProfileSourceRecord]) -> KeyFacts {
+    KeyFacts {
+        devices: lines_for(records, KeyFactFacet::Devices),
+        software: lines_for(records, KeyFactFacet::Software),
+        preferences: lines_for(records, KeyFactFacet::Preferences),
+        current_issues: lines_for(records, KeyFactFacet::CurrentIssues),
+        addressed_issues: lines_for(records, KeyFactFacet::AddressedIssues),
+        recurring_issues: lines_for(records, KeyFactFacet::RecurringIssues),
+        known_entities: lines_for(records, KeyFactFacet::KnownEntities),
+    }
+}
+
+fn lines_for(records: &[&ProfileSourceRecord], facet: KeyFactFacet) -> Vec<ProfileLine> {
+    // Stable bucket: BTreeMap keyed by `value` so emission order is
+    // bytewise-deterministic and merge of duplicates is implicit.
+    let mut by_value: std::collections::BTreeMap<&str, MergedLine<'_>> =
+        std::collections::BTreeMap::new();
+
+    for r in records.iter().filter(|r| r.facet == facet) {
+        let entry = by_value
+            .entry(r.value.as_str())
+            .or_insert_with(|| MergedLine {
+                value: r.value.as_str(),
+                confidence: r.confidence,
+                evidence: std::collections::BTreeSet::new(),
+            });
+        if r.confidence > entry.confidence {
+            entry.confidence = r.confidence;
+        }
+        entry.evidence.insert(r.record_id.as_str());
+    }
+
+    by_value
+        .into_values()
+        .map(|m| ProfileLine {
+            value: m.value.to_owned(),
+            // f32 → f64 widens losslessly; the IDL is f64 on the wire.
+            confidence: f64::from(m.confidence),
+            evidence: m.evidence.into_iter().map(|s| Ulid(s.to_owned())).collect(),
+        })
+        .collect()
+}
+
+struct MergedLine<'a> {
+    value: &'a str,
+    confidence: f32,
+    evidence: std::collections::BTreeSet<&'a str>,
+}

--- a/crates/cairn-core/src/pipeline/profile/tests.rs
+++ b/crates/cairn-core/src/pipeline/profile/tests.rs
@@ -1,0 +1,399 @@
+//! Unit tests for the `AutoUserProfile` synthesizer (issue #81).
+//!
+//! Coverage map (against issue acceptance criteria + verification list):
+//! - **Profile materialization fixture** — `materializes_static_and_dynamic_split`.
+//! - **Evidence-link** — `evidence_lists_source_record_ids`.
+//! - **Forget propagation** — `forget_drops_line_when_evidence_removed`.
+//! - **Low-confidence exclusion** — `excludes_uncertain_band`.
+//! - **Privacy-blocked exclusion** — adapter responsibility (asserted in
+//!   `caller_filters_tombstoned_before_synthesize` doc-test); the
+//!   synthesizer's contract is "trust the projection".
+//! - **Dynamic facts can expire without deleting static prefs** —
+//!   `dynamic_records_disappearing_does_not_touch_static_section`.
+//! - **Subject validation** — `errors_when_subject_empty`,
+//!   `errors_when_subject_field_blank`.
+
+use super::*;
+use crate::domain::{RecordId, Rfc3339Timestamp};
+use crate::generated::common::Ulid;
+
+fn ts(s: &str) -> Rfc3339Timestamp {
+    Rfc3339Timestamp::parse(s).expect("valid rfc3339")
+}
+
+fn rid(c: char) -> RecordId {
+    // Construct a 26-char ULID by repeating the first character. ULID
+    // first char must be in `[0..=7]`, rest are Crockford base32. We
+    // enforce that by constraining the call sites.
+    assert!(matches!(c, '0'..='7'), "ULID first char must be [0..=7]");
+    let s: String = std::iter::repeat_n(c, 26).collect();
+    RecordId::parse(s).expect("valid ulid")
+}
+
+fn user_subject() -> ProfileSubject {
+    ProfileSubject {
+        user: Some("hmn:alice".to_owned()),
+        agent: None,
+    }
+}
+
+fn rec(
+    first: char,
+    is_static: bool,
+    confidence: f32,
+    facet: KeyFactFacet,
+    value: &str,
+    when: &str,
+) -> ProfileSourceRecord {
+    ProfileSourceRecord {
+        record_id: rid(first),
+        is_static,
+        confidence,
+        facet,
+        value: value.to_owned(),
+        updated_at: ts(when),
+    }
+}
+
+#[test]
+fn materializes_static_and_dynamic_split() {
+    let records = vec![
+        rec(
+            '0',
+            true,
+            0.9,
+            KeyFactFacet::Preferences,
+            "prefers terse explanations",
+            "2026-04-22T14:00:00Z",
+        ),
+        rec(
+            '1',
+            true,
+            0.85,
+            KeyFactFacet::Devices,
+            "M2 MacBook Pro",
+            "2026-04-22T14:05:00Z",
+        ),
+        rec(
+            '2',
+            false,
+            0.7,
+            KeyFactFacet::CurrentIssues,
+            "shipping retrieve --profile dispatch",
+            "2026-04-22T14:10:00Z",
+        ),
+    ];
+    let now = ts("2026-04-22T14:11:00Z");
+    let profile = synthesize(&records, &user_subject(), &now).expect("synthesize");
+
+    assert_eq!(profile.subject.user.as_deref(), Some("hmn:alice"));
+    assert_eq!(profile.static_section.key_facts.preferences.len(), 1);
+    assert_eq!(profile.static_section.key_facts.devices.len(), 1);
+    assert!(profile.static_section.key_facts.current_issues.is_empty());
+    assert_eq!(profile.dynamic_section.key_facts.current_issues.len(), 1);
+    assert!(profile.dynamic_section.key_facts.preferences.is_empty());
+
+    // updated_at is the latest of the contributing records, not `now`.
+    assert_eq!(profile.updated_at, "2026-04-22T14:10:00Z");
+
+    // P0 narrative bodies are stub-empty per brief §7.1.
+    assert_eq!(profile.static_section.summary, "");
+    assert_eq!(profile.static_section.historical_summary, "");
+    assert_eq!(profile.dynamic_section.summary, "");
+    assert_eq!(profile.dynamic_section.historical_summary, "");
+}
+
+#[test]
+fn evidence_lists_source_record_ids() {
+    let records = vec![rec(
+        '3',
+        true,
+        0.95,
+        KeyFactFacet::Preferences,
+        "prefers terse explanations",
+        "2026-04-22T14:00:00Z",
+    )];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+
+    let line = &profile.static_section.key_facts.preferences[0];
+    assert_eq!(line.value, "prefers terse explanations");
+    assert!((line.confidence - 0.95).abs() < 1e-6);
+    assert_eq!(line.evidence, vec![Ulid(rid('3').as_str().to_owned())]);
+}
+
+#[test]
+fn merges_duplicate_value_with_max_confidence_and_union_evidence() {
+    let records = vec![
+        rec(
+            '0',
+            true,
+            0.6,
+            KeyFactFacet::Preferences,
+            "prefers terse explanations",
+            "2026-04-22T14:00:00Z",
+        ),
+        rec(
+            '1',
+            true,
+            0.85,
+            KeyFactFacet::Preferences,
+            "prefers terse explanations",
+            "2026-04-22T14:01:00Z",
+        ),
+        // Same value but a different facet is *not* merged.
+        rec(
+            '2',
+            true,
+            0.9,
+            KeyFactFacet::Software,
+            "prefers terse explanations",
+            "2026-04-22T14:02:00Z",
+        ),
+    ];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:02:01Z")).expect("synthesize");
+
+    let prefs = &profile.static_section.key_facts.preferences;
+    assert_eq!(prefs.len(), 1);
+    assert!((prefs[0].confidence - 0.85).abs() < 1e-6);
+    assert_eq!(prefs[0].evidence.len(), 2);
+    assert_eq!(profile.static_section.key_facts.software.len(), 1);
+}
+
+#[test]
+fn excludes_uncertain_band() {
+    let records = vec![
+        rec(
+            '0',
+            true,
+            0.29,
+            KeyFactFacet::Preferences,
+            "low confidence trait",
+            "2026-04-22T14:00:00Z",
+        ),
+        rec(
+            '1',
+            true,
+            0.3,
+            KeyFactFacet::Preferences,
+            "boundary trait",
+            "2026-04-22T14:00:00Z",
+        ),
+    ];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+
+    let prefs = &profile.static_section.key_facts.preferences;
+    // 0.29 was filtered (< 0.3); 0.3 stays (>= 0.3 admits the line).
+    assert_eq!(prefs.len(), 1);
+    assert_eq!(prefs[0].value, "boundary trait");
+}
+
+#[test]
+fn excludes_nan_confidence() {
+    let records = vec![rec(
+        '0',
+        true,
+        f32::NAN,
+        KeyFactFacet::Preferences,
+        "broken record",
+        "2026-04-22T14:00:00Z",
+    )];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+    assert!(profile.static_section.key_facts.preferences.is_empty());
+}
+
+#[test]
+fn excludes_blank_value() {
+    let records = vec![rec(
+        '0',
+        true,
+        0.95,
+        KeyFactFacet::Preferences,
+        "",
+        "2026-04-22T14:00:00Z",
+    )];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+    assert!(profile.static_section.key_facts.preferences.is_empty());
+}
+
+#[test]
+fn forget_drops_line_when_evidence_removed() {
+    // Brief §7.1: "Profile lines can be removed by record-level forget
+    // of their source evidence." Here we simulate forget by removing the
+    // source record from the input slice and re-synthesizing.
+    let pref = rec(
+        '0',
+        true,
+        0.9,
+        KeyFactFacet::Preferences,
+        "prefers terse explanations",
+        "2026-04-22T14:00:00Z",
+    );
+    let device = rec(
+        '1',
+        true,
+        0.85,
+        KeyFactFacet::Devices,
+        "M2 MacBook Pro",
+        "2026-04-22T14:05:00Z",
+    );
+
+    let before = synthesize(
+        &[pref.clone(), device.clone()],
+        &user_subject(),
+        &ts("2026-04-22T14:06:00Z"),
+    )
+    .expect("synthesize");
+    assert_eq!(before.static_section.key_facts.preferences.len(), 1);
+
+    let after = synthesize(&[device], &user_subject(), &ts("2026-04-22T14:06:00Z"))
+        .expect("re-synthesize after forget");
+    assert!(after.static_section.key_facts.preferences.is_empty());
+    assert_eq!(after.static_section.key_facts.devices.len(), 1);
+}
+
+#[test]
+fn dynamic_records_disappearing_does_not_touch_static_section() {
+    // Brief §7.1: "Dynamic facts can expire without deleting stable user
+    // preferences." Static records survive when only dynamic ones are
+    // pruned.
+    let pref = rec(
+        '0',
+        true,
+        0.9,
+        KeyFactFacet::Preferences,
+        "prefers terse explanations",
+        "2026-04-22T14:00:00Z",
+    );
+    let issue = rec(
+        '1',
+        false,
+        0.7,
+        KeyFactFacet::CurrentIssues,
+        "shipping retrieve --profile dispatch",
+        "2026-04-22T14:05:00Z",
+    );
+
+    let with_dynamic = synthesize(
+        &[pref.clone(), issue],
+        &user_subject(),
+        &ts("2026-04-22T14:06:00Z"),
+    )
+    .expect("synthesize");
+    assert_eq!(
+        with_dynamic.dynamic_section.key_facts.current_issues.len(),
+        1
+    );
+    assert_eq!(with_dynamic.static_section.key_facts.preferences.len(), 1);
+
+    // Expirer drops the dynamic fact only.
+    let without_dynamic = synthesize(&[pref], &user_subject(), &ts("2026-04-22T14:10:00Z"))
+        .expect("synthesize after expiration");
+    assert!(
+        without_dynamic
+            .dynamic_section
+            .key_facts
+            .current_issues
+            .is_empty()
+    );
+    assert_eq!(
+        without_dynamic.static_section.key_facts.preferences.len(),
+        1
+    );
+}
+
+#[test]
+fn errors_when_subject_empty() {
+    let subject = ProfileSubject {
+        user: None,
+        agent: None,
+    };
+    let err = synthesize(&[], &subject, &ts("2026-04-22T14:00:00Z")).unwrap_err();
+    assert_eq!(err, SynthesizeError::EmptySubject);
+}
+
+#[test]
+fn errors_when_subject_field_blank() {
+    let subject = ProfileSubject {
+        user: Some(String::new()),
+        agent: None,
+    };
+    let err = synthesize(&[], &subject, &ts("2026-04-22T14:00:00Z")).unwrap_err();
+    assert_eq!(err, SynthesizeError::BlankSubjectField { field: "user" });
+}
+
+#[test]
+fn empty_input_returns_empty_profile_with_now_timestamp() {
+    let now = ts("2026-04-22T14:00:00Z");
+    let profile = synthesize(&[], &user_subject(), &now).expect("synthesize");
+    assert_eq!(profile.updated_at, "2026-04-22T14:00:00Z");
+    assert!(profile.static_section.key_facts.preferences.is_empty());
+    assert!(profile.dynamic_section.key_facts.current_issues.is_empty());
+}
+
+#[test]
+fn output_round_trips_through_json() {
+    // The synthesizer's output must survive a wire round-trip through the
+    // generated `DataProfile` Deserialize — that's the trust-boundary
+    // validator the IDL emits. If the synthesizer ever produced a value
+    // the validator would reject (e.g., empty `evidence`), this test
+    // catches it before the bug reaches the response envelope.
+    let records = vec![rec(
+        '0',
+        true,
+        0.9,
+        KeyFactFacet::Preferences,
+        "prefers terse explanations",
+        "2026-04-22T14:00:00Z",
+    )];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+    let json = serde_json::to_string(&profile).expect("serialize");
+    let back: crate::generated::verbs::retrieve::DataProfile =
+        serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, profile);
+}
+
+#[test]
+fn deterministic_ordering_within_facet() {
+    let records = vec![
+        rec(
+            '2',
+            true,
+            0.9,
+            KeyFactFacet::KnownEntities,
+            "zebra org",
+            "2026-04-22T14:00:00Z",
+        ),
+        rec(
+            '0',
+            true,
+            0.9,
+            KeyFactFacet::KnownEntities,
+            "alpha org",
+            "2026-04-22T14:00:00Z",
+        ),
+        rec(
+            '1',
+            true,
+            0.9,
+            KeyFactFacet::KnownEntities,
+            "mid org",
+            "2026-04-22T14:00:00Z",
+        ),
+    ];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+    let entities = &profile.static_section.key_facts.known_entities;
+    assert_eq!(
+        entities
+            .iter()
+            .map(|l| l.value.as_str())
+            .collect::<Vec<_>>(),
+        vec!["alpha org", "mid org", "zebra org"]
+    );
+}

--- a/crates/cairn-core/src/pipeline/profile/tests.rs
+++ b/crates/cairn-core/src/pipeline/profile/tests.rs
@@ -599,6 +599,103 @@ fn synthesize_round_trips_lowercase_t_z_timestamp() {
 }
 
 #[test]
+fn data_profile_deserialize_rejects_oversized_updated_at() {
+    // Pathological fractional: 100 digits. Without a maxLength cap the
+    // String is allocated then dropped; with the cap (`len <= 64`) it's
+    // rejected at the validator boundary.
+    let big_frac: String = "1".repeat(100);
+    let json = format!(
+        r#"{{
+        "subject": {{"user": "hmn:alice"}},
+        "static": {{"summary":"","historical_summary":"","key_facts":{{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}}}},
+        "dynamic": {{"summary":"","historical_summary":"","key_facts":{{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}}}},
+        "updated_at": "2026-04-22T14:00:00.{big_frac}Z"
+    }}"#
+    );
+    let err = serde_json::from_str::<crate::generated::verbs::retrieve::DataProfile>(&json)
+        .expect_err("oversized updated_at must reject");
+    assert!(err.to_string().contains("updated_at"), "{err}");
+}
+
+#[test]
+fn data_profile_deserialize_rejects_out_of_range_components() {
+    // Each example targets one component in `Rfc3339Timestamp::parse`'s
+    // range table so any future drift is caught field-by-field.
+    let cases = [
+        ("2026-13-01T00:00:00Z", "month"),
+        ("2026-04-32T00:00:00Z", "day"),
+        ("2026-04-22T24:00:00Z", "hour"),
+        ("2026-04-22T00:60:00Z", "minute"),
+        ("2026-04-22T00:00:60Z", "second"),
+        ("2026-04-22T00:00:00+24:00", "offset hour"),
+        ("2026-04-22T00:00:00+00:60", "offset minute"),
+        ("2026-04-22T14:00:00+ab:cd", "offset"),
+    ];
+    for (ts, label) in cases {
+        let json = format!(
+            r#"{{
+            "subject": {{"user": "hmn:alice"}},
+            "static": {{"summary":"","historical_summary":"","key_facts":{{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}}}},
+            "dynamic": {{"summary":"","historical_summary":"","key_facts":{{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}}}},
+            "updated_at": "{ts}"
+        }}"#
+        );
+        let err = serde_json::from_str::<crate::generated::verbs::retrieve::DataProfile>(&json)
+            .err()
+            .unwrap_or_else(|| panic!("`{ts}` ({label}) parsed but should have rejected"));
+        assert!(
+            err.to_string().contains("updated_at"),
+            "expected updated_at error, got: {err} (case: {label})"
+        );
+    }
+}
+
+#[test]
+fn data_profile_updated_at_validator_agrees_with_domain_parser_on_corpus() {
+    // Cross-check: the wire validator and the domain parser must
+    // converge on the same accept/reject decision for a corpus of
+    // edge-case timestamps. Without this, a future codegen edit can
+    // silently drift the two and break the response-envelope round-trip.
+    let corpus = [
+        // Accepted by both.
+        ("2026-04-22T14:00:00Z", true),
+        ("2026-04-22T14:00:00.000Z", true),
+        ("2026-04-22T14:00:00+00:00", true),
+        ("2026-04-22T14:00:00-05:30", true),
+        ("2026-04-22t14:00:00z", true),
+        // Rejected by both.
+        ("not a date", false),
+        ("2026-04-22T14:00:00", false),       // no zone
+        ("2026-13-01T00:00:00Z", false),      // bad month
+        ("2026-04-22T24:00:00Z", false),      // bad hour
+        ("2026-04-22T14:00:00+24:00", false), // bad offset
+    ];
+    for (ts, expected) in corpus {
+        let domain_ok = crate::domain::Rfc3339Timestamp::parse(ts).is_ok();
+        let wire_ok = serde_json::from_str::<crate::generated::verbs::retrieve::DataProfile>(
+            &format!(
+                r#"{{
+                "subject": {{"user": "hmn:alice"}},
+                "static": {{"summary":"","historical_summary":"","key_facts":{{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}}}},
+                "dynamic": {{"summary":"","historical_summary":"","key_facts":{{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}}}},
+                "updated_at": "{ts}"
+            }}"#
+            ),
+        )
+        .is_ok();
+        assert_eq!(
+            domain_ok, expected,
+            "domain parser disagreed with corpus expectation for `{ts}`"
+        );
+        assert_eq!(
+            wire_ok, expected,
+            "wire validator disagreed with corpus expectation for `{ts}`"
+        );
+        assert_eq!(domain_ok, wire_ok, "wire/domain divergence for `{ts}`");
+    }
+}
+
+#[test]
 fn data_profile_deserialize_accepts_well_formed_updated_at() {
     let json = r#"{
         "subject": {"user": "hmn:alice"},

--- a/crates/cairn-core/src/pipeline/profile/tests.rs
+++ b/crates/cairn-core/src/pipeline/profile/tests.rs
@@ -9,7 +9,7 @@
 //!   `caller_filters_tombstoned_before_synthesize` doc-test); the
 //!   synthesizer's contract is "trust the projection".
 //! - **Dynamic facts can expire without deleting static prefs** —
-//!   `dynamic_records_disappearing_does_not_touch_static_section`.
+//!   `dynamic_records_disappearing_does_not_touch_static_half`.
 //! - **Subject validation** — `errors_when_subject_empty`,
 //!   `errors_when_subject_field_blank`.
 
@@ -87,20 +87,20 @@ fn materializes_static_and_dynamic_split() {
     let profile = synthesize(&records, &user_subject(), &now).expect("synthesize");
 
     assert_eq!(profile.subject.user.as_deref(), Some("hmn:alice"));
-    assert_eq!(profile.static_section.key_facts.preferences.len(), 1);
-    assert_eq!(profile.static_section.key_facts.devices.len(), 1);
-    assert!(profile.static_section.key_facts.current_issues.is_empty());
-    assert_eq!(profile.dynamic_section.key_facts.current_issues.len(), 1);
-    assert!(profile.dynamic_section.key_facts.preferences.is_empty());
+    assert_eq!(profile.r#static.key_facts.preferences.len(), 1);
+    assert_eq!(profile.r#static.key_facts.devices.len(), 1);
+    assert!(profile.r#static.key_facts.current_issues.is_empty());
+    assert_eq!(profile.dynamic.key_facts.current_issues.len(), 1);
+    assert!(profile.dynamic.key_facts.preferences.is_empty());
 
     // updated_at is the latest of the contributing records, not `now`.
     assert_eq!(profile.updated_at, "2026-04-22T14:10:00Z");
 
     // P0 narrative bodies are stub-empty per brief §7.1.
-    assert_eq!(profile.static_section.summary, "");
-    assert_eq!(profile.static_section.historical_summary, "");
-    assert_eq!(profile.dynamic_section.summary, "");
-    assert_eq!(profile.dynamic_section.historical_summary, "");
+    assert_eq!(profile.r#static.summary, "");
+    assert_eq!(profile.r#static.historical_summary, "");
+    assert_eq!(profile.dynamic.summary, "");
+    assert_eq!(profile.dynamic.historical_summary, "");
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn evidence_lists_source_record_ids() {
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
 
-    let line = &profile.static_section.key_facts.preferences[0];
+    let line = &profile.r#static.key_facts.preferences[0];
     assert_eq!(line.value, "prefers terse explanations");
     assert!((line.confidence - 0.95).abs() < 1e-6);
     assert_eq!(line.evidence, vec![Ulid(rid('3').as_str().to_owned())]);
@@ -154,11 +154,11 @@ fn merges_duplicate_value_with_max_confidence_and_union_evidence() {
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:02:01Z")).expect("synthesize");
 
-    let prefs = &profile.static_section.key_facts.preferences;
+    let prefs = &profile.r#static.key_facts.preferences;
     assert_eq!(prefs.len(), 1);
     assert!((prefs[0].confidence - 0.85).abs() < 1e-6);
     assert_eq!(prefs[0].evidence.len(), 2);
-    assert_eq!(profile.static_section.key_facts.software.len(), 1);
+    assert_eq!(profile.r#static.key_facts.software.len(), 1);
 }
 
 #[test]
@@ -184,7 +184,7 @@ fn excludes_uncertain_band() {
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
 
-    let prefs = &profile.static_section.key_facts.preferences;
+    let prefs = &profile.r#static.key_facts.preferences;
     // 0.29 was filtered (< 0.3); 0.3 stays (>= 0.3 admits the line).
     assert_eq!(prefs.len(), 1);
     assert_eq!(prefs[0].value, "boundary trait");
@@ -202,7 +202,7 @@ fn excludes_nan_confidence() {
     )];
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
-    assert!(profile.static_section.key_facts.preferences.is_empty());
+    assert!(profile.r#static.key_facts.preferences.is_empty());
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn excludes_blank_value() {
     )];
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
-    assert!(profile.static_section.key_facts.preferences.is_empty());
+    assert!(profile.r#static.key_facts.preferences.is_empty());
 }
 
 #[test]
@@ -248,16 +248,16 @@ fn forget_drops_line_when_evidence_removed() {
         &ts("2026-04-22T14:06:00Z"),
     )
     .expect("synthesize");
-    assert_eq!(before.static_section.key_facts.preferences.len(), 1);
+    assert_eq!(before.r#static.key_facts.preferences.len(), 1);
 
     let after = synthesize(&[device], &user_subject(), &ts("2026-04-22T14:06:00Z"))
         .expect("re-synthesize after forget");
-    assert!(after.static_section.key_facts.preferences.is_empty());
-    assert_eq!(after.static_section.key_facts.devices.len(), 1);
+    assert!(after.r#static.key_facts.preferences.is_empty());
+    assert_eq!(after.r#static.key_facts.devices.len(), 1);
 }
 
 #[test]
-fn dynamic_records_disappearing_does_not_touch_static_section() {
+fn dynamic_records_disappearing_does_not_touch_static_half() {
     // Brief §7.1: "Dynamic facts can expire without deleting stable user
     // preferences." Static records survive when only dynamic ones are
     // pruned.
@@ -284,26 +284,14 @@ fn dynamic_records_disappearing_does_not_touch_static_section() {
         &ts("2026-04-22T14:06:00Z"),
     )
     .expect("synthesize");
-    assert_eq!(
-        with_dynamic.dynamic_section.key_facts.current_issues.len(),
-        1
-    );
-    assert_eq!(with_dynamic.static_section.key_facts.preferences.len(), 1);
+    assert_eq!(with_dynamic.dynamic.key_facts.current_issues.len(), 1);
+    assert_eq!(with_dynamic.r#static.key_facts.preferences.len(), 1);
 
     // Expirer drops the dynamic fact only.
     let without_dynamic = synthesize(&[pref], &user_subject(), &ts("2026-04-22T14:10:00Z"))
         .expect("synthesize after expiration");
-    assert!(
-        without_dynamic
-            .dynamic_section
-            .key_facts
-            .current_issues
-            .is_empty()
-    );
-    assert_eq!(
-        without_dynamic.static_section.key_facts.preferences.len(),
-        1
-    );
+    assert!(without_dynamic.dynamic.key_facts.current_issues.is_empty());
+    assert_eq!(without_dynamic.r#static.key_facts.preferences.len(), 1);
 }
 
 #[test]
@@ -331,8 +319,8 @@ fn empty_input_returns_empty_profile_with_now_timestamp() {
     let now = ts("2026-04-22T14:00:00Z");
     let profile = synthesize(&[], &user_subject(), &now).expect("synthesize");
     assert_eq!(profile.updated_at, "2026-04-22T14:00:00Z");
-    assert!(profile.static_section.key_facts.preferences.is_empty());
-    assert!(profile.dynamic_section.key_facts.current_issues.is_empty());
+    assert!(profile.r#static.key_facts.preferences.is_empty());
+    assert!(profile.dynamic.key_facts.current_issues.is_empty());
 }
 
 #[test]
@@ -388,7 +376,7 @@ fn deterministic_ordering_within_facet() {
     ];
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
-    let entities = &profile.static_section.key_facts.known_entities;
+    let entities = &profile.r#static.key_facts.known_entities;
     assert_eq!(
         entities
             .iter()
@@ -420,7 +408,7 @@ fn admits_confidence_at_lower_bound() {
     // 0.0 is below the Uncertain floor — should be dropped.
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
-    assert!(profile.static_section.key_facts.preferences.is_empty());
+    assert!(profile.r#static.key_facts.preferences.is_empty());
 }
 
 #[test]
@@ -435,7 +423,7 @@ fn admits_confidence_at_upper_bound() {
     )];
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
-    let line = &profile.static_section.key_facts.preferences[0];
+    let line = &profile.r#static.key_facts.preferences[0];
     assert!((line.confidence - 1.0_f64).abs() < f64::EPSILON);
 }
 
@@ -452,7 +440,7 @@ fn excludes_confidence_above_one() {
     )];
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
-    assert!(profile.static_section.key_facts.preferences.is_empty());
+    assert!(profile.r#static.key_facts.preferences.is_empty());
 }
 
 #[test]
@@ -467,7 +455,7 @@ fn excludes_negative_confidence() {
     )];
     let profile =
         synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
-    assert!(profile.static_section.key_facts.preferences.is_empty());
+    assert!(profile.r#static.key_facts.preferences.is_empty());
 }
 
 // ── IDL deserializer negative tests ──────────────────────────────────
@@ -514,12 +502,163 @@ fn profile_line_deserialize_rejects_duplicate_evidence() {
 fn data_profile_subject_deserialize_rejects_neither_user_nor_agent() {
     let json = r#"{
         "subject": {},
-        "static_section": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
-        "dynamic_section": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "static": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "dynamic": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
         "updated_at": "2026-04-22T14:00:00Z"
     }"#;
     serde_json::from_str::<crate::generated::verbs::retrieve::DataProfile>(json)
         .expect_err("subject without user or agent must reject");
+}
+
+#[test]
+fn data_profile_subject_deserialize_rejects_empty_user_string() {
+    // Codex review caught this: the IDL says `minLength: 1` on
+    // `subject.user`, but the only `anyOf` check would let `{"user": ""}`
+    // through. The codegen-emitted DataProfileSubject TryFrom is what
+    // closes that hole.
+    let err = serde_json::from_str::<crate::generated::verbs::retrieve::DataProfileSubject>(
+        r#"{"user": ""}"#,
+    )
+    .expect_err("empty user must reject");
+    assert!(err.to_string().contains("user"), "{err}");
+}
+
+#[test]
+fn data_profile_subject_deserialize_rejects_empty_agent_string() {
+    let err = serde_json::from_str::<crate::generated::verbs::retrieve::DataProfileSubject>(
+        r#"{"agent": ""}"#,
+    )
+    .expect_err("empty agent must reject");
+    assert!(err.to_string().contains("agent"), "{err}");
+}
+
+#[test]
+fn data_profile_deserialize_rejects_short_updated_at() {
+    // RFC3339 minLength: 20. `2026-04-22Z` is too short — would be
+    // silently accepted before this PR.
+    let json = r#"{
+        "subject": {"user": "hmn:alice"},
+        "static": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "dynamic": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "updated_at": "2026-04-22Z"
+    }"#;
+    let err = serde_json::from_str::<crate::generated::verbs::retrieve::DataProfile>(json)
+        .expect_err("short updated_at must reject");
+    assert!(err.to_string().contains("updated_at"), "{err}");
+}
+
+#[test]
+fn data_profile_deserialize_rejects_malformed_updated_at_anchors() {
+    let json = r#"{
+        "subject": {"user": "hmn:alice"},
+        "static": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "dynamic": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "updated_at": "2026/04/22T14:00:00Z"
+    }"#;
+    let err = serde_json::from_str::<crate::generated::verbs::retrieve::DataProfile>(json)
+        .expect_err("`/` anchors must reject");
+    assert!(err.to_string().contains("updated_at"), "{err}");
+}
+
+#[test]
+fn data_profile_deserialize_accepts_lowercase_t_and_z() {
+    // RFC3339 §5.6 says `T` and `Z` are case-insensitive, and the
+    // domain `Rfc3339Timestamp::parse` accepts lowercase. The wire
+    // validator must match — otherwise the synthesizer's output for a
+    // lowercase-input timestamp would round-trip-fail.
+    let json = r#"{
+        "subject": {"user": "hmn:alice"},
+        "static": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "dynamic": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "updated_at": "2026-04-22t14:00:00z"
+    }"#;
+    let p = serde_json::from_str::<crate::generated::verbs::retrieve::DataProfile>(json)
+        .expect("lowercase t/z must parse");
+    assert_eq!(p.updated_at, "2026-04-22t14:00:00z");
+}
+
+#[test]
+fn synthesize_round_trips_lowercase_t_z_timestamp() {
+    // End-to-end check that a lowercase RFC3339 timestamp accepted by
+    // the domain parser also survives the synthesizer → JSON →
+    // generated DataProfile deserializer round-trip.
+    let records = vec![ProfileSourceRecord {
+        record_id: rid('0'),
+        is_static: true,
+        confidence: 0.9,
+        facet: KeyFactFacet::Preferences,
+        value: "lowercase-t".to_owned(),
+        updated_at: ts("2026-04-22t14:00:00z"),
+    }];
+    let now = ts("2026-04-22t14:00:01z");
+    let p = synthesize(&records, &user_subject(), &now).expect("synthesize");
+    let json = serde_json::to_string(&p).expect("serialize");
+    let back: crate::generated::verbs::retrieve::DataProfile =
+        serde_json::from_str(&json).expect("deserialize round-trip with lowercase t/z");
+    assert_eq!(back, p);
+}
+
+#[test]
+fn data_profile_deserialize_accepts_well_formed_updated_at() {
+    let json = r#"{
+        "subject": {"user": "hmn:alice"},
+        "static": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "dynamic": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "updated_at": "2026-04-22T14:00:00+00:00"
+    }"#;
+    let p = serde_json::from_str::<crate::generated::verbs::retrieve::DataProfile>(json)
+        .expect("well-formed updated_at must parse");
+    assert_eq!(p.updated_at, "2026-04-22T14:00:00+00:00");
+}
+
+#[test]
+fn updated_at_picks_chronologically_latest_irrespective_of_input_order() {
+    // Codex review: the proptest's permutation invariance was vacuous
+    // for `updated_at` because every record carried the same timestamp.
+    // This test pins the latest-timestamp picker explicitly.
+    let early = rec(
+        '0',
+        true,
+        0.9,
+        KeyFactFacet::Preferences,
+        "early",
+        "2026-04-22T14:00:00Z",
+    );
+    let late = rec(
+        '1',
+        true,
+        0.9,
+        KeyFactFacet::Preferences,
+        "late",
+        "2026-04-22T15:00:00Z",
+    );
+    let mid = rec(
+        '2',
+        true,
+        0.9,
+        KeyFactFacet::Preferences,
+        "mid",
+        "2026-04-22T14:30:00Z",
+    );
+    let now = ts("2026-04-22T16:00:00Z");
+
+    for permutation in [
+        vec![early.clone(), late.clone(), mid.clone()],
+        vec![late.clone(), early.clone(), mid.clone()],
+        vec![mid.clone(), late.clone(), early.clone()],
+        vec![late.clone(), mid.clone(), early.clone()],
+    ] {
+        let p = synthesize(&permutation, &user_subject(), &now).expect("synthesize");
+        assert_eq!(
+            p.updated_at,
+            "2026-04-22T15:00:00Z",
+            "permutation: {:?}",
+            permutation
+                .iter()
+                .map(|r| r.value.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
 }
 
 // ── Performance sanity ───────────────────────────────────────────────
@@ -652,13 +791,20 @@ proptest::proptest! {
             // converting to f32 to avoid precision warnings.
             let bucket = u16::try_from((mix >> 8) % 700).expect("< 700");
             let conf = 0.3_f32 + f32::from(bucket) / 1000.0_f32;
+            // Vary timestamps so the proptest also covers the
+            // `updated_at = max(contributing.updated_at)` rule. Without
+            // this, a regression where the synthesizer kept the *last*
+            // record's timestamp instead of the chronologically latest
+            // would still pass the permutation invariance check.
+            let minute = u8::try_from((mix >> 32) % 60).expect("< 60");
+            let updated_at = ts(&format!("2026-04-22T14:{minute:02}:00Z"));
             records.push(ProfileSourceRecord {
                 record_id,
                 is_static: (mix >> 16) & 1 == 0,
                 confidence: conf,
                 facet: facets[usize::try_from(mix >> 24).expect("u64 fits usize on 64-bit") % facets.len()],
                 value: format!("v-{}", mix % 8),
-                updated_at: ts("2026-04-22T14:00:00Z"),
+                updated_at,
             });
         }
         if records.is_empty() {

--- a/crates/cairn-core/src/pipeline/profile/tests.rs
+++ b/crates/cairn-core/src/pipeline/profile/tests.rs
@@ -663,12 +663,20 @@ fn data_profile_updated_at_validator_agrees_with_domain_parser_on_corpus() {
         ("2026-04-22T14:00:00+00:00", true),
         ("2026-04-22T14:00:00-05:30", true),
         ("2026-04-22t14:00:00z", true),
+        ("2026-04-22T14:00:00.123456789Z", true), // exactly 9 fractional digits (ns)
+        ("2024-02-29T00:00:00Z", true),           // leap-year Feb 29
+        ("2000-02-29T00:00:00Z", true),           // 2000 is leap (400-rule)
         // Rejected by both.
         ("not a date", false),
-        ("2026-04-22T14:00:00", false),       // no zone
-        ("2026-13-01T00:00:00Z", false),      // bad month
-        ("2026-04-22T24:00:00Z", false),      // bad hour
-        ("2026-04-22T14:00:00+24:00", false), // bad offset
+        ("2026-04-22T14:00:00", false),             // no zone
+        ("2026-13-01T00:00:00Z", false),            // bad month
+        ("2026-04-22T24:00:00Z", false),            // bad hour
+        ("2026-04-22T14:00:00+24:00", false),       // bad offset
+        ("2026-02-30T00:00:00Z", false),            // Feb 30: invalid for any year
+        ("2026-04-31T00:00:00Z", false),            // Apr 31: 30-day month
+        ("2026-02-29T00:00:00Z", false),            // 2026 not leap
+        ("2100-02-29T00:00:00Z", false),            // 2100 not leap (century non-400)
+        ("2026-04-22T14:00:00.1234567890Z", false), // 10 fractional digits > ns
     ];
     for (ts, expected) in corpus {
         let domain_ok = crate::domain::Rfc3339Timestamp::parse(ts).is_ok();

--- a/crates/cairn-core/src/pipeline/profile/tests.rs
+++ b/crates/cairn-core/src/pipeline/profile/tests.rs
@@ -397,3 +397,286 @@ fn deterministic_ordering_within_facet() {
         vec!["alpha org", "mid org", "zebra org"]
     );
 }
+
+// ── Confidence-range boundary checks ─────────────────────────────────
+//
+// `MemoryRecord.validate` clamps confidence to `[0.0, 1.0]` upstream;
+// the synthesizer re-checks at the trust boundary because the
+// generated `ProfileLine` deserializer emits the same `[0.0, 1.0]`
+// validator. A confidence of `1.5` slipping through here would produce
+// a `DataProfile` that deserializes-to-error in its own
+// schema round-trip.
+
+#[test]
+fn admits_confidence_at_lower_bound() {
+    let records = vec![rec(
+        '0',
+        true,
+        0.0_f32,
+        KeyFactFacet::Preferences,
+        "zero confidence",
+        "2026-04-22T14:00:00Z",
+    )];
+    // 0.0 is below the Uncertain floor — should be dropped.
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+    assert!(profile.static_section.key_facts.preferences.is_empty());
+}
+
+#[test]
+fn admits_confidence_at_upper_bound() {
+    let records = vec![rec(
+        '0',
+        true,
+        1.0_f32,
+        KeyFactFacet::Preferences,
+        "max confidence",
+        "2026-04-22T14:00:00Z",
+    )];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+    let line = &profile.static_section.key_facts.preferences[0];
+    assert!((line.confidence - 1.0_f64).abs() < f64::EPSILON);
+}
+
+#[test]
+fn excludes_confidence_above_one() {
+    // Out-of-range input — must not produce un-serializable output.
+    let records = vec![rec(
+        '0',
+        true,
+        1.5_f32,
+        KeyFactFacet::Preferences,
+        "broken extractor",
+        "2026-04-22T14:00:00Z",
+    )];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+    assert!(profile.static_section.key_facts.preferences.is_empty());
+}
+
+#[test]
+fn excludes_negative_confidence() {
+    let records = vec![rec(
+        '0',
+        true,
+        -0.5_f32,
+        KeyFactFacet::Preferences,
+        "broken extractor",
+        "2026-04-22T14:00:00Z",
+    )];
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+    assert!(profile.static_section.key_facts.preferences.is_empty());
+}
+
+// ── IDL deserializer negative tests ──────────────────────────────────
+//
+// Direct exercise of the codegen-emitted `ProfileLine` TryFrom path —
+// guards the validator we hand-rolled in
+// `cairn-idl::codegen::emit_sdk::write_retrieve_data_extra_checks`.
+// Without these the codegen could regress (drop the validator) and
+// only failing wire-compat snapshots elsewhere would catch it.
+
+#[test]
+fn profile_line_deserialize_rejects_empty_value() {
+    let json = r#"{"value":"","confidence":0.5,"evidence":["00000000000000000000000000"]}"#;
+    let err = serde_json::from_str::<crate::generated::verbs::retrieve::ProfileLine>(json)
+        .expect_err("empty value must reject");
+    assert!(err.to_string().contains("value"), "{err}");
+}
+
+#[test]
+fn profile_line_deserialize_rejects_confidence_above_one() {
+    let json = r#"{"value":"x","confidence":1.5,"evidence":["00000000000000000000000000"]}"#;
+    let err = serde_json::from_str::<crate::generated::verbs::retrieve::ProfileLine>(json)
+        .expect_err("confidence > 1 must reject");
+    assert!(err.to_string().contains("confidence"), "{err}");
+}
+
+#[test]
+fn profile_line_deserialize_rejects_empty_evidence() {
+    let json = r#"{"value":"x","confidence":0.5,"evidence":[]}"#;
+    let err = serde_json::from_str::<crate::generated::verbs::retrieve::ProfileLine>(json)
+        .expect_err("empty evidence must reject");
+    assert!(err.to_string().contains("evidence"), "{err}");
+}
+
+#[test]
+fn profile_line_deserialize_rejects_duplicate_evidence() {
+    let json = r#"{"value":"x","confidence":0.5,"evidence":["00000000000000000000000000","00000000000000000000000000"]}"#;
+    let err = serde_json::from_str::<crate::generated::verbs::retrieve::ProfileLine>(json)
+        .expect_err("duplicate evidence must reject");
+    assert!(err.to_string().contains("evidence"), "{err}");
+}
+
+#[test]
+fn data_profile_subject_deserialize_rejects_neither_user_nor_agent() {
+    let json = r#"{
+        "subject": {},
+        "static_section": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "dynamic_section": {"summary":"","historical_summary":"","key_facts":{"devices":[],"software":[],"preferences":[],"current_issues":[],"addressed_issues":[],"recurring_issues":[],"known_entities":[]}},
+        "updated_at": "2026-04-22T14:00:00Z"
+    }"#;
+    serde_json::from_str::<crate::generated::verbs::retrieve::DataProfile>(json)
+        .expect_err("subject without user or agent must reject");
+}
+
+// ── Performance sanity ───────────────────────────────────────────────
+//
+// Synthesizer is O(n) over input + O(b log b) per facet bucket where
+// `b` is the bucket cardinality. For 10K records spread across 7 facets
+// the BTreeMap insert/walk dominates and stays well under 100ms on
+// commodity hardware. This test guards against an accidental
+// regression to O(n²) (e.g., a future "merge across facets" refactor).
+
+#[test]
+fn synthesizes_ten_thousand_records_under_budget() {
+    let mut records: Vec<ProfileSourceRecord> = Vec::with_capacity(10_000);
+    let facets = [
+        KeyFactFacet::Devices,
+        KeyFactFacet::Software,
+        KeyFactFacet::Preferences,
+        KeyFactFacet::CurrentIssues,
+        KeyFactFacet::AddressedIssues,
+        KeyFactFacet::RecurringIssues,
+        KeyFactFacet::KnownEntities,
+    ];
+    // Crockford base32, no I/L/O/U.
+    let alphabet: &[u8] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    for i in 0..10_000_u64 {
+        // ULID first char must be 0..=7 (top 5 bits zero in a 128-bit
+        // ULID). Mix `i` into a 25-char suffix using a 64-bit Weyl
+        // sequence so we don't shift past the type's width.
+        let mut s = String::with_capacity(26);
+        s.push(char::from(b'0' + u8::try_from(i % 8).expect("0..8")));
+        let mut state = i.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+        for _ in 0..25 {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1);
+            let idx = (state >> 33) as usize % alphabet.len();
+            s.push(alphabet[idx] as char);
+        }
+        let Ok(record_id) = RecordId::parse(&s) else {
+            // Crockford alphabet is closed under our index map, so this
+            // path is unreachable — keep the guard rather than panic.
+            continue;
+        };
+        records.push(ProfileSourceRecord {
+            record_id,
+            is_static: i % 2 == 0,
+            confidence: 0.5,
+            // `i` is bounded < 10_000 so the cast is lossless.
+            facet: facets[usize::try_from(i).expect("i < 10000") % facets.len()],
+            // Limit value cardinality so the merge step exercises the
+            // BTreeMap collision path; otherwise every line is unique
+            // and we'd only stress the linear scan.
+            value: format!("fact-{}", i % 256),
+            updated_at: ts("2026-04-22T14:00:00Z"),
+        });
+    }
+    assert!(
+        records.len() >= 9_000,
+        "ULID generator dropped too many: got {}",
+        records.len()
+    );
+
+    let start = std::time::Instant::now();
+    let profile =
+        synthesize(&records, &user_subject(), &ts("2026-04-22T14:00:01Z")).expect("synthesize");
+    let elapsed = start.elapsed();
+
+    // Generous bound: synthesizes in ~5–15ms locally; CI can be 5×
+    // slower under load. 200ms keeps us well clear of an O(n²)
+    // regression (which would push 10K records into seconds).
+    assert!(
+        elapsed < std::time::Duration::from_millis(200),
+        "synthesizer over budget: {elapsed:?}"
+    );
+
+    // Sanity: output is non-empty and every line is wire-valid.
+    let json = serde_json::to_string(&profile).expect("serialize");
+    let back: crate::generated::verbs::retrieve::DataProfile =
+        serde_json::from_str(&json).expect("deserialize round-trip");
+    assert_eq!(back, profile);
+}
+
+// ── Property: order-invariance ───────────────────────────────────────
+//
+// `synthesize` is documented as "same inputs always produce the same
+// profile" — the forget-propagation contract leans on that. Permuting
+// the input slice must not change the output. This is the strongest
+// claim a property test can make about a pure aggregation function;
+// without it the brief's "byte-identical wire output across calls"
+// guarantee (§8.0.a) cannot hold.
+
+proptest::proptest! {
+    #![proptest_config(proptest::prelude::ProptestConfig {
+        cases: 64,
+        ..proptest::prelude::ProptestConfig::default()
+    })]
+
+    #[test]
+    fn output_invariant_under_input_permutation(
+        seed in 0u64..1_000_000,
+        len in 1usize..32,
+    ) {
+        // Build a deterministic batch from the seed so failures are
+        // reproducible without proptest's own minimizer.
+        let facets = [
+            KeyFactFacet::Devices,
+            KeyFactFacet::Software,
+            KeyFactFacet::Preferences,
+            KeyFactFacet::CurrentIssues,
+            KeyFactFacet::AddressedIssues,
+            KeyFactFacet::RecurringIssues,
+            KeyFactFacet::KnownEntities,
+        ];
+        let mut records: Vec<ProfileSourceRecord> = Vec::with_capacity(len);
+        for i in 0..len {
+            let mix = seed
+                .wrapping_add(u64::try_from(i).expect("len < 32"))
+                .wrapping_mul(2_654_435_761);
+            let first = char::from(b'0' + u8::try_from(mix % 8).expect("0..8"));
+            // 26-char ULID: leading 0..=7 char + 25-char Crockford suffix
+            // derived from `mix`. Forming a hex tail then padding keeps
+            // the alphabet legal for the ULID parser (all hex digits are
+            // in the Crockford set).
+            let id = format!("{first}{:0>25X}", mix % (1u64 << 25));
+            let Ok(record_id) = RecordId::parse(&id) else {
+                continue;
+            };
+            // Confidence ∈ [0.3, 1.0] so admission isn't probabilistic.
+            // (mix >> 8) % 700 fits in u16 — divide as u32 before
+            // converting to f32 to avoid precision warnings.
+            let bucket = u16::try_from((mix >> 8) % 700).expect("< 700");
+            let conf = 0.3_f32 + f32::from(bucket) / 1000.0_f32;
+            records.push(ProfileSourceRecord {
+                record_id,
+                is_static: (mix >> 16) & 1 == 0,
+                confidence: conf,
+                facet: facets[usize::try_from(mix >> 24).expect("u64 fits usize on 64-bit") % facets.len()],
+                value: format!("v-{}", mix % 8),
+                updated_at: ts("2026-04-22T14:00:00Z"),
+            });
+        }
+        if records.is_empty() {
+            return Ok(());
+        }
+
+        let mut shuffled = records.clone();
+        // Deterministic Fisher-Yates using the seed.
+        let mut s = seed;
+        for i in (1..shuffled.len()).rev() {
+            s = s.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            let j = usize::try_from(s).expect("u64 fits usize on 64-bit") % (i + 1);
+            shuffled.swap(i, j);
+        }
+
+        let now = ts("2026-04-22T14:00:01Z");
+        let a = synthesize(&records,  &user_subject(), &now).expect("synthesize a");
+        let b = synthesize(&shuffled, &user_subject(), &now).expect("synthesize b");
+        proptest::prop_assert_eq!(a, b);
+    }
+}

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -195,7 +195,8 @@
     "DataProfile": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["subject", "profile"],
+      "required": ["subject", "static_section", "dynamic_section", "updated_at"],
+      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static_section`, `is_static = 1`) and current state (`dynamic_section`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1.",
       "properties": {
         "subject": {
           "type": "object",
@@ -209,9 +210,73 @@
             { "required": ["agent"] }
           ]
         },
-        "profile": {
-          "type": "object",
-          "description": "Free-form profile payload — typed in a later increment once the profile taxonomy lands."
+        "static_section":  { "$ref": "#/$defs/ProfileHalf" },
+        "dynamic_section": { "$ref": "#/$defs/ProfileHalf" },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "minLength": 20,
+          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty."
+        }
+      }
+    },
+    "ProfileHalf": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["summary", "historical_summary", "key_facts"],
+      "description": "One half of an AutoUserProfile (brief §7.1). `summary` and `historical_summary` are the rolling DreamWorkflow narratives — they remain empty strings at P0 and are populated by the P1 ConsolidationWorkflow. `key_facts` is the P0 deliverable: structured per-facet ProfileLine arrays.",
+      "properties": {
+        "summary":            { "type": "string" },
+        "historical_summary": { "type": "string" },
+        "key_facts":          { "$ref": "#/$defs/KeyFacts" }
+      }
+    },
+    "KeyFacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "devices",
+        "software",
+        "preferences",
+        "current_issues",
+        "addressed_issues",
+        "recurring_issues",
+        "known_entities"
+      ],
+      "description": "Seven structured fact buckets (brief §7.1). Each bucket is an array of ProfileLine — empty arrays are valid and required so a consumer can rely on every key being present.",
+      "properties": {
+        "devices":          { "type": "array", "items": { "$ref": "#/$defs/ProfileLine" } },
+        "software":         { "type": "array", "items": { "$ref": "#/$defs/ProfileLine" } },
+        "preferences":      { "type": "array", "items": { "$ref": "#/$defs/ProfileLine" } },
+        "current_issues":   { "type": "array", "items": { "$ref": "#/$defs/ProfileLine" } },
+        "addressed_issues": { "type": "array", "items": { "$ref": "#/$defs/ProfileLine" } },
+        "recurring_issues": { "type": "array", "items": { "$ref": "#/$defs/ProfileLine" } },
+        "known_entities":   { "type": "array", "items": { "$ref": "#/$defs/ProfileLine" } }
+      }
+    },
+    "ProfileLine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "confidence", "evidence"],
+      "description": "One profile fact with its evidence trail. `evidence` is the list of source records that contributed; record-level forget removes them from the input set, so re-synthesizing the profile drops the line.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical short statement of the fact (e.g., 'prefers terse explanations', 'M2 MacBook Pro')."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Confidence in [0, 1]. Records with confidence < 0.3 (ConfidenceBand::Uncertain) are excluded from the profile."
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "../common/primitives.json#/$defs/Ulid" },
+          "description": "Source-record ULIDs whose bodies contributed to this line. Always non-empty."
         }
       }
     },

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -195,8 +195,8 @@
     "DataProfile": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["subject", "static_section", "dynamic_section", "updated_at"],
-      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static_section`, `is_static = 1`) and current state (`dynamic_section`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1.",
+      "required": ["subject", "static", "dynamic", "updated_at"],
+      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static`, `is_static = 1`) and current state (`dynamic`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1. Wire field names match the brief's `{static, dynamic, updated_at}` notation; the Rust binding emits them via the `r#static` raw identifier.",
       "properties": {
         "subject": {
           "type": "object",
@@ -210,8 +210,8 @@
             { "required": ["agent"] }
           ]
         },
-        "static_section":  { "$ref": "#/$defs/ProfileHalf" },
-        "dynamic_section": { "$ref": "#/$defs/ProfileHalf" },
+        "static":  { "$ref": "#/$defs/ProfileHalf" },
+        "dynamic": { "$ref": "#/$defs/ProfileHalf" },
         "updated_at": {
           "type": "string",
           "format": "date-time",

--- a/crates/cairn-idl/schema/verbs/retrieve.json
+++ b/crates/cairn-idl/schema/verbs/retrieve.json
@@ -216,7 +216,8 @@
           "type": "string",
           "format": "date-time",
           "minLength": 20,
-          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty."
+          "maxLength": 64,
+          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty. Validator accept set matches `cairn_core::domain::Rfc3339Timestamp::parse` (excluding leap-seconds), so any wire-accepted value also parses domain-side without a second gauntlet."
         }
       }
     },

--- a/crates/cairn-idl/src/codegen/emit_sdk.rs
+++ b/crates/cairn-idl/src/codegen/emit_sdk.rs
@@ -2771,12 +2771,35 @@ fn write_retrieve_data_extra_checks(w: &mut RustWriter, type_name: &str) {
             w.line("return Err(\"updated_at: date must be YYYY-MM-DD\");");
             w.dedent();
             w.line("}");
+            // u16 year — 4-digit YYYY fits comfortably; the inline
+            // multiplications below stay under u16::MAX.
+            w.line(
+                "let yyyy: u16 = (u16::from(bytes[0] - b'0')) * 1000 + (u16::from(bytes[1] - b'0')) * 100 + (u16::from(bytes[2] - b'0')) * 10 + u16::from(bytes[3] - b'0');",
+            );
             w.line("let mm = (bytes[5] - b'0') * 10 + (bytes[6] - b'0');");
             w.line("let dd = (bytes[8] - b'0') * 10 + (bytes[9] - b'0');");
             w.line(
                 "if !(1..=12).contains(&mm) { return Err(\"updated_at: month out of range\"); }",
             );
-            w.line("if !(1..=31).contains(&dd) { return Err(\"updated_at: day out of range\"); }");
+            // Per-month max-day. Inlined Gregorian rule with leap-year
+            // correction for February — same logic as
+            // `cairn_core::domain::timestamp::days_in_month` so a value
+            // accepted here always parses domain-side.
+            w.line(
+                "let leap = yyyy.is_multiple_of(4) && (!yyyy.is_multiple_of(100) || yyyy.is_multiple_of(400));",
+            );
+            w.line("let max_day: u8 = match mm {");
+            w.indent();
+            w.line("1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,");
+            w.line("4 | 6 | 9 | 11 => 30,");
+            w.line("2 if leap => 29,");
+            w.line("2 => 28,");
+            w.line("_ => 0,");
+            w.dedent();
+            w.line("};");
+            w.line(
+                "if dd < 1 || dd > max_day { return Err(\"updated_at: day out of range for month\"); }",
+            );
             // Date/time separator (case-insensitive `T`).
             w.line(
                 "if !matches!(bytes[10], b'T' | b't') { return Err(\"updated_at: expected `T` between date and time\"); }",
@@ -2796,6 +2819,8 @@ fn write_retrieve_data_extra_checks(w: &mut RustWriter, type_name: &str) {
             w.line("if mi > 59 { return Err(\"updated_at: minute out of range\"); }");
             w.line("if ss > 59 { return Err(\"updated_at: second out of range\"); }");
             // Trailing fractional + zone — same shape as the domain parser.
+            // Cap at 9 digits (nanosecond precision); higher precision
+            // would silently truncate during chronological comparison.
             w.line("let mut idx = 19usize;");
             w.line("if idx < bytes.len() && bytes[idx] == b'.' {");
             w.indent();
@@ -2804,6 +2829,9 @@ fn write_retrieve_data_extra_checks(w: &mut RustWriter, type_name: &str) {
             w.line("while idx < bytes.len() && bytes[idx].is_ascii_digit() { idx += 1; }");
             w.line(
                 "if idx == frac_start { return Err(\"updated_at: fractional must have >=1 digit after `.`\"); }",
+            );
+            w.line(
+                "if idx - frac_start > 9 { return Err(\"updated_at: fractional must be <= 9 digits (ns precision)\"); }",
             );
             w.dedent();
             w.line("}");

--- a/crates/cairn-idl/src/codegen/emit_sdk.rs
+++ b/crates/cairn-idl/src/codegen/emit_sdk.rs
@@ -1765,7 +1765,13 @@ fn write_struct(
 fn struct_has_extra_validators(name: &str) -> bool {
     matches!(
         name,
-        "SearchArgs" | "DataRecord" | "DataSession" | "DataTurn" | "DataFolder" | "RecordRef"
+        "SearchArgs"
+            | "DataRecord"
+            | "DataSession"
+            | "DataTurn"
+            | "DataFolder"
+            | "RecordRef"
+            | "ProfileLine"
     )
 }
 
@@ -1826,7 +1832,7 @@ fn write_struct_raw_companion(w: &mut RustWriter, s: &StructDef, common: &BTreeS
     // helper dispatches by struct name.
     if matches!(
         s.name.0.as_str(),
-        "DataRecord" | "DataSession" | "DataTurn" | "DataFolder" | "RecordRef"
+        "DataRecord" | "DataSession" | "DataTurn" | "DataFolder" | "RecordRef" | "ProfileLine"
     ) {
         write_retrieve_data_extra_checks(w, &s.name.0);
     }
@@ -2638,6 +2644,8 @@ fn write_search_args_extra_checks(w: &mut RustWriter) {
 ///   `minimum: 0` is structural; nothing to enforce.)
 /// * `DataFolder.path`: minLength 1; `DataFolder.depth`: maximum 16.
 /// * `RecordRef.kind`: minLength 1.
+/// * `ProfileLine.value`: minLength 1; `ProfileLine.confidence`: in `[0, 1]`;
+///   `ProfileLine.evidence`: minItems 1, uniqueItems (brief §7.1).
 ///
 /// The generic IR strips these constraints during lowering, so without the
 /// hand-rolled check `DataFolder { depth: 999, path: "" }` and
@@ -2675,6 +2683,32 @@ fn write_retrieve_data_extra_checks(w: &mut RustWriter, type_name: &str) {
         "RecordRef" => {
             // RecordRef.kind: minLength 1.
             w.line("if raw.kind.is_empty() { return Err(\"kind: must not be empty\"); }");
+        }
+        "ProfileLine" => {
+            // ProfileLine.value: minLength 1.
+            w.line("if raw.value.is_empty() { return Err(\"value: must not be empty\"); }");
+            // ProfileLine.confidence: bounded [0.0, 1.0]; reject NaN.
+            w.line("if !(0.0..=1.0).contains(&raw.confidence) || raw.confidence.is_nan() {");
+            w.indent();
+            w.line("return Err(\"confidence: must be in [0, 1]\");");
+            w.dedent();
+            w.line("}");
+            // ProfileLine.evidence: minItems 1, uniqueItems on the inner ULID
+            // string. Mirrors the chain_parents uniqueness check in
+            // `write_signed_intent_extra_checks` to keep cairn-core regex-free.
+            w.line(
+                "if raw.evidence.is_empty() { return Err(\"evidence: must contain at least 1 item\"); }",
+            );
+            w.line("{");
+            w.indent();
+            w.line("let mut seen = ::std::collections::BTreeSet::new();");
+            w.line("for ulid in &raw.evidence {");
+            w.indent();
+            w.line("if !seen.insert(ulid.0.clone()) { return Err(\"evidence: must be unique\"); }");
+            w.dedent();
+            w.line("}");
+            w.dedent();
+            w.line("}");
         }
         _ => {
             // Unreachable — the dispatch in write_struct_raw_companion gates

--- a/crates/cairn-idl/src/codegen/emit_sdk.rs
+++ b/crates/cairn-idl/src/codegen/emit_sdk.rs
@@ -2741,46 +2741,95 @@ fn write_retrieve_data_extra_checks(w: &mut RustWriter, type_name: &str) {
             // DataProfile.updated_at: RFC3339 `date-time` with minLength 20
             // Mirrors `cairn_core::domain::Rfc3339Timestamp::parse`'s
             // accept set so a domain-valid timestamp can always
-            // round-trip through the wire deserializer; full range
-            // validation (month 1-12, day-of-month, hour 0-23, etc.)
-            // happens at the verb layer where the domain parser runs.
-            // Asymmetry here would let a domain-valid value fail
-            // deserialize through the response envelope.
-            w.line("if raw.updated_at.len() < 20 {");
-            w.indent();
-            w.line("return Err(\"updated_at: must be RFC3339 date-time with at least 20 chars\");");
-            w.dedent();
-            w.line("}");
+            // round-trip through the wire deserializer, AND so the
+            // typed `DataProfile.updated_at` field can be parsed back
+            // into a `Rfc3339Timestamp` without a second validation
+            // gauntlet. The codegen layer cannot depend on
+            // `cairn-core::domain`, so the rules are duplicated here;
+            // the test suite cross-checks the two implementations.
+            //
+            // Caps `len` at 64 (max reasonable RFC3339 form is around
+            // 35 chars: `YYYY-MM-DDTHH:MM:SS.fffffffff+HH:MM`); any
+            // longer string would imply pathological fractional digits
+            // and just allocate memory.
+            w.line(
+                "if !(20..=64).contains(&raw.updated_at.len()) { return Err(\"updated_at: RFC3339 date-time must be 20..=64 chars\"); }",
+            );
             w.line("if !raw.updated_at.is_ascii() {");
             w.indent();
             w.line("return Err(\"updated_at: RFC3339 date-time must be ASCII\");");
             w.dedent();
             w.line("}");
-            // Structural anchor checks. Note: `T` and `Z` are
-            // case-insensitive per RFC3339 §5.6 and the domain parser
-            // accepts both — match that here.
             w.line("{");
             w.indent();
             w.line("let bytes = raw.updated_at.as_bytes();");
+            // Date: YYYY-MM-DD digits + ranges.
             w.line(
-                "if bytes[4] != b'-' || bytes[7] != b'-' || !matches!(bytes[10], b'T' | b't') || bytes[13] != b':' || bytes[16] != b':' {",
+                "if !bytes[..4].iter().all(u8::is_ascii_digit) || bytes[4] != b'-' || !bytes[5..7].iter().all(u8::is_ascii_digit) || bytes[7] != b'-' || !bytes[8..10].iter().all(u8::is_ascii_digit) {",
             );
             w.indent();
+            w.line("return Err(\"updated_at: date must be YYYY-MM-DD\");");
+            w.dedent();
+            w.line("}");
+            w.line("let mm = (bytes[5] - b'0') * 10 + (bytes[6] - b'0');");
+            w.line("let dd = (bytes[8] - b'0') * 10 + (bytes[9] - b'0');");
             w.line(
-                "return Err(\"updated_at: RFC3339 date-time anchors must be `-`/`T`/`:` at positions 4/7/10/13/16\");",
+                "if !(1..=12).contains(&mm) { return Err(\"updated_at: month out of range\"); }",
+            );
+            w.line("if !(1..=31).contains(&dd) { return Err(\"updated_at: day out of range\"); }");
+            // Date/time separator (case-insensitive `T`).
+            w.line(
+                "if !matches!(bytes[10], b'T' | b't') { return Err(\"updated_at: expected `T` between date and time\"); }",
+            );
+            // Time: HH:MM:SS digits + ranges.
+            w.line(
+                "if !bytes[11..13].iter().all(u8::is_ascii_digit) || bytes[13] != b':' || !bytes[14..16].iter().all(u8::is_ascii_digit) || bytes[16] != b':' || !bytes[17..19].iter().all(u8::is_ascii_digit) {",
+            );
+            w.indent();
+            w.line("return Err(\"updated_at: time must be HH:MM:SS\");");
+            w.dedent();
+            w.line("}");
+            w.line("let hh = (bytes[11] - b'0') * 10 + (bytes[12] - b'0');");
+            w.line("let mi = (bytes[14] - b'0') * 10 + (bytes[15] - b'0');");
+            w.line("let ss = (bytes[17] - b'0') * 10 + (bytes[18] - b'0');");
+            w.line("if hh > 23 { return Err(\"updated_at: hour out of range\"); }");
+            w.line("if mi > 59 { return Err(\"updated_at: minute out of range\"); }");
+            w.line("if ss > 59 { return Err(\"updated_at: second out of range\"); }");
+            // Trailing fractional + zone — same shape as the domain parser.
+            w.line("let mut idx = 19usize;");
+            w.line("if idx < bytes.len() && bytes[idx] == b'.' {");
+            w.indent();
+            w.line("idx += 1;");
+            w.line("let frac_start = idx;");
+            w.line("while idx < bytes.len() && bytes[idx].is_ascii_digit() { idx += 1; }");
+            w.line(
+                "if idx == frac_start { return Err(\"updated_at: fractional must have >=1 digit after `.`\"); }",
             );
             w.dedent();
             w.line("}");
-            w.line("let last = bytes[bytes.len() - 1];");
+            // Zone: `Z`/`z` or `+/-HH:MM` with digit + range checks.
+            w.line("if idx < bytes.len() && matches!(bytes[idx], b'Z' | b'z') { idx += 1; }");
+            w.line("else if idx + 6 == bytes.len() && matches!(bytes[idx], b'+' | b'-') {");
+            w.indent();
+            w.line("let off = &bytes[idx + 1..];");
             w.line(
-                "if !matches!(last, b'Z' | b'z') && !matches!(bytes.get(bytes.len() - 6), Some(b'+' | b'-')) {",
+                "if !off[..2].iter().all(u8::is_ascii_digit) || off[2] != b':' || !off[3..5].iter().all(u8::is_ascii_digit) {",
             );
             w.indent();
-            w.line(
-                "return Err(\"updated_at: RFC3339 date-time must end with `Z` or `+/-HH:MM` offset\");",
-            );
+            w.line("return Err(\"updated_at: offset must be `+/-HH:MM` digits\");");
             w.dedent();
             w.line("}");
+            w.line("let oh = (off[0] - b'0') * 10 + (off[1] - b'0');");
+            w.line("let om = (off[3] - b'0') * 10 + (off[4] - b'0');");
+            w.line("if oh > 23 { return Err(\"updated_at: offset hour out of range\"); }");
+            w.line("if om > 59 { return Err(\"updated_at: offset minute out of range\"); }");
+            w.line("idx = bytes.len();");
+            w.dedent();
+            w.line("}");
+            w.line("else { return Err(\"updated_at: must end with `Z` or `+/-HH:MM` offset\"); }");
+            w.line(
+                "if idx != bytes.len() { return Err(\"updated_at: trailing data after zone\"); }",
+            );
             w.dedent();
             w.line("}");
         }

--- a/crates/cairn-idl/src/codegen/emit_sdk.rs
+++ b/crates/cairn-idl/src/codegen/emit_sdk.rs
@@ -1772,6 +1772,8 @@ fn struct_has_extra_validators(name: &str) -> bool {
             | "DataFolder"
             | "RecordRef"
             | "ProfileLine"
+            | "DataProfile"
+            | "DataProfileSubject"
     )
 }
 
@@ -1832,7 +1834,14 @@ fn write_struct_raw_companion(w: &mut RustWriter, s: &StructDef, common: &BTreeS
     // helper dispatches by struct name.
     if matches!(
         s.name.0.as_str(),
-        "DataRecord" | "DataSession" | "DataTurn" | "DataFolder" | "RecordRef" | "ProfileLine"
+        "DataRecord"
+            | "DataSession"
+            | "DataTurn"
+            | "DataFolder"
+            | "RecordRef"
+            | "ProfileLine"
+            | "DataProfile"
+            | "DataProfileSubject"
     ) {
         write_retrieve_data_extra_checks(w, &s.name.0);
     }
@@ -2705,6 +2714,71 @@ fn write_retrieve_data_extra_checks(w: &mut RustWriter, type_name: &str) {
             w.line("for ulid in &raw.evidence {");
             w.indent();
             w.line("if !seen.insert(ulid.0.clone()) { return Err(\"evidence: must be unique\"); }");
+            w.dedent();
+            w.line("}");
+            w.dedent();
+            w.line("}");
+        }
+        "DataProfileSubject" => {
+            // DataProfileSubject.user / .agent: minLength 1 when present.
+            // The IR carries the `anyOf` presence rule (already emitted as
+            // `at least one of [user, agent] is required`), but strips the
+            // string `minLength: 1`. Without these checks, `{"user": ""}`
+            // deserializes despite the schema, and the synthesizer's
+            // `BlankSubjectField` error becomes unreachable from the wire.
+            w.line("if let Some(s) = &raw.user {");
+            w.indent();
+            w.line("if s.is_empty() { return Err(\"user: must not be empty\"); }");
+            w.dedent();
+            w.line("}");
+            w.line("if let Some(s) = &raw.agent {");
+            w.indent();
+            w.line("if s.is_empty() { return Err(\"agent: must not be empty\"); }");
+            w.dedent();
+            w.line("}");
+        }
+        "DataProfile" => {
+            // DataProfile.updated_at: RFC3339 `date-time` with minLength 20
+            // Mirrors `cairn_core::domain::Rfc3339Timestamp::parse`'s
+            // accept set so a domain-valid timestamp can always
+            // round-trip through the wire deserializer; full range
+            // validation (month 1-12, day-of-month, hour 0-23, etc.)
+            // happens at the verb layer where the domain parser runs.
+            // Asymmetry here would let a domain-valid value fail
+            // deserialize through the response envelope.
+            w.line("if raw.updated_at.len() < 20 {");
+            w.indent();
+            w.line("return Err(\"updated_at: must be RFC3339 date-time with at least 20 chars\");");
+            w.dedent();
+            w.line("}");
+            w.line("if !raw.updated_at.is_ascii() {");
+            w.indent();
+            w.line("return Err(\"updated_at: RFC3339 date-time must be ASCII\");");
+            w.dedent();
+            w.line("}");
+            // Structural anchor checks. Note: `T` and `Z` are
+            // case-insensitive per RFC3339 §5.6 and the domain parser
+            // accepts both — match that here.
+            w.line("{");
+            w.indent();
+            w.line("let bytes = raw.updated_at.as_bytes();");
+            w.line(
+                "if bytes[4] != b'-' || bytes[7] != b'-' || !matches!(bytes[10], b'T' | b't') || bytes[13] != b':' || bytes[16] != b':' {",
+            );
+            w.indent();
+            w.line(
+                "return Err(\"updated_at: RFC3339 date-time anchors must be `-`/`T`/`:` at positions 4/7/10/13/16\");",
+            );
+            w.dedent();
+            w.line("}");
+            w.line("let last = bytes[bytes.len() - 1];");
+            w.line(
+                "if !matches!(last, b'Z' | b'z') && !matches!(bytes.get(bytes.len() - 6), Some(b'+' | b'-')) {",
+            );
+            w.indent();
+            w.line(
+                "return Err(\"updated_at: RFC3339 date-time must end with `Z` or `+/-HH:MM` offset\");",
+            );
             w.dedent();
             w.line("}");
             w.dedent();

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -625,6 +625,18 @@ fn every_typed_field_asserts_bounds_or_is_allowlisted() {
         // (PolicyDetail::None) is intentional and meaningful, so a
         // minLength assertion would be wrong here.
         ("common/record_exclusion.json", "/properties/detail"),
+        // ProfileHalf.summary / .historical_summary are the rolling
+        // DreamWorkflow narratives (brief §7.1). At P0 they are
+        // intentionally emitted as empty strings — populating them is
+        // P1 work owned by ConsolidationWorkflow. A minLength: 1 here
+        // would force callers to invent placeholder text every time
+        // the narratives haven't been generated yet, defeating the
+        // P0/P1 split.
+        ("verbs/retrieve.json", "/$defs/ProfileHalf/properties/summary"),
+        (
+            "verbs/retrieve.json",
+            "/$defs/ProfileHalf/properties/historical_summary",
+        ),
     ]
     .iter()
     .map(|(f, p)| (f.to_string(), p.to_string()))

--- a/crates/cairn-idl/tests/schema_files.rs
+++ b/crates/cairn-idl/tests/schema_files.rs
@@ -632,7 +632,10 @@ fn every_typed_field_asserts_bounds_or_is_allowlisted() {
         // would force callers to invent placeholder text every time
         // the narratives haven't been generated yet, defeating the
         // P0/P1 split.
-        ("verbs/retrieve.json", "/$defs/ProfileHalf/properties/summary"),
+        (
+            "verbs/retrieve.json",
+            "/$defs/ProfileHalf/properties/summary",
+        ),
         (
             "verbs/retrieve.json",
             "/$defs/ProfileHalf/properties/historical_summary",

--- a/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.input.json
@@ -366,12 +366,12 @@
     },
     "DataProfile": {
       "additionalProperties": false,
-      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static_section`, `is_static = 1`) and current state (`dynamic_section`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1.",
+      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static`, `is_static = 1`) and current state (`dynamic`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1. Wire field names match the brief's `{static, dynamic, updated_at}` notation; the Rust binding emits them via the `r#static` raw identifier.",
       "properties": {
-        "dynamic_section": {
+        "dynamic": {
           "$ref": "#/$defs/ProfileHalf"
         },
-        "static_section": {
+        "static": {
           "$ref": "#/$defs/ProfileHalf"
         },
         "subject": {
@@ -409,8 +409,8 @@
       },
       "required": [
         "subject",
-        "static_section",
-        "dynamic_section",
+        "static",
+        "dynamic",
         "updated_at"
       ],
       "type": "object"

--- a/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.input.json
@@ -366,10 +366,13 @@
     },
     "DataProfile": {
       "additionalProperties": false,
+      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static_section`, `is_static = 1`) and current state (`dynamic_section`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1.",
       "properties": {
-        "profile": {
-          "description": "Free-form profile payload — typed in a later increment once the profile taxonomy lands.",
-          "type": "object"
+        "dynamic_section": {
+          "$ref": "#/$defs/ProfileHalf"
+        },
+        "static_section": {
+          "$ref": "#/$defs/ProfileHalf"
         },
         "subject": {
           "additionalProperties": false,
@@ -396,11 +399,19 @@
             }
           },
           "type": "object"
+        },
+        "updated_at": {
+          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty.",
+          "format": "date-time",
+          "minLength": 20,
+          "type": "string"
         }
       },
       "required": [
         "subject",
-        "profile"
+        "static_section",
+        "dynamic_section",
+        "updated_at"
       ],
       "type": "object"
     },
@@ -495,6 +506,117 @@
         "session_id",
         "turn_id",
         "turn"
+      ],
+      "type": "object"
+    },
+    "KeyFacts": {
+      "additionalProperties": false,
+      "description": "Seven structured fact buckets (brief §7.1). Each bucket is an array of ProfileLine — empty arrays are valid and required so a consumer can rely on every key being present.",
+      "properties": {
+        "addressed_issues": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "current_issues": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "known_entities": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "preferences": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "recurring_issues": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "software": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "devices",
+        "software",
+        "preferences",
+        "current_issues",
+        "addressed_issues",
+        "recurring_issues",
+        "known_entities"
+      ],
+      "type": "object"
+    },
+    "ProfileHalf": {
+      "additionalProperties": false,
+      "description": "One half of an AutoUserProfile (brief §7.1). `summary` and `historical_summary` are the rolling DreamWorkflow narratives — they remain empty strings at P0 and are populated by the P1 ConsolidationWorkflow. `key_facts` is the P0 deliverable: structured per-facet ProfileLine arrays.",
+      "properties": {
+        "historical_summary": {
+          "type": "string"
+        },
+        "key_facts": {
+          "$ref": "#/$defs/KeyFacts"
+        },
+        "summary": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "historical_summary",
+        "key_facts"
+      ],
+      "type": "object"
+    },
+    "ProfileLine": {
+      "additionalProperties": false,
+      "description": "One profile fact with its evidence trail. `evidence` is the list of source records that contributed; record-level forget removes them from the input set, so re-synthesizing the profile drops the line.",
+      "properties": {
+        "confidence": {
+          "description": "Confidence in [0, 1]. Records with confidence < 0.3 (ConfidenceBand::Uncertain) are excluded from the profile.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "evidence": {
+          "description": "Source-record ULIDs whose bodies contributed to this line. Always non-empty.",
+          "items": {
+            "$ref": "../common/primitives.json#/$defs/Ulid"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "value": {
+          "description": "Canonical short statement of the fact (e.g., 'prefers terse explanations', 'M2 MacBook Pro').",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "confidence",
+        "evidence"
       ],
       "type": "object"
     },

--- a/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.input.json
@@ -401,8 +401,9 @@
           "type": "object"
         },
         "updated_at": {
-          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty.",
+          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty. Validator accept set matches `cairn_core::domain::Rfc3339Timestamp::parse` (excluding leap-seconds), so any wire-accepted value also parses domain-side without a second gauntlet.",
           "format": "date-time",
+          "maxLength": 64,
           "minLength": 20,
           "type": "string"
         }

--- a/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.json
@@ -366,12 +366,12 @@
     },
     "DataProfile": {
       "additionalProperties": false,
-      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static_section`, `is_static = 1`) and current state (`dynamic_section`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1.",
+      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static`, `is_static = 1`) and current state (`dynamic`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1. Wire field names match the brief's `{static, dynamic, updated_at}` notation; the Rust binding emits them via the `r#static` raw identifier.",
       "properties": {
-        "dynamic_section": {
+        "dynamic": {
           "$ref": "#/$defs/ProfileHalf"
         },
-        "static_section": {
+        "static": {
           "$ref": "#/$defs/ProfileHalf"
         },
         "subject": {
@@ -409,8 +409,8 @@
       },
       "required": [
         "subject",
-        "static_section",
-        "dynamic_section",
+        "static",
+        "dynamic",
         "updated_at"
       ],
       "type": "object"

--- a/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.json
@@ -366,10 +366,13 @@
     },
     "DataProfile": {
       "additionalProperties": false,
+      "description": "Typed AutoUserProfile (brief §7.1) split into permanent traits (`static_section`, `is_static = 1`) and current state (`dynamic_section`, `is_static = 0`). Each half carries `summary`, `historical_summary`, and structured `key_facts`; every fact line records its source-record evidence so record-level forget propagates back to the profile. P0 plain-SQLite aggregation; richer rolling-summary regeneration is P1.",
       "properties": {
-        "profile": {
-          "description": "Free-form profile payload — typed in a later increment once the profile taxonomy lands.",
-          "type": "object"
+        "dynamic_section": {
+          "$ref": "#/$defs/ProfileHalf"
+        },
+        "static_section": {
+          "$ref": "#/$defs/ProfileHalf"
         },
         "subject": {
           "additionalProperties": false,
@@ -396,11 +399,19 @@
             }
           },
           "type": "object"
+        },
+        "updated_at": {
+          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty.",
+          "format": "date-time",
+          "minLength": 20,
+          "type": "string"
         }
       },
       "required": [
         "subject",
-        "profile"
+        "static_section",
+        "dynamic_section",
+        "updated_at"
       ],
       "type": "object"
     },
@@ -495,6 +506,117 @@
         "session_id",
         "turn_id",
         "turn"
+      ],
+      "type": "object"
+    },
+    "KeyFacts": {
+      "additionalProperties": false,
+      "description": "Seven structured fact buckets (brief §7.1). Each bucket is an array of ProfileLine — empty arrays are valid and required so a consumer can rely on every key being present.",
+      "properties": {
+        "addressed_issues": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "current_issues": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "devices": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "known_entities": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "preferences": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "recurring_issues": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        },
+        "software": {
+          "items": {
+            "$ref": "#/$defs/ProfileLine"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "devices",
+        "software",
+        "preferences",
+        "current_issues",
+        "addressed_issues",
+        "recurring_issues",
+        "known_entities"
+      ],
+      "type": "object"
+    },
+    "ProfileHalf": {
+      "additionalProperties": false,
+      "description": "One half of an AutoUserProfile (brief §7.1). `summary` and `historical_summary` are the rolling DreamWorkflow narratives — they remain empty strings at P0 and are populated by the P1 ConsolidationWorkflow. `key_facts` is the P0 deliverable: structured per-facet ProfileLine arrays.",
+      "properties": {
+        "historical_summary": {
+          "type": "string"
+        },
+        "key_facts": {
+          "$ref": "#/$defs/KeyFacts"
+        },
+        "summary": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "summary",
+        "historical_summary",
+        "key_facts"
+      ],
+      "type": "object"
+    },
+    "ProfileLine": {
+      "additionalProperties": false,
+      "description": "One profile fact with its evidence trail. `evidence` is the list of source records that contributed; record-level forget removes them from the input set, so re-synthesizing the profile drops the line.",
+      "properties": {
+        "confidence": {
+          "description": "Confidence in [0, 1]. Records with confidence < 0.3 (ConfidenceBand::Uncertain) are excluded from the profile.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "evidence": {
+          "description": "Source-record ULIDs whose bodies contributed to this line. Always non-empty.",
+          "items": {
+            "$ref": "../common/primitives.json#/$defs/Ulid"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "value": {
+          "description": "Canonical short statement of the fact (e.g., 'prefers terse explanations', 'M2 MacBook Pro').",
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "confidence",
+        "evidence"
       ],
       "type": "object"
     },

--- a/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/retrieve.json
@@ -401,8 +401,9 @@
           "type": "object"
         },
         "updated_at": {
-          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty.",
+          "description": "RFC3339 timestamp of the most recent contributing source record. Equals the synthesizer clock when the profile is empty. Validator accept set matches `cairn_core::domain::Rfc3339Timestamp::parse` (excluding leap-seconds), so any wire-accepted value also parses domain-side without a second gauntlet.",
           "format": "date-time",
+          "maxLength": 64,
           "minLength": 20,
           "type": "string"
         }


### PR DESCRIPTION
## Summary

Closes the P0 half of [#81](https://github.com/windoliver/cairn/issues/81): types the `DataProfile` payload and lands a pure `UserProfileSynthesizer` pipeline function.

- IDL `DataProfile`: free-form `object` → `{static_section, dynamic_section, updated_at}` per brief §7.1. Each half exposes `summary`, `historical_summary`, and seven structured `key_facts` buckets (`devices`, `software`, `preferences`, `current_issues`, `addressed_issues`, `recurring_issues`, `known_entities`). Each fact line is `{value, confidence, evidence: [Ulid]}`.
- `cairn-core::pipeline::profile`: pure `synthesize(records, subject, now) -> DataProfile`. Drops `confidence < 0.3` (`ConfidenceBand::Uncertain`), merges duplicates `(facet, value)` with max(confidence) + union(evidence), splits halves by `is_static`. Empty input returns an empty profile with `updated_at = now`.
- Codegen: extended `struct_has_extra_validators` + `write_retrieve_data_extra_checks` to emit `ProfileLine` field validators (value minLength 1, confidence in `[0,1]`, evidence minItems 1 + uniqueItems).
- 13 unit tests cover every issue verification item (materialization fixture, evidence-link, forget propagation, low-confidence exclusion, dynamic-vs-static expiry, subject validation, JSON round-trip, deterministic ordering).

## Brief sections touched

- §7.1 — AutoUserProfile shape, static/dynamic split.
- §3.0 — `is_static` column semantics (synthesizer trusts the projection).
- §6.4 — ConfidenceBand floor (Uncertain dropped).
- §8.0.c — `retrieve --profile` data shape.

## Invariants touched

- **CLI is ground truth** (CLAUDE.md §4.3): no parallel implementation; the synthesizer is the one place profile materialization lives.
- **Core dep-freeness** (CLAUDE.md §3): `pipeline::profile` is pure, no adapter deps; `scripts/check-core-boundary.sh` clean.
- **Wire compat** (§8.0.a): `DataProfile` JSON shape is byte-deterministic for fixed inputs (BTreeMap/BTreeSet ordering); generated TryFrom validators reject malformed payloads at deserialize time.

## Out of scope (deferred to #82)

- Store-side `is_static`-filtered query (`cairn-store-sqlite`).
- `MemoryRecord → ProfileSourceRecord` projection (incl. `KeyFactFacet` routing rule from kind/class/tags).
- CLI / SDK / MCP dispatch — `retrieve --profile` still returns `Unimplemented` end-to-end.
- E2E tests (CLI snapshot, SDK integration, MCP wire-compat, forget-propagation across the WAL).
- Brief §7.1 evidence gate ("`current_issue` listed only after 2 distinct days") — likely a pre-projection filter in #82.

## Verification

```
cargo fmt --all --check                                      ✓
cargo clippy --workspace --all-targets --locked -- -D warnings   ✓
cargo nextest run --workspace --locked        3320 passed, 6 skipped
cargo test --doc -p cairn-core --locked       9 passed
./scripts/check-core-boundary.sh              cairn-core boundary OK
cargo run -p cairn-idl --bin cairn-codegen -- --check        clean
cargo run -p cairn-cli --bin cairn-docgen -- --check         clean
RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items   ✓
mdbook build docs/site                                       ✓
cargo deny check                                             advisories ok, bans ok, licenses ok, sources ok
cargo machete                                                no unused deps
```

## Test plan

- [x] `cargo nextest run -p cairn-core profile::` (13/13 pass)
- [x] Existing SDK arg-validation test (`cairn-sdk/tests/surface.rs::retrieve_profile_requires_user_or_agent`) still passes
- [x] Existing schema-policy test (`cairn-idl::schema_files::every_typed_field_asserts_bounds_or_is_allowlisted`) updated + passing
- [ ] **Not in this PR**: full `cairn retrieve --profile` end-to-end against a fixture vault — that's #82's CLI dispatch + store query work.