### PR TITLE
feat(assemble_hot): hot prefix retrieval for the six v1 recipe steps (issue #82)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "async-trait",
  "blake3",
  "bon",
+ "cairn-core",
  "chrono",
  "ed25519-dalek",
  "insta",

--- a/crates/cairn-cli/Cargo.toml
+++ b/crates/cairn-cli/Cargo.toml
@@ -62,7 +62,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 cairn-sdk = { workspace = true }
-cairn-core = { workspace = true, features = ["test-helpers"] }
+cairn-core = { workspace = true, features = ["test-helpers", "test-fixtures"] }
 cairn-test-fixtures = { workspace = true }
 cairn-store-sqlite = { workspace = true }
 insta = { workspace = true }

--- a/crates/cairn-cli/src/generated/verbs.rs
+++ b/crates/cairn-cli/src/generated/verbs.rs
@@ -78,6 +78,7 @@ pub fn assemble_hot_subcommand() -> clap::Command {
         .about("cairn.mcp.v1 verb: assemble_hot")
         .arg(clap::Arg::new("session_id").long("session").value_name("STRING"))
         .arg(clap::Arg::new("budget").long("budget").value_name("U32").value_parser(clap::value_parser!(u32)))
+        .arg(clap::Arg::new("explain").long("explain").action(clap::ArgAction::SetTrue))
 }
 
 /// `cairn capture_trace` subcommand builder.

--- a/crates/cairn-cli/src/verbs/assemble_hot.rs
+++ b/crates/cairn-cli/src/verbs/assemble_hot.rs
@@ -137,12 +137,38 @@ async fn run_async(args: AssembleHotArgs, vault_root: PathBuf, config: CairnConf
         loaded.bodies,
         Some(budget),
     ) {
-        Ok(data) => super::signed::committed(
-            ResponseVerb::AssembleHot,
-            auth.operation_id,
-            ResponseData::AssembleHot(data),
-            policy_trace,
-        ),
+        Ok(mut data) => {
+            // `--explain` (Args.explain) layers a typed per-step debug
+            // trace on top of the assembled prefix. The trace runs the
+            // pure source modules + admissibility predicate over the
+            // same per-kind candidate sets the CLI just queried; the
+            // prefix bytes themselves still come from the auth-aware
+            // loader above. Bodies and trace use the same record set,
+            // but the source modules' top-K caps may differ slightly
+            // from the loader's byte-trim heuristic — acceptable for
+            // a debug surface.
+            if args.explain.unwrap_or(false) {
+                match build_explain_debug(
+                    &ctx.store,
+                    &ctx.vault_root,
+                    &ctx.config,
+                    &auth,
+                    args.session_id.as_deref(),
+                    budget,
+                )
+                .await
+                {
+                    Ok(debug) => data.debug = Some(debug),
+                    Err(resp) => return merge_policy_trace(policy_trace, resp),
+                }
+            }
+            super::signed::committed(
+                ResponseVerb::AssembleHot,
+                auth.operation_id,
+                ResponseData::AssembleHot(data),
+                policy_trace,
+            )
+        }
         Err(e) => {
             let resp =
                 super::signed::aborted(ResponseVerb::AssembleHot, format!("assemble_hot: {e}"));
@@ -305,6 +331,135 @@ fn truncate_body_to_budget(body: &mut String, budget: u64) {
         end = end.saturating_sub(1);
     }
     body.truncate(end);
+}
+
+/// Build the `--explain` debug payload by re-running the pure source
+/// modules (`assemble_hot_with_inputs`) over the same per-kind record
+/// set the loader queried. The payload contains per-step
+/// inclusion + redacted exclusion traces; the prefix bytes returned
+/// to the caller still come from the auth-aware loader above.
+async fn build_explain_debug(
+    store: &cairn_store_sqlite::SqliteMemoryStore,
+    vault_root: &Path,
+    config: &CairnConfig,
+    auth: &ReadAuthorization,
+    session_id: Option<&str>,
+    budget: u64,
+) -> Result<cairn_core::generated::verbs::assemble_hot::HotMemoryDebug, Response> {
+    use cairn_core::verbs::assemble_hot::loader::read_vault_markdown_file;
+    use cairn_core::verbs::assemble_hot::{HotMemoryInputs, assemble_hot_with_inputs};
+
+    let pinned_records = load_records_for_kinds(
+        store,
+        &[MemoryKind::User, MemoryKind::Feedback],
+        auth,
+        None,
+        64,
+    )
+    .await?;
+    let project_records =
+        load_records_for_kinds(store, &[MemoryKind::Project], auth, None, 64).await?;
+    let playbook_records =
+        load_records_for_kinds(store, &[MemoryKind::Playbook], auth, None, 64).await?;
+    let signal_records =
+        load_records_for_kinds(store, &[MemoryKind::UserSignal], auth, session_id, 64).await?;
+
+    let purpose_md = read_vault_markdown_file(vault_root, Path::new("purpose.md"), budget)
+        .or_else(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Ok(String::new())
+            } else {
+                Err(e)
+            }
+        })
+        .map_err(|e| {
+            internal_error_response(
+                ResponseVerb::AssembleHot,
+                &format!("explain read purpose.md: {e}"),
+            )
+        })?;
+    let index_md = read_vault_markdown_file(vault_root, Path::new("index.md"), budget)
+        .or_else(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Ok(String::new())
+            } else {
+                Err(e)
+            }
+        })
+        .map_err(|e| {
+            internal_error_response(
+                ResponseVerb::AssembleHot,
+                &format!("explain read index.md: {e}"),
+            )
+        })?;
+
+    let pinned_refs: Vec<&MemoryRecord> = pinned_records.iter().collect();
+    let project_refs: Vec<&MemoryRecord> = project_records.iter().collect();
+    let playbook_refs: Vec<&MemoryRecord> = playbook_records.iter().collect();
+    let signal_refs: Vec<&MemoryRecord> = signal_records.iter().collect();
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "unix seconds fit in i64 for all practical dates"
+    )]
+    let secs_i64 = now_secs as i64;
+    let now = cairn_core::domain::Rfc3339Timestamp::from_unix_secs(secs_i64).unwrap_or_else(|_| {
+        cairn_core::domain::Rfc3339Timestamp::parse("1970-01-01T00:00:00Z").expect("epoch literal")
+    });
+
+    let auth_vis = effective_explain_visibility(auth.max_visibility);
+    let inputs = HotMemoryInputs {
+        purpose_md: &purpose_md,
+        index_md: &index_md,
+        pinned_candidates: &pinned_refs,
+        project_candidates: &project_refs,
+        playbook_candidates: &playbook_refs,
+        user_signal_candidates: &signal_refs,
+        now,
+        scope: auth.scope.clone(),
+        authorized_visibility: &auth_vis,
+        include_debug: true,
+    };
+
+    let mut explain_cfg = config.vault.hot_memory.clone();
+    if let Ok(b) = u32::try_from(budget) {
+        explain_cfg.max_bytes = b.min(explain_cfg.max_bytes);
+    }
+
+    match assemble_hot_with_inputs(&inputs, &explain_cfg) {
+        Ok(data) => {
+            Ok(data
+                .debug
+                .unwrap_or(cairn_core::generated::verbs::assemble_hot::HotMemoryDebug {
+                    steps: Vec::new(),
+                }))
+        }
+        Err(e) => Err(internal_error_response(
+            ResponseVerb::AssembleHot,
+            &format!("explain assemble: {e}"),
+        )),
+    }
+}
+
+/// Visibility tiers admitted to the explain trace. Mirrors the tiers
+/// `load_records_for_kinds` will populate (Project / Private / Session)
+/// — never broader than `auth.max_visibility`.
+fn effective_explain_visibility(max: MemoryVisibility) -> Vec<MemoryVisibility> {
+    let cap = effective_read_visibility(max);
+    [
+        MemoryVisibility::Private,
+        MemoryVisibility::Session,
+        MemoryVisibility::Project,
+        MemoryVisibility::Team,
+        MemoryVisibility::Org,
+        MemoryVisibility::Public,
+    ]
+    .into_iter()
+    .filter(|v| *v <= cap)
+    .collect()
 }
 
 async fn load_records_for_kinds(
@@ -708,6 +863,11 @@ fn assemble_args_from_matches(sub: &ArgMatches) -> Result<AssembleHotArgs, Respo
         "session_id",
         sub.get_one::<String>("session_id").cloned(),
     );
+    if sub.get_flag("explain")
+        && let Some(obj) = value.as_object_mut()
+    {
+        obj.insert("explain".to_owned(), serde_json::Value::Bool(true));
+    }
     serde_json::from_value(value)
         .map_err(|e| invalid_args_response(ResponseVerb::AssembleHot, "args", &e.to_string()))
 }

--- a/crates/cairn-cli/tests/assemble_hot_smoke.rs
+++ b/crates/cairn-cli/tests/assemble_hot_smoke.rs
@@ -1,0 +1,35 @@
+//! Smoke test: build a fixture-driven `HotMemoryInputs` and call
+//! `assemble_hot` end-to-end. Full `SQLite` + filesystem adapter wiring
+//! is owned by issue #80; this test only proves the pure path is
+//! reachable from outside `cairn-core`.
+
+use cairn_core::config::HotMemoryConfig;
+use cairn_core::domain::Rfc3339Timestamp;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::scope::ScopeTuple;
+use cairn_core::domain::taxonomy::{MemoryKind, MemoryVisibility};
+use cairn_core::verbs::assemble_hot::{HotMemoryInputs, assemble_hot_with_inputs};
+
+#[test]
+fn assemble_hot_runs_with_minimal_inputs() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    let pinned = [&r];
+    let inputs = HotMemoryInputs {
+        purpose_md: "# Purpose\nact carefully.\n",
+        index_md: "# Index\n",
+        pinned_candidates: &pinned,
+        project_candidates: &[],
+        playbook_candidates: &[],
+        user_signal_candidates: &[],
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+        scope: ScopeTuple::default(),
+        authorized_visibility: &[MemoryVisibility::Private],
+        include_debug: false,
+    };
+    let cfg = HotMemoryConfig::default();
+    let data = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+    assert!(data.bytes > 0);
+    let segments = data.segments.expect("segments emitted");
+    assert_eq!(segments.len(), cfg.recipe.len());
+}

--- a/crates/cairn-cli/tests/cli_assemble_hot_explain.rs
+++ b/crates/cairn-cli/tests/cli_assemble_hot_explain.rs
@@ -1,0 +1,195 @@
+//! End-to-end CLI test for the `--explain` debug surface (issue #82).
+//!
+//! Bootstraps a tempdir vault, seeds the default identity via an
+//! initial ingest (matching the pattern in `cli_assemble_hot.rs`), then
+//! ingests a user / project / playbook record and asserts:
+//!
+//! 1. `cairn assemble_hot --json` emits no `debug` field by default
+//!    (wire-compat with older clients).
+//! 2. `cairn assemble_hot --json --explain` emits a `debug.steps`
+//!    array of length 6 (one trace per recipe step).
+//! 3. The pinned / project / playbook traces each include the
+//!    `record_id` of the ingested record with a stable `note`.
+//! 4. `--budget N` truncates the prefix to N bytes (`bytes <= N`).
+
+use std::path::Path;
+use std::process::Command;
+
+use cairn_cli::vault::{BootstrapOpts, bootstrap};
+
+fn cli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_cairn"))
+}
+
+fn seed_default_identity(vault: &Path) {
+    let out = cli()
+        .current_dir(vault)
+        .args([
+            "ingest",
+            "--kind",
+            "reference",
+            "--body",
+            "identity seed",
+            "--json",
+        ])
+        .output()
+        .expect("seed default identity");
+    assert!(
+        out.status.success(),
+        "seed identity failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn ingest(vault: &Path, kind: &str, body: &str, tags: &[&str]) {
+    let mut cmd = cli();
+    cmd.current_dir(vault)
+        .args(["ingest", "--kind", kind, "--body", body]);
+    for t in tags {
+        cmd.args(["--tags", t]);
+    }
+    let out = cmd.output().expect("ingest");
+    assert!(
+        out.status.success(),
+        "ingest --kind {kind} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn assemble_hot_json(vault: &Path, extra: &[&str]) -> serde_json::Value {
+    let mut args: Vec<&str> = vec!["assemble_hot", "--json"];
+    args.extend(extra);
+    let out = cli()
+        .current_dir(vault)
+        .args(&args)
+        .output()
+        .expect("assemble_hot");
+    let stdout = String::from_utf8(out.stdout.clone()).expect("utf-8 stdout");
+    assert!(
+        out.status.success(),
+        "assemble_hot exit={:?} stdout={stdout} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_str(stdout.trim()).expect("valid JSON on stdout")
+}
+
+fn bootstrap_vault() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    bootstrap(&BootstrapOpts {
+        vault_path: dir.path().to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+    seed_default_identity(dir.path());
+    dir
+}
+
+#[test]
+fn debug_field_is_absent_without_explain_flag() {
+    let vault = bootstrap_vault();
+    let value = assemble_hot_json(vault.path(), &[]);
+    assert!(
+        value.pointer("/data/debug").is_none(),
+        "debug field must be absent when --explain is not set: {value}"
+    );
+}
+
+#[test]
+fn explain_flag_populates_per_step_debug_trace() {
+    let vault = bootstrap_vault();
+    ingest(
+        vault.path(),
+        "user",
+        "user prefers terse explanations",
+        &["pinned"],
+    );
+    ingest(
+        vault.path(),
+        "project",
+        "current project: cairn refactor",
+        &[],
+    );
+    ingest(vault.path(), "playbook", "deploy via kubectl rollout", &[]);
+
+    let value = assemble_hot_json(vault.path(), &["--explain"]);
+    let steps = value
+        .pointer("/data/debug/steps")
+        .and_then(|v| v.as_array())
+        .expect("debug.steps populated");
+    assert_eq!(steps.len(), 6, "default recipe has 6 steps");
+
+    // Pinned step must include the user record.
+    let pinned = steps
+        .iter()
+        .find(|s| s.pointer("/step").and_then(|v| v.as_str()) == Some("pinned_feedback"))
+        .expect("pinned_feedback trace");
+    let pinned_included = pinned
+        .pointer("/included")
+        .and_then(|v| v.as_array())
+        .expect("pinned included");
+    assert_eq!(pinned_included.len(), 1, "user record must be pinned");
+    assert_eq!(
+        pinned_included[0]
+            .pointer("/note")
+            .and_then(|v| v.as_str())
+            .expect("pinned note"),
+        "salience × recency",
+    );
+
+    // Project step must include the project record.
+    let project = steps
+        .iter()
+        .find(|s| s.pointer("/step").and_then(|v| v.as_str()) == Some("top_salience_project"))
+        .expect("top_salience_project trace");
+    assert_eq!(
+        project
+            .pointer("/included")
+            .and_then(serde_json::Value::as_array)
+            .map_or(0, Vec::len),
+        1,
+        "project record must be included"
+    );
+
+    // Playbook step must include the playbook record.
+    let playbook = steps
+        .iter()
+        .find(|s| s.pointer("/step").and_then(|v| v.as_str()) == Some("active_playbook"))
+        .expect("active_playbook trace");
+    assert_eq!(
+        playbook
+            .pointer("/included")
+            .and_then(serde_json::Value::as_array)
+            .map_or(0, Vec::len),
+        1,
+        "playbook record must be included"
+    );
+}
+
+#[test]
+fn budget_flag_truncates_prefix() {
+    let vault = bootstrap_vault();
+    ingest(
+        vault.path(),
+        "user",
+        "user prefers terse explanations",
+        &["pinned"],
+    );
+    let value = assemble_hot_json(vault.path(), &["--budget", "64"]);
+    let bytes = value
+        .pointer("/data/bytes")
+        .and_then(serde_json::Value::as_u64)
+        .expect("bytes is u64");
+    assert!(bytes <= 64, "budget=64 must cap bytes; got {bytes}");
+    let prefix_len = value
+        .pointer("/data/prefix")
+        .and_then(|v| v.as_str())
+        .map_or(0, str::len);
+    let bytes_usize = usize::try_from(bytes).expect("bytes fit in usize on 64-bit targets");
+    assert_eq!(
+        bytes_usize, prefix_len,
+        "data.bytes must equal prefix.len()",
+    );
+}

--- a/crates/cairn-core/Cargo.toml
+++ b/crates/cairn-core/Cargo.toml
@@ -70,6 +70,11 @@ rand_core = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 tracing-test = "0.2"
+# Self-dep activates the `test-fixtures` feature for integration tests
+# under `tests/`. Cargo's `[dev-dependencies]` is the standard hook for
+# turning a library feature on for tests without leaking it into the
+# default-feature production build.
+cairn-core = { workspace = true, features = ["test-fixtures"] }
 
 [[bin]]
 name = "filter_smoke"

--- a/crates/cairn-core/src/generated/schemas/verbs/assemble_hot.json
+++ b/crates/cairn-core/src/generated/schemas/verbs/assemble_hot.json
@@ -9,6 +9,10 @@
           "minimum": 0,
           "type": "integer"
         },
+        "explain": {
+          "description": "When true, the response carries a `debug` payload describing per-step inclusion + typed exclusion reasons. Defaults to false; older callers omit it.",
+          "type": "boolean"
+        },
         "session_id": {
           "minLength": 1,
           "type": "string"
@@ -23,6 +27,10 @@
           "maximum": 4194304,
           "minimum": 0,
           "type": "integer"
+        },
+        "debug": {
+          "$ref": "#/$defs/HotMemoryDebug",
+          "description": "Optional inclusion/exclusion trace per recipe step. Absent unless the caller requested debug output via Args.explain. Wire-compatible addition for cairn.mcp.v1: older consumers ignore unknown fields."
         },
         "prefix": {
           "description": "Assembled hot-memory text ready to inject into the agent prompt. May be empty when no hot-memory is available.",
@@ -44,6 +52,75 @@
       ],
       "type": "object",
       "x-cairn-validate": true
+    },
+    "HotExclusion": {
+      "additionalProperties": false,
+      "properties": {
+        "reason": {
+          "$ref": "#/$defs/HotExclusionReason"
+        },
+        "record_id": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "record_id",
+        "reason"
+      ],
+      "type": "object"
+    },
+    "HotExclusionReason": {
+      "enum": [
+        "tombstoned",
+        "forgotten_scope",
+        "below_confidence_floor",
+        "out_of_scope",
+        "visibility_denied",
+        "outside_recency_window",
+        "beyond_top_k",
+        "not_pinned",
+        "empty_body"
+      ],
+      "type": "string"
+    },
+    "HotInclusion": {
+      "additionalProperties": false,
+      "properties": {
+        "note": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "record_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "score": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "record_id",
+        "score",
+        "note"
+      ],
+      "type": "object"
+    },
+    "HotMemoryDebug": {
+      "additionalProperties": false,
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/$defs/HotStepTrace"
+          },
+          "maxItems": 64,
+          "type": "array"
+        }
+      },
+      "required": [
+        "steps"
+      ],
+      "type": "object"
     },
     "HotRecipeStep": {
       "description": "Frozen for the lifetime of cairn.mcp.v1. Adding a recipe step requires bumping to cairn.mcp.v2.",
@@ -91,6 +168,32 @@
       ],
       "type": "object"
     },
+    "HotStepTrace": {
+      "additionalProperties": false,
+      "properties": {
+        "excluded": {
+          "items": {
+            "$ref": "#/$defs/HotExclusion"
+          },
+          "type": "array"
+        },
+        "included": {
+          "items": {
+            "$ref": "#/$defs/HotInclusion"
+          },
+          "type": "array"
+        },
+        "step": {
+          "$ref": "#/$defs/HotRecipeStep"
+        }
+      },
+      "required": [
+        "step",
+        "included",
+        "excluded"
+      ],
+      "type": "object"
+    },
     "SegmentStability": {
       "description": "Cache-lifetime hint per segment. Frozen for the lifetime of cairn.mcp.v1.",
       "enum": [
@@ -119,6 +222,11 @@
         "long": "budget",
         "name": "budget",
         "value_source": "u32"
+      },
+      {
+        "long": "explain",
+        "name": "explain",
+        "value_source": "bool"
       }
     ]
   },

--- a/crates/cairn-core/src/generated/verbs/assemble_hot.rs
+++ b/crates/cairn-core/src/generated/verbs/assemble_hot.rs
@@ -5,6 +5,42 @@
 
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HotExclusion {
+    pub reason: HotExclusionReason,
+    pub record_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum HotExclusionReason {
+    Tombstoned,
+    ForgottenScope,
+    BelowConfidenceFloor,
+    OutOfScope,
+    VisibilityDenied,
+    OutsideRecencyWindow,
+    BeyondTopK,
+    NotPinned,
+    EmptyBody,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HotInclusion {
+    pub note: String,
+    pub record_id: String,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HotMemoryDebug {
+    pub steps: Vec<HotStepTrace>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -28,6 +64,14 @@ pub struct HotSegment {
     pub step: HotRecipeStep,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HotStepTrace {
+    pub excluded: Vec<HotExclusion>,
+    pub included: Vec<HotInclusion>,
+    pub step: HotRecipeStep,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -45,6 +89,9 @@ pub struct AssembleHotArgs {
     /// Byte budget for the assembled prefix (default 25000; hard cap 4 MiB).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub budget: Option<u64>,
+    /// When true, the response carries a `debug` payload describing per-step inclusion + typed exclusion reasons. Defaults to false; older callers omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub explain: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
 }
@@ -54,6 +101,9 @@ pub struct AssembleHotArgs {
 #[serde(deny_unknown_fields)]
 pub struct AssembleHotData {
     pub bytes: u64,
+    /// Optional inclusion/exclusion trace per recipe step. Absent unless the caller requested debug output via Args.explain. Wire-compatible addition for cairn.mcp.v1: older consumers ignore unknown fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub debug: Option<HotMemoryDebug>,
     /// Assembled hot-memory text ready to inject into the agent prompt. May be empty when no hot-memory is available.
     pub prefix: String,
     /// Recipe-step segments covering [0, bytes) contiguously, in declaration order. Three-state contract: (1) FIELD ABSENT ON THE WIRE — legacy cairn.mcp.v1 producer that predates this feature; consumers MUST treat prefix as opaque. (2) "segments": [] — new producer ran with NO recipe configured; the producer explicitly opts into the new contract but had nothing to emit. REQUIRED INVARIANT: prefix == "" AND bytes == 0. (3) "segments": [...] — new producer with a configured recipe; len() mirrors HotMemoryConfig.recipe.len() 1:1, including N zero-length entries when the recipe ran with no content. The Rust binding distinguishes (1) from (2) via Option<Vec<HotSegment>> (None vs Some(vec![])); JSON-only consumers distinguish them by field presence. NOTE: there is intentionally NO default: [] here — schema-aware tooling that materialized defaults would rewrite legacy-absent into canonical-empty and trip the EmptySegmentsRequiresEmptyPrefix invariant. Forward-compat depends on absence staying absence.
@@ -65,6 +115,9 @@ pub struct AssembleHotData {
 #[serde(deny_unknown_fields)]
 pub struct AssembleHotDataRaw {
     pub bytes: u64,
+    /// Optional inclusion/exclusion trace per recipe step. Absent unless the caller requested debug output via Args.explain. Wire-compatible addition for cairn.mcp.v1: older consumers ignore unknown fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub debug: Option<HotMemoryDebug>,
     /// Assembled hot-memory text ready to inject into the agent prompt. May be empty when no hot-memory is available.
     pub prefix: String,
     /// Recipe-step segments covering [0, bytes) contiguously, in declaration order. Three-state contract: (1) FIELD ABSENT ON THE WIRE — legacy cairn.mcp.v1 producer that predates this feature; consumers MUST treat prefix as opaque. (2) "segments": [] — new producer ran with NO recipe configured; the producer explicitly opts into the new contract but had nothing to emit. REQUIRED INVARIANT: prefix == "" AND bytes == 0. (3) "segments": [...] — new producer with a configured recipe; len() mirrors HotMemoryConfig.recipe.len() 1:1, including N zero-length entries when the recipe ran with no content. The Rust binding distinguishes (1) from (2) via Option<Vec<HotSegment>> (None vs Some(vec![])); JSON-only consumers distinguish them by field presence. NOTE: there is intentionally NO default: [] here — schema-aware tooling that materialized defaults would rewrite legacy-absent into canonical-empty and trip the EmptySegmentsRequiresEmptyPrefix invariant. Forward-compat depends on absence staying absence.

--- a/crates/cairn-core/src/verbs/assemble_hot/admissibility.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/admissibility.rs
@@ -1,0 +1,139 @@
+//! Uniform admissibility predicate (issue #82, brief §6, §7).
+//!
+//! Every source delegates to [`admit`] before its own ranking. This
+//! re-checks visibility / scope / confidence / body invariants the
+//! adapter is supposed to have applied — defense-in-depth at the
+//! trust boundary so a buggy or malicious adapter cannot smuggle a
+//! record into the hot prefix.
+
+use crate::domain::record::MemoryRecord;
+use crate::domain::scope::ScopeTuple;
+use crate::domain::taxonomy::MemoryVisibility;
+
+use super::inclusion::ExclusionReason;
+
+/// Confidence floor — matches `pipeline::profile::synthesize::CONFIDENCE_FLOOR`.
+pub const CONFIDENCE_FLOOR: f32 = 0.3;
+
+/// Returns `Ok(())` if the record passes the uniform admissibility
+/// gates, otherwise the typed exclusion reason.
+///
+/// Gate order, cheapest check first: body → scope → visibility →
+/// confidence. The first failing gate wins; later gates are not
+/// evaluated. Tombstoned rows never reach this predicate (the adapter
+/// filters them at the store boundary).
+pub fn admit(
+    record: &MemoryRecord,
+    authorized_scope: &ScopeTuple,
+    authorized_visibility: &[MemoryVisibility],
+) -> Result<(), ExclusionReason> {
+    if record.body.is_empty() {
+        return Err(ExclusionReason::EmptyBody);
+    }
+    if !scope_satisfied(authorized_scope, &record.scope) {
+        return Err(ExclusionReason::OutOfScope);
+    }
+    if !authorized_visibility.contains(&record.visibility) {
+        return Err(ExclusionReason::VisibilityDenied);
+    }
+    if record.confidence.is_nan() || record.confidence < CONFIDENCE_FLOOR {
+        return Err(ExclusionReason::BelowConfidenceFloor);
+    }
+    Ok(())
+}
+
+/// Every set dimension on `authorized` must equal the record's value
+/// on the same dimension. The record may carry additional dimensions
+/// (e.g. `session_id`) — those are not narrowed.
+fn scope_satisfied(authorized: &ScopeTuple, record: &ScopeTuple) -> bool {
+    let pairs: [(&Option<String>, &Option<String>); 7] = [
+        (&authorized.tenant, &record.tenant),
+        (&authorized.workspace, &record.workspace),
+        (&authorized.project, &record.project),
+        (&authorized.session_id, &record.session_id),
+        (&authorized.entity, &record.entity),
+        (&authorized.user, &record.user),
+        (&authorized.agent, &record.agent),
+    ];
+    for (auth, rec) in pairs {
+        if let Some(a) = auth
+            && Some(a) != rec.as_ref()
+        {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+
+    fn allow_private() -> Vec<MemoryVisibility> {
+        vec![MemoryVisibility::Private]
+    }
+
+    fn matching_scope() -> ScopeTuple {
+        ScopeTuple {
+            user: Some("hmn:tafeng".to_owned()),
+            ..ScopeTuple::default()
+        }
+    }
+
+    #[test]
+    fn admits_canonical_sample_record() {
+        let r = sample_record();
+        assert_eq!(admit(&r, &matching_scope(), &allow_private()), Ok(()));
+    }
+
+    #[test]
+    fn rejects_empty_body() {
+        let mut r = sample_record();
+        r.body = String::new();
+        assert_eq!(
+            admit(&r, &matching_scope(), &allow_private()),
+            Err(ExclusionReason::EmptyBody)
+        );
+    }
+
+    #[test]
+    fn rejects_visibility_not_in_allowlist() {
+        let r = sample_record();
+        let only_public = vec![MemoryVisibility::Public];
+        assert_eq!(
+            admit(&r, &matching_scope(), &only_public),
+            Err(ExclusionReason::VisibilityDenied)
+        );
+    }
+
+    #[test]
+    fn rejects_below_confidence_floor() {
+        let mut r = sample_record();
+        r.confidence = 0.29;
+        assert_eq!(
+            admit(&r, &matching_scope(), &allow_private()),
+            Err(ExclusionReason::BelowConfidenceFloor)
+        );
+    }
+
+    #[test]
+    fn rejects_scope_mismatch() {
+        let r = sample_record();
+        let other_user = ScopeTuple {
+            user: Some("hmn:someoneelse".to_owned()),
+            ..ScopeTuple::default()
+        };
+        assert_eq!(
+            admit(&r, &other_user, &allow_private()),
+            Err(ExclusionReason::OutOfScope)
+        );
+    }
+
+    #[test]
+    fn empty_authorized_scope_admits_any_scope() {
+        let r = sample_record();
+        let empty = ScopeTuple::default();
+        assert_eq!(admit(&r, &empty, &allow_private()), Ok(()));
+    }
+}

--- a/crates/cairn-core/src/verbs/assemble_hot/assembler.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/assembler.rs
@@ -78,6 +78,7 @@ where
         bytes,
         prefix,
         segments: Some(segments),
+        debug: None,
     };
     // Run the same trust-boundary validator a deserializer would apply.
     // Catches contract-violating outputs (e.g. recipe.len() > MAX_SEGMENTS)
@@ -109,6 +110,7 @@ pub fn assemble_hot_from_bodies(
         bytes: prefix.len() as u64,
         prefix,
         segments: Some(segments),
+        debug: None,
     };
     validate_with_recipe(&data, &recipe)?;
     Ok(data)
@@ -123,6 +125,159 @@ fn validate_config_recipe_len(config: &HotMemoryConfig) -> Result<(), AssembleHo
         .into());
     }
     Ok(())
+}
+
+/// Assemble hot memory from a typed `HotMemoryInputs` projection
+/// (issue #82). Walks `config.recipe`, dispatches each step to its
+/// source-specific `select`, glues the bodies via [`build_segments`],
+/// validates the wire shape, and (when `inputs.include_debug` is true)
+/// emits a per-step inclusion / exclusion trace on
+/// `AssembleHotData.debug`.
+///
+/// Distinct from [`assemble_hot_from_bodies`]: this entry point lets
+/// callers express the per-step ranking + admissibility logic via the
+/// `sources::*` modules instead of pre-loading bodies, which is the
+/// path the CLI uses when `--explain` is requested.
+///
+/// # Errors
+///
+/// Returns [`AssembleHotError::Segments`] if the assembled segments
+/// violate the wire contract; [`AssembleHotError::BudgetExceeded`] if
+/// the byte total exceeds `config.max_bytes`.
+pub fn assemble_hot_with_inputs(
+    inputs: &super::inputs::HotMemoryInputs<'_>,
+    config: &HotMemoryConfig,
+) -> Result<AssembleHotData, AssembleHotError> {
+    use crate::generated::verbs::assemble_hot::{HotMemoryDebug, HotStepTrace};
+
+    validate_config_recipe_len(config)?;
+    let recipe: Vec<HotRecipeStep> = config
+        .recipe
+        .iter()
+        .copied()
+        .map(HotRecipeStep::from)
+        .collect();
+
+    let mut bodies: Vec<String> = Vec::with_capacity(recipe.len());
+    let mut traces: Vec<HotStepTrace> = Vec::with_capacity(recipe.len());
+
+    for step in recipe.iter().copied() {
+        let segment = inputs_run_step(step, inputs);
+        if inputs.include_debug {
+            traces.push(inputs_to_step_trace(step, &segment));
+        }
+        bodies.push(segment.body);
+    }
+
+    let bodies_refs: Vec<&str> = bodies.iter().map(String::as_str).collect();
+    let (prefix, segments) = build_segments(&recipe, &bodies_refs)?;
+
+    let bytes = prefix.len() as u64;
+    let max = u64::from(config.max_bytes);
+    if bytes > max {
+        return Err(AssembleHotError::BudgetExceeded { got: bytes, max });
+    }
+
+    let debug = if inputs.include_debug {
+        Some(HotMemoryDebug { steps: traces })
+    } else {
+        None
+    };
+
+    let data = AssembleHotData {
+        bytes,
+        prefix,
+        segments: Some(segments),
+        debug,
+    };
+    validate(&data)?;
+    Ok(data)
+}
+
+fn inputs_run_step(
+    step: HotRecipeStep,
+    inputs: &super::inputs::HotMemoryInputs<'_>,
+) -> super::inclusion::LoadedSegment {
+    match step {
+        HotRecipeStep::Purpose => super::sources::purpose::select(inputs),
+        HotRecipeStep::Index => super::sources::index::select(inputs),
+        HotRecipeStep::PinnedFeedback => super::sources::pinned::select(inputs),
+        HotRecipeStep::TopSalienceProject => super::sources::project::select(inputs),
+        HotRecipeStep::ActivePlaybook => super::sources::playbook::select(inputs),
+        HotRecipeStep::RecentUserSignal => super::sources::user_signal::select(inputs),
+    }
+}
+
+fn inputs_to_step_trace(
+    step: HotRecipeStep,
+    segment: &super::inclusion::LoadedSegment,
+) -> crate::generated::verbs::assemble_hot::HotStepTrace {
+    use crate::generated::verbs::assemble_hot::{HotExclusion, HotStepTrace};
+
+    // Authorization-related exclusions (`OutOfScope`, `VisibilityDenied`,
+    // `ForgottenScope`) MUST NOT appear on the wire trace. The
+    // candidate slot can legitimately contain records the caller is not
+    // allowed to see — the assembler's `admit()` predicate is the trust
+    // boundary, and emitting their record_id on `data.debug` would turn
+    // `--explain` into an enumeration channel.
+    let safe_excluded: Vec<HotExclusion> = segment
+        .excluded
+        .iter()
+        .filter(|t| !inputs_is_auth_redacted(t.reason))
+        .map(inputs_to_exclusion)
+        .collect();
+    HotStepTrace {
+        step,
+        included: segment.included.iter().map(inputs_to_inclusion).collect(),
+        excluded: safe_excluded,
+    }
+}
+
+const fn inputs_is_auth_redacted(reason: super::inclusion::ExclusionReason) -> bool {
+    use super::inclusion::ExclusionReason;
+    matches!(
+        reason,
+        ExclusionReason::OutOfScope
+            | ExclusionReason::VisibilityDenied
+            | ExclusionReason::ForgottenScope
+    )
+}
+
+fn inputs_to_inclusion(
+    trace: &super::inclusion::InclusionTrace,
+) -> crate::generated::verbs::assemble_hot::HotInclusion {
+    crate::generated::verbs::assemble_hot::HotInclusion {
+        record_id: trace.record_id.as_str().to_owned(),
+        score: trace.score,
+        note: trace.note.to_owned(),
+    }
+}
+
+fn inputs_to_exclusion(
+    trace: &super::inclusion::ExclusionTrace,
+) -> crate::generated::verbs::assemble_hot::HotExclusion {
+    crate::generated::verbs::assemble_hot::HotExclusion {
+        record_id: trace.record_id.as_str().to_owned(),
+        reason: inputs_to_wire_reason(trace.reason),
+    }
+}
+
+fn inputs_to_wire_reason(
+    reason: super::inclusion::ExclusionReason,
+) -> crate::generated::verbs::assemble_hot::HotExclusionReason {
+    use super::inclusion::ExclusionReason;
+    use crate::generated::verbs::assemble_hot::HotExclusionReason;
+    match reason {
+        ExclusionReason::Tombstoned => HotExclusionReason::Tombstoned,
+        ExclusionReason::ForgottenScope => HotExclusionReason::ForgottenScope,
+        ExclusionReason::BelowConfidenceFloor => HotExclusionReason::BelowConfidenceFloor,
+        ExclusionReason::OutOfScope => HotExclusionReason::OutOfScope,
+        ExclusionReason::VisibilityDenied => HotExclusionReason::VisibilityDenied,
+        ExclusionReason::OutsideRecencyWindow => HotExclusionReason::OutsideRecencyWindow,
+        ExclusionReason::BeyondTopK => HotExclusionReason::BeyondTopK,
+        ExclusionReason::NotPinned => HotExclusionReason::NotPinned,
+        ExclusionReason::EmptyBody => HotExclusionReason::EmptyBody,
+    }
 }
 
 /// Load the body for one recipe step. Stub: always `Ok("")`. The

--- a/crates/cairn-core/src/verbs/assemble_hot/inclusion.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/inclusion.rs
@@ -1,0 +1,129 @@
+//! Inclusion / exclusion trace types for `assemble_hot` (issue #82).
+//!
+//! Surface the typed reason a record either entered the assembled hot
+//! prefix or was filtered out. Adapter callers gate this behind a
+//! per-call `include_debug` flag so production callers do not pay for
+//! the bookkeeping when they do not need it.
+
+use crate::domain::RecordId;
+
+/// Why a candidate record did not enter the assembled hot prefix.
+///
+/// Wire form: `snake_case` strings matching `HotExclusion.reason`
+/// in `cairn-idl/schema/verbs/assemble_hot.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExclusionReason {
+    /// The record's `tombstoned` flag was set.
+    ///
+    /// Reserved for the store adapter (issue #80): `MemoryRecord` does
+    /// not carry a `tombstoned` field, so core never emits this
+    /// variant. The store layer filters tombstoned rows at the query
+    /// boundary; this reason is the wire shape it will use when it
+    /// does report them.
+    Tombstoned,
+    /// The record sat under a forget-state-scope.
+    ///
+    /// Reserved for the store adapter (issue #80). Core does not
+    /// inspect the forget-state journal; the variant exists so the
+    /// adapter can populate the debug trace with a typed reason.
+    ForgottenScope,
+    /// `record.confidence < 0.3` (matches the profile synthesizer floor).
+    BelowConfidenceFloor,
+    /// The record's `scope` is not satisfied by the caller's authorized scope.
+    OutOfScope,
+    /// The record's `visibility` is not in `authorized_visibility`.
+    VisibilityDenied,
+    /// The record's `updated_at` is older than the source's recency window.
+    OutsideRecencyWindow,
+    /// The record was admissible but ranked below the source's top-K cap.
+    BeyondTopK,
+    /// The record did not match the source's pin / kind narrowing.
+    NotPinned,
+    /// `record.body` was empty.
+    EmptyBody,
+}
+
+impl ExclusionReason {
+    /// Wire-form name as exported by the IDL `HotExclusion.reason` enum.
+    #[must_use]
+    pub const fn as_wire(self) -> &'static str {
+        match self {
+            Self::Tombstoned => "tombstoned",
+            Self::ForgottenScope => "forgotten_scope",
+            Self::BelowConfidenceFloor => "below_confidence_floor",
+            Self::OutOfScope => "out_of_scope",
+            Self::VisibilityDenied => "visibility_denied",
+            Self::OutsideRecencyWindow => "outside_recency_window",
+            Self::BeyondTopK => "beyond_top_k",
+            Self::NotPinned => "not_pinned",
+            Self::EmptyBody => "empty_body",
+        }
+    }
+}
+
+/// Why a record did enter the assembled hot prefix, with the rank score.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InclusionTrace {
+    /// Record that contributed to the segment body.
+    pub record_id: RecordId,
+    /// Source-specific score (e.g. `salience × recency` for pinned).
+    pub score: f64,
+    /// Human-readable note describing why this record won (`"top-1 by updated_at"`).
+    pub note: &'static str,
+}
+
+/// Why a record was filtered, paired with its `record_id`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExclusionTrace {
+    /// Record that was filtered.
+    pub record_id: RecordId,
+    /// Typed reason.
+    pub reason: ExclusionReason,
+}
+
+/// Output of one source's `select` call.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct LoadedSegment {
+    /// Concatenated markdown body produced by the source.
+    pub body: String,
+    /// Records that contributed to `body`, in emission order.
+    pub included: Vec<InclusionTrace>,
+    /// Records that were filtered, in evaluation order.
+    pub excluded: Vec<ExclusionTrace>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusion_reason_wire_strings_match_idl() {
+        assert_eq!(ExclusionReason::Tombstoned.as_wire(), "tombstoned");
+        assert_eq!(ExclusionReason::ForgottenScope.as_wire(), "forgotten_scope");
+        assert_eq!(
+            ExclusionReason::BelowConfidenceFloor.as_wire(),
+            "below_confidence_floor"
+        );
+        assert_eq!(ExclusionReason::OutOfScope.as_wire(), "out_of_scope");
+        assert_eq!(
+            ExclusionReason::VisibilityDenied.as_wire(),
+            "visibility_denied"
+        );
+        assert_eq!(
+            ExclusionReason::OutsideRecencyWindow.as_wire(),
+            "outside_recency_window"
+        );
+        assert_eq!(ExclusionReason::BeyondTopK.as_wire(), "beyond_top_k");
+        assert_eq!(ExclusionReason::NotPinned.as_wire(), "not_pinned");
+        assert_eq!(ExclusionReason::EmptyBody.as_wire(), "empty_body");
+    }
+
+    #[test]
+    fn loaded_segment_default_is_empty() {
+        let s = LoadedSegment::default();
+        assert!(s.body.is_empty());
+        assert!(s.included.is_empty());
+        assert!(s.excluded.is_empty());
+    }
+}

--- a/crates/cairn-core/src/verbs/assemble_hot/inputs.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/inputs.rs
@@ -1,0 +1,81 @@
+//! Pure-projection inputs for `assemble_hot` (issue #82).
+//!
+//! Adapters (`cairn-cli`, `cairn-sdk`) materialize this struct from a
+//! `MemoryStore` query + filesystem reads. Core never touches the
+//! store or the filesystem.
+
+use crate::domain::Rfc3339Timestamp;
+use crate::domain::record::MemoryRecord;
+use crate::domain::scope::ScopeTuple;
+use crate::domain::taxonomy::MemoryVisibility;
+
+/// Pre-filtered record + filesystem inputs for [`super::assemble_hot`].
+///
+/// Slot contracts (caller-side responsibility, all enforced by the
+/// adapter, double-checked by core):
+///
+/// * `pinned_candidates`: `kind ∈ {user, feedback} ∧ is_static = 1`,
+///   already narrowed to the authorized scope/visibility. `is_static`
+///   is a store-side projection (no field on `MemoryRecord`); the
+///   caller is the only authority for it.
+/// * `project_candidates`: `kind = project`.
+/// * `playbook_candidates`: `kind = playbook`.
+/// * `user_signal_candidates`: `kind = user_signal`.
+/// * `purpose_md` / `index_md`: pre-read file content.
+///
+/// Each record-bearing slot may include records the source-side ranker
+/// later excludes (low confidence, scope mismatch, etc.). Core's
+/// admissibility check is the trust boundary, not the slot membership.
+#[derive(Debug, Clone)]
+pub struct HotMemoryInputs<'a> {
+    /// Body of `purpose.md`, already read from disk by the adapter.
+    pub purpose_md: &'a str,
+    /// Body of `index.md`, already read from disk by the adapter.
+    pub index_md: &'a str,
+    /// Caller-narrowed pinned-feedback candidates.
+    pub pinned_candidates: &'a [&'a MemoryRecord],
+    /// `project`-kind candidates for the salience source.
+    pub project_candidates: &'a [&'a MemoryRecord],
+    /// `playbook`-kind candidates.
+    pub playbook_candidates: &'a [&'a MemoryRecord],
+    /// `user_signal`-kind candidates.
+    pub user_signal_candidates: &'a [&'a MemoryRecord],
+    /// Reference instant. Recency windows are computed against this.
+    pub now: Rfc3339Timestamp,
+    /// Authorized scope for this assembly call (re-checked per record).
+    pub scope: ScopeTuple,
+    /// Visibility tiers the caller is authorized to see.
+    pub authorized_visibility: &'a [MemoryVisibility],
+    /// When `true`, the assembler populates `AssembleHotData.debug`.
+    pub include_debug: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    #[test]
+    fn inputs_is_constructible() {
+        let r = sample_record();
+        let recs = [&r];
+        let now = Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid");
+        let scope = ScopeTuple::default();
+        let allow = [MemoryVisibility::Private];
+        let inputs = HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &recs,
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now,
+            scope,
+            authorized_visibility: &allow,
+            include_debug: false,
+        };
+        assert_eq!(inputs.pinned_candidates.len(), 1);
+        assert!(!inputs.include_debug);
+    }
+}

--- a/crates/cairn-core/src/verbs/assemble_hot/mod.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/mod.rs
@@ -1,12 +1,21 @@
 //! `assemble_hot` verb: hot-memory recipe assembly with cache-breakpoint
 //! segment markers. Brief §5, §7, §8.0.f. Issue #288.
 
+pub mod admissibility;
 pub mod assembler;
+pub mod inclusion;
+pub mod inputs;
 pub mod loader;
 pub mod raw;
 pub mod segments;
+pub mod sources;
 
-pub use assembler::{AssembleHotError, assemble_hot, assemble_hot_from_bodies};
+pub use admissibility::{CONFIDENCE_FLOOR, admit};
+pub use assembler::{
+    AssembleHotError, assemble_hot, assemble_hot_from_bodies, assemble_hot_with_inputs,
+};
+pub use inclusion::{ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment};
+pub use inputs::HotMemoryInputs;
 pub use segments::{
     AssembleHotValidationError, MAX_SEGMENTS, build_segments, default_stability, validate,
     validate_base, validate_segments, validate_with_recipe,

--- a/crates/cairn-core/src/verbs/assemble_hot/raw.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/raw.rs
@@ -17,6 +17,7 @@ impl TryFrom<AssembleHotDataRaw> for AssembleHotData {
             bytes: raw.bytes,
             prefix: raw.prefix,
             segments: raw.segments,
+            debug: raw.debug,
         };
         validate_base(&data)?;
         validate_segments(&data)?;
@@ -30,6 +31,7 @@ impl From<AssembleHotData> for AssembleHotDataRaw {
             bytes: data.bytes,
             prefix: data.prefix,
             segments: data.segments,
+            debug: data.debug,
         }
     }
 }

--- a/crates/cairn-core/src/verbs/assemble_hot/segments.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/segments.rs
@@ -524,6 +524,7 @@ mod tests {
             bytes: prefix.len() as u64,
             prefix,
             segments: Some(segments),
+            debug: None,
         }
     }
 
@@ -548,6 +549,7 @@ mod tests {
             bytes: 0,
             prefix: String::new(),
             segments: Some(vec![]),
+            debug: None,
         };
         assert!(validate_segments(&d).is_ok());
     }
@@ -558,6 +560,7 @@ mod tests {
             bytes: 3,
             prefix: "abc".into(),
             segments: Some(vec![]),
+            debug: None,
         };
         assert!(matches!(
             validate_segments(&d),
@@ -576,6 +579,7 @@ mod tests {
             bytes: 0,
             prefix: String::new(),
             segments: None,
+            debug: None,
         };
         assert!(validate_segments(&d).is_ok());
     }
@@ -664,6 +668,7 @@ mod tests {
             bytes: MAX_BYTES + 1,
             prefix: String::new(),
             segments: None,
+            debug: None,
         };
         assert!(matches!(
             validate_base(&d),
@@ -699,6 +704,7 @@ mod tests {
             bytes: prefix_len,
             prefix,
             segments: Some(vec![s0, s1]),
+            debug: None,
         };
         assert!(matches!(
             validate_segments(&d),
@@ -728,6 +734,7 @@ mod tests {
             bytes: 0,
             prefix: String::new(),
             segments: Some(segs),
+            debug: None,
         };
         assert!(matches!(
             validate_segments(&d),
@@ -776,6 +783,7 @@ mod tests {
             bytes: 0,
             prefix: String::new(),
             segments: None,
+            debug: None,
         };
         assert!(matches!(
             validate_with_recipe(&d, &[]),
@@ -792,6 +800,7 @@ mod tests {
             bytes: prefix.len() as u64,
             prefix,
             segments: Some(segments),
+            debug: None,
         };
         validate(&d).unwrap();
         validate_with_recipe(&d, &recipe).unwrap();

--- a/crates/cairn-core/src/verbs/assemble_hot/sources/index.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/sources/index.rs
@@ -1,0 +1,43 @@
+//! `Index` source: pass-through `index.md` content.
+
+use crate::verbs::assemble_hot::inclusion::LoadedSegment;
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+/// Render the index segment by copying `inputs.index_md` verbatim.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    LoadedSegment {
+        body: inputs.index_md.to_owned(),
+        included: Vec::new(),
+        excluded: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::Rfc3339Timestamp;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn empty_inputs(index: &str) -> HotMemoryInputs<'_> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: index,
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn passes_index_md_through_verbatim() {
+        let s = select(&empty_inputs("# Index\n- a.md\n"));
+        assert_eq!(s.body, "# Index\n- a.md\n");
+    }
+}

--- a/crates/cairn-core/src/verbs/assemble_hot/sources/mod.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/sources/mod.rs
@@ -1,0 +1,11 @@
+//! Source-specific `select` functions for each `HotRecipeStep`. Each
+//! one returns a [`super::inclusion::LoadedSegment`] — never errors —
+//! so the assembler can compose them deterministically.
+
+pub mod index;
+pub mod pinned;
+pub mod playbook;
+pub mod project;
+pub mod purpose;
+pub mod render;
+pub mod user_signal;

--- a/crates/cairn-core/src/verbs/assemble_hot/sources/pinned.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/sources/pinned.rs
@@ -1,0 +1,233 @@
+//! `PinnedFeedback` source — top 8 `user`/`feedback` records ranked by
+//! `salience × recency_decay(now − updated_at)`.
+//!
+//! Pin semantics for v0.1: caller pre-filters to records with
+//! `kind ∈ {user, feedback} ∧ is_static = 1`. Core re-checks the
+//! `kind` half (signed payload) but trusts the caller for `is_static`
+//! (store-side projection, not on `MemoryRecord`). See spec
+//! "Pin semantics" + design brief §7.1.
+
+use crate::domain::Rfc3339Timestamp;
+use crate::domain::record::MemoryRecord;
+use crate::domain::taxonomy::MemoryKind;
+use crate::verbs::assemble_hot::admissibility::admit;
+use crate::verbs::assemble_hot::inclusion::{
+    ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment,
+};
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+use super::render::render_record_block;
+
+/// Top-K cap from brief §7 ("top 8 by salience × recency").
+const TOP_K: usize = 8;
+
+/// Half-life for the recency decay term, in seconds.
+/// 30 days × 86400 s/day. Matches the brief's "salience × recency"
+/// shorthand by giving recent records a non-trivial multiplier without
+/// fully cliff-sliding old high-salience records.
+const RECENCY_HALF_LIFE_SECS: f64 = 30.0 * 86_400.0;
+
+/// Select up to 8 pinned-feedback records for the hot prefix.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    let mut included_with_score: Vec<(InclusionTrace, &MemoryRecord)> = Vec::new();
+    let mut excluded: Vec<ExclusionTrace> = Vec::new();
+
+    for &record in inputs.pinned_candidates {
+        if !is_pinned_kind(record.kind) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::NotPinned,
+            });
+            continue;
+        }
+        if let Err(reason) = admit(record, &inputs.scope, inputs.authorized_visibility) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason,
+            });
+            continue;
+        }
+        let score = pin_score(record, &inputs.now);
+        included_with_score.push((
+            InclusionTrace {
+                record_id: record.id.clone(),
+                score,
+                note: "salience × recency",
+            },
+            record,
+        ));
+    }
+
+    // Sort: score desc, then record_id desc as deterministic tiebreaker.
+    included_with_score.sort_by(|a, b| {
+        b.0.score
+            .partial_cmp(&a.0.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.0.record_id.as_str().cmp(a.0.record_id.as_str()))
+    });
+
+    // Bucket overflow into BeyondTopK exclusions before truncation so
+    // the debug trace explains why a candidate did not make the cut.
+    let overflow = included_with_score.split_off(TOP_K.min(included_with_score.len()));
+    for (trace, _) in overflow {
+        excluded.push(ExclusionTrace {
+            record_id: trace.record_id,
+            reason: ExclusionReason::BeyondTopK,
+        });
+    }
+
+    let mut body = String::new();
+    let mut included: Vec<InclusionTrace> = Vec::with_capacity(included_with_score.len());
+    for (trace, record) in included_with_score {
+        body.push_str(&render_record_block(record));
+        included.push(trace);
+    }
+
+    LoadedSegment {
+        body,
+        included,
+        excluded,
+    }
+}
+
+fn is_pinned_kind(kind: MemoryKind) -> bool {
+    matches!(kind, MemoryKind::User | MemoryKind::Feedback)
+}
+
+fn pin_score(record: &MemoryRecord, now: &Rfc3339Timestamp) -> f64 {
+    let age_secs = age_seconds(now, &record.updated_at);
+    let decay = (-age_secs / RECENCY_HALF_LIFE_SECS).exp();
+    f64::from(record.salience) * decay
+}
+
+fn age_seconds(now: &Rfc3339Timestamp, updated_at: &Rfc3339Timestamp) -> f64 {
+    // Negative ages (record stamped slightly in the future relative
+    // to `now`) clamp to zero so decay never blows up past 1.0.
+    let now_dt = now.as_chrono();
+    let upd_dt = updated_at.as_chrono();
+    let secs = (now_dt - upd_dt).num_seconds().max(0);
+    // i64 → f64 widens; clippy::cast_precision_loss is acceptable here
+    // because `secs` is bounded by realistic timestamps (≤ ~10⁹ s for
+    // the next century) and the decay exp() saturates well before f64
+    // precision becomes a problem.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "bounded by realistic timestamps"
+    )]
+    (secs as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn fresh_input<'a>(records: &'a [&'a MemoryRecord], now: &str) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: records,
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse(now).expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    fn user_record(id: &str, salience: f32, updated_at: &str) -> MemoryRecord {
+        let mut r = sample_record();
+        r.id = crate::domain::RecordId::parse(id).expect("valid id");
+        r.target_id = crate::domain::TargetId::parse(id).expect("valid target");
+        r.kind = MemoryKind::User;
+        r.salience = salience;
+        r.updated_at = Rfc3339Timestamp::parse(updated_at).expect("valid");
+        r
+    }
+
+    #[test]
+    fn ranks_by_salience_times_recency() {
+        let recent_low = user_record("01HQZX9F5N0000000000000001", 0.4, "2026-04-22T14:00:00Z");
+        let old_high = user_record("01HQZX9F5N0000000000000002", 0.9, "2025-04-22T14:00:00Z");
+        let now = "2026-04-22T15:00:00Z";
+        let candidates = [&recent_low, &old_high];
+        let inputs = fresh_input(&candidates, now);
+        let s = select(&inputs);
+        // 0.4 × ~1.0 = 0.4 ; 0.9 × exp(-365/30) ≈ 0.9 × 5.7e-6 ≈ 5e-6.
+        // Recent low-salience must win.
+        assert_eq!(s.included[0].record_id, recent_low.id);
+        assert_eq!(s.included[1].record_id, old_high.id);
+    }
+
+    #[test]
+    fn caps_at_top_8_and_emits_beyond_top_k() {
+        let recs: Vec<MemoryRecord> = (1_i32..=12)
+            .map(|i| {
+                user_record(
+                    &format!("01HQZX9F5N00000000000000{i:02}"),
+                    #[allow(
+                        clippy::cast_precision_loss,
+                        reason = "small bounded integer, test only"
+                    )]
+                    (i as f32 / 12.0),
+                    "2026-04-22T14:00:00Z",
+                )
+            })
+            .collect();
+        let record_refs: Vec<&MemoryRecord> = recs.iter().collect();
+        let s = select(&fresh_input(&record_refs, "2026-04-22T15:00:00Z"));
+        assert_eq!(s.included.len(), 8);
+        let beyond = s
+            .excluded
+            .iter()
+            .filter(|e| e.reason == ExclusionReason::BeyondTopK)
+            .count();
+        assert_eq!(beyond, 4);
+    }
+
+    #[test]
+    fn excludes_non_user_feedback_kind_with_not_pinned() {
+        let mut r = user_record("01HQZX9F5N0000000000000001", 0.9, "2026-04-22T14:00:00Z");
+        r.kind = MemoryKind::Project;
+        let s = select(&fresh_input(&[&r], "2026-04-22T15:00:00Z"));
+        assert!(s.included.is_empty());
+        assert_eq!(s.excluded.len(), 1);
+        assert_eq!(s.excluded[0].reason, ExclusionReason::NotPinned);
+    }
+
+    #[test]
+    fn excludes_low_confidence() {
+        let mut r = user_record("01HQZX9F5N0000000000000001", 0.9, "2026-04-22T14:00:00Z");
+        r.confidence = 0.2;
+        let s = select(&fresh_input(&[&r], "2026-04-22T15:00:00Z"));
+        assert_eq!(s.excluded[0].reason, ExclusionReason::BelowConfidenceFloor);
+    }
+
+    #[test]
+    fn deterministic_tiebreaker_on_equal_score() {
+        let a = user_record("01HQZX9F5N0000000000000001", 0.5, "2026-04-22T14:00:00Z");
+        let b = user_record("01HQZX9F5N0000000000000002", 0.5, "2026-04-22T14:00:00Z");
+        let s = select(&fresh_input(&[&a, &b], "2026-04-22T15:00:00Z"));
+        // Tiebreaker: record_id desc → id ending …02 first, then …01.
+        assert_eq!(s.included[0].record_id, b.id);
+        assert_eq!(s.included[1].record_id, a.id);
+    }
+
+    #[test]
+    fn future_timestamp_clamps_age_to_zero() {
+        let r = user_record(
+            "01HQZX9F5N0000000000000001",
+            0.5,
+            "2026-04-22T15:00:01Z", // 1s after now
+        );
+        let s = select(&fresh_input(&[&r], "2026-04-22T15:00:00Z"));
+        // No panic, no NaN — the record is included with score == salience.
+        assert_eq!(s.included.len(), 1);
+        assert!((s.included[0].score - 0.5).abs() < 1e-9);
+    }
+}

--- a/crates/cairn-core/src/verbs/assemble_hot/sources/playbook.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/sources/playbook.rs
@@ -1,0 +1,139 @@
+//! `ActivePlaybook` source — single most-recently-updated `playbook` record.
+
+use crate::domain::record::MemoryRecord;
+use crate::domain::taxonomy::MemoryKind;
+use crate::verbs::assemble_hot::admissibility::admit;
+use crate::verbs::assemble_hot::inclusion::{
+    ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment,
+};
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+use super::render::render_record_block;
+
+const TOP_K: usize = 1;
+
+/// Select the single most-recently-updated admissible `playbook` record.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    let mut admissible: Vec<(InclusionTrace, &MemoryRecord)> = Vec::new();
+    let mut excluded: Vec<ExclusionTrace> = Vec::new();
+
+    for &record in inputs.playbook_candidates {
+        // NotPinned is reused as the wire-form "wrong kind for this
+        // source" reason. Spec §"Selection rules per source" calls this
+        // a NotPinned-equivalent. A future WrongKind variant could
+        // disambiguate; revisit if downstream tooling needs it.
+        if record.kind != MemoryKind::Playbook {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::NotPinned,
+            });
+            continue;
+        }
+        if let Err(reason) = admit(record, &inputs.scope, inputs.authorized_visibility) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason,
+            });
+            continue;
+        }
+        admissible.push((
+            InclusionTrace {
+                record_id: record.id.clone(),
+                score: 0.0,
+                note: "most recent updated_at",
+            },
+            record,
+        ));
+    }
+
+    admissible.sort_by(|a, b| {
+        b.1.updated_at
+            .cmp_chronological(&a.1.updated_at)
+            .then_with(|| b.0.record_id.as_str().cmp(a.0.record_id.as_str()))
+    });
+
+    let overflow = admissible.split_off(TOP_K.min(admissible.len()));
+    for (trace, _) in overflow {
+        excluded.push(ExclusionTrace {
+            record_id: trace.record_id,
+            reason: ExclusionReason::BeyondTopK,
+        });
+    }
+
+    let mut body = String::new();
+    let mut included: Vec<InclusionTrace> = Vec::with_capacity(admissible.len());
+    for (trace, record) in admissible {
+        body.push_str(&render_record_block(record));
+        included.push(trace);
+    }
+
+    LoadedSegment {
+        body,
+        included,
+        excluded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::Rfc3339Timestamp;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn playbook_record(id: &str, updated_at: &str) -> MemoryRecord {
+        let mut r = sample_record();
+        r.id = crate::domain::RecordId::parse(id).expect("valid");
+        r.target_id = crate::domain::TargetId::parse(id).expect("valid");
+        r.kind = MemoryKind::Playbook;
+        r.updated_at = Rfc3339Timestamp::parse(updated_at).expect("valid");
+        r
+    }
+
+    fn input_with<'a>(records: &'a [&'a MemoryRecord]) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: records,
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn most_recent_wins() {
+        let old = playbook_record("01HQZX9F5N0000000000000001", "2026-04-20T12:00:00Z");
+        let new_p = playbook_record("01HQZX9F5N0000000000000002", "2026-04-22T14:00:00Z");
+        let recs = [&old, &new_p];
+        let seg = select(&input_with(&recs));
+        assert_eq!(seg.included.len(), 1);
+        assert_eq!(seg.included[0].record_id, new_p.id);
+        assert_eq!(seg.excluded.len(), 1);
+        assert_eq!(seg.excluded[0].reason, ExclusionReason::BeyondTopK);
+    }
+
+    #[test]
+    fn empty_input_emits_empty_body() {
+        let seg = select(&input_with(&[]));
+        assert!(seg.body.is_empty());
+        assert!(seg.included.is_empty());
+        assert!(seg.excluded.is_empty());
+    }
+
+    #[test]
+    fn rejects_non_playbook_kind() {
+        let mut r = playbook_record("01HQZX9F5N0000000000000001", "2026-04-22T14:00:00Z");
+        r.kind = MemoryKind::Project;
+        let recs = [&r];
+        let seg = select(&input_with(&recs));
+        assert!(seg.included.is_empty());
+        assert_eq!(seg.excluded[0].reason, ExclusionReason::NotPinned);
+    }
+}

--- a/crates/cairn-core/src/verbs/assemble_hot/sources/project.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/sources/project.rs
@@ -1,0 +1,162 @@
+//! `TopSalienceProject` source — top 6 `project`-kind records by salience.
+//!
+//! Sort key matches the lint canary regression
+//! (`tied_salience_top_k_picks_largest_records_conservatively`):
+//! salience desc, then byte size desc as tiebreaker, then `record_id` desc
+//! to keep the assembled prefix bytewise-deterministic.
+
+use crate::domain::record::MemoryRecord;
+use crate::domain::taxonomy::MemoryKind;
+use crate::verbs::assemble_hot::admissibility::admit;
+use crate::verbs::assemble_hot::inclusion::{
+    ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment,
+};
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+use super::render::render_record_block;
+
+const TOP_K: usize = 6;
+
+/// Select up to 6 project records ranked by salience.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    let mut admissible: Vec<(InclusionTrace, &MemoryRecord)> = Vec::new();
+    let mut excluded: Vec<ExclusionTrace> = Vec::new();
+
+    for &record in inputs.project_candidates {
+        // NotPinned is reused as the wire-form "wrong kind for this
+        // source" reason. Spec §"Selection rules per source" calls this
+        // a NotPinned-equivalent. A future WrongKind variant could
+        // disambiguate; revisit if downstream tooling needs it.
+        if record.kind != MemoryKind::Project {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::NotPinned,
+            });
+            continue;
+        }
+        if let Err(reason) = admit(record, &inputs.scope, inputs.authorized_visibility) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason,
+            });
+            continue;
+        }
+        admissible.push((
+            InclusionTrace {
+                record_id: record.id.clone(),
+                score: f64::from(record.salience),
+                note: "salience desc",
+            },
+            record,
+        ));
+    }
+
+    admissible.sort_by(|a, b| {
+        b.0.score
+            .partial_cmp(&a.0.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.1.body.len().cmp(&a.1.body.len()))
+            .then_with(|| b.0.record_id.as_str().cmp(a.0.record_id.as_str()))
+    });
+
+    let overflow = admissible.split_off(TOP_K.min(admissible.len()));
+    for (trace, _) in overflow {
+        excluded.push(ExclusionTrace {
+            record_id: trace.record_id,
+            reason: ExclusionReason::BeyondTopK,
+        });
+    }
+
+    let mut body = String::new();
+    let mut included: Vec<InclusionTrace> = Vec::with_capacity(admissible.len());
+    for (trace, record) in admissible {
+        body.push_str(&render_record_block(record));
+        included.push(trace);
+    }
+
+    LoadedSegment {
+        body,
+        included,
+        excluded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::Rfc3339Timestamp;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn project_record(id: &str, salience: f32, body: &str) -> MemoryRecord {
+        let mut r = sample_record();
+        r.id = crate::domain::RecordId::parse(id).expect("valid");
+        r.target_id = crate::domain::TargetId::parse(id).expect("valid");
+        r.kind = MemoryKind::Project;
+        r.salience = salience;
+        r.body = body.to_owned();
+        r
+    }
+
+    fn input_with<'a>(records: &'a [&'a MemoryRecord]) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: records,
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn caps_at_top_6() {
+        let recs: Vec<MemoryRecord> = (1..=10)
+            .map(|i| {
+                #[allow(clippy::cast_precision_loss, reason = "i in 1..=10, loss negligible")]
+                let salience = i as f32 / 10.0;
+                project_record(&format!("01HQZX9F5N00000000000000{i:02}"), salience, "body")
+            })
+            .collect();
+        let record_refs: Vec<&MemoryRecord> = recs.iter().collect();
+        let seg = select(&input_with(&record_refs));
+        assert_eq!(seg.included.len(), 6);
+    }
+
+    #[test]
+    fn rejects_non_project_kind_with_not_pinned() {
+        let mut rec = project_record("01HQZX9F5N0000000000000001", 0.9, "x");
+        rec.kind = MemoryKind::Feedback;
+        let recs = [&rec];
+        let seg = select(&input_with(&recs));
+        assert!(seg.included.is_empty());
+        assert_eq!(seg.excluded[0].reason, ExclusionReason::NotPinned);
+    }
+
+    #[test]
+    fn ties_break_by_body_size_then_record_id() {
+        // Six records with identical salience, two of them larger.
+        // Top-6 must include the larger ones; the seventh tied record
+        // is BeyondTopK.
+        let small1 = project_record("01HQZX9F5N0000000000000001", 0.5, "x");
+        let small2 = project_record("01HQZX9F5N0000000000000002", 0.5, "x");
+        let small3 = project_record("01HQZX9F5N0000000000000003", 0.5, "x");
+        let small4 = project_record("01HQZX9F5N0000000000000004", 0.5, "x");
+        let small5 = project_record("01HQZX9F5N0000000000000005", 0.5, "x");
+        let large1 = project_record("01HQZX9F5N0000000000000006", 0.5, &"L".repeat(100));
+        let large2 = project_record("01HQZX9F5N0000000000000007", 0.5, &"L".repeat(100));
+        let all_recs = [
+            &small1, &small2, &small3, &small4, &small5, &large1, &large2,
+        ];
+        let seg = select(&input_with(&all_recs));
+        let included_ids: Vec<&str> = seg.included.iter().map(|i| i.record_id.as_str()).collect();
+        assert!(included_ids.contains(&large1.id.as_str()));
+        assert!(included_ids.contains(&large2.id.as_str()));
+    }
+}

--- a/crates/cairn-core/src/verbs/assemble_hot/sources/purpose.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/sources/purpose.rs
@@ -1,0 +1,51 @@
+//! `Purpose` source: pass-through `purpose.md` content.
+
+use crate::verbs::assemble_hot::inclusion::LoadedSegment;
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+/// Render the purpose segment by copying `inputs.purpose_md` verbatim.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    LoadedSegment {
+        body: inputs.purpose_md.to_owned(),
+        included: Vec::new(),
+        excluded: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::Rfc3339Timestamp;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn empty_inputs(purpose: &str) -> HotMemoryInputs<'_> {
+        HotMemoryInputs {
+            purpose_md: purpose,
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn passes_purpose_md_through_verbatim() {
+        let s = select(&empty_inputs("# Purpose\nI am a purpose.\n"));
+        assert_eq!(s.body, "# Purpose\nI am a purpose.\n");
+        assert!(s.included.is_empty());
+        assert!(s.excluded.is_empty());
+    }
+
+    #[test]
+    fn empty_purpose_emits_empty_segment() {
+        let s = select(&empty_inputs(""));
+        assert!(s.body.is_empty());
+    }
+}

--- a/crates/cairn-core/src/verbs/assemble_hot/sources/render.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/sources/render.rs
@@ -1,0 +1,53 @@
+//! Per-record body framing shared by every record-backed source.
+
+use crate::domain::record::MemoryRecord;
+
+/// Render one record into the canonical hot-prefix block:
+///
+/// ```text
+/// ## <kind>: <first-body-line>
+/// <body>
+///
+/// ```
+///
+/// Trailing blank line separates blocks. Identical for every source so
+/// downstream consumers never have to special-case ranking origin.
+#[must_use]
+pub fn render_record_block(record: &MemoryRecord) -> String {
+    let first_line = record.body.lines().next().unwrap_or_default();
+    let mut out = String::with_capacity(record.body.len() + 64);
+    out.push_str("## ");
+    out.push_str(record.kind.as_str());
+    out.push_str(": ");
+    out.push_str(first_line);
+    out.push('\n');
+    out.push_str(&record.body);
+    if !record.body.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push('\n');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+
+    #[test]
+    fn renders_canonical_block() {
+        let r = sample_record();
+        let out = render_record_block(&r);
+        assert!(out.starts_with("## user: user prefers dark mode\n"));
+        assert!(out.ends_with("\n\n"));
+        assert!(out.contains("user prefers dark mode"));
+    }
+
+    #[test]
+    fn handles_record_body_without_trailing_newline() {
+        let mut r = sample_record();
+        r.body = "single line".to_owned();
+        let out = render_record_block(&r);
+        assert!(out.ends_with("\n\n"), "must always end with blank line");
+    }
+}

--- a/crates/cairn-core/src/verbs/assemble_hot/sources/user_signal.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/sources/user_signal.rs
@@ -1,0 +1,147 @@
+//! `RecentUserSignal` source — `user_signal` records inside the last 24h.
+
+use crate::domain::Rfc3339Timestamp;
+use crate::domain::record::MemoryRecord;
+use crate::domain::taxonomy::MemoryKind;
+use crate::verbs::assemble_hot::admissibility::admit;
+use crate::verbs::assemble_hot::inclusion::{
+    ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment,
+};
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+use super::render::render_record_block;
+
+const RECENCY_WINDOW_SECS: i64 = 24 * 60 * 60;
+
+/// Select all admissible `user_signal` records updated within the last 24 h,
+/// sorted by `updated_at` descending.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    let now_dt = inputs.now.as_chrono();
+    let mut admissible: Vec<(InclusionTrace, &MemoryRecord)> = Vec::new();
+    let mut excluded: Vec<ExclusionTrace> = Vec::new();
+
+    for &record in inputs.user_signal_candidates {
+        // NotPinned is reused as the wire-form "wrong kind for this
+        // source" reason. Spec §"Selection rules per source" calls this
+        // a NotPinned-equivalent. A future WrongKind variant could
+        // disambiguate; revisit if downstream tooling needs it.
+        if record.kind != MemoryKind::UserSignal {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::NotPinned,
+            });
+            continue;
+        }
+        if let Err(reason) = admit(record, &inputs.scope, inputs.authorized_visibility) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason,
+            });
+            continue;
+        }
+        if !within_window(&record.updated_at, &now_dt) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::OutsideRecencyWindow,
+            });
+            continue;
+        }
+        admissible.push((
+            InclusionTrace {
+                record_id: record.id.clone(),
+                score: 0.0,
+                note: "last 24h, updated_at desc",
+            },
+            record,
+        ));
+    }
+
+    admissible.sort_by(|a, b| {
+        b.1.updated_at
+            .cmp_chronological(&a.1.updated_at)
+            .then_with(|| b.0.record_id.as_str().cmp(a.0.record_id.as_str()))
+    });
+
+    let mut body = String::new();
+    let mut included: Vec<InclusionTrace> = Vec::with_capacity(admissible.len());
+    for (trace, record) in admissible {
+        body.push_str(&render_record_block(record));
+        included.push(trace);
+    }
+
+    LoadedSegment {
+        body,
+        included,
+        excluded,
+    }
+}
+
+fn within_window(updated_at: &Rfc3339Timestamp, now_dt: &chrono::DateTime<chrono::Utc>) -> bool {
+    let upd_dt = updated_at.as_chrono();
+    let age = (*now_dt - upd_dt).num_seconds();
+    (0..=RECENCY_WINDOW_SECS).contains(&age)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn signal(id: &str, updated_at: &str) -> MemoryRecord {
+        let mut r = sample_record();
+        r.id = crate::domain::RecordId::parse(id).expect("valid");
+        r.target_id = crate::domain::TargetId::parse(id).expect("valid");
+        r.kind = MemoryKind::UserSignal;
+        r.updated_at = Rfc3339Timestamp::parse(updated_at).expect("valid");
+        r
+    }
+
+    fn input_with<'a>(records: &'a [&'a MemoryRecord], now: &str) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: records,
+            now: Rfc3339Timestamp::parse(now).expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn includes_record_at_window_boundary() {
+        // 2026-04-21T15:00:00Z → 2026-04-22T15:00:00Z is exactly 86_400 s.
+        let r = signal("01HQZX9F5N0000000000000001", "2026-04-21T15:00:00Z");
+        let recs = [&r];
+        let seg = select(&input_with(&recs, "2026-04-22T15:00:00Z"));
+        assert_eq!(seg.included.len(), 1);
+    }
+
+    #[test]
+    fn excludes_record_one_second_past_window() {
+        let r = signal("01HQZX9F5N0000000000000001", "2026-04-21T14:59:59Z");
+        let recs = [&r];
+        let seg = select(&input_with(&recs, "2026-04-22T15:00:00Z"));
+        assert!(seg.included.is_empty());
+        assert_eq!(
+            seg.excluded[0].reason,
+            ExclusionReason::OutsideRecencyWindow
+        );
+    }
+
+    #[test]
+    fn rejects_non_signal_kind() {
+        let mut r = signal("01HQZX9F5N0000000000000001", "2026-04-22T14:59:59Z");
+        r.kind = MemoryKind::Project;
+        let recs = [&r];
+        let seg = select(&input_with(&recs, "2026-04-22T15:00:00Z"));
+        assert!(seg.included.is_empty());
+        assert_eq!(seg.excluded[0].reason, ExclusionReason::NotPinned);
+    }
+}

--- a/crates/cairn-core/tests/assemble_hot_debug.rs
+++ b/crates/cairn-core/tests/assemble_hot_debug.rs
@@ -1,0 +1,114 @@
+//! `include_debug` round-trip: every recipe step emits a `HotStepTrace`,
+//! and an excluded record carries a typed reason.
+
+use cairn_core::config::HotMemoryConfig;
+use cairn_core::domain::Rfc3339Timestamp;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::scope::ScopeTuple;
+use cairn_core::domain::taxonomy::{MemoryKind, MemoryVisibility};
+use cairn_core::generated::verbs::assemble_hot::{HotExclusionReason, HotRecipeStep};
+use cairn_core::verbs::assemble_hot::{HotMemoryInputs, assemble_hot_with_inputs};
+
+#[test]
+fn debug_field_present_when_requested() {
+    let cfg = HotMemoryConfig::default();
+    let inputs = HotMemoryInputs {
+        purpose_md: "",
+        index_md: "",
+        pinned_candidates: &[],
+        project_candidates: &[],
+        playbook_candidates: &[],
+        user_signal_candidates: &[],
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+        scope: ScopeTuple::default(),
+        authorized_visibility: &[MemoryVisibility::Private],
+        include_debug: true,
+    };
+    let data = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+    let debug = data.debug.expect("debug present");
+    assert_eq!(debug.steps.len(), cfg.recipe.len());
+}
+
+#[test]
+fn auth_failed_exclusions_are_redacted_from_debug() {
+    // OutOfScope / VisibilityDenied / ForgottenScope must NOT appear in
+    // the wire trace: the candidate slot can contain records the caller
+    // is not authorized to see, and emitting their record_id on the
+    // debug surface would turn --explain into an enumeration channel.
+    let mut visible = sample_record();
+    visible.kind = MemoryKind::User;
+    let mut hidden = sample_record();
+    hidden.kind = MemoryKind::User;
+    hidden.id = cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000099").unwrap();
+    hidden.target_id = cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000099").unwrap();
+    hidden.visibility = MemoryVisibility::Org; // not in allowlist
+    let pinned = [&visible, &hidden];
+
+    let inputs = HotMemoryInputs {
+        purpose_md: "",
+        index_md: "",
+        pinned_candidates: &pinned,
+        project_candidates: &[],
+        playbook_candidates: &[],
+        user_signal_candidates: &[],
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+        scope: ScopeTuple::default(),
+        authorized_visibility: &[MemoryVisibility::Private],
+        include_debug: true,
+    };
+    let cfg = HotMemoryConfig::default();
+    let data = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+    let debug = data.debug.expect("debug present");
+    let pinned_step = debug
+        .steps
+        .iter()
+        .find(|t| t.step == HotRecipeStep::PinnedFeedback)
+        .expect("pinned step trace");
+    assert!(
+        !pinned_step
+            .excluded
+            .iter()
+            .any(|e| e.record_id == hidden.id.as_str()),
+        "auth-failed record_id leaked into debug trace: {:?}",
+        pinned_step.excluded
+    );
+    assert_eq!(
+        pinned_step.included.len(),
+        1,
+        "the visible record must be included"
+    );
+    assert_eq!(pinned_step.included[0].record_id, visible.id.as_str());
+}
+
+#[test]
+fn excluded_record_carries_typed_reason() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    r.confidence = 0.1; // below floor
+    let pinned = [&r];
+    let inputs = HotMemoryInputs {
+        purpose_md: "",
+        index_md: "",
+        pinned_candidates: &pinned,
+        project_candidates: &[],
+        playbook_candidates: &[],
+        user_signal_candidates: &[],
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+        scope: ScopeTuple::default(),
+        authorized_visibility: &[MemoryVisibility::Private],
+        include_debug: true,
+    };
+    let cfg = HotMemoryConfig::default();
+    let data = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+    let debug = data.debug.expect("debug present");
+    let pinned_step = debug
+        .steps
+        .iter()
+        .find(|t| t.step == HotRecipeStep::PinnedFeedback)
+        .expect("pinned step trace");
+    assert_eq!(pinned_step.excluded.len(), 1);
+    assert_eq!(
+        pinned_step.excluded[0].reason,
+        HotExclusionReason::BelowConfidenceFloor
+    );
+}

--- a/crates/cairn-core/tests/assemble_hot_inputs.rs
+++ b/crates/cairn-core/tests/assemble_hot_inputs.rs
@@ -1,0 +1,144 @@
+//! End-to-end integration: default-recipe assembly with mixed-kind
+//! fixtures. Asserts the prefix bytes stay under budget and every
+//! recipe step contributes exactly one segment.
+
+use cairn_core::config::HotMemoryConfig;
+use cairn_core::domain::Rfc3339Timestamp;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::scope::ScopeTuple;
+use cairn_core::domain::taxonomy::{MemoryKind, MemoryVisibility};
+use cairn_core::verbs::assemble_hot::{HotMemoryInputs, assemble_hot_with_inputs};
+use proptest::prelude::*;
+
+#[test]
+fn default_recipe_with_mixed_records_stays_within_budget() {
+    let mut user = sample_record();
+    user.id = cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000001").expect("valid");
+    user.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000001").expect("valid");
+    user.kind = MemoryKind::User;
+
+    let mut project = sample_record();
+    project.id = cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000002").expect("valid");
+    project.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000002").expect("valid");
+    project.kind = MemoryKind::Project;
+
+    let mut playbook = sample_record();
+    playbook.id = cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000003").expect("valid");
+    playbook.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000003").expect("valid");
+    playbook.kind = MemoryKind::Playbook;
+
+    let mut signal = sample_record();
+    signal.id = cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000004").expect("valid");
+    signal.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000004").expect("valid");
+    signal.kind = MemoryKind::UserSignal;
+    // user_signal needs a recent timestamp inside the 24h window.
+    signal.updated_at = Rfc3339Timestamp::parse("2026-04-22T14:30:00Z").expect("valid");
+
+    let pinned = [&user];
+    let projects = [&project];
+    let playbooks = [&playbook];
+    let signals = [&signal];
+
+    let inputs = HotMemoryInputs {
+        purpose_md: "# Purpose\nact as a careful agent.\n",
+        index_md: "# Index\n- a.md\n- b.md\n",
+        pinned_candidates: &pinned,
+        project_candidates: &projects,
+        playbook_candidates: &playbooks,
+        user_signal_candidates: &signals,
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+        scope: ScopeTuple::default(),
+        authorized_visibility: &[MemoryVisibility::Private],
+        include_debug: false,
+    };
+    let cfg = HotMemoryConfig::default();
+    let data = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+
+    assert!(data.bytes <= u64::from(cfg.max_bytes));
+    let segments = data.segments.expect("segments emitted");
+    assert_eq!(segments.len(), cfg.recipe.len());
+    assert!(data.prefix.contains("user prefers dark mode"));
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
+    fn assemble_hot_is_deterministic_for_same_inputs(seed in 0u64..1024) {
+        let mut r = sample_record();
+        r.id = cairn_core::domain::RecordId::parse(format!(
+            "01HQZX9F5N0000000000000{:03}",
+            seed % 1000
+        )).expect("valid id");
+        r.target_id = cairn_core::domain::TargetId::parse(format!(
+            "01HQZX9F5N0000000000000{:03}",
+            seed % 1000
+        )).expect("valid target");
+        r.kind = MemoryKind::User;
+        let pinned = [&r];
+
+        let inputs = HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &pinned,
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        };
+        let cfg = HotMemoryConfig::default();
+        let a = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+        let b = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+        prop_assert_eq!(a.prefix, b.prefix);
+        prop_assert_eq!(a.bytes, b.bytes);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
+    fn assemble_hot_either_fits_budget_or_fails_typed(
+        max_bytes in 0u32..1024,
+        body_size in 0usize..512,
+    ) {
+        // Drive a non-empty body through the purpose source so byte
+        // counts vary with the proptest-supplied size; the recipe is
+        // the default 6-step shape so segments overhead is constant.
+        let purpose: String = "p".repeat(body_size);
+        let cfg = HotMemoryConfig {
+            max_bytes,
+            ..HotMemoryConfig::default()
+        };
+        let inputs = HotMemoryInputs {
+            purpose_md: &purpose,
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        };
+        match assemble_hot_with_inputs(&inputs, &cfg) {
+            Ok(data) => prop_assert!(data.bytes <= u64::from(max_bytes)),
+            Err(cairn_core::verbs::assemble_hot::AssembleHotError::BudgetExceeded {
+                got,
+                max,
+            }) => {
+                prop_assert!(got > max);
+                prop_assert_eq!(max, u64::from(max_bytes));
+            }
+            Err(other) => prop_assert!(false, "unexpected error: {other:?}"),
+        }
+    }
+}

--- a/crates/cairn-core/tests/assemble_hot_privacy.rs
+++ b/crates/cairn-core/tests/assemble_hot_privacy.rs
@@ -1,0 +1,68 @@
+//! Privacy regressions: low-confidence, scope mismatch, and visibility
+//! denials must exclude records across every source.
+
+use cairn_core::config::HotMemoryConfig;
+use cairn_core::domain::Rfc3339Timestamp;
+use cairn_core::domain::record::MemoryRecord;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::scope::ScopeTuple;
+use cairn_core::domain::taxonomy::{MemoryKind, MemoryVisibility};
+use cairn_core::verbs::assemble_hot::{HotMemoryInputs, assemble_hot_with_inputs};
+
+fn make_input<'a>(
+    pinned: &'a [&'a MemoryRecord],
+    visibility: &'a [MemoryVisibility],
+    scope: ScopeTuple,
+) -> HotMemoryInputs<'a> {
+    HotMemoryInputs {
+        purpose_md: "",
+        index_md: "",
+        pinned_candidates: pinned,
+        project_candidates: &[],
+        playbook_candidates: &[],
+        user_signal_candidates: &[],
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+        scope,
+        authorized_visibility: visibility,
+        include_debug: true,
+    }
+}
+
+#[test]
+fn pinned_record_with_low_confidence_does_not_appear() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    r.confidence = 0.1;
+    let pinned = [&r];
+    let inputs = make_input(&pinned, &[MemoryVisibility::Private], ScopeTuple::default());
+    let cfg = HotMemoryConfig::default();
+    let data = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+    assert!(!data.prefix.contains(&r.body));
+}
+
+#[test]
+fn pinned_record_with_visibility_denial_does_not_appear() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    r.visibility = MemoryVisibility::Org;
+    let pinned = [&r];
+    let inputs = make_input(&pinned, &[MemoryVisibility::Private], ScopeTuple::default());
+    let cfg = HotMemoryConfig::default();
+    let data = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+    assert!(!data.prefix.contains(&r.body));
+}
+
+#[test]
+fn pinned_record_with_scope_mismatch_does_not_appear() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    let pinned = [&r];
+    let other_user = ScopeTuple {
+        user: Some("hmn:other".to_owned()),
+        ..ScopeTuple::default()
+    };
+    let inputs = make_input(&pinned, &[MemoryVisibility::Private], other_user);
+    let cfg = HotMemoryConfig::default();
+    let data = assemble_hot_with_inputs(&inputs, &cfg).expect("assemble");
+    assert!(!data.prefix.contains(&r.body));
+}

--- a/crates/cairn-core/tests/assemble_hot_snapshots.rs
+++ b/crates/cairn-core/tests/assemble_hot_snapshots.rs
@@ -28,6 +28,7 @@ fn assemble_hot_data_canonical_json() {
         bytes: prefix.len() as u64,
         prefix,
         segments: Some(segments),
+        debug: None,
     };
     let json = serde_json::to_string_pretty(&data).unwrap();
     insta::assert_snapshot!(json);

--- a/crates/cairn-idl/schema/verbs/assemble_hot.json
+++ b/crates/cairn-idl/schema/verbs/assemble_hot.json
@@ -10,7 +10,8 @@
     "command": "assemble_hot",
     "flags": [
       { "name": "session_id", "long": "session", "value_source": "string" },
-      { "name": "budget",     "long": "budget",  "value_source": "u32" }
+      { "name": "budget",     "long": "budget",  "value_source": "u32" },
+      { "name": "explain",    "long": "explain", "value_source": "bool" }
     ]
   },
   "x-cairn-skill-triggers": {
@@ -25,7 +26,8 @@
       "additionalProperties": false,
       "properties": {
         "session_id": { "type": "string", "minLength": 1 },
-        "budget":     { "type": "integer", "minimum": 0, "maximum": 4194304, "description": "Byte budget for the assembled prefix (default 25000; hard cap 4 MiB)." }
+        "budget":     { "type": "integer", "minimum": 0, "maximum": 4194304, "description": "Byte budget for the assembled prefix (default 25000; hard cap 4 MiB)." },
+        "explain":    { "type": "boolean", "description": "When true, the response carries a `debug` payload describing per-step inclusion + typed exclusion reasons. Defaults to false; older callers omit it." }
       }
     },
     "Data": {
@@ -42,6 +44,10 @@
           "maxItems": 64,
           "x-cairn-reject-null": true,
           "description": "Recipe-step segments covering [0, bytes) contiguously, in declaration order. Three-state contract: (1) FIELD ABSENT ON THE WIRE — legacy cairn.mcp.v1 producer that predates this feature; consumers MUST treat prefix as opaque. (2) \"segments\": [] — new producer ran with NO recipe configured; the producer explicitly opts into the new contract but had nothing to emit. REQUIRED INVARIANT: prefix == \"\" AND bytes == 0. (3) \"segments\": [...] — new producer with a configured recipe; len() mirrors HotMemoryConfig.recipe.len() 1:1, including N zero-length entries when the recipe ran with no content. The Rust binding distinguishes (1) from (2) via Option<Vec<HotSegment>> (None vs Some(vec![])); JSON-only consumers distinguish them by field presence. NOTE: there is intentionally NO default: [] here — schema-aware tooling that materialized defaults would rewrite legacy-absent into canonical-empty and trip the EmptySegmentsRequiresEmptyPrefix invariant. Forward-compat depends on absence staying absence."
+        },
+        "debug": {
+          "$ref": "#/$defs/HotMemoryDebug",
+          "description": "Optional inclusion/exclusion trace per recipe step. Absent unless the caller requested debug output via Args.explain. Wire-compatible addition for cairn.mcp.v1: older consumers ignore unknown fields."
         }
       }
     },
@@ -66,6 +72,61 @@
       "type": "string",
       "enum": ["stable_1h", "stable_5m", "volatile"],
       "description": "Cache-lifetime hint per segment. Frozen for the lifetime of cairn.mcp.v1."
+    },
+    "HotMemoryDebug": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["steps"],
+      "properties": {
+        "steps": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/HotStepTrace" }
+        }
+      }
+    },
+    "HotStepTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step", "included", "excluded"],
+      "properties": {
+        "step":     { "$ref": "#/$defs/HotRecipeStep" },
+        "included": { "type": "array", "items": { "$ref": "#/$defs/HotInclusion" } },
+        "excluded": { "type": "array", "items": { "$ref": "#/$defs/HotExclusion" } }
+      }
+    },
+    "HotInclusion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "score", "note"],
+      "properties": {
+        "record_id": { "type": "string", "minLength": 1 },
+        "score":     { "type": "number" },
+        "note":      { "type": "string", "minLength": 1 }
+      }
+    },
+    "HotExclusion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "reason"],
+      "properties": {
+        "record_id": { "type": "string", "minLength": 1 },
+        "reason":    { "$ref": "#/$defs/HotExclusionReason" }
+      }
+    },
+    "HotExclusionReason": {
+      "type": "string",
+      "enum": [
+        "tombstoned",
+        "forgotten_scope",
+        "below_confidence_floor",
+        "out_of_scope",
+        "visibility_denied",
+        "outside_recency_window",
+        "beyond_top_k",
+        "not_pinned",
+        "empty_body"
+      ]
     }
   }
 }

--- a/crates/cairn-idl/tests/snapshots/codegen_snapshot__snapshot_skill_md.snap
+++ b/crates/cairn-idl/tests/snapshots/codegen_snapshot__snapshot_skill_md.snap
@@ -258,6 +258,10 @@ cairn assemble_hot --session SESSION_ID
 cairn assemble_hot --budget 0
 ```
 
+```bash
+cairn assemble_hot --explain
+```
+
 ## `cairn capture_trace`
 
 **Use when:**

--- a/crates/cairn-mcp/src/generated/schemas/verbs/assemble_hot.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/assemble_hot.input.json
@@ -9,6 +9,10 @@
           "minimum": 0,
           "type": "integer"
         },
+        "explain": {
+          "description": "When true, the response carries a `debug` payload describing per-step inclusion + typed exclusion reasons. Defaults to false; older callers omit it.",
+          "type": "boolean"
+        },
         "session_id": {
           "minLength": 1,
           "type": "string"
@@ -23,6 +27,10 @@
           "maximum": 4194304,
           "minimum": 0,
           "type": "integer"
+        },
+        "debug": {
+          "$ref": "#/$defs/HotMemoryDebug",
+          "description": "Optional inclusion/exclusion trace per recipe step. Absent unless the caller requested debug output via Args.explain. Wire-compatible addition for cairn.mcp.v1: older consumers ignore unknown fields."
         },
         "prefix": {
           "description": "Assembled hot-memory text ready to inject into the agent prompt. May be empty when no hot-memory is available.",
@@ -44,6 +52,75 @@
       ],
       "type": "object",
       "x-cairn-validate": true
+    },
+    "HotExclusion": {
+      "additionalProperties": false,
+      "properties": {
+        "reason": {
+          "$ref": "#/$defs/HotExclusionReason"
+        },
+        "record_id": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "record_id",
+        "reason"
+      ],
+      "type": "object"
+    },
+    "HotExclusionReason": {
+      "enum": [
+        "tombstoned",
+        "forgotten_scope",
+        "below_confidence_floor",
+        "out_of_scope",
+        "visibility_denied",
+        "outside_recency_window",
+        "beyond_top_k",
+        "not_pinned",
+        "empty_body"
+      ],
+      "type": "string"
+    },
+    "HotInclusion": {
+      "additionalProperties": false,
+      "properties": {
+        "note": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "record_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "score": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "record_id",
+        "score",
+        "note"
+      ],
+      "type": "object"
+    },
+    "HotMemoryDebug": {
+      "additionalProperties": false,
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/$defs/HotStepTrace"
+          },
+          "maxItems": 64,
+          "type": "array"
+        }
+      },
+      "required": [
+        "steps"
+      ],
+      "type": "object"
     },
     "HotRecipeStep": {
       "description": "Frozen for the lifetime of cairn.mcp.v1. Adding a recipe step requires bumping to cairn.mcp.v2.",
@@ -88,6 +165,32 @@
         "byte_end",
         "stability",
         "content_hash"
+      ],
+      "type": "object"
+    },
+    "HotStepTrace": {
+      "additionalProperties": false,
+      "properties": {
+        "excluded": {
+          "items": {
+            "$ref": "#/$defs/HotExclusion"
+          },
+          "type": "array"
+        },
+        "included": {
+          "items": {
+            "$ref": "#/$defs/HotInclusion"
+          },
+          "type": "array"
+        },
+        "step": {
+          "$ref": "#/$defs/HotRecipeStep"
+        }
+      },
+      "required": [
+        "step",
+        "included",
+        "excluded"
       ],
       "type": "object"
     },

--- a/crates/cairn-mcp/src/generated/schemas/verbs/assemble_hot.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/assemble_hot.json
@@ -9,6 +9,10 @@
           "minimum": 0,
           "type": "integer"
         },
+        "explain": {
+          "description": "When true, the response carries a `debug` payload describing per-step inclusion + typed exclusion reasons. Defaults to false; older callers omit it.",
+          "type": "boolean"
+        },
         "session_id": {
           "minLength": 1,
           "type": "string"
@@ -23,6 +27,10 @@
           "maximum": 4194304,
           "minimum": 0,
           "type": "integer"
+        },
+        "debug": {
+          "$ref": "#/$defs/HotMemoryDebug",
+          "description": "Optional inclusion/exclusion trace per recipe step. Absent unless the caller requested debug output via Args.explain. Wire-compatible addition for cairn.mcp.v1: older consumers ignore unknown fields."
         },
         "prefix": {
           "description": "Assembled hot-memory text ready to inject into the agent prompt. May be empty when no hot-memory is available.",
@@ -44,6 +52,75 @@
       ],
       "type": "object",
       "x-cairn-validate": true
+    },
+    "HotExclusion": {
+      "additionalProperties": false,
+      "properties": {
+        "reason": {
+          "$ref": "#/$defs/HotExclusionReason"
+        },
+        "record_id": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "record_id",
+        "reason"
+      ],
+      "type": "object"
+    },
+    "HotExclusionReason": {
+      "enum": [
+        "tombstoned",
+        "forgotten_scope",
+        "below_confidence_floor",
+        "out_of_scope",
+        "visibility_denied",
+        "outside_recency_window",
+        "beyond_top_k",
+        "not_pinned",
+        "empty_body"
+      ],
+      "type": "string"
+    },
+    "HotInclusion": {
+      "additionalProperties": false,
+      "properties": {
+        "note": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "record_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "score": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "record_id",
+        "score",
+        "note"
+      ],
+      "type": "object"
+    },
+    "HotMemoryDebug": {
+      "additionalProperties": false,
+      "properties": {
+        "steps": {
+          "items": {
+            "$ref": "#/$defs/HotStepTrace"
+          },
+          "maxItems": 64,
+          "type": "array"
+        }
+      },
+      "required": [
+        "steps"
+      ],
+      "type": "object"
     },
     "HotRecipeStep": {
       "description": "Frozen for the lifetime of cairn.mcp.v1. Adding a recipe step requires bumping to cairn.mcp.v2.",
@@ -91,6 +168,32 @@
       ],
       "type": "object"
     },
+    "HotStepTrace": {
+      "additionalProperties": false,
+      "properties": {
+        "excluded": {
+          "items": {
+            "$ref": "#/$defs/HotExclusion"
+          },
+          "type": "array"
+        },
+        "included": {
+          "items": {
+            "$ref": "#/$defs/HotInclusion"
+          },
+          "type": "array"
+        },
+        "step": {
+          "$ref": "#/$defs/HotRecipeStep"
+        }
+      },
+      "required": [
+        "step",
+        "included",
+        "excluded"
+      ],
+      "type": "object"
+    },
     "SegmentStability": {
       "description": "Cache-lifetime hint per segment. Frozen for the lifetime of cairn.mcp.v1.",
       "enum": [
@@ -119,6 +222,11 @@
         "long": "budget",
         "name": "budget",
         "value_source": "u32"
+      },
+      {
+        "long": "explain",
+        "name": "explain",
+        "value_source": "bool"
       }
     ]
   },

--- a/crates/cairn-sdk/tests/surface.rs
+++ b/crates/cairn-sdk/tests/surface.rs
@@ -905,6 +905,7 @@ fn assemble_hot_rejects_oversized_budget_with_invalid_args() {
     let args = AssembleHotArgs {
         budget: Some(4_194_305),
         session_id: None,
+        explain: None,
     };
     match sdk().assemble_hot(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => assert!(reason.contains("budget"), "reason: {reason}"),
@@ -971,6 +972,7 @@ fn assemble_hot_rejects_any_budget_until_loader_lands() {
     let args = AssembleHotArgs {
         budget: Some(1024),
         session_id: None,
+        explain: None,
     };
     match sdk().assemble_hot(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => {
@@ -986,6 +988,7 @@ fn assemble_hot_rejects_any_session_id_until_loader_lands() {
     let args = AssembleHotArgs {
         budget: None,
         session_id: Some("01J0000000000000000000000A".to_owned()),
+        explain: None,
     };
     match sdk().assemble_hot(&args).expect_err("must reject") {
         SdkError::InvalidArgs { reason } => {
@@ -1006,6 +1009,7 @@ fn assemble_hot_returns_unimplemented_in_sdk() {
     let args = AssembleHotArgs {
         budget: None,
         session_id: None,
+        explain: None,
     };
     assert_unimplemented("assemble_hot", sdk().assemble_hot(&args));
 

--- a/docs/site/src/reference/generated/commands/assemble_hot.md
+++ b/docs/site/src/reference/generated/commands/assemble_hot.md
@@ -18,6 +18,9 @@ Options:
       --budget <U32>
 
 
+      --explain
+
+
       --json
           Emit machine-readable JSON response envelope to stdout
 

--- a/docs/superpowers/plans/2026-05-08-issue-82-hot-prefix-retrieval.md
+++ b/docs/superpowers/plans/2026-05-08-issue-82-hot-prefix-retrieval.md
@@ -1,0 +1,2382 @@
+# Issue #82 — Hot Prefix Retrieval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the stub `load_step_body` with real source-specific
+retrieval for the six v1 `HotRecipeStep` variants, applying uniform
+admissibility (visibility, scope, confidence, staleness) and emitting
+typed inclusion/exclusion traces.
+
+**Architecture:** Pure-projection: caller (cairn-cli/sdk) pre-filters
+records by kind/visibility/scope and feeds them into a typed
+`HotMemoryInputs`. Core applies admissibility + ranking + top-K + body
+assembly. The IDL grows one optional `debug` field on `AssembleHotData`;
+the recipe enum stays frozen for cairn.mcp.v1.
+
+**Tech Stack:** Rust 1.95, edition 2024, `thiserror`, `chrono`,
+`insta`, `proptest`, `cargo-nextest`, `cairn-idl` codegen.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-issue-82-hot-prefix-retrieval-design.md`
+
+---
+
+## File Map
+
+**Create:**
+- `crates/cairn-core/src/verbs/assemble_hot/inclusion.rs`
+- `crates/cairn-core/src/verbs/assemble_hot/admissibility.rs`
+- `crates/cairn-core/src/verbs/assemble_hot/sources/mod.rs`
+- `crates/cairn-core/src/verbs/assemble_hot/sources/purpose.rs`
+- `crates/cairn-core/src/verbs/assemble_hot/sources/index.rs`
+- `crates/cairn-core/src/verbs/assemble_hot/sources/pinned.rs`
+- `crates/cairn-core/src/verbs/assemble_hot/sources/project.rs`
+- `crates/cairn-core/src/verbs/assemble_hot/sources/playbook.rs`
+- `crates/cairn-core/src/verbs/assemble_hot/sources/user_signal.rs`
+- `crates/cairn-core/src/verbs/assemble_hot/inputs.rs` — `HotMemoryInputs`
+- `crates/cairn-core/tests/assemble_hot_inputs.rs`
+- `crates/cairn-core/tests/assemble_hot_privacy.rs`
+- `crates/cairn-core/tests/assemble_hot_debug.rs`
+- `crates/cairn-cli/tests/assemble_hot_smoke.rs`
+
+**Modify:**
+- `crates/cairn-idl/schema/verbs/assemble_hot.json` — add optional `debug` + `HotStepTrace` def
+- `crates/cairn-core/src/generated/verbs/assemble_hot.rs` — regenerated
+- `crates/cairn-core/src/verbs/assemble_hot/mod.rs` — re-exports
+- `crates/cairn-core/src/verbs/assemble_hot/assembler.rs` — refactor to take `HotMemoryInputs`
+- `crates/cairn-core/tests/assemble_hot_snapshots.rs` — fixture-driven, deterministic body
+
+---
+
+## Task 1: IDL — add optional `debug` field + `HotStepTrace`
+
+**Files:**
+- Modify: `crates/cairn-idl/schema/verbs/assemble_hot.json`
+- Regenerate: `crates/cairn-core/src/generated/verbs/assemble_hot.rs`
+
+- [ ] **Step 1: Read current IDL**
+
+```bash
+cat crates/cairn-idl/schema/verbs/assemble_hot.json
+```
+
+- [ ] **Step 2: Add `debug` ref + named defs**
+
+Edit `crates/cairn-idl/schema/verbs/assemble_hot.json`. Add `"debug"` after `"segments"` inside `Data.properties` as a `$ref` so codegen emits a stable type name:
+
+```json
+        "debug": {
+          "$ref": "#/$defs/HotMemoryDebug",
+          "description": "Optional inclusion/exclusion trace per recipe step. Absent unless the caller requested debug output. Wire-compatible addition for cairn.mcp.v1: older consumers ignore unknown fields."
+        }
+```
+
+Add four new `$defs` entries after `SegmentStability`:
+
+```json
+    ,
+    "HotMemoryDebug": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["steps"],
+      "properties": {
+        "steps": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/HotStepTrace" }
+        }
+      }
+    },
+    "HotStepTrace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step", "included", "excluded"],
+      "properties": {
+        "step":     { "$ref": "#/$defs/HotRecipeStep" },
+        "included": { "type": "array", "items": { "$ref": "#/$defs/HotInclusion" } },
+        "excluded": { "type": "array", "items": { "$ref": "#/$defs/HotExclusion" } }
+      }
+    },
+    "HotInclusion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "score", "note"],
+      "properties": {
+        "record_id": { "type": "string", "minLength": 1 },
+        "score":     { "type": "number" },
+        "note":      { "type": "string" }
+      }
+    },
+    "HotExclusion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["record_id", "reason"],
+      "properties": {
+        "record_id": { "type": "string", "minLength": 1 },
+        "reason":    { "$ref": "#/$defs/HotExclusionReason" }
+      }
+    },
+    "HotExclusionReason": {
+      "type": "string",
+      "enum": [
+        "tombstoned",
+        "forgotten_scope",
+        "below_confidence_floor",
+        "out_of_scope",
+        "visibility_denied",
+        "outside_recency_window",
+        "beyond_top_k",
+        "not_pinned",
+        "empty_body"
+      ]
+    }
+```
+
+After `cargo run -p cairn-idl --bin cairn-codegen --locked` runs, verify the generated module exports types named `HotMemoryDebug`, `HotStepTrace`, `HotInclusion`, `HotExclusion`, and `HotExclusionReason`:
+
+```bash
+grep -E 'pub (struct|enum) (HotMemoryDebug|HotStepTrace|HotInclusion|HotExclusion|HotExclusionReason)' \
+  crates/cairn-core/src/generated/verbs/assemble_hot.rs
+```
+
+Expected: five hits. If a name differs (e.g., codegen emits `Debug` instead of `HotMemoryDebug` for an inline object), reconcile by renaming in Tasks 11/12 — the names referenced there must match codegen output verbatim.
+
+- [ ] **Step 3: Regenerate codegen**
+
+Run: `cargo run -p cairn-idl --bin cairn-codegen --locked`
+Expected: writes new types into `crates/cairn-core/src/generated/verbs/assemble_hot.rs`. No errors.
+
+- [ ] **Step 4: Verify codegen idempotency**
+
+Run: `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
+Expected: exit 0, no diff.
+
+- [ ] **Step 5: Build to confirm no breakage**
+
+Run: `cargo check -p cairn-core --locked`
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-idl/schema/verbs/assemble_hot.json \
+        crates/cairn-core/src/generated/verbs/assemble_hot.rs
+git commit -m "feat(idl): add optional debug field on AssembleHotData (issue #82)
+
+Adds HotStepTrace + HotInclusion + HotExclusion definitions and an
+optional debug property on Data. Wire-compatible addition for
+cairn.mcp.v1; older consumers ignore unknown fields. The HotRecipeStep
+enum is unchanged."
+```
+
+---
+
+## Task 2: ExclusionReason + InclusionTrace types
+
+**Files:**
+- Create: `crates/cairn-core/src/verbs/assemble_hot/inclusion.rs`
+- Modify: `crates/cairn-core/src/verbs/assemble_hot/mod.rs`
+
+- [ ] **Step 1: Write the inclusion module skeleton + unit test**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/inclusion.rs`:
+
+```rust
+//! Inclusion / exclusion trace types for `assemble_hot` (issue #82).
+//!
+//! Surface the typed reason a record either entered the assembled hot
+//! prefix or was filtered out. Adapter callers gate this behind a
+//! per-call `include_debug` flag so production callers do not pay for
+//! the bookkeeping when they do not need it.
+
+use crate::domain::RecordId;
+
+/// Why a candidate record did not enter the assembled hot prefix.
+///
+/// Wire form: snake_case strings matching `HotExclusion.reason`
+/// in `cairn-idl/schema/verbs/assemble_hot.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExclusionReason {
+    /// The record's `tombstoned` flag was set.
+    Tombstoned,
+    /// The record sat under a forget-state-scope.
+    ForgottenScope,
+    /// `record.confidence < 0.3` (matches the profile synthesizer floor).
+    BelowConfidenceFloor,
+    /// The record's `scope` is not satisfied by the caller's authorized scope.
+    OutOfScope,
+    /// The record's `visibility` is not in `authorized_visibility`.
+    VisibilityDenied,
+    /// The record's `updated_at` is older than the source's recency window.
+    OutsideRecencyWindow,
+    /// The record was admissible but ranked below the source's top-K cap.
+    BeyondTopK,
+    /// The record did not match the source's pin / kind narrowing.
+    NotPinned,
+    /// `record.body` was empty.
+    EmptyBody,
+}
+
+impl ExclusionReason {
+    /// Wire-form name as exported by the IDL `HotExclusion.reason` enum.
+    #[must_use]
+    pub const fn as_wire(self) -> &'static str {
+        match self {
+            Self::Tombstoned => "tombstoned",
+            Self::ForgottenScope => "forgotten_scope",
+            Self::BelowConfidenceFloor => "below_confidence_floor",
+            Self::OutOfScope => "out_of_scope",
+            Self::VisibilityDenied => "visibility_denied",
+            Self::OutsideRecencyWindow => "outside_recency_window",
+            Self::BeyondTopK => "beyond_top_k",
+            Self::NotPinned => "not_pinned",
+            Self::EmptyBody => "empty_body",
+        }
+    }
+}
+
+/// Why a record did enter the assembled hot prefix, with the rank score.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InclusionTrace {
+    /// Record that contributed to the segment body.
+    pub record_id: RecordId,
+    /// Source-specific score (e.g. `salience × recency` for pinned).
+    pub score: f64,
+    /// Human-readable note describing why this record won (`"top-1 by updated_at"`).
+    pub note: &'static str,
+}
+
+/// Why a record was filtered, paired with its `record_id`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExclusionTrace {
+    /// Record that was filtered.
+    pub record_id: RecordId,
+    /// Typed reason.
+    pub reason: ExclusionReason,
+}
+
+/// Output of one source's `select` call.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct LoadedSegment {
+    /// Concatenated markdown body produced by the source.
+    pub body: String,
+    /// Records that contributed to `body`, in emission order.
+    pub included: Vec<InclusionTrace>,
+    /// Records that were filtered, in evaluation order.
+    pub excluded: Vec<ExclusionTrace>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusion_reason_wire_strings_match_idl() {
+        // The wire strings must mirror the IDL HotExclusion.reason enum.
+        assert_eq!(ExclusionReason::Tombstoned.as_wire(), "tombstoned");
+        assert_eq!(ExclusionReason::ForgottenScope.as_wire(), "forgotten_scope");
+        assert_eq!(
+            ExclusionReason::BelowConfidenceFloor.as_wire(),
+            "below_confidence_floor"
+        );
+        assert_eq!(ExclusionReason::OutOfScope.as_wire(), "out_of_scope");
+        assert_eq!(
+            ExclusionReason::VisibilityDenied.as_wire(),
+            "visibility_denied"
+        );
+        assert_eq!(
+            ExclusionReason::OutsideRecencyWindow.as_wire(),
+            "outside_recency_window"
+        );
+        assert_eq!(ExclusionReason::BeyondTopK.as_wire(), "beyond_top_k");
+        assert_eq!(ExclusionReason::NotPinned.as_wire(), "not_pinned");
+        assert_eq!(ExclusionReason::EmptyBody.as_wire(), "empty_body");
+    }
+
+    #[test]
+    fn loaded_segment_default_is_empty() {
+        let s = LoadedSegment::default();
+        assert!(s.body.is_empty());
+        assert!(s.included.is_empty());
+        assert!(s.excluded.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Add module to `mod.rs`**
+
+Edit `crates/cairn-core/src/verbs/assemble_hot/mod.rs` — add `pub mod inclusion;` and re-export:
+
+```rust
+pub mod assembler;
+pub mod inclusion;
+pub mod raw;
+pub mod segments;
+
+pub use assembler::{AssembleHotError, assemble_hot};
+pub use inclusion::{ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment};
+pub use segments::{
+    AssembleHotValidationError, MAX_SEGMENTS, build_segments, default_stability, validate,
+    validate_base, validate_segments, validate_with_recipe,
+};
+```
+
+- [ ] **Step 3: Run unit tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot::inclusion`
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Run clippy**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/inclusion.rs \
+        crates/cairn-core/src/verbs/assemble_hot/mod.rs
+git commit -m "feat(assemble_hot): typed inclusion/exclusion traces (issue #82)"
+```
+
+---
+
+## Task 3: Admissibility predicate
+
+**Files:**
+- Create: `crates/cairn-core/src/verbs/assemble_hot/admissibility.rs`
+- Modify: `crates/cairn-core/src/verbs/assemble_hot/mod.rs`
+
+- [ ] **Step 1: Write tests + module in one file**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/admissibility.rs`:
+
+```rust
+//! Uniform admissibility predicate (issue #82, brief §6, §7).
+//!
+//! Every source delegates to [`admit`] before its own ranking. This
+//! re-checks visibility / scope / confidence / body invariants the
+//! adapter is supposed to have applied — defense-in-depth at the
+//! trust boundary so a buggy or malicious adapter cannot smuggle a
+//! record into the hot prefix.
+
+use crate::domain::record::MemoryRecord;
+use crate::domain::scope::ScopeTuple;
+use crate::domain::taxonomy::MemoryVisibility;
+
+use super::inclusion::ExclusionReason;
+
+/// Confidence floor — matches `pipeline::profile::synthesize::CONFIDENCE_FLOOR`.
+pub const CONFIDENCE_FLOOR: f32 = 0.3;
+
+/// Returns `Ok(())` if the record passes the uniform admissibility
+/// gates, otherwise the typed exclusion reason.
+///
+/// Order matches §7's "fail-closed" intent: tombstone > scope >
+/// visibility > confidence > body. The first failing gate wins; later
+/// gates are not evaluated.
+pub fn admit(
+    record: &MemoryRecord,
+    authorized_scope: &ScopeTuple,
+    authorized_visibility: &[MemoryVisibility],
+) -> Result<(), ExclusionReason> {
+    if record.body.is_empty() {
+        return Err(ExclusionReason::EmptyBody);
+    }
+    if !scope_satisfied(authorized_scope, &record.scope) {
+        return Err(ExclusionReason::OutOfScope);
+    }
+    if !authorized_visibility.contains(&record.visibility) {
+        return Err(ExclusionReason::VisibilityDenied);
+    }
+    if record.confidence.is_nan() || record.confidence < CONFIDENCE_FLOOR {
+        return Err(ExclusionReason::BelowConfidenceFloor);
+    }
+    Ok(())
+}
+
+/// Every set dimension on `authorized` must equal the record's value
+/// on the same dimension. The record may carry additional dimensions
+/// (e.g. session_id) — those are not narrowed.
+fn scope_satisfied(authorized: &ScopeTuple, record: &ScopeTuple) -> bool {
+    let pairs: [(&Option<String>, &Option<String>); 7] = [
+        (&authorized.tenant, &record.tenant),
+        (&authorized.workspace, &record.workspace),
+        (&authorized.project, &record.project),
+        (&authorized.session_id, &record.session_id),
+        (&authorized.entity, &record.entity),
+        (&authorized.user, &record.user),
+        (&authorized.agent, &record.agent),
+    ];
+    for (auth, rec) in pairs {
+        if let Some(a) = auth
+            && Some(a) != rec.as_ref()
+        {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+
+    fn allow_private() -> Vec<MemoryVisibility> {
+        vec![MemoryVisibility::Private]
+    }
+
+    fn matching_scope() -> ScopeTuple {
+        ScopeTuple {
+            user: Some("hmn:tafeng".to_owned()),
+            ..ScopeTuple::default()
+        }
+    }
+
+    #[test]
+    fn admits_canonical_sample_record() {
+        let r = sample_record();
+        assert_eq!(admit(&r, &matching_scope(), &allow_private()), Ok(()));
+    }
+
+    #[test]
+    fn rejects_empty_body() {
+        let mut r = sample_record();
+        r.body = String::new();
+        assert_eq!(
+            admit(&r, &matching_scope(), &allow_private()),
+            Err(ExclusionReason::EmptyBody)
+        );
+    }
+
+    #[test]
+    fn rejects_visibility_not_in_allowlist() {
+        let r = sample_record();
+        // sample_record() is Private; allowlist only Public → denied.
+        let only_public = vec![MemoryVisibility::Public];
+        assert_eq!(
+            admit(&r, &matching_scope(), &only_public),
+            Err(ExclusionReason::VisibilityDenied)
+        );
+    }
+
+    #[test]
+    fn rejects_below_confidence_floor() {
+        let mut r = sample_record();
+        r.confidence = 0.29;
+        assert_eq!(
+            admit(&r, &matching_scope(), &allow_private()),
+            Err(ExclusionReason::BelowConfidenceFloor)
+        );
+    }
+
+    #[test]
+    fn rejects_scope_mismatch() {
+        let r = sample_record();
+        let other_user = ScopeTuple {
+            user: Some("hmn:someoneelse".to_owned()),
+            ..ScopeTuple::default()
+        };
+        assert_eq!(
+            admit(&r, &other_user, &allow_private()),
+            Err(ExclusionReason::OutOfScope)
+        );
+    }
+
+    #[test]
+    fn empty_authorized_scope_admits_any_scope() {
+        let r = sample_record();
+        let empty = ScopeTuple::default();
+        assert_eq!(admit(&r, &empty, &allow_private()), Ok(()));
+    }
+}
+```
+
+- [ ] **Step 2: Register the module in `mod.rs`**
+
+Edit `crates/cairn-core/src/verbs/assemble_hot/mod.rs`:
+
+```rust
+pub mod admissibility;
+pub mod assembler;
+pub mod inclusion;
+pub mod raw;
+pub mod segments;
+
+pub use admissibility::{CONFIDENCE_FLOOR, admit};
+```
+
+(keep existing re-exports below.)
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot::admissibility`
+Expected: 6 tests pass.
+
+- [ ] **Step 4: Run clippy**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/admissibility.rs \
+        crates/cairn-core/src/verbs/assemble_hot/mod.rs
+git commit -m "feat(assemble_hot): uniform admissibility predicate (issue #82)"
+```
+
+---
+
+## Task 4: HotMemoryInputs struct
+
+**Files:**
+- Create: `crates/cairn-core/src/verbs/assemble_hot/inputs.rs`
+- Modify: `crates/cairn-core/src/verbs/assemble_hot/mod.rs`
+
+- [ ] **Step 1: Write the inputs module + smoke test**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/inputs.rs`:
+
+```rust
+//! Pure-projection inputs for `assemble_hot` (issue #82).
+//!
+//! Adapters (`cairn-cli`, `cairn-sdk`) materialize this struct from a
+//! `MemoryStore` query + filesystem reads. Core never touches the
+//! store or the filesystem.
+
+use crate::domain::Rfc3339Timestamp;
+use crate::domain::record::MemoryRecord;
+use crate::domain::scope::ScopeTuple;
+use crate::domain::taxonomy::MemoryVisibility;
+
+/// Pre-filtered record + filesystem inputs for [`super::assemble_hot`].
+///
+/// Slot contracts (caller-side responsibility, all enforced by the
+/// adapter, double-checked by core):
+///
+/// * `pinned_candidates`: `kind ∈ {user, feedback} ∧ is_static = 1`,
+///   already narrowed to the authorized scope/visibility. `is_static`
+///   is a store-side projection (no field on `MemoryRecord`); the
+///   caller is the only authority for it.
+/// * `project_candidates`: `kind = project`.
+/// * `playbook_candidates`: `kind = playbook`.
+/// * `user_signal_candidates`: `kind = user_signal`.
+/// * `purpose_md` / `index_md`: pre-read file content.
+///
+/// Each record-bearing slot may include records the source-side ranker
+/// later excludes (low confidence, scope mismatch, etc.). Core's
+/// admissibility check is the trust boundary, not the slot membership.
+#[derive(Debug, Clone)]
+pub struct HotMemoryInputs<'a> {
+    /// Body of `purpose.md`, already read from disk by the adapter.
+    pub purpose_md: &'a str,
+    /// Body of `index.md`, already read from disk by the adapter.
+    pub index_md: &'a str,
+    /// Caller-narrowed pinned-feedback candidates.
+    pub pinned_candidates: &'a [&'a MemoryRecord],
+    /// `project`-kind candidates for the salience source.
+    pub project_candidates: &'a [&'a MemoryRecord],
+    /// `playbook`-kind candidates.
+    pub playbook_candidates: &'a [&'a MemoryRecord],
+    /// `user_signal`-kind candidates.
+    pub user_signal_candidates: &'a [&'a MemoryRecord],
+    /// Reference instant. Recency windows are computed against this.
+    pub now: Rfc3339Timestamp,
+    /// Authorized scope for this assembly call (re-checked per record).
+    pub scope: ScopeTuple,
+    /// Visibility tiers the caller is authorized to see.
+    pub authorized_visibility: &'a [MemoryVisibility],
+    /// When `true`, the assembler populates `AssembleHotData.debug`.
+    pub include_debug: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    #[test]
+    fn inputs_is_constructible() {
+        let r = sample_record();
+        let recs = [&r];
+        let now = Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid");
+        let scope = ScopeTuple::default();
+        let allow = [MemoryVisibility::Private];
+        let inputs = HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &recs,
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now,
+            scope,
+            authorized_visibility: &allow,
+            include_debug: false,
+        };
+        assert_eq!(inputs.pinned_candidates.len(), 1);
+        assert!(!inputs.include_debug);
+    }
+}
+```
+
+- [ ] **Step 2: Re-export from `mod.rs`**
+
+Edit `crates/cairn-core/src/verbs/assemble_hot/mod.rs` — add `pub mod inputs;` and `pub use inputs::HotMemoryInputs;`.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot::inputs`
+Expected: 1 test pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/inputs.rs \
+        crates/cairn-core/src/verbs/assemble_hot/mod.rs
+git commit -m "feat(assemble_hot): HotMemoryInputs projection (issue #82)"
+```
+
+---
+
+## Task 5: Sources scaffold + purpose/index pass-through
+
+**Files:**
+- Create: `crates/cairn-core/src/verbs/assemble_hot/sources/mod.rs`
+- Create: `crates/cairn-core/src/verbs/assemble_hot/sources/purpose.rs`
+- Create: `crates/cairn-core/src/verbs/assemble_hot/sources/index.rs`
+- Modify: `crates/cairn-core/src/verbs/assemble_hot/mod.rs`
+
+- [ ] **Step 1: Create the sources module**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/sources/mod.rs`:
+
+```rust
+//! Source-specific `select` functions for each `HotRecipeStep`. Each
+//! one returns a [`super::inclusion::LoadedSegment`] — never errors —
+//! so the assembler can compose them deterministically.
+
+pub mod index;
+pub mod pinned;
+pub mod playbook;
+pub mod project;
+pub mod purpose;
+pub mod user_signal;
+```
+
+- [ ] **Step 2: Write the purpose source + tests**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/sources/purpose.rs`:
+
+```rust
+//! `Purpose` source: pass-through `purpose.md` content.
+
+use crate::verbs::assemble_hot::inclusion::LoadedSegment;
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+/// Render the purpose segment by copying `inputs.purpose_md` verbatim.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    LoadedSegment {
+        body: inputs.purpose_md.to_owned(),
+        included: Vec::new(),
+        excluded: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::Rfc3339Timestamp;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn empty_inputs<'a>(purpose: &'a str) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: purpose,
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn passes_purpose_md_through_verbatim() {
+        let s = select(&empty_inputs("# Purpose\nI am a purpose.\n"));
+        assert_eq!(s.body, "# Purpose\nI am a purpose.\n");
+        assert!(s.included.is_empty());
+        assert!(s.excluded.is_empty());
+    }
+
+    #[test]
+    fn empty_purpose_emits_empty_segment() {
+        let s = select(&empty_inputs(""));
+        assert!(s.body.is_empty());
+    }
+}
+```
+
+- [ ] **Step 3: Write the index source + tests (mirrors purpose)**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/sources/index.rs`:
+
+```rust
+//! `Index` source: pass-through `index.md` content.
+
+use crate::verbs::assemble_hot::inclusion::LoadedSegment;
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+/// Render the index segment by copying `inputs.index_md` verbatim.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    LoadedSegment {
+        body: inputs.index_md.to_owned(),
+        included: Vec::new(),
+        excluded: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::Rfc3339Timestamp;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn empty_inputs<'a>(index: &'a str) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: index,
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn passes_index_md_through_verbatim() {
+        let s = select(&empty_inputs("# Index\n- a.md\n"));
+        assert_eq!(s.body, "# Index\n- a.md\n");
+    }
+}
+```
+
+- [ ] **Step 4: Wire into `mod.rs`**
+
+Edit `crates/cairn-core/src/verbs/assemble_hot/mod.rs` — add `pub mod sources;`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot::sources`
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/sources \
+        crates/cairn-core/src/verbs/assemble_hot/mod.rs
+git commit -m "feat(assemble_hot): purpose + index pass-through sources (issue #82)"
+```
+
+---
+
+## Task 6: Body framing helper
+
+**Files:**
+- Create: `crates/cairn-core/src/verbs/assemble_hot/sources/render.rs`
+- Modify: `crates/cairn-core/src/verbs/assemble_hot/sources/mod.rs`
+
+- [ ] **Step 1: Write the renderer + tests**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/sources/render.rs`:
+
+```rust
+//! Per-record body framing shared by every record-backed source.
+
+use crate::domain::record::MemoryRecord;
+
+/// Render one record into the canonical hot-prefix block:
+///
+/// ```text
+/// ## <kind>: <first-body-line>
+/// <body>
+///
+/// ```
+///
+/// Trailing blank line separates blocks. Identical for every source so
+/// downstream consumers never have to special-case ranking origin.
+#[must_use]
+pub fn render_record_block(record: &MemoryRecord) -> String {
+    let first_line = record.body.lines().next().unwrap_or_default();
+    let mut out = String::with_capacity(record.body.len() + 64);
+    out.push_str("## ");
+    out.push_str(record.kind.as_str());
+    out.push_str(": ");
+    out.push_str(first_line);
+    out.push('\n');
+    out.push_str(&record.body);
+    if !record.body.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push('\n');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+
+    #[test]
+    fn renders_canonical_block() {
+        let r = sample_record();
+        let out = render_record_block(&r);
+        assert!(out.starts_with("## user: user prefers dark mode\n"));
+        assert!(out.ends_with("\n\n"));
+        assert!(out.contains("user prefers dark mode"));
+    }
+
+    #[test]
+    fn handles_record_body_without_trailing_newline() {
+        let mut r = sample_record();
+        r.body = "single line".to_owned();
+        let out = render_record_block(&r);
+        assert!(out.ends_with("\n\n"), "must always end with blank line");
+    }
+}
+```
+
+- [ ] **Step 2: Add module to `sources/mod.rs`**
+
+Edit `crates/cairn-core/src/verbs/assemble_hot/sources/mod.rs`:
+
+```rust
+pub mod index;
+pub mod pinned;
+pub mod playbook;
+pub mod project;
+pub mod purpose;
+pub mod render;
+pub mod user_signal;
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot::sources::render`
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/sources/render.rs \
+        crates/cairn-core/src/verbs/assemble_hot/sources/mod.rs
+git commit -m "feat(assemble_hot): canonical record-body framing helper (issue #82)"
+```
+
+---
+
+## Task 7: PinnedFeedback source
+
+**Files:**
+- Create: `crates/cairn-core/src/verbs/assemble_hot/sources/pinned.rs`
+
+- [ ] **Step 1: Write the failing tests + source**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/sources/pinned.rs`:
+
+```rust
+//! `PinnedFeedback` source — top 8 `user`/`feedback` records ranked by
+//! `salience × recency_decay(now − updated_at)`.
+//!
+//! Pin semantics for v0.1: caller pre-filters to records with
+//! `kind ∈ {user, feedback} ∧ is_static = 1`. Core re-checks the
+//! `kind` half (signed payload) but trusts the caller for `is_static`
+//! (store-side projection, not on `MemoryRecord`). See spec
+//! "Pin semantics" + design brief §7.1.
+
+use crate::domain::Rfc3339Timestamp;
+use crate::domain::record::MemoryRecord;
+use crate::domain::taxonomy::MemoryKind;
+use crate::verbs::assemble_hot::admissibility::admit;
+use crate::verbs::assemble_hot::inclusion::{
+    ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment,
+};
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+use super::render::render_record_block;
+
+/// Top-K cap from brief §7 ("top 8 by salience × recency").
+const TOP_K: usize = 8;
+
+/// Half-life for the recency decay term, in seconds.
+/// 30 days × 86400 s/day. Matches the brief's "salience × recency"
+/// shorthand by giving recent records a non-trivial multiplier without
+/// fully cliff-sliding old high-salience records.
+const RECENCY_HALF_LIFE_SECS: f64 = 30.0 * 86_400.0;
+
+/// Select up to 8 pinned-feedback records for the hot prefix.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    let mut included_with_score: Vec<(InclusionTrace, &MemoryRecord)> = Vec::new();
+    let mut excluded: Vec<ExclusionTrace> = Vec::new();
+
+    for &record in inputs.pinned_candidates {
+        if !is_pinned_kind(record.kind) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::NotPinned,
+            });
+            continue;
+        }
+        if let Err(reason) =
+            admit(record, &inputs.scope, inputs.authorized_visibility)
+        {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason,
+            });
+            continue;
+        }
+        let score = pin_score(record, &inputs.now);
+        included_with_score.push((
+            InclusionTrace {
+                record_id: record.id.clone(),
+                score,
+                note: "salience × recency",
+            },
+            record,
+        ));
+    }
+
+    // Sort: score desc, then record_id desc as deterministic tiebreaker.
+    included_with_score.sort_by(|a, b| {
+        b.0.score
+            .partial_cmp(&a.0.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.0.record_id.as_str().cmp(a.0.record_id.as_str()))
+    });
+
+    // Bucket overflow into BeyondTopK exclusions before truncation so
+    // the debug trace explains why a candidate did not make the cut.
+    let overflow = included_with_score.split_off(TOP_K.min(included_with_score.len()));
+    for (trace, _) in overflow {
+        excluded.push(ExclusionTrace {
+            record_id: trace.record_id,
+            reason: ExclusionReason::BeyondTopK,
+        });
+    }
+
+    let mut body = String::new();
+    let mut included: Vec<InclusionTrace> = Vec::with_capacity(included_with_score.len());
+    for (trace, record) in included_with_score {
+        body.push_str(&render_record_block(record));
+        included.push(trace);
+    }
+
+    LoadedSegment {
+        body,
+        included,
+        excluded,
+    }
+}
+
+fn is_pinned_kind(kind: MemoryKind) -> bool {
+    matches!(kind, MemoryKind::User | MemoryKind::Feedback)
+}
+
+fn pin_score(record: &MemoryRecord, now: &Rfc3339Timestamp) -> f64 {
+    let age_secs = age_seconds(now, &record.updated_at);
+    let decay = (-age_secs / RECENCY_HALF_LIFE_SECS).exp();
+    f64::from(record.salience) * decay
+}
+
+fn age_seconds(now: &Rfc3339Timestamp, updated_at: &Rfc3339Timestamp) -> f64 {
+    // Negative ages (record stamped slightly in the future relative
+    // to `now`) clamp to zero so decay never blows up past 1.0.
+    let now_dt = now.as_chrono();
+    let upd_dt = updated_at.as_chrono();
+    let secs = (now_dt - upd_dt).num_seconds().max(0);
+    secs as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn fresh_input<'a>(records: &'a [&'a MemoryRecord], now: &str) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: records,
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse(now).expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    fn user_record(id: &str, salience: f32, updated_at: &str) -> MemoryRecord {
+        let mut r = sample_record();
+        r.id = crate::domain::RecordId::parse(id).expect("valid id");
+        r.target_id = crate::domain::TargetId::parse(id).expect("valid target");
+        r.kind = MemoryKind::User;
+        r.salience = salience;
+        r.updated_at = Rfc3339Timestamp::parse(updated_at).expect("valid");
+        r
+    }
+
+    #[test]
+    fn ranks_by_salience_times_recency() {
+        let recent_low = user_record(
+            "01HQZX9F5N0000000000000001",
+            0.4,
+            "2026-04-22T14:00:00Z",
+        );
+        let old_high = user_record(
+            "01HQZX9F5N0000000000000002",
+            0.9,
+            "2025-04-22T14:00:00Z",
+        );
+        let now = "2026-04-22T15:00:00Z";
+        let inputs = fresh_input(&[&recent_low, &old_high], now);
+        let s = select(&inputs);
+        // 0.4 × ~1.0 = 0.4 ; 0.9 × exp(-365/30) ≈ 0.9 × 5.7e-6 ≈ 5e-6.
+        // Recent low-salience must win.
+        assert_eq!(s.included[0].record_id, recent_low.id);
+        assert_eq!(s.included[1].record_id, old_high.id);
+    }
+
+    #[test]
+    fn caps_at_top_8_and_emits_beyond_top_k() {
+        let recs: Vec<MemoryRecord> = (1..=12)
+            .map(|i| {
+                user_record(
+                    &format!("01HQZX9F5N00000000000000{:02}", i),
+                    f32::from(i) / 12.0,
+                    "2026-04-22T14:00:00Z",
+                )
+            })
+            .collect();
+        let refs: Vec<&MemoryRecord> = recs.iter().collect();
+        let s = select(&fresh_input(&refs, "2026-04-22T15:00:00Z"));
+        assert_eq!(s.included.len(), 8);
+        let beyond = s
+            .excluded
+            .iter()
+            .filter(|e| e.reason == ExclusionReason::BeyondTopK)
+            .count();
+        assert_eq!(beyond, 4);
+    }
+
+    #[test]
+    fn excludes_non_user_feedback_kind_with_not_pinned() {
+        let mut r = user_record("01HQZX9F5N0000000000000001", 0.9, "2026-04-22T14:00:00Z");
+        r.kind = MemoryKind::Project;
+        let s = select(&fresh_input(&[&r], "2026-04-22T15:00:00Z"));
+        assert!(s.included.is_empty());
+        assert_eq!(s.excluded.len(), 1);
+        assert_eq!(s.excluded[0].reason, ExclusionReason::NotPinned);
+    }
+
+    #[test]
+    fn excludes_low_confidence() {
+        let mut r = user_record("01HQZX9F5N0000000000000001", 0.9, "2026-04-22T14:00:00Z");
+        r.confidence = 0.2;
+        let s = select(&fresh_input(&[&r], "2026-04-22T15:00:00Z"));
+        assert_eq!(s.excluded[0].reason, ExclusionReason::BelowConfidenceFloor);
+    }
+
+    #[test]
+    fn deterministic_tiebreaker_on_equal_score() {
+        let a = user_record("01HQZX9F5N0000000000000001", 0.5, "2026-04-22T14:00:00Z");
+        let b = user_record("01HQZX9F5N0000000000000002", 0.5, "2026-04-22T14:00:00Z");
+        let s = select(&fresh_input(&[&a, &b], "2026-04-22T15:00:00Z"));
+        // Tiebreaker: record_id desc → id ending …02 first, then …01.
+        assert_eq!(s.included[0].record_id, b.id);
+        assert_eq!(s.included[1].record_id, a.id);
+    }
+
+    #[test]
+    fn future_timestamp_clamps_age_to_zero() {
+        let r = user_record(
+            "01HQZX9F5N0000000000000001",
+            0.5,
+            "2026-04-22T15:00:01Z", // 1s after now
+        );
+        let s = select(&fresh_input(&[&r], "2026-04-22T15:00:00Z"));
+        // No panic, no NaN — the record is included with score == salience.
+        assert_eq!(s.included.len(), 1);
+        assert!((s.included[0].score - 0.5).abs() < 1e-9);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot::sources::pinned`
+Expected: 6 tests pass.
+
+- [ ] **Step 3: Run clippy**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: no warnings. If `clippy::cast_precision_loss` fires for `secs as f64`, allow it locally with a one-line reason or use `f64::from(i32::try_from(secs).unwrap_or(i32::MAX))`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/sources/pinned.rs
+git commit -m "feat(assemble_hot): pinned-feedback source (issue #82)"
+```
+
+---
+
+## Task 8: TopSalienceProject source
+
+**Files:**
+- Create: `crates/cairn-core/src/verbs/assemble_hot/sources/project.rs`
+
+- [ ] **Step 1: Write the source + tests**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/sources/project.rs`:
+
+```rust
+//! `TopSalienceProject` source — top 6 `project`-kind records by salience.
+//!
+//! Sort key matches the lint canary regression
+//! (`tied_salience_top_k_picks_largest_records_conservatively`):
+//! salience desc, then byte size desc as tiebreaker, then record_id desc
+//! to keep the assembled prefix bytewise-deterministic.
+
+use crate::domain::record::MemoryRecord;
+use crate::domain::taxonomy::MemoryKind;
+use crate::verbs::assemble_hot::admissibility::admit;
+use crate::verbs::assemble_hot::inclusion::{
+    ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment,
+};
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+use super::render::render_record_block;
+
+const TOP_K: usize = 6;
+
+/// Select up to 6 project records ranked by salience.
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    let mut admissible: Vec<(InclusionTrace, &MemoryRecord)> = Vec::new();
+    let mut excluded: Vec<ExclusionTrace> = Vec::new();
+
+    for &record in inputs.project_candidates {
+        if record.kind != MemoryKind::Project {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::NotPinned,
+            });
+            continue;
+        }
+        if let Err(reason) = admit(record, &inputs.scope, inputs.authorized_visibility) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason,
+            });
+            continue;
+        }
+        admissible.push((
+            InclusionTrace {
+                record_id: record.id.clone(),
+                score: f64::from(record.salience),
+                note: "salience desc",
+            },
+            record,
+        ));
+    }
+
+    admissible.sort_by(|a, b| {
+        b.0.score
+            .partial_cmp(&a.0.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.1.body.len().cmp(&a.1.body.len()))
+            .then_with(|| b.0.record_id.as_str().cmp(a.0.record_id.as_str()))
+    });
+
+    let overflow = admissible.split_off(TOP_K.min(admissible.len()));
+    for (trace, _) in overflow {
+        excluded.push(ExclusionTrace {
+            record_id: trace.record_id,
+            reason: ExclusionReason::BeyondTopK,
+        });
+    }
+
+    let mut body = String::new();
+    let mut included: Vec<InclusionTrace> = Vec::with_capacity(admissible.len());
+    for (trace, record) in admissible {
+        body.push_str(&render_record_block(record));
+        included.push(trace);
+    }
+
+    LoadedSegment { body, included, excluded }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::Rfc3339Timestamp;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn project_record(id: &str, salience: f32, body: &str) -> MemoryRecord {
+        let mut r = sample_record();
+        r.id = crate::domain::RecordId::parse(id).expect("valid");
+        r.target_id = crate::domain::TargetId::parse(id).expect("valid");
+        r.kind = MemoryKind::Project;
+        r.salience = salience;
+        r.body = body.to_owned();
+        r
+    }
+
+    fn input_with<'a>(records: &'a [&'a MemoryRecord]) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: records,
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn caps_at_top_6() {
+        let recs: Vec<MemoryRecord> = (1..=10)
+            .map(|i| {
+                project_record(
+                    &format!("01HQZX9F5N00000000000000{:02}", i),
+                    f32::from(i) / 10.0,
+                    "body",
+                )
+            })
+            .collect();
+        let refs: Vec<&MemoryRecord> = recs.iter().collect();
+        let s = select(&input_with(&refs));
+        assert_eq!(s.included.len(), 6);
+    }
+
+    #[test]
+    fn rejects_non_project_kind_with_not_pinned() {
+        let mut r = project_record("01HQZX9F5N0000000000000001", 0.9, "x");
+        r.kind = MemoryKind::Feedback;
+        let s = select(&input_with(&[&r]));
+        assert!(s.included.is_empty());
+        assert_eq!(s.excluded[0].reason, ExclusionReason::NotPinned);
+    }
+
+    #[test]
+    fn ties_break_by_body_size_then_record_id() {
+        // Six records with identical salience, two of them larger.
+        // Top-6 must include the larger ones; the seventh tied record
+        // is BeyondTopK.
+        let small1 = project_record("01HQZX9F5N0000000000000001", 0.5, "x");
+        let small2 = project_record("01HQZX9F5N0000000000000002", 0.5, "x");
+        let small3 = project_record("01HQZX9F5N0000000000000003", 0.5, "x");
+        let small4 = project_record("01HQZX9F5N0000000000000004", 0.5, "x");
+        let small5 = project_record("01HQZX9F5N0000000000000005", 0.5, "x");
+        let large1 = project_record("01HQZX9F5N0000000000000006", 0.5, &"L".repeat(100));
+        let large2 = project_record("01HQZX9F5N0000000000000007", 0.5, &"L".repeat(100));
+        let recs = [&small1, &small2, &small3, &small4, &small5, &large1, &large2];
+        let s = select(&input_with(&recs));
+        let included_ids: Vec<&str> = s.included.iter().map(|i| i.record_id.as_str()).collect();
+        // Both larges must be included.
+        assert!(included_ids.contains(&large1.id.as_str()));
+        assert!(included_ids.contains(&large2.id.as_str()));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot::sources::project`
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/sources/project.rs
+git commit -m "feat(assemble_hot): top-salience project source (issue #82)"
+```
+
+---
+
+## Task 9: ActivePlaybook source
+
+**Files:**
+- Create: `crates/cairn-core/src/verbs/assemble_hot/sources/playbook.rs`
+
+- [ ] **Step 1: Write the source + tests**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/sources/playbook.rs`:
+
+```rust
+//! `ActivePlaybook` source — single most-recently-updated `playbook` record.
+
+use crate::domain::record::MemoryRecord;
+use crate::domain::taxonomy::MemoryKind;
+use crate::verbs::assemble_hot::admissibility::admit;
+use crate::verbs::assemble_hot::inclusion::{
+    ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment,
+};
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+use super::render::render_record_block;
+
+const TOP_K: usize = 1;
+
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    let mut admissible: Vec<(InclusionTrace, &MemoryRecord)> = Vec::new();
+    let mut excluded: Vec<ExclusionTrace> = Vec::new();
+
+    for &record in inputs.playbook_candidates {
+        if record.kind != MemoryKind::Playbook {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::NotPinned,
+            });
+            continue;
+        }
+        if let Err(reason) = admit(record, &inputs.scope, inputs.authorized_visibility) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason,
+            });
+            continue;
+        }
+        admissible.push((
+            InclusionTrace {
+                record_id: record.id.clone(),
+                score: 0.0,
+                note: "most recent updated_at",
+            },
+            record,
+        ));
+    }
+
+    admissible.sort_by(|a, b| {
+        b.1.updated_at
+            .cmp_chronological(&a.1.updated_at)
+            .then_with(|| b.0.record_id.as_str().cmp(a.0.record_id.as_str()))
+    });
+
+    let overflow = admissible.split_off(TOP_K.min(admissible.len()));
+    for (trace, _) in overflow {
+        excluded.push(ExclusionTrace {
+            record_id: trace.record_id,
+            reason: ExclusionReason::BeyondTopK,
+        });
+    }
+
+    let mut body = String::new();
+    let mut included: Vec<InclusionTrace> = Vec::with_capacity(admissible.len());
+    for (trace, record) in admissible {
+        body.push_str(&render_record_block(record));
+        included.push(trace);
+    }
+
+    LoadedSegment { body, included, excluded }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::Rfc3339Timestamp;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn playbook_record(id: &str, updated_at: &str) -> MemoryRecord {
+        let mut r = sample_record();
+        r.id = crate::domain::RecordId::parse(id).expect("valid");
+        r.target_id = crate::domain::TargetId::parse(id).expect("valid");
+        r.kind = MemoryKind::Playbook;
+        r.updated_at = Rfc3339Timestamp::parse(updated_at).expect("valid");
+        r
+    }
+
+    fn input_with<'a>(records: &'a [&'a MemoryRecord]) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: records,
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn most_recent_wins() {
+        let old = playbook_record("01HQZX9F5N0000000000000001", "2026-04-20T12:00:00Z");
+        let new = playbook_record("01HQZX9F5N0000000000000002", "2026-04-22T14:00:00Z");
+        let s = select(&input_with(&[&old, &new]));
+        assert_eq!(s.included.len(), 1);
+        assert_eq!(s.included[0].record_id, new.id);
+        assert_eq!(s.excluded.len(), 1);
+        assert_eq!(s.excluded[0].reason, ExclusionReason::BeyondTopK);
+    }
+
+    #[test]
+    fn empty_input_emits_empty_body() {
+        let s = select(&input_with(&[]));
+        assert!(s.body.is_empty());
+        assert!(s.included.is_empty());
+        assert!(s.excluded.is_empty());
+    }
+
+    #[test]
+    fn rejects_non_playbook_kind() {
+        let mut r = playbook_record("01HQZX9F5N0000000000000001", "2026-04-22T14:00:00Z");
+        r.kind = MemoryKind::Project;
+        let s = select(&input_with(&[&r]));
+        assert!(s.included.is_empty());
+        assert_eq!(s.excluded[0].reason, ExclusionReason::NotPinned);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot::sources::playbook`
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/sources/playbook.rs
+git commit -m "feat(assemble_hot): active-playbook source (issue #82)"
+```
+
+---
+
+## Task 10: RecentUserSignal source
+
+**Files:**
+- Create: `crates/cairn-core/src/verbs/assemble_hot/sources/user_signal.rs`
+
+- [ ] **Step 1: Write the source + tests**
+
+Create `crates/cairn-core/src/verbs/assemble_hot/sources/user_signal.rs`:
+
+```rust
+//! `RecentUserSignal` source — `user_signal` records inside the last 24h.
+
+use crate::domain::Rfc3339Timestamp;
+use crate::domain::record::MemoryRecord;
+use crate::domain::taxonomy::MemoryKind;
+use crate::verbs::assemble_hot::admissibility::admit;
+use crate::verbs::assemble_hot::inclusion::{
+    ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment,
+};
+use crate::verbs::assemble_hot::inputs::HotMemoryInputs;
+
+use super::render::render_record_block;
+
+const RECENCY_WINDOW_SECS: i64 = 24 * 60 * 60;
+
+#[must_use]
+pub fn select(inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    let now_dt = inputs.now.as_chrono();
+    let mut admissible: Vec<(InclusionTrace, &MemoryRecord)> = Vec::new();
+    let mut excluded: Vec<ExclusionTrace> = Vec::new();
+
+    for &record in inputs.user_signal_candidates {
+        if record.kind != MemoryKind::UserSignal {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::NotPinned,
+            });
+            continue;
+        }
+        if let Err(reason) = admit(record, &inputs.scope, inputs.authorized_visibility) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason,
+            });
+            continue;
+        }
+        if !within_window(&record.updated_at, &now_dt) {
+            excluded.push(ExclusionTrace {
+                record_id: record.id.clone(),
+                reason: ExclusionReason::OutsideRecencyWindow,
+            });
+            continue;
+        }
+        admissible.push((
+            InclusionTrace {
+                record_id: record.id.clone(),
+                score: 0.0,
+                note: "last 24h, updated_at desc",
+            },
+            record,
+        ));
+    }
+
+    admissible.sort_by(|a, b| {
+        b.1.updated_at
+            .cmp_chronological(&a.1.updated_at)
+            .then_with(|| b.0.record_id.as_str().cmp(a.0.record_id.as_str()))
+    });
+
+    let mut body = String::new();
+    let mut included: Vec<InclusionTrace> = Vec::with_capacity(admissible.len());
+    for (trace, record) in admissible {
+        body.push_str(&render_record_block(record));
+        included.push(trace);
+    }
+
+    LoadedSegment { body, included, excluded }
+}
+
+fn within_window(
+    updated_at: &Rfc3339Timestamp,
+    now_dt: &chrono::DateTime<chrono::Utc>,
+) -> bool {
+    let upd_dt = updated_at.as_chrono();
+    let age = (*now_dt - upd_dt).num_seconds();
+    (0..=RECENCY_WINDOW_SECS).contains(&age)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn signal(id: &str, updated_at: &str) -> MemoryRecord {
+        let mut r = sample_record();
+        r.id = crate::domain::RecordId::parse(id).expect("valid");
+        r.target_id = crate::domain::TargetId::parse(id).expect("valid");
+        r.kind = MemoryKind::UserSignal;
+        r.updated_at = Rfc3339Timestamp::parse(updated_at).expect("valid");
+        r
+    }
+
+    fn input_with<'a>(records: &'a [&'a MemoryRecord], now: &str) -> HotMemoryInputs<'a> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: records,
+            now: Rfc3339Timestamp::parse(now).expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn includes_record_at_window_boundary() {
+        // 2026-04-21T15:00:00Z → 2026-04-22T15:00:00Z is exactly 86_400 s.
+        let r = signal("01HQZX9F5N0000000000000001", "2026-04-21T15:00:00Z");
+        let s = select(&input_with(&[&r], "2026-04-22T15:00:00Z"));
+        assert_eq!(s.included.len(), 1);
+    }
+
+    #[test]
+    fn excludes_record_one_second_past_window() {
+        let r = signal("01HQZX9F5N0000000000000001", "2026-04-21T14:59:59Z");
+        let s = select(&input_with(&[&r], "2026-04-22T15:00:00Z"));
+        assert!(s.included.is_empty());
+        assert_eq!(s.excluded[0].reason, ExclusionReason::OutsideRecencyWindow);
+    }
+
+    #[test]
+    fn rejects_non_signal_kind() {
+        let mut r = signal("01HQZX9F5N0000000000000001", "2026-04-22T14:59:59Z");
+        r.kind = MemoryKind::Project;
+        let s = select(&input_with(&[&r], "2026-04-22T15:00:00Z"));
+        assert!(s.included.is_empty());
+        assert_eq!(s.excluded[0].reason, ExclusionReason::NotPinned);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot::sources::user_signal`
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/sources/user_signal.rs
+git commit -m "feat(assemble_hot): recent-user-signal source (issue #82)"
+```
+
+---
+
+## Task 11: Refactor assembler to take HotMemoryInputs + emit debug
+
+**Files:**
+- Modify: `crates/cairn-core/src/verbs/assemble_hot/assembler.rs`
+- Modify: `crates/cairn-core/src/verbs/assemble_hot/mod.rs`
+- Modify: `crates/cairn-core/tests/assemble_hot_snapshots.rs` (existing test that uses old assembler)
+
+- [ ] **Step 1: Read the existing test that depends on the old signature**
+
+Run: `cat crates/cairn-core/tests/assemble_hot_snapshots.rs`
+Expected: identifies the call sites that pass `&HotMemoryConfig` directly.
+
+- [ ] **Step 2: Rewrite `assembler.rs`**
+
+Replace `crates/cairn-core/src/verbs/assemble_hot/assembler.rs` with:
+
+```rust
+//! `HotMemoryAssembler` — pure top-level entry point (issue #82).
+//!
+//! Walks `config.recipe`, dispatches each step to its source-specific
+//! `select`, glues the bodies together via `build_segments`, validates
+//! the wire shape, and (when `inputs.include_debug` is true) emits a
+//! `HotStepTrace` per step.
+
+use crate::config::HotMemoryConfig;
+use crate::generated::verbs::assemble_hot::{
+    AssembleHotData, HotExclusion, HotExclusionReason, HotInclusion, HotRecipeStep, HotStepTrace,
+    HotMemoryDebug,
+};
+
+use super::inclusion::{ExclusionReason, ExclusionTrace, InclusionTrace, LoadedSegment};
+use super::inputs::HotMemoryInputs;
+use super::segments::{AssembleHotValidationError, build_segments, validate};
+use super::sources;
+
+/// Errors returned by [`assemble_hot`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum AssembleHotError {
+    /// Segment construction or validation failed.
+    #[error("segment construction: {0}")]
+    Segments(#[from] AssembleHotValidationError),
+    /// The assembled prefix exceeds the vault's configured `max_bytes`.
+    #[error("hot memory exceeded budget: {got} > {max} bytes")]
+    BudgetExceeded {
+        /// Actual prefix length.
+        got: u64,
+        /// Configured `HotMemoryConfig.max_bytes`.
+        max: u64,
+    },
+}
+
+/// Run the recipe and emit a validated `AssembleHotData`. Pure: same
+/// inputs always produce the same output.
+pub fn assemble_hot(
+    inputs: &HotMemoryInputs<'_>,
+    config: &HotMemoryConfig,
+) -> Result<AssembleHotData, AssembleHotError> {
+    let recipe: Vec<HotRecipeStep> = config
+        .recipe
+        .iter()
+        .copied()
+        .map(HotRecipeStep::from)
+        .collect();
+
+    let mut bodies: Vec<String> = Vec::with_capacity(recipe.len());
+    let mut traces: Vec<HotStepTrace> = Vec::with_capacity(recipe.len());
+
+    for step in recipe.iter().copied() {
+        let segment = run_step(step, inputs);
+        if inputs.include_debug {
+            traces.push(to_step_trace(step, &segment));
+        }
+        bodies.push(segment.body);
+    }
+
+    let bodies_refs: Vec<&str> = bodies.iter().map(String::as_str).collect();
+    let (prefix, segments) = build_segments(&recipe, &bodies_refs)?;
+
+    let bytes = prefix.len() as u64;
+    let max = u64::from(config.max_bytes);
+    if bytes > max {
+        return Err(AssembleHotError::BudgetExceeded { got: bytes, max });
+    }
+
+    let debug = if inputs.include_debug {
+        Some(HotMemoryDebug { steps: traces })
+    } else {
+        None
+    };
+
+    let data = AssembleHotData {
+        bytes,
+        prefix,
+        segments: Some(segments),
+        debug,
+    };
+    validate(&data)?;
+    Ok(data)
+}
+
+fn run_step(step: HotRecipeStep, inputs: &HotMemoryInputs<'_>) -> LoadedSegment {
+    match step {
+        HotRecipeStep::Purpose => sources::purpose::select(inputs),
+        HotRecipeStep::Index => sources::index::select(inputs),
+        HotRecipeStep::PinnedFeedback => sources::pinned::select(inputs),
+        HotRecipeStep::TopSalienceProject => sources::project::select(inputs),
+        HotRecipeStep::ActivePlaybook => sources::playbook::select(inputs),
+        HotRecipeStep::RecentUserSignal => sources::user_signal::select(inputs),
+    }
+}
+
+fn to_step_trace(step: HotRecipeStep, segment: &LoadedSegment) -> HotStepTrace {
+    HotStepTrace {
+        step,
+        included: segment.included.iter().map(to_inclusion).collect(),
+        excluded: segment.excluded.iter().map(to_exclusion).collect(),
+    }
+}
+
+fn to_inclusion(trace: &InclusionTrace) -> HotInclusion {
+    HotInclusion {
+        record_id: trace.record_id.as_str().to_owned(),
+        score: trace.score,
+        note: trace.note.to_owned(),
+    }
+}
+
+fn to_exclusion(trace: &ExclusionTrace) -> HotExclusion {
+    HotExclusion {
+        record_id: trace.record_id.as_str().to_owned(),
+        reason: to_wire_reason(trace.reason),
+    }
+}
+
+fn to_wire_reason(reason: ExclusionReason) -> HotExclusionReason {
+    match reason {
+        ExclusionReason::Tombstoned => HotExclusionReason::Tombstoned,
+        ExclusionReason::ForgottenScope => HotExclusionReason::ForgottenScope,
+        ExclusionReason::BelowConfidenceFloor => HotExclusionReason::BelowConfidenceFloor,
+        ExclusionReason::OutOfScope => HotExclusionReason::OutOfScope,
+        ExclusionReason::VisibilityDenied => HotExclusionReason::VisibilityDenied,
+        ExclusionReason::OutsideRecencyWindow => HotExclusionReason::OutsideRecencyWindow,
+        ExclusionReason::BeyondTopK => HotExclusionReason::BeyondTopK,
+        ExclusionReason::NotPinned => HotExclusionReason::NotPinned,
+        ExclusionReason::EmptyBody => HotExclusionReason::EmptyBody,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::HotMemoryConfig;
+    use crate::domain::Rfc3339Timestamp;
+    use crate::domain::scope::ScopeTuple;
+    use crate::domain::taxonomy::MemoryVisibility;
+
+    fn empty_inputs() -> HotMemoryInputs<'static> {
+        HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &[],
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        }
+    }
+
+    #[test]
+    fn default_recipe_with_empty_inputs_returns_zero_bytes() {
+        let cfg = HotMemoryConfig::default();
+        let data = assemble_hot(&empty_inputs(), &cfg).unwrap();
+        assert_eq!(data.prefix, "");
+        assert_eq!(data.bytes, 0);
+        assert_eq!(data.debug, None);
+    }
+
+    #[test]
+    fn budget_exceeded_returns_typed_error() {
+        let cfg = HotMemoryConfig {
+            max_bytes: 8,
+            ..HotMemoryConfig::default()
+        };
+        let mut inputs = empty_inputs();
+        let big = "AAAA".repeat(8); // 32 bytes
+        inputs.purpose_md = &big;
+        let err = assemble_hot(&inputs, &cfg).unwrap_err();
+        match err {
+            AssembleHotError::BudgetExceeded { got, max } => {
+                assert_eq!(got, 32);
+                assert_eq!(max, 8);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn include_debug_populates_per_step_trace() {
+        let cfg = HotMemoryConfig::default();
+        let mut inputs = empty_inputs();
+        inputs.include_debug = true;
+        let data = assemble_hot(&inputs, &cfg).unwrap();
+        let debug = data.debug.expect("debug populated");
+        assert_eq!(debug.steps.len(), cfg.recipe.len());
+    }
+
+    #[test]
+    fn include_debug_false_omits_field() {
+        let cfg = HotMemoryConfig::default();
+        let data = assemble_hot(&empty_inputs(), &cfg).unwrap();
+        assert!(data.debug.is_none());
+    }
+}
+```
+
+- [ ] **Step 3: Update existing snapshot test**
+
+Read `crates/cairn-core/tests/assemble_hot_snapshots.rs` first:
+
+Run: `cat crates/cairn-core/tests/assemble_hot_snapshots.rs`
+
+Then rewrite the call sites that previously used `assemble_hot(&cfg)` /
+`assemble_hot_with_loader(&cfg, |_| Ok(...))` to construct
+`HotMemoryInputs` and pass it positionally.
+
+For an empty-input snapshot:
+
+```rust
+let inputs = HotMemoryInputs {
+    purpose_md: "purpose body\n",
+    index_md: "index body\n",
+    pinned_candidates: &[],
+    project_candidates: &[],
+    playbook_candidates: &[],
+    user_signal_candidates: &[],
+    now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").expect("valid"),
+    scope: ScopeTuple::default(),
+    authorized_visibility: &[MemoryVisibility::Private],
+    include_debug: false,
+};
+let data = assemble_hot(&inputs, &cfg).expect("assemble");
+insta::assert_yaml_snapshot!(data);
+```
+
+If the prior snapshot file fails: regenerate via `cargo insta review`.
+
+- [ ] **Step 4: Run all assemble_hot tests**
+
+Run: `cargo nextest run -p cairn-core --locked verbs::assemble_hot`
+Expected: every source test + 4 new assembler tests pass.
+
+- [ ] **Step 5: Run snapshot test**
+
+Run: `cargo nextest run -p cairn-core --locked --test assemble_hot_snapshots`
+Expected: tests pass after `cargo insta accept` if there is intentional drift.
+
+- [ ] **Step 6: Run clippy**
+
+Run: `cargo clippy -p cairn-core --all-targets --locked -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cairn-core/src/verbs/assemble_hot/assembler.rs \
+        crates/cairn-core/src/verbs/assemble_hot/mod.rs \
+        crates/cairn-core/tests/assemble_hot_snapshots.rs \
+        crates/cairn-core/tests/snapshots/
+git commit -m "feat(assemble_hot): refactor assembler to take HotMemoryInputs (issue #82)"
+```
+
+---
+
+## Task 12: Privacy + integration tests
+
+**Files:**
+- Create: `crates/cairn-core/tests/assemble_hot_inputs.rs`
+- Create: `crates/cairn-core/tests/assemble_hot_privacy.rs`
+- Create: `crates/cairn-core/tests/assemble_hot_debug.rs`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `crates/cairn-core/tests/assemble_hot_inputs.rs`:
+
+```rust
+//! End-to-end integration: default-recipe assembly with mixed-kind
+//! fixtures. Asserts the prefix bytes stay under budget and every
+//! recipe step contributes exactly one segment.
+
+use cairn_core::config::HotMemoryConfig;
+use cairn_core::domain::Rfc3339Timestamp;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::scope::ScopeTuple;
+use cairn_core::domain::taxonomy::{MemoryKind, MemoryVisibility};
+use cairn_core::verbs::assemble_hot::{HotMemoryInputs, assemble_hot};
+
+#[test]
+fn default_recipe_with_mixed_records_stays_within_budget() {
+    let mut user = sample_record();
+    user.id = cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000001").unwrap();
+    user.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000001").unwrap();
+    user.kind = MemoryKind::User;
+    let mut project = sample_record();
+    project.id = cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000002").unwrap();
+    project.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000002").unwrap();
+    project.kind = MemoryKind::Project;
+    let mut playbook = sample_record();
+    playbook.id =
+        cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000003").unwrap();
+    playbook.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000003").unwrap();
+    playbook.kind = MemoryKind::Playbook;
+    let mut signal = sample_record();
+    signal.id = cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000004").unwrap();
+    signal.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000004").unwrap();
+    signal.kind = MemoryKind::UserSignal;
+
+    let pinned = [&user];
+    let projects = [&project];
+    let playbooks = [&playbook];
+    let signals = [&signal];
+
+    let inputs = HotMemoryInputs {
+        purpose_md: "# Purpose\nact as a careful agent.\n",
+        index_md: "# Index\n- a.md\n- b.md\n",
+        pinned_candidates: &pinned,
+        project_candidates: &projects,
+        playbook_candidates: &playbooks,
+        user_signal_candidates: &signals,
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").unwrap(),
+        scope: ScopeTuple::default(),
+        authorized_visibility: &[MemoryVisibility::Private],
+        include_debug: false,
+    };
+    let cfg = HotMemoryConfig::default();
+    let data = assemble_hot(&inputs, &cfg).expect("assemble");
+
+    assert!(data.bytes <= u64::from(cfg.max_bytes));
+    let segments = data.segments.expect("segments emitted");
+    assert_eq!(segments.len(), cfg.recipe.len());
+    assert!(data.prefix.contains("user prefers dark mode"));
+}
+```
+
+- [ ] **Step 2: Write the privacy test**
+
+Create `crates/cairn-core/tests/assemble_hot_privacy.rs`:
+
+```rust
+//! Privacy regressions: tombstone, low-confidence, scope mismatch, and
+//! visibility denials must exclude records across every source.
+
+use cairn_core::config::HotMemoryConfig;
+use cairn_core::domain::Rfc3339Timestamp;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::scope::ScopeTuple;
+use cairn_core::domain::taxonomy::{MemoryKind, MemoryVisibility};
+use cairn_core::verbs::assemble_hot::{HotMemoryInputs, assemble_hot};
+
+fn make_input<'a>(
+    pinned: &'a [&'a cairn_core::domain::record::MemoryRecord],
+    visibility: &'a [MemoryVisibility],
+    scope: ScopeTuple,
+) -> HotMemoryInputs<'a> {
+    HotMemoryInputs {
+        purpose_md: "",
+        index_md: "",
+        pinned_candidates: pinned,
+        project_candidates: &[],
+        playbook_candidates: &[],
+        user_signal_candidates: &[],
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").unwrap(),
+        scope,
+        authorized_visibility: visibility,
+        include_debug: true,
+    }
+}
+
+#[test]
+fn pinned_record_with_low_confidence_does_not_appear() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    r.confidence = 0.1;
+    let cfg = HotMemoryConfig::default();
+    let pinned = [&r];
+    let inputs = make_input(
+        &pinned,
+        &[MemoryVisibility::Private],
+        ScopeTuple::default(),
+    );
+    let data = assemble_hot(&inputs, &cfg).unwrap();
+    assert!(!data.prefix.contains(&r.body));
+}
+
+#[test]
+fn pinned_record_with_visibility_denial_does_not_appear() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    r.visibility = MemoryVisibility::Org;
+    let cfg = HotMemoryConfig::default();
+    let pinned = [&r];
+    let inputs = make_input(&pinned, &[MemoryVisibility::Private], ScopeTuple::default());
+    let data = assemble_hot(&inputs, &cfg).unwrap();
+    assert!(!data.prefix.contains(&r.body));
+}
+
+#[test]
+fn pinned_record_with_scope_mismatch_does_not_appear() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    let cfg = HotMemoryConfig::default();
+    let pinned = [&r];
+    let other_user = ScopeTuple {
+        user: Some("hmn:other".to_owned()),
+        ..ScopeTuple::default()
+    };
+    let inputs = make_input(&pinned, &[MemoryVisibility::Private], other_user);
+    let data = assemble_hot(&inputs, &cfg).unwrap();
+    assert!(!data.prefix.contains(&r.body));
+}
+```
+
+- [ ] **Step 3: Write the debug-output test**
+
+Create `crates/cairn-core/tests/assemble_hot_debug.rs`:
+
+```rust
+//! `include_debug` round-trip: every recipe step emits a `HotStepTrace`,
+//! and an excluded record carries a typed reason.
+
+use cairn_core::config::HotMemoryConfig;
+use cairn_core::domain::Rfc3339Timestamp;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::scope::ScopeTuple;
+use cairn_core::domain::taxonomy::{MemoryKind, MemoryVisibility};
+use cairn_core::generated::verbs::assemble_hot::HotExclusionReason;
+use cairn_core::verbs::assemble_hot::{HotMemoryInputs, assemble_hot};
+
+#[test]
+fn debug_field_present_when_requested() {
+    let cfg = HotMemoryConfig::default();
+    let inputs = HotMemoryInputs {
+        purpose_md: "",
+        index_md: "",
+        pinned_candidates: &[],
+        project_candidates: &[],
+        playbook_candidates: &[],
+        user_signal_candidates: &[],
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").unwrap(),
+        scope: ScopeTuple::default(),
+        authorized_visibility: &[MemoryVisibility::Private],
+        include_debug: true,
+    };
+    let data = assemble_hot(&inputs, &cfg).unwrap();
+    let debug = data.debug.expect("debug present");
+    assert_eq!(debug.steps.len(), cfg.recipe.len());
+}
+
+#[test]
+fn excluded_record_carries_typed_reason() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    r.confidence = 0.1; // below floor
+    let cfg = HotMemoryConfig::default();
+    let pinned = [&r];
+    let inputs = HotMemoryInputs {
+        purpose_md: "",
+        index_md: "",
+        pinned_candidates: &pinned,
+        project_candidates: &[],
+        playbook_candidates: &[],
+        user_signal_candidates: &[],
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").unwrap(),
+        scope: ScopeTuple::default(),
+        authorized_visibility: &[MemoryVisibility::Private],
+        include_debug: true,
+    };
+    let data = assemble_hot(&inputs, &cfg).unwrap();
+    let debug = data.debug.expect("debug present");
+    let pinned_step = debug
+        .steps
+        .iter()
+        .find(|t| t.step == cairn_core::generated::verbs::assemble_hot::HotRecipeStep::PinnedFeedback)
+        .expect("pinned step trace");
+    assert_eq!(pinned_step.excluded.len(), 1);
+    assert_eq!(
+        pinned_step.excluded[0].reason,
+        HotExclusionReason::BelowConfidenceFloor
+    );
+}
+```
+
+- [ ] **Step 4: Run all integration tests**
+
+Run: `cargo nextest run -p cairn-core --locked --tests`
+Expected: every test passes. If a generated type name (`HotMemoryDebug`,
+`HotExclusionReason`, `HotInclusion`, `HotExclusion`, `HotStepTrace`)
+disagrees with what codegen emits, replace the references with the
+real codegen names.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/tests/assemble_hot_inputs.rs \
+        crates/cairn-core/tests/assemble_hot_privacy.rs \
+        crates/cairn-core/tests/assemble_hot_debug.rs
+git commit -m "test(assemble_hot): privacy + debug + integration coverage (issue #82)"
+```
+
+---
+
+## Task 13: Determinism property test
+
+**Files:**
+- Modify: `crates/cairn-core/tests/assemble_hot_inputs.rs` (extend with proptest)
+- Modify: `crates/cairn-core/Cargo.toml` (add proptest dev-dep if absent)
+
+- [ ] **Step 1: Verify proptest dep**
+
+Run: `grep -c '^proptest' crates/cairn-core/Cargo.toml`
+Expected: a non-zero count, indicating the dev-dep is already declared.
+If zero, add `proptest = { workspace = true }` under `[dev-dependencies]`.
+
+- [ ] **Step 2: Add the determinism test to `assemble_hot_inputs.rs`**
+
+Append to `crates/cairn-core/tests/assemble_hot_inputs.rs`:
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
+    fn assemble_hot_is_deterministic_for_same_inputs(seed in 0u64..1024) {
+        let mut r = sample_record();
+        r.id = cairn_core::domain::RecordId::parse(&format!(
+            "01HQZX9F5N0000000000000{:03}",
+            seed % 1000
+        )).unwrap();
+        r.target_id = cairn_core::domain::TargetId::parse(&format!(
+            "01HQZX9F5N0000000000000{:03}",
+            seed % 1000
+        )).unwrap();
+        r.kind = MemoryKind::User;
+        let pinned = [&r];
+
+        let inputs = HotMemoryInputs {
+            purpose_md: "",
+            index_md: "",
+            pinned_candidates: &pinned,
+            project_candidates: &[],
+            playbook_candidates: &[],
+            user_signal_candidates: &[],
+            now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").unwrap(),
+            scope: ScopeTuple::default(),
+            authorized_visibility: &[MemoryVisibility::Private],
+            include_debug: false,
+        };
+        let cfg = HotMemoryConfig::default();
+        let a = assemble_hot(&inputs, &cfg).expect("assemble");
+        let b = assemble_hot(&inputs, &cfg).expect("assemble");
+        prop_assert_eq!(a.prefix, b.prefix);
+        prop_assert_eq!(a.bytes, b.bytes);
+    }
+}
+```
+
+- [ ] **Step 3: Run the property test**
+
+Run: `cargo nextest run -p cairn-core --locked --test assemble_hot_inputs`
+Expected: 32 cases pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-core/tests/assemble_hot_inputs.rs \
+        crates/cairn-core/Cargo.toml
+git commit -m "test(assemble_hot): proptest determinism (issue #82)"
+```
+
+---
+
+## Task 14: CLI smoke test
+
+**Files:**
+- Create: `crates/cairn-cli/tests/assemble_hot_smoke.rs`
+
+- [ ] **Step 1: Check existing CLI test layout**
+
+Run: `ls crates/cairn-cli/tests/ | head`
+Expected: existing fixture-based tests show how `cairn-cli` wires
+config + inputs in tests.
+
+- [ ] **Step 2: Write the smoke test**
+
+Create `crates/cairn-cli/tests/assemble_hot_smoke.rs`:
+
+```rust
+//! Smoke test: build a fixture-driven `HotMemoryInputs` and call
+//! `assemble_hot` end-to-end. Full SQLite + filesystem adapter wiring
+//! is owned by issue #80; this test only proves the pure path is
+//! reachable from outside `cairn-core`.
+
+use cairn_core::config::HotMemoryConfig;
+use cairn_core::domain::Rfc3339Timestamp;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::scope::ScopeTuple;
+use cairn_core::domain::taxonomy::{MemoryKind, MemoryVisibility};
+use cairn_core::verbs::assemble_hot::{HotMemoryInputs, assemble_hot};
+
+#[test]
+fn assemble_hot_runs_with_minimal_inputs() {
+    let mut r = sample_record();
+    r.kind = MemoryKind::User;
+    let pinned = [&r];
+    let inputs = HotMemoryInputs {
+        purpose_md: "# Purpose\nact carefully.\n",
+        index_md: "# Index\n",
+        pinned_candidates: &pinned,
+        project_candidates: &[],
+        playbook_candidates: &[],
+        user_signal_candidates: &[],
+        now: Rfc3339Timestamp::parse("2026-04-22T15:00:00Z").unwrap(),
+        scope: ScopeTuple::default(),
+        authorized_visibility: &[MemoryVisibility::Private],
+        include_debug: false,
+    };
+    let cfg = HotMemoryConfig::default();
+    let data = assemble_hot(&inputs, &cfg).expect("assemble");
+    assert!(data.bytes > 0);
+    let segments = data.segments.expect("segments emitted");
+    assert_eq!(segments.len(), cfg.recipe.len());
+}
+```
+
+- [ ] **Step 3: Verify cairn-cli has cairn-core in dev-deps**
+
+Run: `grep '^cairn-core' crates/cairn-cli/Cargo.toml`
+Expected: a workspace dependency line. If missing under `[dev-dependencies]`, add it.
+
+- [ ] **Step 4: Run the smoke test**
+
+Run: `cargo nextest run -p cairn-cli --locked --test assemble_hot_smoke`
+Expected: 1 test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-cli/tests/assemble_hot_smoke.rs
+git commit -m "test(cairn-cli): assemble_hot smoke (issue #82)"
+```
+
+---
+
+## Task 15: Final verification sweep
+
+**Files:** none (read-only checks)
+
+- [ ] **Step 1: fmt**
+
+Run: `cargo fmt --all --check`
+Expected: exit 0. If not, run `cargo fmt --all` and amend the most-recent commit.
+
+- [ ] **Step 2: clippy**
+
+Run: `cargo clippy --workspace --all-targets --locked -- -D warnings`
+Expected: exit 0.
+
+- [ ] **Step 3: check**
+
+Run: `cargo check --workspace --all-targets --locked`
+Expected: exit 0.
+
+- [ ] **Step 4: nextest**
+
+Run: `cargo nextest run --workspace --locked --no-fail-fast`
+Expected: every test passes. Capture failure list if any.
+
+- [ ] **Step 5: doctest**
+
+Run: `cargo test --doc --workspace --locked`
+Expected: every doctest passes.
+
+- [ ] **Step 6: core boundary**
+
+Run: `./scripts/check-core-boundary.sh`
+Expected: exit 0.
+
+- [ ] **Step 7: codegen drift**
+
+Run: `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
+Expected: exit 0, no diff.
+
+- [ ] **Step 8: docgen**
+
+Run: `cargo run -p cairn-cli --bin cairn-docgen --locked -- --check`
+Expected: exit 0. If config defaults grew via this issue, run without
+`--check`, commit the docs change in a separate `docs:` commit.
+
+- [ ] **Step 9: rustdoc**
+
+Run:
+```bash
+RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" \
+  cargo doc --workspace --no-deps --document-private-items --locked
+```
+Expected: exit 0.
+
+- [ ] **Step 10: PR-ready summary**
+
+Verify the branch contains commits for:
+- `feat(idl): …` (Task 1)
+- `feat(assemble_hot): typed inclusion/exclusion …` (Task 2)
+- `feat(assemble_hot): uniform admissibility …` (Task 3)
+- `feat(assemble_hot): HotMemoryInputs …` (Task 4)
+- `feat(assemble_hot): purpose + index …` (Task 5)
+- `feat(assemble_hot): canonical record-body framing …` (Task 6)
+- `feat(assemble_hot): pinned-feedback source …` (Task 7)
+- `feat(assemble_hot): top-salience project source …` (Task 8)
+- `feat(assemble_hot): active-playbook source …` (Task 9)
+- `feat(assemble_hot): recent-user-signal source …` (Task 10)
+- `feat(assemble_hot): refactor assembler …` (Task 11)
+- `test(assemble_hot): privacy + debug + integration …` (Task 12)
+- `test(assemble_hot): proptest determinism …` (Task 13)
+- `test(cairn-cli): assemble_hot smoke (issue #82)` (Task 14)
+
+Run: `git log --oneline main..HEAD`
+Expected: 14 commits in the listed order.

--- a/docs/superpowers/specs/2026-05-08-issue-82-hot-prefix-retrieval-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-82-hot-prefix-retrieval-design.md
@@ -1,0 +1,346 @@
+# Issue #82 — Profile, Pinned, and Playbook Retrieval for Hot Prefix
+
+**Status:** Approved 2026-05-08
+**Issue:** [windoliver/cairn#82](https://github.com/windoliver/cairn/issues/82)
+**Parent epic:** #14
+**Depends on:** #81 (DataProfile synthesizer — merged)
+**Successor work:** #80 (full assembler + ordering), #83 (cache + lint)
+**Brief sections:** §7 Hot Memory, §7.1 AutoUserProfile, §6 Taxonomy
+
+## Problem
+
+`crates/cairn-core/src/verbs/assemble_hot/assembler.rs` ships with a stub
+`load_step_body` that returns `""` for every recipe step. The verb produces
+a syntactically-valid `AssembleHotData` of zero bytes regardless of vault
+contents, so:
+
+- Hot prefix has no content.
+- Pinned `user`/`feedback` memories never reach the agent.
+- The active playbook never reaches the agent.
+- The lint check `hot_memory_over_budget` (§6.6) defers four of six steps
+  because there is no source-side selector at all.
+
+Issue #82 closes the gap for everything except cache + invalidation
+(#83) and full cross-step ordering (#80).
+
+## Goals (acceptance criteria)
+
+1. Source-specific retrieval functions for the six frozen v1 recipe
+   steps: `Purpose`, `Index`, `PinnedFeedback`, `TopSalienceProject`,
+   `ActivePlaybook`, `RecentUserSignal`. Profile retrieval is exposed
+   via `retrieve --profile` (shipped in #81); see "Profile in the hot
+   prefix" below.
+2. Visibility, scope, confidence, staleness, and salience scoring applied
+   uniformly with normal `search` / `retrieve`.
+3. Pinned records win over ordinary ranking but still obey visibility +
+   forget state.
+4. Debug output (per-segment included + excluded record list with typed
+   reasons) explains why a memory entered or did not enter hot context.
+
+## Non-goals
+
+- Cache + invalidation (owned by #83).
+- Cross-step ordering and global truncation (owned by #80).
+- Adding `Profile` to `HotRecipeStep` — the IDL pins the enum:
+  `"Frozen for the lifetime of cairn.mcp.v1. Adding a recipe step
+  requires bumping to cairn.mcp.v2."` (see
+  `crates/cairn-idl/schema/verbs/assemble_hot.json`). Including the
+  synthesized profile inside the assembled prefix waits on the v2 bump
+  and a recipe-shape decision; this issue does not touch it.
+- Explicit per-record `pinned` schema column (out of scope; tracked as a
+  follow-up — see [Open questions](#open-questions)).
+- Rolling profile narrative (`summary` / `historical_summary`) — P1,
+  produced by `DreamWorkflow`.
+
+### Profile in the hot prefix
+
+Brief §7's token budget table lists `AutoUserProfile summary ~400
+tokens`. With the IDL recipe enum frozen in v1, we cannot add a
+`Profile` recipe step in #82. Two paths remain available without
+breaking wire compat, but both are out of scope here:
+
+- **Option A (deferred):** bump to cairn.mcp.v2 and add the recipe
+  step. Owner: a new design issue.
+- **Option B (deferred):** synthesize the profile body into
+  `purpose.md` or `index.md` so the existing recipe step carries it.
+  Owner: `cairn-cli` adapter wiring (#80).
+
+Either way, this issue keeps the synthesizer path callable via
+`retrieve --profile` (already plumbed by #81) so the data is reachable
+even before hot-prefix inclusion lands.
+
+## Design decisions (Q&A)
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Pinned semantics | `kind ∈ {user, feedback} ∧ is_static = 1` | No schema change; closest existing signal per brief §7.1. Documented as v0.1 narrowing. |
+| Profile in recipe | **Deferred** — IDL freezes the enum at v1. Profile stays on `retrieve --profile`. | `assemble_hot.json` says `Frozen for the lifetime of cairn.mcp.v1`. Adding a step is a v2 wire bump. Out of scope for #82. |
+| Debug surface | Optional `debug` field on `AssembleHotData` IDL | One verb, one wire shape. Gated by `--explain` / `include_debug = true`. New optional fields are wire-compatible additions. |
+| Adapter coupling | Pure-projection `HotMemoryInputs` | Mirrors profile synthesizer. Adapter pre-filters by kind/visibility/scope; core does ranking + top-K + body assembly. Keeps `cairn-core` boundary clean. |
+
+## Architecture
+
+```
+crates/cairn-core/src/verbs/assemble_hot/
+  mod.rs                  re-exports
+  assembler.rs            (refactored) takes HotMemoryInputs
+  segments.rs             unchanged
+  raw.rs                  unchanged
+  admissibility.rs        NEW — uniform per-record predicate
+  inclusion.rs            NEW — InclusionTrace, ExclusionTrace, ExclusionReason
+  sources/
+    mod.rs
+    purpose.rs            pass-through markdown
+    index.rs              pass-through markdown
+    pinned.rs             PinnedFeedback: salience × recency, top 8
+    project.rs            TopSalienceProject: salience desc, top 6
+    playbook.rs           ActivePlaybook: most-recent updated_at, top 1
+    user_signal.rs        RecentUserSignal: last 24h window
+```
+
+Each `sources/<step>.rs` exposes:
+
+```rust
+pub(super) fn select(
+    inputs: &HotMemoryInputs<'_>,
+) -> LoadedSegment;
+```
+
+The assembler walks the recipe in `HotMemoryConfig.recipe`, calls each
+`select` once, builds segments via the existing `segments::build_segments`,
+re-applies the `validate` trust-boundary check, and assembles the
+`AssembleHotData { prefix, segments, debug? }`.
+
+## Public types
+
+```rust
+pub struct HotMemoryInputs<'a> {
+    pub purpose_md: &'a str,
+    pub index_md: &'a str,
+    pub pinned_candidates: &'a [&'a MemoryRecord],
+    pub project_candidates: &'a [&'a MemoryRecord],
+    pub playbook_candidates: &'a [&'a MemoryRecord],
+    pub user_signal_candidates: &'a [&'a MemoryRecord],
+    pub now: Rfc3339Timestamp,
+    pub scope: ScopeTuple,
+    pub authorized_visibility: &'a [MemoryVisibility],
+    pub include_debug: bool,
+}
+
+pub struct LoadedSegment {
+    pub body: String,
+    pub included: Vec<InclusionTrace>,
+    pub excluded: Vec<ExclusionTrace>,
+}
+
+pub struct InclusionTrace {
+    pub record_id: RecordId,
+    pub score: f64,
+    pub note: &'static str,
+}
+
+pub struct ExclusionTrace {
+    pub record_id: RecordId,
+    pub reason: ExclusionReason,
+}
+
+#[non_exhaustive]
+pub enum ExclusionReason {
+    Tombstoned,
+    ForgottenScope,
+    BelowConfidenceFloor,
+    OutOfScope,
+    VisibilityDenied,
+    OutsideRecencyWindow,
+    BeyondTopK,
+    NotPinned,
+    EmptyBody,
+}
+```
+
+The existing `assemble_hot_with_loader(FnMut)` test entry point is
+removed; tests rebuild via `HotMemoryInputs` constructors fed by
+`cairn-test-fixtures`.
+
+## Selection rules per source
+
+Common admissibility (`admissibility.rs`), applied first by every source:
+
+- `tombstoned` → `Tombstoned`
+- `confidence < 0.3` → `BelowConfidenceFloor` (matches profile synthesizer)
+- `record.visibility ∉ inputs.authorized_visibility` → `VisibilityDenied`
+- `record.scope` not subset of `inputs.scope` → `OutOfScope`
+- `body.is_empty()` → `EmptyBody`
+
+Per-source extras + ranking:
+
+| Source | Filter | Sort key | Cap |
+|---|---|---|---|
+| `Purpose` | n/a (string pass-through) | n/a | n/a |
+| `Index` | n/a | n/a | n/a |
+| `PinnedFeedback` | `kind ∈ {user, feedback} ∧ is_static = 1` | `salience × exp(-(now-updated_at)/30d)` desc, then `record_id` desc | top 8 |
+| `TopSalienceProject` | `kind = project` | `salience` desc, then `len(body)` desc, then `record_id` desc | top 6 |
+| `ActivePlaybook` | `kind = playbook` | `updated_at` desc, then `record_id` desc | top 1 |
+| `RecentUserSignal` | `kind = user_signal ∧ now - updated_at ≤ 86_400s` | `updated_at` desc, then `record_id` desc | bounded by segment budget |
+
+Determinism: tiebreakers always end on `record_id`, so identical inputs
+produce byte-identical output. Forget-propagation tests rely on this.
+
+Body rendering:
+
+- File-backed (Purpose/Index): pass-through.
+- Record-backed (Pinned/Project/Playbook/UserSignal): each record →
+  `## <kind>: <first body line>\n<body>\n`. Blank line between records.
+
+## IDL + config changes
+
+`crates/cairn-idl/schema/verbs/assemble_hot.json`:
+
+- **No change to `HotRecipeStep`.** Frozen for cairn.mcp.v1 per the
+  schema's own description; bumping is out of scope for #82.
+- Add optional `debug` property on `Data`:
+
+  ```json
+  "debug": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "steps": {
+        "type": "array",
+        "items": { "$ref": "#/$defs/HotStepTrace" }
+      }
+    }
+  }
+  ```
+
+  Plus a new `$defs/HotStepTrace`:
+  `{ step: HotRecipeStep, included: [{record_id, score, note}], excluded: [{record_id, reason}] }`.
+  `null`-skipped on serialize. Optional fields are wire-compatible
+  additions for cairn.mcp.v1 — older consumers ignore unknown fields.
+
+`crates/cairn-core/src/config/mod.rs`:
+
+- **No change.** Recipe enum and default recipe are unchanged.
+
+`crates/cairn-core/src/verbs/lint/checks/hot_memory.rs`:
+
+- **No new arm.** Recipe is unchanged. The runtime `inclusion.rs`
+  trace produced by this issue could later feed a new lint check, but
+  that is a follow-up under #259, not a #82 deliverable.
+
+`crates/cairn-core/src/generated/`: regenerated by
+`cargo run -p cairn-idl --bin cairn-codegen` for the new optional
+`debug` field, and committed.
+
+## Snapshot drift
+
+The default recipe is unchanged. Existing snapshot tests in
+`crates/cairn-core/tests/assemble_hot_snapshots.rs` may need
+regeneration only if the per-record body framing (`## kind: ...`)
+changes the assembled bytes for fixtures the snapshots already
+exercise. Tests SHOULD pin a fixed body text to keep snapshots
+deterministic across runs.
+
+## Tests
+
+**Unit (per source module):**
+
+- `pinned`:
+  - ranks by `salience × recency`, top-8 cap;
+  - ties on score break by `record_id` desc;
+  - `is_static = 0` records excluded with `NotPinned`;
+  - non-`{user, feedback}` kinds excluded with `NotPinned`;
+  - `confidence < 0.3` excluded with `BelowConfidenceFloor`.
+- `project`:
+  - top-6 by salience;
+  - byte-size tiebreaker on tied salience matches lint regression;
+  - non-`project` kind excluded with `NotPinned`-equivalent.
+- `playbook`:
+  - most-recent `updated_at` wins;
+  - non-`playbook` kind excluded;
+  - empty input → empty body, no error.
+- `user_signal`:
+  - record at `now - 86_400s` included;
+  - record at `now - 86_401s` excluded with `OutsideRecencyWindow`.
+- `admissibility`:
+  - one minimal fixture per `ExclusionReason` variant.
+
+**Integration (`crates/cairn-core/tests/`):**
+
+- `assemble_hot_inputs.rs`: full default-recipe assembly with mixed-kind
+  fixtures, asserts inclusion order + `bytes ≤ max_bytes`.
+- `assemble_hot_debug.rs`: with `include_debug = true`, every step emits
+  a `HotStepTrace`; with `false`, `data.debug` is `None`.
+- `assemble_hot_privacy.rs`: tombstoned, low-confidence, out-of-scope,
+  visibility-blocked records excluded across every source. A pinned
+  record carrying any of these states never reaches the body.
+
+**Property (`proptest`):**
+
+- Determinism: `assemble_hot(inputs)` byte-equals second call with same
+  inputs.
+- Budget: arbitrary recipes never produce body bytes > `max_bytes`, or
+  fail with `AssembleHotError::BudgetExceeded`.
+
+**Snapshot (`insta`):**
+
+- `assemble_hot_snapshots.rs` regenerated for the new default recipe.
+
+**CLI smoke (`crates/cairn-cli/tests/`):**
+
+- Build `HotMemoryInputs` from a fixture vault, call `assemble_hot`,
+  assert the segment count matches the recipe length and at least one
+  segment is non-empty. The full SQLite + FS adapter wiring is owned by
+  #80; this issue ships the smallest test that exercises the end-to-end
+  pure path.
+
+## Verification (CLAUDE.md §8)
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo check --workspace --all-targets --locked
+cargo nextest run --workspace --locked --no-fail-fast
+cargo test --doc --workspace --locked
+./scripts/check-core-boundary.sh
+cargo run -p cairn-idl --bin cairn-codegen --locked -- --check
+cargo run -p cairn-cli --bin cairn-docgen --locked -- --check
+mdbook build docs/site
+RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" \
+  cargo doc --workspace --no-deps --document-private-items --locked
+```
+
+## Open questions
+
+- **Explicit `pinned` schema column.** Brief mentions `pinned: true`
+  exactly once (§3852, OpenCode mapping). v0.1 reuses `is_static = 1`
+  for `user`/`feedback`. A follow-up issue should decide whether to add
+  a dedicated `is_pinned` column to `MemoryRecord` + the canonical
+  signature surface; that decision is not part of #82.
+
+## Risk + mitigation
+
+- **Insta snapshot churn.** Per-record body framing may shift
+  byte-counts for snapshots that include record-backed content.
+  Mitigation: pin fixture bodies and verify the `## kind:` framing in
+  the snapshot delta is intentional.
+- **IDL deserializer drift.** New `Profile` enum variant + optional
+  `debug` field both flagged `non_exhaustive` / serde `default`-skipped
+  so older clients deserialize successfully.
+- **Test coupling to time.** `now` is a parameter, not a clock read;
+  recency-window tests pin `now` to a fixed RFC3339 timestamp.
+- **Pinned narrowing too aggressive.** v0.1 maps `pinned ↔ is_static`
+  for `user`/`feedback`. If a vault already carries `is_static = 0` user
+  preferences, they are excluded from `PinnedFeedback`. Acceptable for
+  P0 because the static-promotion classifier (#81 territory) writes
+  `is_static = 1` by default for those kinds.
+
+## Sequencing
+
+1. IDL: add optional `debug` field + `HotStepTrace` definition;
+   regenerate codegen.
+2. Core: `admissibility.rs`, `inclusion.rs`, `sources/*` modules.
+3. Core: refactor `assembler.rs` to take `HotMemoryInputs`.
+4. Tests: unit per source, integration, property, snapshot.
+5. CLI smoke: minimal fixture-driven assembly.
+6. Verification sweep.

--- a/scripts/check-core-boundary.sh
+++ b/scripts/check-core-boundary.sh
@@ -15,15 +15,19 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # Emit every dep declared by cairn-core whose name starts with `cairn-`,
-# regardless of kind. An empty result means clean.
+# excluding the self-referential dev-dep used to activate the
+# `test-fixtures` feature for integration tests under `tests/`. An empty
+# result means clean. The self-dep does not introduce adapter-crate
+# coupling — it only flips a feature flag — so the invariant is preserved.
 violations=$(
   cargo metadata --format-version 1 --locked \
     | jq -r '
         .packages[]
         | select(.name == "cairn-core")
         | .dependencies[]
+        | select(.name | startswith("cairn-"))
+        | select(.name != "cairn-core")
         | .name
-        | select(startswith("cairn-"))
       '
 )
 

--- a/skills/cairn/SKILL.md
+++ b/skills/cairn/SKILL.md
@@ -254,6 +254,10 @@ cairn assemble_hot --session SESSION_ID
 cairn assemble_hot --budget 0
 ```
 
+```bash
+cairn assemble_hot --explain
+```
+
 ## `cairn capture_trace`
 
 **Use when:**


### PR DESCRIPTION
## Summary

- Implements source-specific retrieval for the six frozen `cairn.mcp.v1` recipe steps (`Purpose`, `Index`, `PinnedFeedback`, `TopSalienceProject`, `ActivePlaybook`, `RecentUserSignal`) — replaces the stub `load_step_body` returning `""`.
- Adds a uniform admissibility predicate (visibility / scope / confidence / body) called by every record-backed source as defense-in-depth at the trust boundary.
- Adds an optional `debug` field on `AssembleHotData` (wire-compatible IDL extension) carrying per-step `HotStepTrace` with typed inclusion + exclusion reasons.
- Refactors the assembler to take a pure `HotMemoryInputs` projection — `cairn-core` stays adapter-free; the SQLite/FS adapter wiring is owned by #80.

Closes #82.

Spec: `docs/superpowers/specs/2026-05-08-issue-82-hot-prefix-retrieval-design.md`
Plan: `docs/superpowers/plans/2026-05-08-issue-82-hot-prefix-retrieval.md`

## Acceptance criteria

- [x] Retrieval functions for `Purpose`, `Index`, `PinnedFeedback`, `TopSalienceProject`, `ActivePlaybook`, `RecentUserSignal`. Profile retrieval already exposed via `retrieve --profile` (#81); a Profile recipe step is deferred — `HotRecipeStep` is frozen for `cairn.mcp.v1`.
- [x] Visibility, scope, confidence, staleness, salience scoring applied uniformly with `search` / `retrieve`.
- [x] Pinned records win by `salience × recency` (top 8) but obey visibility + forget state (privacy regression tests).
- [x] Debug output (`HotMemoryDebug` + per-step `HotStepTrace`) explains why a memory entered or did not enter hot context.

## Design decisions

| Question | Decision |
|---|---|
| Pinned semantics in v0.1 | `kind ∈ {user, feedback} ∧ is_static = 1` (closest existing signal, no schema change) |
| Profile recipe step | Deferred — IDL freeze on `HotRecipeStep` for `cairn.mcp.v1`; bumping is out of scope |
| Debug surface | Optional `debug` field on `AssembleHotData` (one verb, one wire shape) |
| Adapter coupling | Pure-projection `HotMemoryInputs` — adapter pre-filters, core ranks + caps + assembles |

## Architecture

```
cairn-core/src/verbs/assemble_hot/
├── admissibility.rs        uniform per-record predicate
├── assembler.rs            assemble_hot(inputs, config)
├── inclusion.rs            ExclusionReason + InclusionTrace + LoadedSegment
├── inputs.rs               HotMemoryInputs<'a>
├── segments.rs             unchanged
├── raw.rs                  unchanged (debug field threaded through TryFrom/From)
└── sources/
    ├── purpose.rs          pass-through
    ├── index.rs            pass-through
    ├── render.rs           canonical \`## kind: ...\` block framing
    ├── pinned.rs           top 8 by salience × recency_decay(30d half-life)
    ├── project.rs          top 6 by salience desc, byte-size tiebreaker
    ├── playbook.rs         top 1 by updated_at desc
    └── user_signal.rs      last-24h window, updated_at desc
```

Determinism: every sort ends with \`record_id\` desc as a deterministic tiebreaker (forget-propagation + snapshot stability).

## Out of scope (deferred to follow-ups)

- Real CLI/SDK adapter wiring (\`HotMemoryInputs\` from a SQLite query + filesystem reads) — owned by #80.
- Cache invalidation + stale-context lint — owned by #83.
- Profile in the hot prefix — needs a \`cairn.mcp.v2\` IDL bump.
- Explicit per-record \`pinned\` schema column (v0.1 uses \`is_static = 1\`).
- \`--explain\` CLI flag pass-through (core supports it; CLI wiring lands with #80).
- Dedicated \`WrongKind\` exclusion variant — \`NotPinned\` is reused with documented overloading.

## Test plan

- [x] Per-source unit tests (admissibility + ranking + top-K + tiebreakers): 65/65 passing
- [x] Integration tests: \`assemble_hot_inputs\` (mixed-kind end-to-end), \`assemble_hot_privacy\` (low-conf / vis / scope rejection), \`assemble_hot_debug\` (trace round-trip)
- [x] Determinism proptest (32 cases, byte-equal output for equal inputs)
- [x] Budget proptest (32 cases × random \`max_bytes\` × random \`body_size\` — either fits budget or fails with typed \`BudgetExceeded\`)
- [x] CLI smoke test (\`cairn-cli\` calls the pure path with fixture inputs)

## Verification (CLAUDE.md §8)

All gates pass on the head commit:

- \`cargo fmt --all --check\`
- \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- \`cargo check --workspace --all-targets --locked\`
- \`cargo nextest run --workspace --locked --no-fail-fast\` — **3498/3498**
- \`cargo test --doc --workspace --locked\`
- \`./scripts/check-core-boundary.sh\` — passes (the script was updated to exempt the \`cairn-core\` self-dev-dep used to activate the \`test-fixtures\` feature for integration tests; this does not weaken the no-adapter-coupling invariant)
- \`cargo run -p cairn-idl --bin cairn-codegen --locked -- --check\`
- \`cargo run -p cairn-cli --bin cairn-docgen --locked -- --check\`
- \`RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" cargo doc --workspace --no-deps --document-private-items --locked\`

## Sweep commits

In addition to the 14 task commits:

- \`chore(fmt):\` — rustfmt sweep on the new modules
- \`fix(idl):\` — \`minLength: 1\` on \`HotInclusion.note\` so the schema-bounds invariant test stays clean (notes are always non-empty static strs)
- \`fix(boundary):\` — \`scripts/check-core-boundary.sh\` now exempts the \`cairn-core\` self-dev-dep used for feature activation in integration tests
- \`docs(assemble_hot):\` — final-review follow-ups (document Tombstoned/ForgottenScope as adapter-side, NotPinned overloading note, budget proptest)