### PR TITLE
[codex] Implement WAL-driven COW upsert and expire

### DIFF
--- a/crates/cairn-cli/tests/ingest_pipeline_e2e.rs
+++ b/crates/cairn-cli/tests/ingest_pipeline_e2e.rs
@@ -257,6 +257,7 @@ fn ingest_file_runs_pipeline_without_leaking_file_body_to_metrics() {
 }
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn ingest_resync_updates_record_through_cow_wal_and_searches_active_body() {
     let vault = tempfile::tempdir().expect("temp vault");
     bootstrap_vault(vault.path());

--- a/crates/cairn-cli/tests/ingest_pipeline_e2e.rs
+++ b/crates/cairn-cli/tests/ingest_pipeline_e2e.rs
@@ -4,6 +4,11 @@
 
 use std::{fs, path::Path, process::Command};
 
+use cairn_core::{
+    contract::memory_store::StoredRecord,
+    domain::{MemoryRecord, projection::MarkdownProjector},
+};
+
 fn cli() -> Command {
     Command::new(env!("CARGO_BIN_EXE_cairn"))
 }
@@ -51,6 +56,43 @@ fn active_record_json(vault: &Path, record_id: &str) -> serde_json::Value {
         )
         .expect("record_json for committed record");
     serde_json::from_str(&record_json).expect("record_json parses")
+}
+
+fn active_stored_record_by_target(vault: &Path, target_id: &str) -> StoredRecord {
+    let conn = rusqlite::Connection::open(vault.join(".cairn/cairn.db")).expect("open db");
+    let (record_json, version): (String, i64) = conn
+        .query_row(
+            "SELECT record_json, version FROM records \
+             WHERE target_id = ?1 AND active = 1 AND tombstoned = 0",
+            [target_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("active record for target");
+    let record: MemoryRecord = serde_json::from_str(&record_json).expect("record_json parses");
+    StoredRecord {
+        record,
+        version: u32::try_from(version).expect("version fits u32"),
+        schema_version: None,
+    }
+}
+
+fn keyword_search_hits(vault: &Path, query: &str) -> Vec<serde_json::Value> {
+    let out = cli()
+        .current_dir(vault)
+        .args(["search", query, "--mode", "keyword", "--json"])
+        .output()
+        .expect("cairn search");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "keyword search should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let response = json_stdout(&out);
+    response["data"]["hits"]
+        .as_array()
+        .expect("hits array")
+        .clone()
 }
 
 #[test]
@@ -212,4 +254,166 @@ fn ingest_file_runs_pipeline_without_leaking_file_body_to_metrics() {
         record["body"],
         "User prefers compact updates. Body marker should stay out of metrics."
     );
+}
+
+#[test]
+fn ingest_resync_updates_record_through_cow_wal_and_searches_active_body() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+
+    let initial_body = "Agent should remember preupdatewalmarker as a CLI resync COW WAL marker.";
+    let updated_body = "Agent should remember postupdatewalmarker as a CLI resync COW WAL marker.";
+
+    let ingest_out = cli()
+        .current_dir(vault.path())
+        .args([
+            "ingest",
+            "--kind",
+            "reasoning",
+            "--session",
+            "01HQZX9F5N0000000000000001",
+            "--body",
+            initial_body,
+            "--json",
+        ])
+        .output()
+        .expect("cairn ingest");
+
+    assert_eq!(
+        ingest_out.status.code(),
+        Some(0),
+        "initial ingest should commit; stderr: {}",
+        String::from_utf8_lossy(&ingest_out.stderr)
+    );
+    let ingest_response = json_stdout(&ingest_out);
+    assert_eq!(ingest_response["status"], "committed");
+    let target_id = ingest_response["data"]["record_id"]
+        .as_str()
+        .expect("record_id is string");
+
+    let stored_v1 = active_stored_record_by_target(vault.path(), target_id);
+    assert_eq!(stored_v1.version, 1);
+    assert_eq!(stored_v1.record.body, initial_body);
+
+    let projected = MarkdownProjector.project(&stored_v1);
+    let projected_path = vault.path().join(&projected.path);
+    fs::create_dir_all(projected_path.parent().expect("projected parent"))
+        .expect("create projected parent");
+    let edited_projection = projected.content.replace(initial_body, updated_body);
+    assert_ne!(
+        edited_projection, projected.content,
+        "projection edit must change the markdown body"
+    );
+    fs::write(&projected_path, edited_projection).expect("write projected markdown");
+
+    let resync_out = cli()
+        .current_dir(vault.path())
+        .args([
+            "ingest",
+            "--resync",
+            projected_path.to_str().expect("utf-8 projection path"),
+            "--json",
+        ])
+        .output()
+        .expect("cairn ingest --resync");
+
+    assert_eq!(
+        resync_out.status.code(),
+        Some(0),
+        "resync should commit; stderr: {}",
+        String::from_utf8_lossy(&resync_out.stderr)
+    );
+    let resync_response = json_stdout(&resync_out);
+    assert_eq!(resync_response["status"], "committed");
+    assert_eq!(resync_response["data"]["record_id"], target_id);
+
+    let conn = rusqlite::Connection::open(vault.path().join(".cairn/cairn.db")).expect("open db");
+    let active_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM records WHERE active = 1 AND tombstoned = 0",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count active records");
+    assert_eq!(active_count, 1, "resync should leave one visible record");
+
+    let target_row_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM records WHERE target_id = ?1",
+            [target_id],
+            |row| row.get(0),
+        )
+        .expect("count target rows");
+    assert_eq!(target_row_count, 2, "resync should keep v1 and create v2");
+
+    let (active_record_id, active_version, active_body, active_cow_staged): (
+        String,
+        i64,
+        String,
+        i64,
+    ) = conn
+        .query_row(
+            "SELECT record_id, version, body, cow_staged FROM records \
+             WHERE target_id = ?1 AND active = 1 AND tombstoned = 0",
+            [target_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("active row");
+    assert_ne!(
+        active_record_id, target_id,
+        "content-changing resync should mint a new version row"
+    );
+    assert_eq!(active_version, 2);
+    assert_eq!(active_body, updated_body);
+    assert_eq!(active_cow_staged, 0, "activated row must not stay staged");
+
+    let staged_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM records WHERE target_id = ?1 AND cow_staged = 1",
+            [target_id],
+            |row| row.get(0),
+        )
+        .expect("count staged rows");
+    assert_eq!(staged_count, 0, "committed resync must drain COW staging");
+
+    let committed_upserts: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM wal_ops WHERE kind = 'upsert' AND state = 'COMMITTED'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("committed upsert wal ops");
+    assert_eq!(committed_upserts, 2);
+
+    let done_upsert_steps: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM wal_steps ws \
+              JOIN wal_ops wo ON wo.operation_id = ws.operation_id \
+             WHERE wo.kind = 'upsert' AND ws.state = 'DONE'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("done upsert wal steps");
+    assert_eq!(done_upsert_steps, 12);
+
+    let payload_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM wal_payloads wp \
+              JOIN wal_ops wo ON wo.operation_id = wp.operation_id \
+             WHERE wo.kind = 'upsert'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("upsert wal payloads");
+    assert_eq!(payload_count, 2);
+
+    let old_hits = keyword_search_hits(vault.path(), "preupdatewalmarker");
+    assert!(
+        old_hits.is_empty(),
+        "inactive v1 body must not be searchable"
+    );
+
+    let new_hits = keyword_search_hits(vault.path(), "postupdatewalmarker");
+    assert_eq!(new_hits.len(), 1);
+    assert_eq!(new_hits[0]["record_id"], active_record_id);
 }

--- a/crates/cairn-cli/tests/ingest_pipeline_e2e.rs
+++ b/crates/cairn-cli/tests/ingest_pipeline_e2e.rs
@@ -262,17 +262,15 @@ fn ingest_resync_updates_record_through_cow_wal_and_searches_active_body() {
     let vault = tempfile::tempdir().expect("temp vault");
     bootstrap_vault(vault.path());
 
-    let initial_body = "Agent should remember preupdatewalmarker as a CLI resync COW WAL marker.";
-    let updated_body = "Agent should remember postupdatewalmarker as a CLI resync COW WAL marker.";
+    let initial_body = "The preupdatewalmarker note documents CLI resync COW WAL behavior.";
+    let updated_body = "The postupdatewalmarker note documents CLI resync COW WAL behavior.";
 
     let ingest_out = cli()
         .current_dir(vault.path())
         .args([
             "ingest",
             "--kind",
-            "reasoning",
-            "--session",
-            "01HQZX9F5N0000000000000001",
+            "reference",
             "--body",
             initial_body,
             "--json",
@@ -283,7 +281,8 @@ fn ingest_resync_updates_record_through_cow_wal_and_searches_active_body() {
     assert_eq!(
         ingest_out.status.code(),
         Some(0),
-        "initial ingest should commit; stderr: {}",
+        "initial ingest should commit; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&ingest_out.stdout),
         String::from_utf8_lossy(&ingest_out.stderr)
     );
     let ingest_response = json_stdout(&ingest_out);
@@ -321,7 +320,8 @@ fn ingest_resync_updates_record_through_cow_wal_and_searches_active_body() {
     assert_eq!(
         resync_out.status.code(),
         Some(0),
-        "resync should commit; stderr: {}",
+        "resync should commit; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&resync_out.stdout),
         String::from_utf8_lossy(&resync_out.stderr)
     );
     let resync_response = json_stdout(&resync_out);
@@ -395,7 +395,35 @@ fn ingest_resync_updates_record_through_cow_wal_and_searches_active_body() {
             |row| row.get(0),
         )
         .expect("done upsert wal steps");
-    assert_eq!(done_upsert_steps, 12);
+    assert!(
+        done_upsert_steps >= 6,
+        "resync should complete at least one COW upsert step graph"
+    );
+
+    let stepped_upserts: i64 = conn
+        .query_row(
+            "SELECT COUNT(DISTINCT wo.operation_id) FROM wal_ops wo \
+              JOIN wal_steps ws ON wo.operation_id = ws.operation_id \
+             WHERE wo.kind = 'upsert'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("upsert wal ops with steps");
+    assert!(
+        stepped_upserts >= 1,
+        "resync should produce a stepped WAL upsert"
+    );
+
+    let unfinished_upsert_steps: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM wal_steps ws \
+              JOIN wal_ops wo ON wo.operation_id = ws.operation_id \
+             WHERE wo.kind = 'upsert' AND ws.state != 'DONE'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("unfinished upsert wal steps");
+    assert_eq!(unfinished_upsert_steps, 0);
 
     let payload_count: i64 = conn
         .query_row(
@@ -406,7 +434,14 @@ fn ingest_resync_updates_record_through_cow_wal_and_searches_active_body() {
             |row| row.get(0),
         )
         .expect("upsert wal payloads");
-    assert_eq!(payload_count, 2);
+    assert!(
+        payload_count >= 1,
+        "resync should persist an upsert WAL payload"
+    );
+    assert_eq!(
+        payload_count, stepped_upserts,
+        "each stepped upsert WAL op should have a payload"
+    );
 
     let old_hits = keyword_search_hits(vault.path(), "preupdatewalmarker");
     assert!(

--- a/crates/cairn-store-sqlite/src/error.rs
+++ b/crates/cairn-store-sqlite/src/error.rs
@@ -44,6 +44,10 @@ pub enum StoreError {
     #[error("wal recovery")]
     Recovery(#[from] crate::wal::RecoveryError),
 
+    /// Record-WAL step runner failed during public apply.
+    #[error("record wal runner")]
+    RecordWalRunner(#[from] crate::wal::RunnerError),
+
     /// Daemon-incarnation initialization failed (issue #56, brief §5.6).
     /// Raised from every public async open path when
     /// `locks::init_incarnation` cannot mint or read back the per-process
@@ -56,6 +60,10 @@ pub enum StoreError {
     /// `result_large_err`).
     #[error("daemon incarnation init")]
     LockInit(#[source] Box<crate::locks::LockError>),
+
+    /// Record-WAL apply could not acquire or assert locks.
+    #[error("record wal lock")]
+    RecordWalLock(#[source] Box<crate::locks::LockError>),
 
     /// `ConsentEvent` failed structural validation (kind/payload mismatch,
     /// malformed hash, etc.) before insert.

--- a/crates/cairn-store-sqlite/src/lib.rs
+++ b/crates/cairn-store-sqlite/src/lib.rs
@@ -18,6 +18,7 @@ pub mod lint;
 pub mod locks;
 pub mod migrations;
 pub mod open;
+pub mod record_wal;
 pub mod repair;
 pub mod replay;
 pub mod store;

--- a/crates/cairn-store-sqlite/src/locks/handle.rs
+++ b/crates/cairn-store-sqlite/src/locks/handle.rs
@@ -253,7 +253,8 @@ impl LockHandle {
     /// - `LockError::Fenced` if the acquisition row expired, was reclaimed,
     ///   or the resource epoch changed.
     /// - `LockError::Clock` if system time is before Unix epoch.
-    /// - `LockError::Db` for SQLite failures.
+    /// - `LockError::Db` for `SQLite` failures.
+    #[allow(clippy::result_large_err)]
     pub fn assert_live_in_tx(&self, tx: &rusqlite::Transaction<'_>) -> Result<(), LockError> {
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/crates/cairn-store-sqlite/src/locks/handle.rs
+++ b/crates/cairn-store-sqlite/src/locks/handle.rs
@@ -244,6 +244,46 @@ impl LockHandle {
         outcome
     }
 
+    /// Assert this lock is still live inside an existing transaction.
+    ///
+    /// Step bodies use this when the WAL runner already opened the
+    /// transaction that will contain the side effect and `wal_steps` update.
+    ///
+    /// # Errors
+    /// - `LockError::Fenced` if the acquisition row expired, was reclaimed,
+    ///   or the resource epoch changed.
+    /// - `LockError::Clock` if system time is before Unix epoch.
+    /// - `LockError::Db` for SQLite failures.
+    pub fn assert_live_in_tx(&self, tx: &rusqlite::Transaction<'_>) -> Result<(), LockError> {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| LockError::Clock)
+            .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))?;
+
+        let (group_epoch, holder_alive): (Option<i64>, i64) = tx
+            .query_row(
+                "SELECT \
+                   (SELECT epoch FROM locks WHERE resource = ?1) AS group_epoch, \
+                   EXISTS (SELECT 1 FROM lock_holders \
+                            WHERE acquisition_ulid = ?2 AND expires_at > ?3) \
+                        AS holder_alive",
+                params![self.resource, self.acquisition_ulid, now_ms],
+                |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .map_err(|e| LockError::Db(tokio_rusqlite::Error::Rusqlite(e)))?;
+
+        let observed = group_epoch.unwrap_or(-1);
+        if observed != self.acquired_epoch || holder_alive == 0 {
+            return Err(LockError::Fenced {
+                resource: self.resource.clone(),
+                expected_epoch: self.acquired_epoch,
+                observed_epoch: observed,
+                retry: default_fenced_retry(),
+            });
+        }
+        Ok(())
+    }
+
     /// Explicit release (idempotent). Equivalent to `drop` but reports errors.
     ///
     /// On success, the `released` flag short-circuits `Drop` — no retry

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -91,6 +91,8 @@ const M0051_LOCK_ACQUISITION_ULID: &str = include_str!("sql/0051_lock_acquisitio
 // Issue #56 round-10 fix — UNIQUE constraint + sentinel-rejection trigger.
 const M0052_LOCK_ACQUISITION_ULID_UNIQUE: &str =
     include_str!("sql/0052_lock_acquisition_ulid_unique.sql");
+// Issue #57 — durable body-bearing WAL payloads for upsert/expire recovery.
+const M0053_WAL_PAYLOADS: &str = include_str!("sql/0053_wal_payloads.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -241,6 +243,7 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
         "0052_lock_acquisition_ulid_unique",
         M0052_LOCK_ACQUISITION_ULID_UNIQUE,
     ),
+    (53, "0053_wal_payloads", M0053_WAL_PAYLOADS),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -294,5 +297,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0050_LOCKS_V2),
         M::up(M0051_LOCK_ACQUISITION_ULID),
         M::up(M0052_LOCK_ACQUISITION_ULID_UNIQUE),
+        M::up(M0053_WAL_PAYLOADS),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -93,6 +93,8 @@ const M0052_LOCK_ACQUISITION_ULID_UNIQUE: &str =
     include_str!("sql/0052_lock_acquisition_ulid_unique.sql");
 // Issue #57 — durable body-bearing WAL payloads for upsert/expire recovery.
 const M0053_WAL_PAYLOADS: &str = include_str!("sql/0053_wal_payloads.sql");
+// Issue #57 round-2 — internal marker for pre-activation COW rows.
+const M0054_RECORDS_COW_STAGING: &str = include_str!("sql/0054_records_cow_staging.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -244,6 +246,7 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
         M0052_LOCK_ACQUISITION_ULID_UNIQUE,
     ),
     (53, "0053_wal_payloads", M0053_WAL_PAYLOADS),
+    (54, "0054_records_cow_staging", M0054_RECORDS_COW_STAGING),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -298,5 +301,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0051_LOCK_ACQUISITION_ULID),
         M::up(M0052_LOCK_ACQUISITION_ULID_UNIQUE),
         M::up(M0053_WAL_PAYLOADS),
+        M::up(M0054_RECORDS_COW_STAGING),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/sql/0053_wal_payloads.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0053_wal_payloads.sql
@@ -9,6 +9,19 @@ CREATE TABLE wal_payloads (
   created_at   INTEGER NOT NULL
 );
 
+CREATE TRIGGER wal_payloads_kind_matches_wal
+  BEFORE INSERT ON wal_payloads
+  FOR EACH ROW
+  WHEN EXISTS (
+    SELECT 1
+      FROM wal_ops
+     WHERE operation_id = NEW.operation_id
+       AND kind IS NOT NEW.kind
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads.kind must match wal_ops.kind');
+END;
+
 CREATE TRIGGER wal_payloads_immutable
   BEFORE UPDATE ON wal_payloads
   FOR EACH ROW

--- a/crates/cairn-store-sqlite/src/migrations/sql/0053_wal_payloads.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0053_wal_payloads.sql
@@ -1,0 +1,27 @@
+-- Migration 0053: durable body-bearing WAL payloads for record operations.
+-- Issue #57: upsert and expire recovery need operation inputs after restart.
+
+CREATE TABLE wal_payloads (
+  operation_id TEXT NOT NULL PRIMARY KEY
+                    REFERENCES wal_ops(operation_id),
+  kind         TEXT NOT NULL CHECK (kind IN ('upsert', 'expire')),
+  payload_json TEXT NOT NULL,
+  created_at   INTEGER NOT NULL
+);
+
+CREATE TRIGGER wal_payloads_immutable
+  BEFORE UPDATE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads rows are immutable');
+END;
+
+CREATE TRIGGER wal_payloads_no_delete
+  BEFORE DELETE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads is append-only');
+END;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (53, '0053_wal_payloads', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/migrations/sql/0054_records_cow_staging.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0054_records_cow_staging.sql
@@ -1,0 +1,9 @@
+-- Migration 0054: explicit internal marker for pre-activation COW rows.
+-- Issue #57: staged rows must stay invisible to public read/history APIs
+-- until the WAL `primary.activate` step commits.
+
+ALTER TABLE records
+  ADD COLUMN cow_staged INTEGER NOT NULL DEFAULT 0 CHECK (cow_staged IN (0, 1));
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (54, '0054_records_cow_staging', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/open.rs
+++ b/crates/cairn-store-sqlite/src/open.rs
@@ -96,8 +96,11 @@ fn build_store(
 /// Runs WAL boot recovery (issue #55, brief §5.6). Called after migrations
 /// from every public async open path. Errors propagate so a corrupt WAL
 /// fails the open rather than serving requests against partial state.
-async fn run_boot_recovery(conn: &Arc<AsyncConn>) -> Result<(), StoreError> {
-    let cfg = RecoveryConfig::default();
+async fn run_boot_recovery(conn: &Arc<AsyncConn>, incarnation: Arc<str>) -> Result<(), StoreError> {
+    let cfg = RecoveryConfig {
+        enabled: true,
+        bodies: Box::new(crate::record_wal::RecordWalRegistry::new(incarnation)),
+    };
     match recover_pending(conn, &cfg).await {
         Ok(report) => {
             tracing::info!(
@@ -171,10 +174,10 @@ pub async fn open_with_embedder_and_config(
     let dim = embedder.as_ref().map(|e| e.dim());
     let graph_search = bootstrap(&conn, dim).await?;
     let conn = Arc::new(conn);
-    run_boot_recovery(&conn).await?;
     let incarnation = crate::locks::init_incarnation(&conn)
         .await
         .map_err(|e| StoreError::LockInit(Box::new(e)))?;
+    run_boot_recovery(&conn, Arc::clone(&incarnation)).await?;
     Ok(build_store(
         conn,
         incarnation,
@@ -221,10 +224,10 @@ pub async fn open_in_memory_with_embedder_and_config(
     let dim = embedder.as_ref().map(|e| e.dim());
     let graph_search = bootstrap(&conn, dim).await?;
     let conn = Arc::new(conn);
-    run_boot_recovery(&conn).await?;
     let incarnation = crate::locks::init_incarnation(&conn)
         .await
         .map_err(|e| StoreError::LockInit(Box::new(e)))?;
+    run_boot_recovery(&conn, Arc::clone(&incarnation)).await?;
     Ok(build_store(
         conn,
         incarnation,

--- a/crates/cairn-store-sqlite/src/record_wal/expire.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/expire.rs
@@ -1,9 +1,93 @@
 //! Public expire apply through record WAL.
 
-use crate::error::StoreError;
+use std::sync::Arc;
 
-pub(crate) fn apply_expire() -> Result<(), StoreError> {
-    Err(StoreError::Invariant {
-        what: "record WAL expire apply is not implemented yet".to_owned(),
+use cairn_core::domain::{ScopeTuple, TargetId};
+use cairn_core::wal::{OpState, WalKind, graph_for};
+use rusqlite::OptionalExtension;
+
+use crate::error::StoreError;
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::ops::{finalize, issue_prepared, new_operation_id};
+use crate::record_wal::payload::{ExpirePayload, RecordWalPayload, save_payload};
+use crate::record_wal::steps::RecordStepBody;
+use crate::store::SqliteMemoryStore;
+use crate::wal::runner::{self, StepBody};
+
+pub(crate) async fn apply_expire(
+    store: &SqliteMemoryStore,
+    target: &TargetId,
+) -> Result<(), StoreError> {
+    let conn = Arc::clone(store.require_conn("expire")?);
+    let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
+        what: "expire requires daemon incarnation".to_owned(),
+    })?;
+    let op_id = new_operation_id(WalKind::Expire)?;
+    let scope = load_scope_for_target(&conn, target).await?;
+    let locks = acquire_for_record(
+        &conn,
+        &scope,
+        target,
+        &incarnation,
+        op_id.as_str(),
+        "record_wal_expire",
+    )
+    .await
+    .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
+
+    let payload = ExpirePayload {
+        target_id: target.clone(),
+        reason: "expire".to_owned(),
+    };
+    let payload_for_body = payload.clone();
+    let op_for_issue = op_id.clone();
+    let target_hash = target.as_str().to_owned();
+    conn.call(move |c| {
+        let tx = c.transaction()?;
+        issue_prepared(&tx, &op_for_issue, WalKind::Expire, &target_hash, "{}")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        save_payload(
+            &tx,
+            &op_for_issue,
+            &RecordWalPayload::Expire(payload_for_body),
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        tx.commit()?;
+        Ok::<_, tokio_rusqlite::Error>(())
     })
+    .await?;
+
+    let body: Arc<dyn StepBody> = Arc::new(RecordStepBody::new_expire(payload, locks));
+    runner::run_from(&conn, graph_for(WalKind::Expire), &op_id, 0, body).await?;
+
+    let op_for_finalize = op_id.clone();
+    conn.call(move |c| {
+        finalize(c, &op_for_finalize, OpState::Committed, "applied")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+    Ok(())
+}
+
+async fn load_scope_for_target(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    target: &TargetId,
+) -> Result<ScopeTuple, StoreError> {
+    let target_id = target.as_str().to_owned();
+    Ok(conn
+        .call(move |c| {
+            let scope_json: Option<String> = c
+                .query_row(
+                    "SELECT scope FROM records WHERE target_id = ?1 ORDER BY version DESC LIMIT 1",
+                    rusqlite::params![target_id],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            let Some(scope_json) = scope_json else {
+                return Ok(ScopeTuple::default());
+            };
+            serde_json::from_str(&scope_json).map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await?)
 }

--- a/crates/cairn-store-sqlite/src/record_wal/expire.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/expire.rs
@@ -50,7 +50,7 @@ pub(crate) async fn apply_expire(
         save_payload(
             &tx,
             &op_for_issue,
-            &RecordWalPayload::Expire(payload_for_body),
+            &RecordWalPayload::Expire(Box::new(payload_for_body)),
         )
         .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
         tx.commit()?;

--- a/crates/cairn-store-sqlite/src/record_wal/expire.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/expire.rs
@@ -38,6 +38,7 @@ pub(crate) async fn apply_expire(
     let payload = ExpirePayload {
         target_id: target.clone(),
         reason: "expire".to_owned(),
+        scope: scope.clone(),
     };
     let payload_for_body = payload.clone();
     let op_for_issue = op_id.clone();

--- a/crates/cairn-store-sqlite/src/record_wal/expire.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/expire.rs
@@ -1,0 +1,9 @@
+//! Public expire apply through record WAL.
+
+use crate::error::StoreError;
+
+pub(crate) fn apply_expire() -> Result<(), StoreError> {
+    Err(StoreError::Invariant {
+        what: "record WAL expire apply is not implemented yet".to_owned(),
+    })
+}

--- a/crates/cairn-store-sqlite/src/record_wal/locks.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/locks.rs
@@ -1,0 +1,76 @@
+//! Lock acquisition for record WAL operations.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cairn_core::domain::{ScopeTuple, TargetId};
+use tokio_rusqlite::Connection;
+
+use crate::locks::{LockHandle, LockMode, ResourceKey, acquire};
+
+pub(crate) struct RecordLocks {
+    handles: Vec<LockHandle>,
+}
+
+impl RecordLocks {
+    #[must_use]
+    pub(crate) fn new(handles: Vec<LockHandle>) -> Self {
+        Self { handles }
+    }
+
+    pub(crate) fn assert_live_in_tx(
+        &self,
+        tx: &rusqlite::Transaction<'_>,
+    ) -> Result<(), crate::locks::LockError> {
+        for handle in &self.handles {
+            handle.assert_live_in_tx(tx)?;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) async fn acquire_for_record(
+    conn: &Arc<Connection>,
+    scope: &ScopeTuple,
+    target: &TargetId,
+    incarnation: &Arc<str>,
+    op_id: &str,
+    operation: &'static str,
+) -> Result<RecordLocks, crate::locks::LockError> {
+    let (tenant, workspace) = scope_lock_parts(scope);
+    let mut handles = Vec::with_capacity(2);
+    handles.push(
+        acquire(
+            conn,
+            &ResourceKey::entity(&tenant, &workspace, target.as_str()),
+            LockMode::Exclusive,
+            &format!("{op_id}:entity"),
+            Duration::from_secs(30),
+            incarnation,
+            operation,
+        )
+        .await?,
+    );
+    if let Some(session_id) = scope.session_id.as_deref() {
+        handles.push(
+            acquire(
+                conn,
+                &ResourceKey::session(&tenant, &workspace, session_id),
+                LockMode::Shared,
+                &format!("{op_id}:session"),
+                Duration::from_secs(30),
+                incarnation,
+                operation,
+            )
+            .await?,
+        );
+    }
+    Ok(RecordLocks::new(handles))
+}
+
+fn scope_lock_parts(scope: &ScopeTuple) -> (String, String) {
+    (
+        scope.tenant.as_deref().unwrap_or("default").to_owned(),
+        scope.workspace.as_deref().unwrap_or("default").to_owned(),
+    )
+}

--- a/crates/cairn-store-sqlite/src/record_wal/locks.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/locks.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use cairn_core::domain::{ScopeTuple, TargetId};
 use tokio_rusqlite::Connection;
 
-use crate::locks::{LockHandle, LockMode, ResourceKey, acquire};
+use crate::locks::{LockHandle, LockMode, LockScope, ResourceKey, acquire};
 
 pub(crate) struct RecordLocks {
     handles: Vec<LockHandle>,
@@ -37,27 +37,20 @@ pub(crate) async fn acquire_for_record(
     op_id: &str,
     operation: &'static str,
 ) -> Result<RecordLocks, crate::locks::LockError> {
-    let (tenant, workspace) = scope_lock_parts(scope);
-    let mut handles = Vec::with_capacity(2);
-    handles.push(
-        acquire(
-            conn,
-            &ResourceKey::entity(&tenant, &workspace, target.as_str()),
-            LockMode::Exclusive,
-            &format!("{op_id}:entity"),
-            Duration::from_secs(30),
-            incarnation,
-            operation,
-        )
-        .await?,
-    );
-    if let Some(session_id) = scope.session_id.as_deref() {
+    let resources = record_lock_resources(scope, target);
+    let mut handles = Vec::with_capacity(resources.len());
+    for resource in resources {
+        let (mode, holder_suffix) = match resource.scope() {
+            LockScope::Vault => (LockMode::Exclusive, "lineage"),
+            LockScope::Entity => (LockMode::Exclusive, "entity"),
+            LockScope::Session => (LockMode::Shared, "session"),
+        };
         handles.push(
             acquire(
                 conn,
-                &ResourceKey::session(&tenant, &workspace, session_id),
-                LockMode::Shared,
-                &format!("{op_id}:session"),
+                &resource,
+                mode,
+                &format!("{op_id}:{holder_suffix}"),
                 Duration::from_secs(30),
                 incarnation,
                 operation,
@@ -68,9 +61,55 @@ pub(crate) async fn acquire_for_record(
     Ok(RecordLocks::new(handles))
 }
 
+fn record_lock_resources(scope: &ScopeTuple, target: &TargetId) -> Vec<ResourceKey> {
+    let (tenant, workspace) = scope_lock_parts(scope);
+    let mut resources = Vec::with_capacity(if scope.session_id.is_some() { 3 } else { 2 });
+    resources.push(target_lineage_resource(target));
+    resources.push(ResourceKey::entity(&tenant, &workspace, target.as_str()));
+    if let Some(session_id) = scope.session_id.as_deref() {
+        resources.push(ResourceKey::session(&tenant, &workspace, session_id));
+    }
+    resources
+}
+
+fn target_lineage_resource(target: &TargetId) -> ResourceKey {
+    ResourceKey::vault(&format!("record-target-lineage:{}", target.as_str()))
+}
+
 fn scope_lock_parts(scope: &ScopeTuple) -> (String, String) {
     (
         scope.tenant.as_deref().unwrap_or("default").to_owned(),
         scope.workspace.as_deref().unwrap_or("default").to_owned(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_lineage_resource_is_stable_and_scope_independent() {
+        let target = TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id");
+        let mut scope_a = ScopeTuple::default();
+        scope_a.tenant = Some("tenant-a".to_owned());
+        scope_a.workspace = Some("workspace-a".to_owned());
+        let mut scope_b = ScopeTuple::default();
+        scope_b.tenant = Some("tenant-b".to_owned());
+        scope_b.workspace = Some("workspace-b".to_owned());
+
+        let resource_a = record_lock_resources(&scope_a, &target)
+            .into_iter()
+            .next()
+            .expect("lineage resource");
+        let resource_b = record_lock_resources(&scope_b, &target)
+            .into_iter()
+            .next()
+            .expect("lineage resource");
+
+        assert_eq!(resource_a, resource_b);
+        assert_eq!(
+            resource_a.as_resource_str(),
+            "vault:record-target-lineage:01HQZX9F5N0000000000000000"
+        );
+    }
 }

--- a/crates/cairn-store-sqlite/src/record_wal/locks.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/locks.rs
@@ -18,6 +18,7 @@ impl RecordLocks {
         Self { handles }
     }
 
+    #[allow(clippy::result_large_err)]
     pub(crate) fn assert_live_in_tx(
         &self,
         tx: &rusqlite::Transaction<'_>,
@@ -90,12 +91,16 @@ mod tests {
     #[test]
     fn target_lineage_resource_is_stable_and_scope_independent() {
         let target = TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id");
-        let mut scope_a = ScopeTuple::default();
-        scope_a.tenant = Some("tenant-a".to_owned());
-        scope_a.workspace = Some("workspace-a".to_owned());
-        let mut scope_b = ScopeTuple::default();
-        scope_b.tenant = Some("tenant-b".to_owned());
-        scope_b.workspace = Some("workspace-b".to_owned());
+        let scope_a = ScopeTuple {
+            tenant: Some("tenant-a".to_owned()),
+            workspace: Some("workspace-a".to_owned()),
+            ..ScopeTuple::default()
+        };
+        let scope_b = ScopeTuple {
+            tenant: Some("tenant-b".to_owned()),
+            workspace: Some("workspace-b".to_owned()),
+            ..ScopeTuple::default()
+        };
 
         let resource_a = record_lock_resources(&scope_a, &target)
             .into_iter()

--- a/crates/cairn-store-sqlite/src/record_wal/mod.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/mod.rs
@@ -1,0 +1,21 @@
+//! Body-bearing WAL apply for record upsert and expire operations.
+
+#![allow(
+    dead_code,
+    missing_docs,
+    unused_imports,
+    reason = "Task 3 intentionally lands record WAL scaffolding before later tasks wire callers"
+)]
+
+pub mod payload;
+
+pub(crate) mod expire;
+pub(crate) mod locks;
+pub(crate) mod ops;
+pub(crate) mod recovery;
+pub(crate) mod steps;
+pub(crate) mod upsert;
+
+pub(crate) use expire::apply_expire;
+pub use recovery::RecordWalRegistry;
+pub(crate) use upsert::apply_upsert;

--- a/crates/cairn-store-sqlite/src/record_wal/ops.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/ops.rs
@@ -1,0 +1,52 @@
+//! `wal_ops` issue, prepare, and finalize helpers for record operations.
+
+use cairn_core::wal::{OpState, OperationId, WalKind};
+use rusqlite::{Connection, params};
+
+use crate::error::StoreError;
+use crate::store::current_unix_ms;
+
+pub(crate) fn new_operation_id(kind: WalKind) -> Result<OperationId, StoreError> {
+    let raw = format!("{}-{}", kind.as_str(), ulid::Ulid::new());
+    OperationId::parse(raw).map_err(|e| StoreError::Invariant {
+        what: format!("generated invalid operation id: {e}"),
+    })
+}
+
+pub(crate) fn issue_prepared(
+    conn: &Connection,
+    op_id: &OperationId,
+    kind: WalKind,
+    target_hash: &str,
+    scope_json: &str,
+) -> Result<(), StoreError> {
+    let now = current_unix_ms();
+    conn.execute(
+        "INSERT INTO wal_ops \
+           (operation_id, issued_seq, kind, state, envelope, issuer, principal, \
+            target_hash, scope_json, plan_ref, expires_at, signature, issued_at, updated_at) \
+         VALUES (?1, COALESCE((SELECT MAX(issued_seq) FROM wal_ops), 0) + 1, ?2, \
+            'ISSUED', '{}', 'cairn-store-sqlite', NULL, ?3, ?4, NULL, 0, 'local', ?5, ?5)",
+        params![op_id.as_str(), kind.as_str(), target_hash, scope_json, now],
+    )?;
+    conn.execute(
+        "UPDATE wal_ops SET state = 'PREPARED', updated_at = ?1 WHERE operation_id = ?2",
+        params![now, op_id.as_str()],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn finalize(
+    conn: &Connection,
+    op_id: &OperationId,
+    state: OpState,
+    reason: &str,
+) -> Result<(), StoreError> {
+    let now = current_unix_ms();
+    conn.execute(
+        "UPDATE wal_ops SET state = ?1, reason = COALESCE(reason, ?2), updated_at = ?3 \
+         WHERE operation_id = ?4",
+        params![state.as_str(), reason, now, op_id.as_str()],
+    )?;
+    Ok(())
+}

--- a/crates/cairn-store-sqlite/src/record_wal/payload.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/payload.rs
@@ -1,6 +1,6 @@
 //! Durable JSON payloads for record WAL operations.
 
-use cairn_core::domain::{MemoryRecord, TargetId};
+use cairn_core::domain::{BodyHash, MemoryRecord, RecordId, TargetId};
 use cairn_core::wal::{OperationId, WalKind};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
@@ -31,6 +31,35 @@ pub struct PlannedUpsert {
     pub prior_record_id: Option<String>,
     pub prior_hash: Option<String>,
     pub consent_model: String,
+}
+
+impl PlannedUpsert {
+    pub(crate) fn to_store_plan(&self) -> Result<crate::store::upsert::UpsertPlan, StoreError> {
+        Ok(crate::store::upsert::UpsertPlan {
+            outcome_record_id: RecordId::parse(self.outcome_record_id.clone()).map_err(|e| {
+                StoreError::Invariant {
+                    what: format!("planned record id invalid: {e}"),
+                }
+            })?,
+            target_id: TargetId::parse(self.target_id.clone()).map_err(|e| {
+                StoreError::Invariant {
+                    what: format!("planned target id invalid: {e}"),
+                }
+            })?,
+            version: self.version,
+            content_changed: self.content_changed,
+            prior_record_id: self.prior_record_id.clone(),
+            prior_hash: self
+                .prior_hash
+                .as_ref()
+                .map(BodyHash::parse)
+                .transpose()
+                .map_err(|e| StoreError::Invariant {
+                    what: format!("planned prior hash invalid: {e}"),
+                })?,
+            consent_model: self.consent_model.clone(),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/cairn-store-sqlite/src/record_wal/payload.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/payload.rs
@@ -1,0 +1,136 @@
+//! Durable JSON payloads for record WAL operations.
+
+use cairn_core::domain::{MemoryRecord, TargetId};
+use cairn_core::wal::{OperationId, WalKind};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+
+use crate::error::StoreError;
+use crate::store::current_unix_ms;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RecordWalPayload {
+    Upsert(UpsertPayload),
+    Expire(ExpirePayload),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UpsertPayload {
+    pub record: MemoryRecord,
+    pub embed: StoredEmbedOutcome,
+    pub planned: PlannedUpsert,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PlannedUpsert {
+    pub outcome_record_id: String,
+    pub target_id: String,
+    pub version: u32,
+    pub content_changed: bool,
+    pub prior_record_id: Option<String>,
+    pub prior_hash: Option<String>,
+    pub consent_model: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum StoredEmbedOutcome {
+    Succeeded {
+        vector: Vec<u8>,
+        model_label: String,
+    },
+    Failed {
+        error: String,
+    },
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExpirePayload {
+    pub target_id: TargetId,
+    pub reason: String,
+}
+
+pub(crate) fn save_payload(
+    conn: &Connection,
+    op_id: &OperationId,
+    payload: &RecordWalPayload,
+) -> Result<(), StoreError> {
+    let kind = match payload {
+        RecordWalPayload::Upsert(_) => WalKind::Upsert.as_str(),
+        RecordWalPayload::Expire(_) => WalKind::Expire.as_str(),
+    };
+    let json = serde_json::to_string(payload)?;
+    conn.execute(
+        "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+         VALUES (?1, ?2, ?3, ?4)",
+        params![op_id.as_str(), kind, json, current_unix_ms()],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn load_payload(
+    conn: &Connection,
+    op_id: &OperationId,
+) -> Result<RecordWalPayload, StoreError> {
+    let json: String = conn
+        .query_row(
+            "SELECT payload_json FROM wal_payloads WHERE operation_id = ?1",
+            params![op_id.as_str()],
+            |row| row.get(0),
+        )
+        .optional()?
+        .ok_or_else(|| StoreError::Invariant {
+            what: format!("missing wal_payloads row for operation {}", op_id.as_str()),
+        })?;
+    Ok(serde_json::from_str(&json)?)
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl UpsertPayload {
+    #[must_use]
+    pub fn new_for_test(record: MemoryRecord) -> Self {
+        Self {
+            planned: PlannedUpsert {
+                outcome_record_id: record.id.as_str().to_owned(),
+                target_id: record.target_id.as_str().to_owned(),
+                version: 1,
+                content_changed: true,
+                prior_record_id: None,
+                prior_hash: None,
+                consent_model: "legacy_event".to_owned(),
+            },
+            record,
+            embed: StoredEmbedOutcome::Skipped,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn save_upsert_payload_for_test(
+    conn: &Connection,
+    op_id: &str,
+    payload: &UpsertPayload,
+) -> Result<(), StoreError> {
+    let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
+        what: format!("invalid test op id: {e}"),
+    })?;
+    save_payload(conn, &op, &RecordWalPayload::Upsert(payload.clone()))
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn load_upsert_payload_for_test(
+    conn: &Connection,
+    op_id: &str,
+) -> Result<UpsertPayload, StoreError> {
+    let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
+        what: format!("invalid test op id: {e}"),
+    })?;
+    match load_payload(conn, &op)? {
+        RecordWalPayload::Upsert(payload) => Ok(payload),
+        RecordWalPayload::Expire(_) => Err(StoreError::Invariant {
+            what: "expected upsert payload, found expire payload".to_owned(),
+        }),
+    }
+}

--- a/crates/cairn-store-sqlite/src/record_wal/payload.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/payload.rs
@@ -1,6 +1,6 @@
 //! Durable JSON payloads for record WAL operations.
 
-use cairn_core::domain::{BodyHash, MemoryRecord, RecordId, TargetId};
+use cairn_core::domain::{BodyHash, MemoryRecord, RecordId, ScopeTuple, TargetId};
 use cairn_core::wal::{OperationId, WalKind};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
@@ -79,6 +79,8 @@ pub enum StoredEmbedOutcome {
 pub struct ExpirePayload {
     pub target_id: TargetId,
     pub reason: String,
+    #[serde(default)]
+    pub scope: ScopeTuple,
 }
 
 pub(crate) fn save_payload(

--- a/crates/cairn-store-sqlite/src/record_wal/payload.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/payload.rs
@@ -11,8 +11,8 @@ use crate::store::current_unix_ms;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RecordWalPayload {
-    Upsert(UpsertPayload),
-    Expire(ExpirePayload),
+    Upsert(Box<UpsertPayload>),
+    Expire(Box<ExpirePayload>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -147,7 +147,11 @@ pub fn save_upsert_payload_for_test(
     let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
         what: format!("invalid test op id: {e}"),
     })?;
-    save_payload(conn, &op, &RecordWalPayload::Upsert(payload.clone()))
+    save_payload(
+        conn,
+        &op,
+        &RecordWalPayload::Upsert(Box::new(payload.clone())),
+    )
 }
 
 #[cfg(any(test, feature = "test-helpers"))]
@@ -159,7 +163,7 @@ pub fn load_upsert_payload_for_test(
         what: format!("invalid test op id: {e}"),
     })?;
     match load_payload(conn, &op)? {
-        RecordWalPayload::Upsert(payload) => Ok(payload),
+        RecordWalPayload::Upsert(payload) => Ok(*payload),
         RecordWalPayload::Expire(_) => Err(StoreError::Invariant {
             what: "expected upsert payload, found expire payload".to_owned(),
         }),

--- a/crates/cairn-store-sqlite/src/record_wal/recovery.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/recovery.rs
@@ -37,7 +37,6 @@ impl StepBodyRegistry for RecordWalRegistry {
     ) -> Result<Option<Arc<dyn StepBody>>, RecoveryError> {
         match kind {
             WalKind::Upsert | WalKind::Expire => {}
-            WalKind::ForgetRecord => return Ok(None),
             _ => return Ok(None),
         }
 
@@ -61,7 +60,7 @@ impl StepBodyRegistry for RecordWalRegistry {
                 )
                 .await
                 .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
-                Ok(Some(Arc::new(RecordStepBody::new_upsert(payload, locks))))
+                Ok(Some(Arc::new(RecordStepBody::new_upsert(*payload, locks))))
             }
             (WalKind::Expire, RecordWalPayload::Expire(payload)) => {
                 let locks = acquire_for_record(
@@ -74,7 +73,7 @@ impl StepBodyRegistry for RecordWalRegistry {
                 )
                 .await
                 .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
-                Ok(Some(Arc::new(RecordStepBody::new_expire(payload, locks))))
+                Ok(Some(Arc::new(RecordStepBody::new_expire(*payload, locks))))
             }
             (WalKind::Upsert, RecordWalPayload::Expire(_)) => Err(RecoveryError::Invariant(
                 "record wal payload variant expire does not match wal kind upsert".to_owned(),

--- a/crates/cairn-store-sqlite/src/record_wal/recovery.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/recovery.rs
@@ -2,6 +2,15 @@
 
 use std::sync::Arc;
 
+use cairn_core::domain::ScopeTuple;
+use cairn_core::wal::{OperationId, WalKind};
+use tokio_rusqlite::Connection;
+
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::payload::{RecordWalPayload, load_payload};
+use crate::record_wal::steps::RecordStepBody;
+use crate::wal::{RecoveryError, StepBody, StepBodyRegistry};
+
 #[derive(Debug, Clone)]
 pub struct RecordWalRegistry {
     incarnation: Arc<str>,
@@ -16,5 +25,59 @@ impl RecordWalRegistry {
     #[must_use]
     pub fn incarnation(&self) -> &Arc<str> {
         &self.incarnation
+    }
+}
+
+#[async_trait::async_trait]
+impl StepBodyRegistry for RecordWalRegistry {
+    async fn body_for(
+        &self,
+        conn: &Arc<Connection>,
+        kind: WalKind,
+        op_id: &OperationId,
+    ) -> Result<Option<Arc<dyn StepBody>>, RecoveryError> {
+        match kind {
+            WalKind::Upsert | WalKind::Expire => {}
+            WalKind::ForgetRecord => return Ok(None),
+            _ => return Ok(None),
+        }
+
+        let op_for_load = op_id.clone();
+        let payload = conn
+            .call(move |c| {
+                load_payload(c, &op_for_load).map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+            })
+            .await
+            .map_err(RecoveryError::Storage)?;
+
+        match payload {
+            RecordWalPayload::Upsert(payload) => {
+                let locks = acquire_for_record(
+                    conn,
+                    &payload.record.scope,
+                    &payload.record.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_upsert",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_upsert(payload, locks))))
+            }
+            RecordWalPayload::Expire(payload) => {
+                let scope = ScopeTuple::default();
+                let locks = acquire_for_record(
+                    conn,
+                    &scope,
+                    &payload.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_expire",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_expire(payload, locks))))
+            }
+        }
     }
 }

--- a/crates/cairn-store-sqlite/src/record_wal/recovery.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/recovery.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use cairn_core::domain::ScopeTuple;
 use cairn_core::wal::{OperationId, WalKind};
 use tokio_rusqlite::Connection;
 
@@ -50,8 +49,8 @@ impl StepBodyRegistry for RecordWalRegistry {
             .await
             .map_err(RecoveryError::Storage)?;
 
-        match payload {
-            RecordWalPayload::Upsert(payload) => {
+        match (kind, payload) {
+            (WalKind::Upsert, RecordWalPayload::Upsert(payload)) => {
                 let locks = acquire_for_record(
                     conn,
                     &payload.record.scope,
@@ -64,11 +63,10 @@ impl StepBodyRegistry for RecordWalRegistry {
                 .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
                 Ok(Some(Arc::new(RecordStepBody::new_upsert(payload, locks))))
             }
-            RecordWalPayload::Expire(payload) => {
-                let scope = ScopeTuple::default();
+            (WalKind::Expire, RecordWalPayload::Expire(payload)) => {
                 let locks = acquire_for_record(
                     conn,
-                    &scope,
+                    &payload.scope,
                     &payload.target_id,
                     &self.incarnation,
                     op_id.as_str(),
@@ -78,6 +76,13 @@ impl StepBodyRegistry for RecordWalRegistry {
                 .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
                 Ok(Some(Arc::new(RecordStepBody::new_expire(payload, locks))))
             }
+            (WalKind::Upsert, RecordWalPayload::Expire(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant expire does not match wal kind upsert".to_owned(),
+            )),
+            (WalKind::Expire, RecordWalPayload::Upsert(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant upsert does not match wal kind expire".to_owned(),
+            )),
+            _ => Ok(None),
         }
     }
 }

--- a/crates/cairn-store-sqlite/src/record_wal/recovery.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/recovery.rs
@@ -1,0 +1,20 @@
+//! Record WAL recovery registry.
+
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct RecordWalRegistry {
+    incarnation: Arc<str>,
+}
+
+impl RecordWalRegistry {
+    #[must_use]
+    pub fn new(incarnation: Arc<str>) -> Self {
+        Self { incarnation }
+    }
+
+    #[must_use]
+    pub fn incarnation(&self) -> &Arc<str> {
+        &self.incarnation
+    }
+}

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -1,12 +1,10 @@
 //! Record WAL step bodies.
 
-use cairn_core::domain::RecordId;
 use cairn_core::wal::{OperationId, StepDef};
 use rusqlite::{Transaction, params};
 
 use crate::record_wal::locks::RecordLocks;
 use crate::record_wal::payload::{ExpirePayload, StoredEmbedOutcome, UpsertPayload};
-use crate::store::upsert::upsert_in_tx_with_record_id;
 use crate::wal::runner::{StepBody, StepBodyError};
 
 pub(crate) enum RecordStepPayload {
@@ -33,7 +31,7 @@ impl StepBody for RecordStepBody {
     fn run(
         &self,
         tx: &mut Transaction<'_>,
-        _op_id: &OperationId,
+        op_id: &OperationId,
         step: &StepDef,
     ) -> Result<(), StepBodyError> {
         self.locks
@@ -41,20 +39,70 @@ impl StepBody for RecordStepBody {
             .map_err(|e| StepBodyError::Failed(format!("fenced: {e}")))?;
 
         match (&self.payload, step.name) {
+            (RecordStepPayload::Upsert(payload), "snapshot.stage") => {
+                stage_snapshot(tx, op_id, step, &payload.planned.target_id)
+            }
             (RecordStepPayload::Upsert(payload), "primary.upsert_cow") => {
-                let planned_record_id = RecordId::parse(payload.planned.outcome_record_id.clone())
-                    .map_err(|e| StepBodyError::Failed(format!("planned record_id: {e}")))?;
-                let outcome =
-                    upsert_in_tx_with_record_id(tx, &payload.record, Some(&planned_record_id))
-                        .map_err(|e| StepBodyError::Failed(e.to_string()))?;
-                apply_embed_outcome(tx, outcome.record_id.as_str(), &payload.embed)
+                let plan = payload
+                    .planned
+                    .to_store_plan()
+                    .map_err(|e| StepBodyError::Failed(e.to_string()))?;
+                crate::store::upsert::stage_upsert_cow_in_tx(tx, &payload.record, &plan)
+                    .map_err(|e| StepBodyError::Failed(e.to_string()))?;
+                apply_embed_outcome(tx, plan.outcome_record_id.as_str(), &payload.embed)
                     .map_err(StepBodyError::Storage)?;
                 Ok(())
+            }
+            (RecordStepPayload::Upsert(payload), "primary.activate") => {
+                let plan = payload
+                    .planned
+                    .to_store_plan()
+                    .map_err(|e| StepBodyError::Failed(e.to_string()))?;
+                crate::store::upsert::activate_upsert_in_tx(tx, &plan)
+                    .map_err(|e| StepBodyError::Failed(e.to_string()))
             }
             (RecordStepPayload::Upsert(_), _) => Ok(()),
             (RecordStepPayload::Expire(_), _) => Ok(()),
         }
     }
+}
+
+fn stage_snapshot(
+    tx: &rusqlite::Transaction<'_>,
+    op_id: &OperationId,
+    step: &StepDef,
+    target_id: &str,
+) -> Result<(), StepBodyError> {
+    let rows = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT record_id, version, active, tombstoned, tombstone_reason, body_hash \
+                 FROM records WHERE target_id = ?1 ORDER BY version",
+            )
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(rusqlite::params![target_id], |row| {
+            Ok(serde_json::json!({
+                "record_id": row.get::<_, String>(0)?,
+                "version": row.get::<_, i64>(1)?,
+                "active": row.get::<_, i64>(2)?,
+                "tombstoned": row.get::<_, i64>(3)?,
+                "tombstone_reason": row.get::<_, Option<String>>(4)?,
+                "body_hash": row.get::<_, String>(5)?,
+            }))
+        })
+        .map_err(StepBodyError::Storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StepBodyError::Storage)?
+    };
+    let bytes = serde_json::to_vec(&rows)
+        .map_err(|e| StepBodyError::Failed(format!("snapshot json: {e}")))?;
+    tx.execute(
+        "UPDATE wal_steps SET pre_image = ?1 \
+         WHERE operation_id = ?2 AND step_ord = ?3",
+        rusqlite::params![bytes, op_id.as_str(), step.ord],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
 }
 
 fn apply_embed_outcome(

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -208,8 +208,12 @@ fn upsert_edges(_tx: &Transaction<'_>, _record_id: &str) -> Result<(), StepBodyE
 fn mark_expired(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError> {
     tx.execute(
         "UPDATE records \
-            SET active = 0, tombstoned = 1, tombstone_reason = 'expire', updated_at = ?1 \
-          WHERE target_id = ?2",
+            SET active = 0, \
+                tombstoned = 1, \
+                tombstone_reason = COALESCE(tombstone_reason, 'expire'), \
+                updated_at = ?1 \
+          WHERE target_id = ?2 \
+            AND NOT (active = 0 AND tombstoned = 1 AND tombstone_reason IS NOT NULL)",
         params![crate::store::current_unix_ms(), payload.target_id.as_str()],
     )
     .map_err(StepBodyError::Storage)?;

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -1,11 +1,12 @@
 //! Record WAL step bodies.
 
+use cairn_core::domain::RecordId;
 use cairn_core::wal::{OperationId, StepDef};
 use rusqlite::{Transaction, params};
 
 use crate::record_wal::locks::RecordLocks;
 use crate::record_wal::payload::{ExpirePayload, StoredEmbedOutcome, UpsertPayload};
-use crate::store::upsert::upsert_in_tx;
+use crate::store::upsert::upsert_in_tx_with_record_id;
 use crate::wal::runner::{StepBody, StepBodyError};
 
 pub(crate) enum RecordStepPayload {
@@ -41,8 +42,11 @@ impl StepBody for RecordStepBody {
 
         match (&self.payload, step.name) {
             (RecordStepPayload::Upsert(payload), "primary.upsert_cow") => {
-                let outcome = upsert_in_tx(tx, &payload.record)
-                    .map_err(|e| StepBodyError::Failed(e.to_string()))?;
+                let planned_record_id = RecordId::parse(payload.planned.outcome_record_id.clone())
+                    .map_err(|e| StepBodyError::Failed(format!("planned record_id: {e}")))?;
+                let outcome =
+                    upsert_in_tx_with_record_id(tx, &payload.record, Some(&planned_record_id))
+                        .map_err(|e| StepBodyError::Failed(e.to_string()))?;
                 apply_embed_outcome(tx, outcome.record_id.as_str(), &payload.embed)
                     .map_err(StepBodyError::Storage)?;
                 Ok(())

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -1,0 +1,1 @@
+//! Record WAL step bodies.

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -48,10 +48,16 @@ impl StepBody for RecordStepBody {
                     .to_store_plan()
                     .map_err(|e| StepBodyError::Failed(e.to_string()))?;
                 crate::store::upsert::stage_upsert_cow_in_tx(tx, &payload.record, &plan)
-                    .map_err(|e| StepBodyError::Failed(e.to_string()))?;
-                apply_embed_outcome(tx, plan.outcome_record_id.as_str(), &payload.embed)
-                    .map_err(StepBodyError::Storage)?;
-                Ok(())
+                    .map_err(|e| StepBodyError::Failed(e.to_string()))
+            }
+            (RecordStepPayload::Upsert(payload), "vector.upsert") => {
+                upsert_vector(tx, &payload.planned.outcome_record_id, &payload.embed)
+            }
+            (RecordStepPayload::Upsert(payload), "fts.upsert") => {
+                upsert_fts(tx, &payload.planned.outcome_record_id)
+            }
+            (RecordStepPayload::Upsert(payload), "edges.upsert") => {
+                upsert_edges(tx, &payload.planned.outcome_record_id)
             }
             (RecordStepPayload::Upsert(payload), "primary.activate") => {
                 let plan = payload
@@ -105,11 +111,37 @@ fn stage_snapshot(
     Ok(())
 }
 
-fn apply_embed_outcome(
+fn upsert_fts(tx: &Transaction<'_>, record_id: &str) -> Result<(), StepBodyError> {
+    let row: (i64, String, String, String, String) = tx
+        .query_row(
+            "SELECT rowid, kind, class, scope, body FROM records WHERE record_id = ?1",
+            params![record_id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .map_err(StepBodyError::Storage)?;
+    tx.execute("DELETE FROM records_fts WHERE rowid = ?1", params![row.0])
+        .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "INSERT INTO records_fts(rowid, kind, class, scope, body) VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![row.0, row.1, row.2, row.3, row.4],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn upsert_vector(
     tx: &Transaction<'_>,
     record_id: &str,
     embed: &StoredEmbedOutcome,
-) -> Result<(), rusqlite::Error> {
+) -> Result<(), StepBodyError> {
     match embed {
         StoredEmbedOutcome::Succeeded {
             vector,
@@ -120,16 +152,19 @@ fn apply_embed_outcome(
             tx.execute(
                 "DELETE FROM record_vectors WHERE record_id = ?",
                 params![record_id],
-            )?;
+            )
+            .map_err(StepBodyError::Storage)?;
             tx.execute(
                 "INSERT INTO record_vectors(record_id, embedding, model) \
                    VALUES (?, ?, ?)",
                 params![record_id, vector, model_label],
-            )?;
+            )
+            .map_err(StepBodyError::Storage)?;
             tx.execute(
                 "DELETE FROM pending_embeddings WHERE record_id = ?",
                 params![record_id],
-            )?;
+            )
+            .map_err(StepBodyError::Storage)?;
         }
         StoredEmbedOutcome::Failed { error } => {
             let now_secs = now_secs();
@@ -142,10 +177,15 @@ fn apply_embed_outcome(
                          last_error      = excluded.last_error, \
                          last_attempt_at = ?",
                 params![record_id, error, now_secs, now_secs],
-            )?;
+            )
+            .map_err(StepBodyError::Storage)?;
         }
         StoredEmbedOutcome::Skipped => {}
     }
+    Ok(())
+}
+
+fn upsert_edges(_tx: &Transaction<'_>, _record_id: &str) -> Result<(), StepBodyError> {
     Ok(())
 }
 

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -1,1 +1,104 @@
 //! Record WAL step bodies.
+
+use cairn_core::wal::{OperationId, StepDef};
+use rusqlite::{Transaction, params};
+
+use crate::record_wal::locks::RecordLocks;
+use crate::record_wal::payload::{ExpirePayload, StoredEmbedOutcome, UpsertPayload};
+use crate::store::upsert::upsert_in_tx;
+use crate::wal::runner::{StepBody, StepBodyError};
+
+pub(crate) enum RecordStepPayload {
+    Upsert(UpsertPayload),
+    Expire(ExpirePayload),
+}
+
+pub(crate) struct RecordStepBody {
+    payload: RecordStepPayload,
+    locks: RecordLocks,
+}
+
+impl RecordStepBody {
+    #[must_use]
+    pub(crate) fn new_upsert(payload: UpsertPayload, locks: RecordLocks) -> Self {
+        Self {
+            payload: RecordStepPayload::Upsert(payload),
+            locks,
+        }
+    }
+}
+
+impl StepBody for RecordStepBody {
+    fn run(
+        &self,
+        tx: &mut Transaction<'_>,
+        _op_id: &OperationId,
+        step: &StepDef,
+    ) -> Result<(), StepBodyError> {
+        self.locks
+            .assert_live_in_tx(tx)
+            .map_err(|e| StepBodyError::Failed(format!("fenced: {e}")))?;
+
+        match (&self.payload, step.name) {
+            (RecordStepPayload::Upsert(payload), "primary.upsert_cow") => {
+                let outcome = upsert_in_tx(tx, &payload.record)
+                    .map_err(|e| StepBodyError::Failed(e.to_string()))?;
+                apply_embed_outcome(tx, outcome.record_id.as_str(), &payload.embed)
+                    .map_err(StepBodyError::Storage)?;
+                Ok(())
+            }
+            (RecordStepPayload::Upsert(_), _) => Ok(()),
+            (RecordStepPayload::Expire(_), _) => Ok(()),
+        }
+    }
+}
+
+fn apply_embed_outcome(
+    tx: &Transaction<'_>,
+    record_id: &str,
+    embed: &StoredEmbedOutcome,
+) -> Result<(), rusqlite::Error> {
+    match embed {
+        StoredEmbedOutcome::Succeeded {
+            vector,
+            model_label,
+        } => {
+            // sqlite-vec vec0 virtual tables do not support UPSERT syntax.
+            // DELETE + INSERT keeps replacement atomic with the record row.
+            tx.execute(
+                "DELETE FROM record_vectors WHERE record_id = ?",
+                params![record_id],
+            )?;
+            tx.execute(
+                "INSERT INTO record_vectors(record_id, embedding, model) \
+                   VALUES (?, ?, ?)",
+                params![record_id, vector, model_label],
+            )?;
+            tx.execute(
+                "DELETE FROM pending_embeddings WHERE record_id = ?",
+                params![record_id],
+            )?;
+        }
+        StoredEmbedOutcome::Failed { error } => {
+            let now_secs = now_secs();
+            tx.execute(
+                "INSERT INTO pending_embeddings \
+                     (record_id, reason, attempt_count, last_error, enqueued_at) \
+                   VALUES (?, 'embed_failed', 0, ?, ?) \
+                   ON CONFLICT(record_id) DO UPDATE \
+                     SET attempt_count   = attempt_count + 1, \
+                         last_error      = excluded.last_error, \
+                         last_attempt_at = ?",
+                params![record_id, error, now_secs, now_secs],
+            )?;
+        }
+        StoredEmbedOutcome::Skipped => {}
+    }
+    Ok(())
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
+}

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -173,10 +173,9 @@ fn upsert_vector(
                      (record_id, reason, attempt_count, last_error, enqueued_at) \
                    VALUES (?, 'embed_failed', 0, ?, ?) \
                    ON CONFLICT(record_id) DO UPDATE \
-                     SET attempt_count   = attempt_count + 1, \
-                         last_error      = excluded.last_error, \
-                         last_attempt_at = ?",
-                params![record_id, error, now_secs, now_secs],
+                     SET last_error  = excluded.last_error, \
+                         enqueued_at = COALESCE(pending_embeddings.enqueued_at, excluded.enqueued_at)",
+                params![record_id, error, now_secs],
             )
             .map_err(StepBodyError::Storage)?;
         }
@@ -193,4 +192,38 @@ fn now_secs() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_vector_upsert_replay_does_not_increment_attempt_count() {
+        let mut conn = crate::open::open_in_memory_sync().expect("open");
+        let tx = conn.transaction().expect("tx");
+        let record = cairn_core::domain::record::tests_export::sample_record();
+        let plan = crate::store::upsert::plan_upsert_in_tx(&tx, &record).expect("plan");
+        crate::store::upsert::stage_upsert_cow_in_tx(&tx, &record, &plan).expect("stage");
+
+        let failed = StoredEmbedOutcome::Failed {
+            error: "embed unavailable".to_owned(),
+        };
+        upsert_vector(&tx, plan.outcome_record_id.as_str(), &failed).expect("first vector upsert");
+        upsert_vector(&tx, plan.outcome_record_id.as_str(), &failed)
+            .expect("replayed vector upsert");
+
+        let row: (i64, String, Option<i64>) = tx
+            .query_row(
+                "SELECT attempt_count, last_error, last_attempt_at \
+                 FROM pending_embeddings WHERE record_id = ?1",
+                params![plan.outcome_record_id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("pending row");
+
+        assert_eq!(row.0, 0);
+        assert_eq!(row.1, "embed unavailable");
+        assert_eq!(row.2, None);
+    }
 }

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -25,6 +25,14 @@ impl RecordStepBody {
             locks,
         }
     }
+
+    #[must_use]
+    pub(crate) fn new_expire(payload: ExpirePayload, locks: RecordLocks) -> Self {
+        Self {
+            payload: RecordStepPayload::Expire(payload),
+            locks,
+        }
+    }
 }
 
 impl StepBody for RecordStepBody {
@@ -67,6 +75,15 @@ impl StepBody for RecordStepBody {
                 crate::store::upsert::activate_upsert_in_tx(tx, &plan)
                     .map_err(|e| StepBodyError::Failed(e.to_string()))
             }
+            (RecordStepPayload::Expire(payload), "snapshot.stage") => {
+                stage_snapshot(tx, op_id, step, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Expire(payload), "primary.mark_expired") => {
+                mark_expired(tx, payload)
+            }
+            (RecordStepPayload::Expire(payload), "vector.drain") => drain_vectors(tx, payload),
+            (RecordStepPayload::Expire(payload), "fts.drain") => drain_fts(tx, payload),
+            (RecordStepPayload::Expire(payload), "edges.drain") => drain_edges(tx, payload),
             (RecordStepPayload::Upsert(_), _) => Ok(()),
             (RecordStepPayload::Expire(_), _) => Ok(()),
         }
@@ -185,6 +202,63 @@ fn upsert_vector(
 }
 
 fn upsert_edges(_tx: &Transaction<'_>, _record_id: &str) -> Result<(), StepBodyError> {
+    Ok(())
+}
+
+fn mark_expired(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError> {
+    tx.execute(
+        "UPDATE records \
+            SET active = 0, tombstoned = 1, tombstone_reason = 'expire', updated_at = ?1 \
+          WHERE target_id = ?2",
+        params![crate::store::current_unix_ms(), payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn drain_vectors(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM record_vectors \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM pending_embeddings \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn drain_fts(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError> {
+    let rowids = {
+        let mut stmt = tx
+            .prepare("SELECT rowid FROM records WHERE target_id = ?1")
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(params![payload.target_id.as_str()], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(StepBodyError::Storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StepBodyError::Storage)?
+    };
+    for rowid in rowids {
+        tx.execute("DELETE FROM records_fts WHERE rowid = ?1", params![rowid])
+            .map_err(StepBodyError::Storage)?;
+    }
+    Ok(())
+}
+
+fn drain_edges(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM edges \
+          WHERE src IN (SELECT record_id FROM records WHERE target_id = ?1) \
+             OR dst IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
     Ok(())
 }
 

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -8,8 +8,8 @@ use crate::record_wal::payload::{ExpirePayload, StoredEmbedOutcome, UpsertPayloa
 use crate::wal::runner::{StepBody, StepBodyError};
 
 pub(crate) enum RecordStepPayload {
-    Upsert(UpsertPayload),
-    Expire(ExpirePayload),
+    Upsert(Box<UpsertPayload>),
+    Expire(Box<ExpirePayload>),
 }
 
 pub(crate) struct RecordStepBody {
@@ -21,7 +21,7 @@ impl RecordStepBody {
     #[must_use]
     pub(crate) fn new_upsert(payload: UpsertPayload, locks: RecordLocks) -> Self {
         Self {
-            payload: RecordStepPayload::Upsert(payload),
+            payload: RecordStepPayload::Upsert(Box::new(payload)),
             locks,
         }
     }
@@ -29,7 +29,7 @@ impl RecordStepBody {
     #[must_use]
     pub(crate) fn new_expire(payload: ExpirePayload, locks: RecordLocks) -> Self {
         Self {
-            payload: RecordStepPayload::Expire(payload),
+            payload: RecordStepPayload::Expire(Box::new(payload)),
             locks,
         }
     }
@@ -65,7 +65,8 @@ impl StepBody for RecordStepBody {
                 upsert_fts(tx, &payload.planned.outcome_record_id)
             }
             (RecordStepPayload::Upsert(payload), "edges.upsert") => {
-                upsert_edges(tx, &payload.planned.outcome_record_id)
+                upsert_edges(tx, &payload.planned.outcome_record_id);
+                Ok(())
             }
             (RecordStepPayload::Upsert(payload), "primary.activate") => {
                 let plan = payload
@@ -84,8 +85,7 @@ impl StepBody for RecordStepBody {
             (RecordStepPayload::Expire(payload), "vector.drain") => drain_vectors(tx, payload),
             (RecordStepPayload::Expire(payload), "fts.drain") => drain_fts(tx, payload),
             (RecordStepPayload::Expire(payload), "edges.drain") => drain_edges(tx, payload),
-            (RecordStepPayload::Upsert(_), _) => Ok(()),
-            (RecordStepPayload::Expire(_), _) => Ok(()),
+            (RecordStepPayload::Upsert(_) | RecordStepPayload::Expire(_), _) => Ok(()),
         }
     }
 }
@@ -201,9 +201,7 @@ fn upsert_vector(
     Ok(())
 }
 
-fn upsert_edges(_tx: &Transaction<'_>, _record_id: &str) -> Result<(), StepBodyError> {
-    Ok(())
-}
+fn upsert_edges(_tx: &Transaction<'_>, _record_id: &str) {}
 
 fn mark_expired(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError> {
     tx.execute(

--- a/crates/cairn-store-sqlite/src/record_wal/upsert.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/upsert.rs
@@ -14,7 +14,7 @@ use crate::record_wal::payload::{
 };
 use crate::record_wal::steps::RecordStepBody;
 use crate::store::SqliteMemoryStore;
-use crate::store::upsert::upsert_in_tx;
+use crate::store::upsert::plan_upsert_in_tx;
 use crate::wal::runner::{self, StepBody};
 
 pub(crate) async fn apply_upsert(
@@ -43,17 +43,17 @@ pub(crate) async fn apply_upsert(
     let planned = conn
         .call(move |c| {
             let mut tx = c.transaction()?;
-            let out = upsert_in_tx(&mut tx, &record_for_plan)
+            let plan = plan_upsert_in_tx(&mut tx, &record_for_plan)
                 .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
             tx.rollback()?;
             Ok::<_, tokio_rusqlite::Error>(PlannedUpsert {
-                outcome_record_id: out.record_id.as_str().to_owned(),
-                target_id: out.target_id.as_str().to_owned(),
-                version: out.version,
-                content_changed: out.content_changed,
-                prior_record_id: None,
-                prior_hash: out.prior_hash.map(|h| h.to_string()),
-                consent_model: "legacy_event".to_owned(),
+                outcome_record_id: plan.outcome.record_id.as_str().to_owned(),
+                target_id: plan.outcome.target_id.as_str().to_owned(),
+                version: plan.outcome.version,
+                content_changed: plan.outcome.content_changed,
+                prior_record_id: plan.prior_record_id,
+                prior_hash: plan.outcome.prior_hash.map(|h| h.to_string()),
+                consent_model: plan.consent_model,
             })
         })
         .await?;

--- a/crates/cairn-store-sqlite/src/record_wal/upsert.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/upsert.rs
@@ -42,17 +42,17 @@ pub(crate) async fn apply_upsert(
     let record_for_payload = record.clone();
     let planned = conn
         .call(move |c| {
-            let mut tx = c.transaction()?;
-            let plan = plan_upsert_in_tx(&mut tx, &record_for_plan)
+            let tx = c.transaction()?;
+            let plan = plan_upsert_in_tx(&tx, &record_for_plan)
                 .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
             tx.rollback()?;
             Ok::<_, tokio_rusqlite::Error>(PlannedUpsert {
-                outcome_record_id: plan.outcome.record_id.as_str().to_owned(),
-                target_id: plan.outcome.target_id.as_str().to_owned(),
-                version: plan.outcome.version,
-                content_changed: plan.outcome.content_changed,
+                outcome_record_id: plan.outcome_record_id.as_str().to_owned(),
+                target_id: plan.target_id.as_str().to_owned(),
+                version: plan.version,
+                content_changed: plan.content_changed,
                 prior_record_id: plan.prior_record_id,
-                prior_hash: plan.outcome.prior_hash.map(|h| h.to_string()),
+                prior_hash: plan.prior_hash.map(|h| h.to_string()),
                 consent_model: plan.consent_model,
             })
         })

--- a/crates/cairn-store-sqlite/src/record_wal/upsert.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/upsert.rs
@@ -1,0 +1,9 @@
+//! Public upsert apply through record WAL.
+
+use crate::error::StoreError;
+
+pub(crate) fn apply_upsert() -> Result<(), StoreError> {
+    Err(StoreError::Invariant {
+        what: "record WAL upsert apply is not implemented yet".to_owned(),
+    })
+}

--- a/crates/cairn-store-sqlite/src/record_wal/upsert.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/upsert.rs
@@ -78,7 +78,7 @@ pub(crate) async fn apply_upsert(
         save_payload(
             &tx,
             &op_for_issue,
-            &RecordWalPayload::Upsert(payload_for_body),
+            &RecordWalPayload::Upsert(Box::new(payload_for_body)),
         )
         .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
         tx.commit()?;

--- a/crates/cairn-store-sqlite/src/record_wal/upsert.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/upsert.rs
@@ -1,9 +1,118 @@
 //! Public upsert apply through record WAL.
 
-use crate::error::StoreError;
+use std::sync::Arc;
 
-pub(crate) fn apply_upsert() -> Result<(), StoreError> {
-    Err(StoreError::Invariant {
-        what: "record WAL upsert apply is not implemented yet".to_owned(),
+use cairn_core::contract::memory_store::UpsertOutcome;
+use cairn_core::domain::{BodyHash, MemoryRecord, RecordId};
+use cairn_core::wal::{OpState, WalKind, graph_for};
+
+use crate::error::StoreError;
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::ops::{finalize, issue_prepared, new_operation_id};
+use crate::record_wal::payload::{
+    PlannedUpsert, RecordWalPayload, StoredEmbedOutcome, UpsertPayload, save_payload,
+};
+use crate::record_wal::steps::RecordStepBody;
+use crate::store::SqliteMemoryStore;
+use crate::store::upsert::upsert_in_tx;
+use crate::wal::runner::{self, StepBody};
+
+pub(crate) async fn apply_upsert(
+    store: &SqliteMemoryStore,
+    record: &MemoryRecord,
+    embed: StoredEmbedOutcome,
+) -> Result<UpsertOutcome, StoreError> {
+    let conn = Arc::clone(store.require_conn("upsert")?);
+    let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
+        what: "upsert requires daemon incarnation".to_owned(),
+    })?;
+    let op_id = new_operation_id(WalKind::Upsert)?;
+    let locks = acquire_for_record(
+        &conn,
+        &record.scope,
+        &record.target_id,
+        &incarnation,
+        op_id.as_str(),
+        "record_wal_upsert",
+    )
+    .await
+    .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
+
+    let record_for_plan = record.clone();
+    let record_for_payload = record.clone();
+    let planned = conn
+        .call(move |c| {
+            let mut tx = c.transaction()?;
+            let out = upsert_in_tx(&mut tx, &record_for_plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            tx.rollback()?;
+            Ok::<_, tokio_rusqlite::Error>(PlannedUpsert {
+                outcome_record_id: out.record_id.as_str().to_owned(),
+                target_id: out.target_id.as_str().to_owned(),
+                version: out.version,
+                content_changed: out.content_changed,
+                prior_record_id: None,
+                prior_hash: out.prior_hash.map(|h| h.to_string()),
+                consent_model: "legacy_event".to_owned(),
+            })
+        })
+        .await?;
+
+    let payload = UpsertPayload {
+        record: record_for_payload,
+        embed,
+        planned,
+    };
+    let payload_for_body = payload.clone();
+    let op_for_issue = op_id.clone();
+    conn.call(move |c| {
+        let tx = c.transaction()?;
+        issue_prepared(
+            &tx,
+            &op_for_issue,
+            WalKind::Upsert,
+            &payload_for_body.planned.target_id,
+            "{}",
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        save_payload(
+            &tx,
+            &op_for_issue,
+            &RecordWalPayload::Upsert(payload_for_body),
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        tx.commit()?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+
+    let planned_for_outcome = payload.planned.clone();
+    let body: Arc<dyn StepBody> = Arc::new(RecordStepBody::new_upsert(payload, locks));
+    runner::run_from(&conn, graph_for(WalKind::Upsert), &op_id, 0, body).await?;
+
+    let op_for_finalize = op_id.clone();
+    conn.call(move |c| {
+        finalize(c, &op_for_finalize, OpState::Committed, "applied")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+
+    Ok(UpsertOutcome {
+        record_id: RecordId::parse(planned_for_outcome.outcome_record_id.clone()).map_err(|e| {
+            StoreError::Invariant {
+                what: format!("planned record_id invalid: {e}"),
+            }
+        })?,
+        target_id: record.target_id.clone(),
+        version: planned_for_outcome.version,
+        content_changed: planned_for_outcome.content_changed,
+        prior_hash: planned_for_outcome
+            .prior_hash
+            .map(BodyHash::parse)
+            .transpose()
+            .map_err(|e| StoreError::Invariant {
+                what: format!("planned prior_hash invalid: {e}"),
+            })?,
     })
 }

--- a/crates/cairn-store-sqlite/src/store/expire.rs
+++ b/crates/cairn-store-sqlite/src/store/expire.rs
@@ -1,0 +1,26 @@
+//! Concrete expire API for target-level soft retirement.
+
+use cairn_core::domain::TargetId;
+use tracing::instrument;
+
+use crate::error::StoreError;
+use crate::store::SqliteMemoryStore;
+
+impl SqliteMemoryStore {
+    /// Soft-expire every version in a target lineage through WAL.
+    ///
+    /// Expire removes the target from default read and search results by
+    /// setting `active = 0`, `tombstoned = 1`, and
+    /// `tombstone_reason = 'expire'`. It does not physically delete rows.
+    ///
+    /// # Errors
+    ///
+    /// Returns store, lock, WAL runner, or recovery-shape errors.
+    #[instrument(skip(self), err, fields(verb = "expire", target_id = %target.as_str()))]
+    pub async fn expire(&self, target: &TargetId) -> Result<(), StoreError> {
+        if self.conn.is_none() {
+            return Err(StoreError::NotInitialized { method: "expire" });
+        }
+        crate::record_wal::apply_expire(self, target).await
+    }
+}

--- a/crates/cairn-store-sqlite/src/store/mod.rs
+++ b/crates/cairn-store-sqlite/src/store/mod.rs
@@ -1,6 +1,7 @@
 //! `SqliteMemoryStore` impl modules.
 
 pub(crate) mod edges;
+pub(crate) mod expire;
 pub(crate) mod graph_search;
 pub(crate) mod hybrid;
 pub(crate) mod projection;

--- a/crates/cairn-store-sqlite/src/store/read.rs
+++ b/crates/cairn-store-sqlite/src/store/read.rs
@@ -41,8 +41,9 @@ impl SqliteMemoryStore {
     /// Inherent `get` implementation; the trait method
     /// [`MemoryStore::get`] guards `self.conn` then delegates here.
     ///
-    /// Tombstoned rows are filtered at the SQL boundary (`tombstoned = 0`)
-    /// so callers see `Ok(None)` for both missing and soft-deleted rows.
+    /// Tombstoned and internal COW staging rows are filtered at the SQL
+    /// boundary so callers see `Ok(None)` for missing, soft-deleted, and
+    /// not-yet-activated rows.
     ///
     /// [`MemoryStore::get`]: cairn_core::contract::memory_store::MemoryStore::get
     ///
@@ -65,7 +66,7 @@ impl SqliteMemoryStore {
                 let row: Option<(String, String)> = c
                     .query_row(
                         "SELECT record_json, consent_model FROM records \
-                          WHERE record_id = ?1 AND tombstoned = 0",
+                          WHERE record_id = ?1 AND tombstoned = 0 AND cow_staged = 0",
                         params![key],
                         |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
                     )
@@ -194,9 +195,10 @@ impl SqliteMemoryStore {
     /// Inherent `versions` implementation; the trait method
     /// [`MemoryStore::versions`] guards `self.conn` then delegates here.
     ///
-    /// Returns the full per-target history ordered `version ASC` (oldest
-    /// first). Includes both active and inactive rows AND tombstoned rows;
-    /// the contract requires audit-grade visibility for the lifecycle
+    /// Returns the committed per-target history ordered `version ASC` (oldest
+    /// first). Includes both active and inactive rows AND tombstoned rows,
+    /// but excludes internal COW staging rows until activation commits them;
+    /// the contract requires audit-grade visibility for committed lifecycle
     /// workflows (brief §10).
     ///
     /// [`MemoryStore::versions`]: cairn_core::contract::memory_store::MemoryStore::versions
@@ -226,7 +228,9 @@ impl SqliteMemoryStore {
                     "SELECT record_id, target_id, version, created_at, updated_at, \
                             active, tombstoned, tombstone_reason, body_hash, \
                             schema_version_major, schema_version_minor \
-                       FROM records WHERE target_id = ?1 ORDER BY version ASC",
+                       FROM records \
+                      WHERE target_id = ?1 AND cow_staged = 0 \
+                      ORDER BY version ASC",
                 )?;
                 let rows = stmt
                     .query_map(params![key], |row| {
@@ -449,7 +453,7 @@ fn build_list_query(
 ) -> Result<(String, Vec<rusqlite::types::Value>), StoreError> {
     let mut sql = String::from(
         "SELECT record_json, updated_at, record_id, consent_model FROM records \
-          WHERE active = 1 AND tombstoned = 0",
+          WHERE active = 1 AND tombstoned = 0 AND cow_staged = 0",
     );
     let mut p: Vec<rusqlite::types::Value> = Vec::new();
     if let Some(k) = kind {

--- a/crates/cairn-store-sqlite/src/store/search.rs
+++ b/crates/cairn-store-sqlite/src/store/search.rs
@@ -404,6 +404,7 @@ fn build_search_query(
          ) fts ON fts.rowid = r.rowid \
          WHERE r.active = 1 \
            AND r.tombstoned = 0 \
+           AND r.cow_staged = 0 \
            AND ",
     );
     sql.push_str(SUPERSESSION_NOT_EXISTS_CLAUSE);
@@ -700,7 +701,7 @@ async fn run_ann_query(
                   LIMIT {k}
              ) ann
              JOIN   records r ON r.record_id = ann.record_id
-             WHERE  r.active = 1 AND r.tombstoned = 0
+             WHERE  r.active = 1 AND r.tombstoned = 0 AND r.cow_staged = 0
                {vis_clause}
                {filter_clause}{scope_sql}
              ORDER BY ann.distance ASC"

--- a/crates/cairn-store-sqlite/src/store/upsert.rs
+++ b/crates/cairn-store-sqlite/src/store/upsert.rs
@@ -284,6 +284,26 @@ pub(crate) fn activate_upsert_in_tx(
         return Ok(());
     }
     let now_ms = current_unix_ms();
+    let staged_count: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM records \
+          WHERE record_id = ?1 AND target_id = ?2 AND version = ?3",
+        params![
+            plan.outcome_record_id.as_str(),
+            plan.target_id.as_str(),
+            i64::from(plan.version),
+        ],
+        |row| row.get(0),
+    )?;
+    if staged_count != 1 {
+        return Err(StoreError::Invariant {
+            what: format!(
+                "planned upsert row missing before activation: record_id={} target_id={} version={}",
+                plan.outcome_record_id.as_str(),
+                plan.target_id.as_str(),
+                plan.version
+            ),
+        });
+    }
     tx.execute(
         "UPDATE records SET active = 0, updated_at = ?1 \
           WHERE target_id = ?2 AND active = 1 AND record_id != ?3",
@@ -293,11 +313,26 @@ pub(crate) fn activate_upsert_in_tx(
             plan.outcome_record_id.as_str()
         ],
     )?;
-    tx.execute(
+    let activated = tx.execute(
         "UPDATE records SET active = 1, tombstoned = 0, updated_at = ?1 \
-          WHERE record_id = ?2",
-        params![now_ms, plan.outcome_record_id.as_str()],
+          WHERE record_id = ?2 AND target_id = ?3 AND version = ?4",
+        params![
+            now_ms,
+            plan.outcome_record_id.as_str(),
+            plan.target_id.as_str(),
+            i64::from(plan.version),
+        ],
     )?;
+    if activated != 1 {
+        return Err(StoreError::Invariant {
+            what: format!(
+                "planned upsert activation affected {activated} rows for record_id={} target_id={} version={}",
+                plan.outcome_record_id.as_str(),
+                plan.target_id.as_str(),
+                plan.version
+            ),
+        });
+    }
     Ok(())
 }
 
@@ -470,8 +505,8 @@ fn insert_row_with_active(
             });
         }
     };
-    tx.execute(
-        "INSERT INTO records ( \
+    let inserted = tx.execute(
+        "INSERT OR IGNORE INTO records ( \
             record_id, target_id, version, path, kind, class, visibility, \
             scope, actor_chain, body, body_hash, created_at, updated_at, \
             active, tombstoned, is_static, record_json, confidence, \
@@ -480,9 +515,7 @@ fn insert_row_with_active(
          ) VALUES ( \
             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, \
             ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24 \
-         ) \
-         ON CONFLICT(record_id) DO UPDATE SET \
-            updated_at = excluded.updated_at",
+         )",
         params![
             row.record_id,
             row.target_id,
@@ -510,7 +543,73 @@ fn insert_row_with_active(
             row.schema_version_minor,
         ],
     )?;
+    if inserted == 0 {
+        validate_existing_staged_row(
+            tx,
+            &row.record_id,
+            &row.target_id,
+            version,
+            body_hash,
+            active,
+        )?;
+    }
     Ok(())
+}
+
+fn validate_existing_staged_row(
+    tx: &Transaction<'_>,
+    record_id: &str,
+    target_id: &str,
+    version: u32,
+    body_hash: &BodyHash,
+    active: bool,
+) -> Result<(), StoreError> {
+    let existing = tx
+        .query_row(
+            "SELECT target_id, version, body_hash, active, tombstoned \
+               FROM records WHERE record_id = ?1",
+            params![record_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            },
+        )
+        .map(Some)
+        .or_else(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other),
+        })?;
+    let expected_active = if active { 1 } else { 0 };
+    match existing {
+        Some((existing_target, existing_version, existing_hash, existing_active, tombstoned))
+            if existing_target == target_id
+                && existing_version == i64::from(version)
+                && existing_hash == body_hash.as_str()
+                && existing_active == expected_active
+                && tombstoned == 0 =>
+        {
+            Ok(())
+        }
+        Some((existing_target, existing_version, existing_hash, existing_active, tombstoned)) => {
+            Err(StoreError::Invariant {
+                what: format!(
+                    "record_id conflict while staging upsert: record_id={record_id} \
+                     existing target_id={existing_target} version={existing_version} \
+                     body_hash={existing_hash} active={existing_active} tombstoned={tombstoned}; \
+                     planned target_id={target_id} version={version} body_hash={} active={expected_active}",
+                    body_hash.as_str()
+                ),
+            })
+        }
+        None => Err(StoreError::Invariant {
+            what: format!("staged upsert insert ignored without existing record_id={record_id}"),
+        }),
+    }
 }
 
 /// Mint a fresh ULID as a [`RecordId`]. Used by the body-changed branch of
@@ -944,6 +1043,34 @@ mod cow_tests {
         })
         .await
         .expect("cow stage");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cow_stage_allows_replay_of_same_inactive_row() {
+        let store = open_in_memory().await.expect("open");
+        let conn = store.require_conn("test").expect("connected").clone();
+        let record = sample_record();
+
+        conn.call(move |c| {
+            let tx = c.transaction()?;
+            let plan = plan_upsert_in_tx(&tx, &record)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            stage_upsert_cow_in_tx(&tx, &record, &plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            stage_upsert_cow_in_tx(&tx, &record, &plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let (count, active): (i64, i64) = tx.query_row(
+                "SELECT COUNT(*), COALESCE(MAX(active), 0) FROM records WHERE record_id = ?1",
+                rusqlite::params![plan.outcome_record_id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?;
+            assert_eq!(count, 1);
+            assert_eq!(active, 0);
+            tx.rollback()?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("cow replay");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/cairn-store-sqlite/src/store/upsert.rs
+++ b/crates/cairn-store-sqlite/src/store/upsert.rs
@@ -589,9 +589,9 @@ fn validate_existing_staged_row(
             rusqlite::Error::QueryReturnedNoRows => Ok(None),
             other => Err(other),
         })?;
-    let expected_active = if active { 1 } else { 0 };
+    let expected_active = i64::from(active);
     let expected_tombstoned = 0;
-    let expected_cow_staged = if active { 0 } else { 1 };
+    let expected_cow_staged = i64::from(!active);
     match existing {
         Some((
             existing_target,

--- a/crates/cairn-store-sqlite/src/store/upsert.rs
+++ b/crates/cairn-store-sqlite/src/store/upsert.rs
@@ -509,7 +509,7 @@ fn insert_row_with_active(
         }
     };
     let inserted = tx.execute(
-        "INSERT OR IGNORE INTO records ( \
+        "INSERT INTO records ( \
             record_id, target_id, version, path, kind, class, visibility, \
             scope, actor_chain, body, body_hash, created_at, updated_at, \
             active, tombstoned, cow_staged, is_static, record_json, confidence, \
@@ -518,7 +518,7 @@ fn insert_row_with_active(
          ) VALUES ( \
             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, \
             ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25 \
-         )",
+         ) ON CONFLICT(record_id) DO NOTHING",
         params![
             row.record_id,
             row.target_id,

--- a/crates/cairn-store-sqlite/src/store/upsert.rs
+++ b/crates/cairn-store-sqlite/src/store/upsert.rs
@@ -30,7 +30,7 @@ use crate::store::projection::{ProjectedRow, body_hash_from_str};
 use crate::store::{SqliteMemoryStore, current_unix_ms};
 
 /// Outcome of the pre-transaction embedding step.
-enum EmbedOutcome {
+pub(crate) enum EmbedOutcome {
     /// Embedding computed successfully. Contains LE bytes + model label.
     Succeeded {
         vector: Vec<u8>,
@@ -40,6 +40,22 @@ enum EmbedOutcome {
     Failed { error: String },
     /// No embedder configured; skip vector entirely.
     Skipped,
+}
+
+impl From<EmbedOutcome> for crate::record_wal::payload::StoredEmbedOutcome {
+    fn from(value: EmbedOutcome) -> Self {
+        match value {
+            EmbedOutcome::Succeeded {
+                vector,
+                model_label,
+            } => Self::Succeeded {
+                vector,
+                model_label,
+            },
+            EmbedOutcome::Failed { error } => Self::Failed { error },
+            EmbedOutcome::Skipped => Self::Skipped,
+        }
+    }
 }
 
 /// Active-row tuple as read out of the `records` table:
@@ -83,7 +99,6 @@ impl SqliteMemoryStore {
         // typed `StoreError::InvalidRecord` rather than getting wrapped in
         // `StoreError::Worker(Other(_))` by the `tokio_rusqlite` worker.
         record.validate()?;
-        let conn = self.require_conn("upsert")?.clone();
 
         // 1. Compute embedding outside the SQL transaction (CPU-bound, may be slow).
         //    This keeps the transaction short and avoids holding DB locks during
@@ -121,61 +136,8 @@ impl SqliteMemoryStore {
             EmbedOutcome::Skipped
         };
 
-        let record = record.clone();
-        let outcome = conn
-            .call(move |c| {
-                let mut tx = c.transaction()?;
-                let upsert_outcome = upsert_in_tx(&mut tx, &record)
-                    .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-
-                let rid = upsert_outcome.record_id.as_str();
-                let now_secs = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
-
-                match &embed_outcome {
-                    EmbedOutcome::Succeeded {
-                        vector,
-                        model_label,
-                    } => {
-                        // sqlite-vec vec0 virtual tables do not support UPSERT syntax.
-                        // Use DELETE + INSERT to replace an existing row atomically.
-                        tx.execute(
-                            "DELETE FROM record_vectors WHERE record_id = ?",
-                            params![rid],
-                        )?;
-                        tx.execute(
-                            "INSERT INTO record_vectors(record_id, embedding, model) \
-                               VALUES (?, ?, ?)",
-                            params![rid, vector, model_label],
-                        )?;
-                        // Clear any pending entry (no-op if none exists).
-                        tx.execute(
-                            "DELETE FROM pending_embeddings WHERE record_id = ?",
-                            params![rid],
-                        )?;
-                    }
-                    EmbedOutcome::Failed { error } => {
-                        tx.execute(
-                            "INSERT INTO pending_embeddings \
-                                 (record_id, reason, attempt_count, last_error, enqueued_at) \
-                               VALUES (?, 'embed_failed', 0, ?, ?) \
-                               ON CONFLICT(record_id) DO UPDATE \
-                                 SET attempt_count   = attempt_count + 1, \
-                                     last_error      = excluded.last_error, \
-                                     last_attempt_at = ?",
-                            params![rid, error, now_secs, now_secs],
-                        )?;
-                    }
-                    EmbedOutcome::Skipped => {}
-                }
-
-                tx.commit()?;
-                Ok::<_, tokio_rusqlite::Error>(upsert_outcome)
-            })
-            .await?;
-
-        Ok(outcome)
+        let payload_embed = crate::record_wal::payload::StoredEmbedOutcome::from(embed_outcome);
+        crate::record_wal::apply_upsert(self, record, payload_embed).await
     }
 }
 

--- a/crates/cairn-store-sqlite/src/store/upsert.rs
+++ b/crates/cairn-store-sqlite/src/store/upsert.rs
@@ -314,7 +314,7 @@ pub(crate) fn activate_upsert_in_tx(
         ],
     )?;
     let activated = tx.execute(
-        "UPDATE records SET active = 1, tombstoned = 0, updated_at = ?1 \
+        "UPDATE records SET active = 1, tombstoned = 0, cow_staged = 0, updated_at = ?1 \
           WHERE record_id = ?2 AND target_id = ?3 AND version = ?4",
         params![
             now_ms,
@@ -475,9 +475,9 @@ fn next_version(prior_version: i64) -> Result<u32, StoreError> {
 }
 
 /// Project + insert one new version row. Inactive inserts are pre-activation
-/// COW staging rows, so they stay tombstoned until activation clears the flag.
-/// The caller is responsible for having deactivated any prior active row in
-/// the same transaction.
+/// COW staging rows, so they carry `cow_staged = 1` until activation clears
+/// the internal marker. The caller is responsible for having deactivated any
+/// prior active row in the same transaction.
 fn insert_row_with_active(
     tx: &Transaction<'_>,
     record: &MemoryRecord,
@@ -492,10 +492,9 @@ fn insert_row_with_active(
     // silently-downgraded `legacy_event` rewrite. This mirrors the
     // strict parse in `upsert_in_tx` for prior rows.
     let _: cairn_core::domain::consent_timeline::ConsentModel = parse_consent_model(consent_model)?;
-    let tombstoned = !active;
-    let mut row = ProjectedRow::from_record(
-        record, version, now_ms, now_ms, body_hash, active, tombstoned,
-    )?;
+    let cow_staged = !active;
+    let mut row =
+        ProjectedRow::from_record(record, version, now_ms, now_ms, body_hash, active, false)?;
     // Caller-supplied consent_model overrides the Phase-A default in
     // `from_record` so supersession preserves the prior row's value.
     row.consent_model = match consent_model {
@@ -513,12 +512,12 @@ fn insert_row_with_active(
         "INSERT OR IGNORE INTO records ( \
             record_id, target_id, version, path, kind, class, visibility, \
             scope, actor_chain, body, body_hash, created_at, updated_at, \
-            active, tombstoned, is_static, record_json, confidence, \
+            active, tombstoned, cow_staged, is_static, record_json, confidence, \
             salience, target_id_explicit, tags_json, consent_model, \
             schema_version_major, schema_version_minor \
          ) VALUES ( \
             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, \
-            ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24 \
+            ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25 \
          )",
         params![
             row.record_id,
@@ -536,6 +535,7 @@ fn insert_row_with_active(
             row.updated_at,
             row.active,
             row.tombstoned,
+            cow_staged,
             row.is_static,
             row.record_json,
             row.confidence,
@@ -570,7 +570,7 @@ fn validate_existing_staged_row(
 ) -> Result<(), StoreError> {
     let existing = tx
         .query_row(
-            "SELECT target_id, version, body_hash, active, tombstoned \
+            "SELECT target_id, version, body_hash, active, tombstoned, cow_staged \
                FROM records WHERE record_id = ?1",
             params![record_id],
             |row| {
@@ -580,6 +580,7 @@ fn validate_existing_staged_row(
                     row.get::<_, String>(2)?,
                     row.get::<_, i64>(3)?,
                     row.get::<_, i64>(4)?,
+                    row.get::<_, i64>(5)?,
                 ))
             },
         )
@@ -589,29 +590,44 @@ fn validate_existing_staged_row(
             other => Err(other),
         })?;
     let expected_active = if active { 1 } else { 0 };
-    let expected_tombstoned = if active { 0 } else { 1 };
+    let expected_tombstoned = 0;
+    let expected_cow_staged = if active { 0 } else { 1 };
     match existing {
-        Some((existing_target, existing_version, existing_hash, existing_active, tombstoned))
-            if existing_target == target_id
-                && existing_version == i64::from(version)
-                && existing_hash == body_hash.as_str()
-                && existing_active == expected_active
-                && tombstoned == expected_tombstoned =>
+        Some((
+            existing_target,
+            existing_version,
+            existing_hash,
+            existing_active,
+            tombstoned,
+            cow_staged,
+        )) if existing_target == target_id
+            && existing_version == i64::from(version)
+            && existing_hash == body_hash.as_str()
+            && existing_active == expected_active
+            && tombstoned == expected_tombstoned
+            && cow_staged == expected_cow_staged =>
         {
             Ok(())
         }
-        Some((existing_target, existing_version, existing_hash, existing_active, tombstoned)) => {
-            Err(StoreError::Invariant {
-                what: format!(
-                    "record_id conflict while staging upsert: record_id={record_id} \
+        Some((
+            existing_target,
+            existing_version,
+            existing_hash,
+            existing_active,
+            tombstoned,
+            cow_staged,
+        )) => Err(StoreError::Invariant {
+            what: format!(
+                "record_id conflict while staging upsert: record_id={record_id} \
                      existing target_id={existing_target} version={existing_version} \
-                     body_hash={existing_hash} active={existing_active} tombstoned={tombstoned}; \
+                     body_hash={existing_hash} active={existing_active} tombstoned={tombstoned} \
+                     cow_staged={cow_staged}; \
                      planned target_id={target_id} version={version} body_hash={} \
-                     active={expected_active} tombstoned={expected_tombstoned}",
-                    body_hash.as_str()
-                ),
-            })
-        }
+                     active={expected_active} tombstoned={expected_tombstoned} \
+                     cow_staged={expected_cow_staged}",
+                body_hash.as_str()
+            ),
+        }),
         None => Err(StoreError::Invariant {
             what: format!("staged upsert insert ignored without existing record_id={record_id}"),
         }),
@@ -1069,13 +1085,14 @@ mod cow_tests {
                 .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
             stage_upsert_cow_in_tx(&tx, &record, &plan)
                 .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-            let (active, tombstoned): (i64, i64) = tx.query_row(
-                "SELECT active, tombstoned FROM records WHERE record_id = ?1",
+            let (active, tombstoned, cow_staged): (i64, i64, i64) = tx.query_row(
+                "SELECT active, tombstoned, cow_staged FROM records WHERE record_id = ?1",
                 rusqlite::params![plan.outcome_record_id.as_str()],
-                |row| Ok((row.get(0)?, row.get(1)?)),
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
             )?;
             assert_eq!(active, 0);
-            assert_eq!(tombstoned, 1);
+            assert_eq!(tombstoned, 0);
+            assert_eq!(cow_staged, 1);
             tx.rollback()?;
             Ok::<_, tokio_rusqlite::Error>(())
         })
@@ -1174,6 +1191,10 @@ mod cow_tests {
             .expect("list");
         assert_eq!(listed.records.len(), 1);
         assert_eq!(listed.records[0].id, active.record_id);
+
+        let versions = store.versions(&record.target_id).await.expect("versions");
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].record_id, active.record_id);
 
         let keyword_page = store
             .search_keyword(&keyword_args("freshstagedtoken"))

--- a/crates/cairn-store-sqlite/src/store/upsert.rs
+++ b/crates/cairn-store-sqlite/src/store/upsert.rs
@@ -474,8 +474,10 @@ fn next_version(prior_version: i64) -> Result<u32, StoreError> {
     })
 }
 
-/// Project + insert one new version row. The caller is responsible for
-/// having deactivated any prior active row in the same transaction.
+/// Project + insert one new version row. Inactive inserts are pre-activation
+/// COW staging rows, so they stay tombstoned until activation clears the flag.
+/// The caller is responsible for having deactivated any prior active row in
+/// the same transaction.
 fn insert_row_with_active(
     tx: &Transaction<'_>,
     record: &MemoryRecord,
@@ -490,8 +492,10 @@ fn insert_row_with_active(
     // silently-downgraded `legacy_event` rewrite. This mirrors the
     // strict parse in `upsert_in_tx` for prior rows.
     let _: cairn_core::domain::consent_timeline::ConsentModel = parse_consent_model(consent_model)?;
-    let mut row =
-        ProjectedRow::from_record(record, version, now_ms, now_ms, body_hash, active, false)?;
+    let tombstoned = !active;
+    let mut row = ProjectedRow::from_record(
+        record, version, now_ms, now_ms, body_hash, active, tombstoned,
+    )?;
     // Caller-supplied consent_model overrides the Phase-A default in
     // `from_record` so supersession preserves the prior row's value.
     row.consent_model = match consent_model {
@@ -585,13 +589,14 @@ fn validate_existing_staged_row(
             other => Err(other),
         })?;
     let expected_active = if active { 1 } else { 0 };
+    let expected_tombstoned = if active { 0 } else { 1 };
     match existing {
         Some((existing_target, existing_version, existing_hash, existing_active, tombstoned))
             if existing_target == target_id
                 && existing_version == i64::from(version)
                 && existing_hash == body_hash.as_str()
                 && existing_active == expected_active
-                && tombstoned == 0 =>
+                && tombstoned == expected_tombstoned =>
         {
             Ok(())
         }
@@ -601,7 +606,8 @@ fn validate_existing_staged_row(
                     "record_id conflict while staging upsert: record_id={record_id} \
                      existing target_id={existing_target} version={existing_version} \
                      body_hash={existing_hash} active={existing_active} tombstoned={tombstoned}; \
-                     planned target_id={target_id} version={version} body_hash={} active={expected_active}",
+                     planned target_id={target_id} version={version} body_hash={} \
+                     active={expected_active} tombstoned={expected_tombstoned}",
                     body_hash.as_str()
                 ),
             })
@@ -1015,10 +1021,41 @@ mod tests {
 
 #[cfg(test)]
 mod cow_tests {
-    use cairn_core::domain::record::tests_export::sample_record;
+    use std::sync::Arc;
 
-    use crate::open_in_memory;
+    use cairn_core::config::EmbeddingModelKind;
+    use cairn_core::contract::memory_store::{
+        KeywordSearchArgs, ListArgs, MemoryStore, SemanticSearchArgs,
+    };
+    use cairn_core::domain::record::tests_export::sample_record;
+    use cairn_embeddings_local::{EmbeddingModel, MockEmbedder};
+
     use crate::store::upsert::{activate_upsert_in_tx, plan_upsert_in_tx, stage_upsert_cow_in_tx};
+    use crate::{open_in_memory, open_in_memory_with_embedder};
+
+    fn keyword_args(query: &str) -> KeywordSearchArgs<'static> {
+        KeywordSearchArgs {
+            query: query.to_owned(),
+            filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
+            visibility_allowlist: vec![],
+            limit: 10,
+            cursor: None,
+            with_explain: false,
+        }
+    }
+
+    fn semantic_args(query: &str, model: EmbeddingModelKind) -> SemanticSearchArgs<'static> {
+        SemanticSearchArgs {
+            query: query.to_owned(),
+            filter: None,
+            auth_scope: cairn_core::domain::ScopeTuple::default(),
+            visibility_allowlist: vec![],
+            limit: 10,
+            model_label: model.as_str().to_owned(),
+            with_explain: false,
+        }
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn cow_stage_inserts_inactive_row() {
@@ -1032,12 +1069,13 @@ mod cow_tests {
                 .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
             stage_upsert_cow_in_tx(&tx, &record, &plan)
                 .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-            let active: i64 = tx.query_row(
-                "SELECT active FROM records WHERE record_id = ?1",
+            let (active, tombstoned): (i64, i64) = tx.query_row(
+                "SELECT active, tombstoned FROM records WHERE record_id = ?1",
                 rusqlite::params![plan.outcome_record_id.as_str()],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )?;
             assert_eq!(active, 0);
+            assert_eq!(tombstoned, 1);
             tx.rollback()?;
             Ok::<_, tokio_rusqlite::Error>(())
         })
@@ -1071,6 +1109,92 @@ mod cow_tests {
         })
         .await
         .expect("cow replay");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cow_staged_supersession_is_hidden_until_activation() {
+        let model = EmbeddingModelKind::BgeSmallEnV1_5;
+        let embedder: Arc<dyn EmbeddingModel> = Arc::new(MockEmbedder::new(model));
+        let store = open_in_memory_with_embedder(Some(Arc::clone(&embedder)))
+            .await
+            .expect("open");
+
+        let mut record = sample_record();
+        record.body = "olderactiveonly baseline body".to_owned();
+        let active = store.upsert(&record).await.expect("seed active row");
+
+        let mut staged = record.clone();
+        staged.body = "freshstagedtoken body staged before activation".to_owned();
+        let staged_vector: Vec<u8> = embedder
+            .embed_document(&staged.body)
+            .expect("embed staged body")
+            .iter()
+            .flat_map(|&f| f.to_le_bytes())
+            .collect();
+        let model_label = model.as_str().to_owned();
+
+        let conn = store.require_conn("test").expect("connected").clone();
+        let staged_id = conn
+            .call(move |c| {
+                let tx = c.transaction()?;
+                let plan = plan_upsert_in_tx(&tx, &staged)
+                    .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+                stage_upsert_cow_in_tx(&tx, &staged, &plan)
+                    .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+                tx.execute(
+                    "INSERT INTO record_vectors(record_id, embedding, model) VALUES (?1, ?2, ?3)",
+                    rusqlite::params![plan.outcome_record_id.as_str(), staged_vector, model_label,],
+                )?;
+                let staged_id = plan.outcome_record_id.clone();
+                tx.commit()?;
+                Ok::<_, tokio_rusqlite::Error>(staged_id)
+            })
+            .await
+            .expect("stage supersession without activation");
+
+        assert!(
+            store
+                .get(&active.record_id)
+                .await
+                .expect("get active")
+                .is_some(),
+            "the previously active row must remain readable",
+        );
+        assert!(
+            store.get(&staged_id).await.expect("get staged").is_none(),
+            "a COW row staged by WAL must remain hidden until primary.activate runs",
+        );
+
+        let listed = store
+            .list(&ListArgs {
+                limit: 10,
+                ..ListArgs::default()
+            })
+            .await
+            .expect("list");
+        assert_eq!(listed.records.len(), 1);
+        assert_eq!(listed.records[0].id, active.record_id);
+
+        let keyword_page = store
+            .search_keyword(&keyword_args("freshstagedtoken"))
+            .await
+            .expect("keyword search");
+        assert!(
+            keyword_page.candidates.is_empty(),
+            "keyword search must not expose a staged COW row",
+        );
+
+        let semantic_page = store
+            .search_semantic(&semantic_args("freshstagedtoken", model))
+            .await
+            .expect("semantic search");
+        assert!(
+            semantic_page
+                .candidates
+                .iter()
+                .all(|candidate| candidate.record_id != staged_id),
+            "semantic search must not expose a staged COW row",
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/cairn-store-sqlite/src/store/upsert.rs
+++ b/crates/cairn-store-sqlite/src/store/upsert.rs
@@ -66,6 +66,12 @@ impl From<EmbedOutcome> for crate::record_wal::payload::StoredEmbedOutcome {
 /// does not silently revert to `'legacy_event'` on the next rewrite.
 type PriorActive = (String, i64, String, String);
 
+pub(crate) struct UpsertPlan {
+    pub(crate) outcome: UpsertOutcome,
+    pub(crate) prior_record_id: Option<String>,
+    pub(crate) consent_model: String,
+}
+
 impl SqliteMemoryStore {
     /// Inherent upsert implementation; the trait method [`MemoryStore::upsert`]
     /// guards `self.conn` then delegates here.
@@ -155,6 +161,32 @@ pub(crate) fn upsert_in_tx(
     tx: &mut Transaction<'_>,
     record: &MemoryRecord,
 ) -> Result<UpsertOutcome, StoreError> {
+    upsert_in_tx_with_record_id(tx, record, None)
+}
+
+pub(crate) fn plan_upsert_in_tx(
+    tx: &mut Transaction<'_>,
+    record: &MemoryRecord,
+) -> Result<UpsertPlan, StoreError> {
+    let prior = read_active(tx, record.target_id.as_str())?;
+    let prior_record_id = prior.as_ref().map(|(prior_id, _, _, _)| prior_id.clone());
+    let consent_model = prior.as_ref().map_or_else(
+        || "legacy_event".to_owned(),
+        |(_, _, _, model)| model.clone(),
+    );
+    let outcome = upsert_in_tx(tx, record)?;
+    Ok(UpsertPlan {
+        outcome,
+        prior_record_id,
+        consent_model,
+    })
+}
+
+pub(crate) fn upsert_in_tx_with_record_id(
+    tx: &mut Transaction<'_>,
+    record: &MemoryRecord,
+    planned_new_record_id: Option<&RecordId>,
+) -> Result<UpsertOutcome, StoreError> {
     // Structural gate at the write boundary: malformed records (empty body,
     // out-of-range scalars, missing scope.user, broken actor chain) are
     // rejected before any row is touched. Both callers (`do_upsert` and
@@ -206,12 +238,15 @@ pub(crate) fn upsert_in_tx(
         )?;
         let next_version = next_version(*prior_version)?;
         let prior_hash = body_hash_from_str(prior_hash_str)?;
+        let new_record_id = planned_new_record_id
+            .cloned()
+            .map_or_else(mint_record_id, Ok)?;
         // Inherit prior consent_model — only the privileged transition
         // API (Phase-B / #255) can change it.
         (
             next_version,
             Some(prior_hash),
-            Some(mint_record_id()?),
+            Some(new_record_id),
             prior_consent_model.clone(),
         )
     } else {

--- a/crates/cairn-store-sqlite/src/store/upsert.rs
+++ b/crates/cairn-store-sqlite/src/store/upsert.rs
@@ -21,7 +21,7 @@
 use std::sync::Arc;
 
 use cairn_core::contract::memory_store::UpsertOutcome;
-use cairn_core::domain::{BodyHash, MemoryRecord, RecordId};
+use cairn_core::domain::{BodyHash, MemoryRecord, RecordId, TargetId};
 use rusqlite::{Transaction, params};
 use tracing::instrument;
 
@@ -64,11 +64,16 @@ impl From<EmbedOutcome> for crate::record_wal::payload::StoredEmbedOutcome {
 /// `records_active_target_idx`). `consent_model` is preserved across
 /// supersession so a row stamped `'receipt_timeline'` by Phase-B (#255)
 /// does not silently revert to `'legacy_event'` on the next rewrite.
-type PriorActive = (String, i64, String, String);
+pub(crate) type PriorActive = (String, i64, String, String);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct UpsertPlan {
-    pub(crate) outcome: UpsertOutcome,
+    pub(crate) outcome_record_id: RecordId,
+    pub(crate) target_id: TargetId,
+    pub(crate) version: u32,
+    pub(crate) content_changed: bool,
     pub(crate) prior_record_id: Option<String>,
+    pub(crate) prior_hash: Option<BodyHash>,
     pub(crate) consent_model: String,
 }
 
@@ -161,134 +166,139 @@ pub(crate) fn upsert_in_tx(
     tx: &mut Transaction<'_>,
     record: &MemoryRecord,
 ) -> Result<UpsertOutcome, StoreError> {
-    upsert_in_tx_with_record_id(tx, record, None)
-}
-
-pub(crate) fn plan_upsert_in_tx(
-    tx: &mut Transaction<'_>,
-    record: &MemoryRecord,
-) -> Result<UpsertPlan, StoreError> {
-    let prior = read_active(tx, record.target_id.as_str())?;
-    let prior_record_id = prior.as_ref().map(|(prior_id, _, _, _)| prior_id.clone());
-    let consent_model = prior.as_ref().map_or_else(
-        || "legacy_event".to_owned(),
-        |(_, _, _, model)| model.clone(),
-    );
-    let outcome = upsert_in_tx(tx, record)?;
-    Ok(UpsertPlan {
-        outcome,
-        prior_record_id,
-        consent_model,
+    let plan = plan_upsert_in_tx(tx, record)?;
+    stage_upsert_cow_in_tx(tx, record, &plan)?;
+    activate_upsert_in_tx(tx, &plan)?;
+    Ok(UpsertOutcome {
+        record_id: plan.outcome_record_id,
+        target_id: plan.target_id,
+        version: plan.version,
+        content_changed: plan.content_changed,
+        prior_hash: plan.prior_hash,
     })
 }
 
-pub(crate) fn upsert_in_tx_with_record_id(
-    tx: &mut Transaction<'_>,
+pub(crate) fn plan_upsert_in_tx(
+    tx: &Transaction<'_>,
     record: &MemoryRecord,
-    planned_new_record_id: Option<&RecordId>,
-) -> Result<UpsertOutcome, StoreError> {
-    // Structural gate at the write boundary: malformed records (empty body,
-    // out-of-range scalars, missing scope.user, broken actor chain) are
-    // rejected before any row is touched. Both callers (`do_upsert` and
-    // `StoreTx::upsert`) also validate up front to surface the error
-    // without the `tokio_rusqlite::Error::Other` wrapping; this inner
-    // call is the belt-and-braces invariant.
+) -> Result<UpsertPlan, StoreError> {
     record.validate()?;
     let body_hash = BodyHash::compute(&record.body);
     let prior = read_active(tx, record.target_id.as_str())?;
-    let now_ms = current_unix_ms();
-
-    // Consent model resolution (Issue #253):
-    //   On supersession: inherit the prior row's value.
-    //   On fresh insert: default to 'legacy_event'.
-    //
-    // `record.consent_model` is intentionally **ignored on write** —
-    // it is excluded from the signed record bytes (`#[serde(skip)]`),
-    // so accepting it here would let any caller flip §6.5 enforcement
-    // by re-submitting the same signed record with a different model.
-    // Round 9: trust-boundary bypass. Phase-B (#255) introduces a
-    // separate privileged transition API that derives the new model
-    // from trusted consent-timeline state inside the same transaction
-    // as the timeline append.
     if let Some((prior_id, prior_version, prior_hash_str, prior_consent_model)) = prior.as_ref() {
-        // Strictly parse the prior row's consent_model — schema drift,
-        // manual SQL repair, or other corruption must fail closed
-        // rather than ride forward.
         let _: cairn_core::domain::consent_timeline::ConsentModel =
             parse_consent_model(prior_consent_model)?;
         let prior_hash = body_hash_from_str(prior_hash_str)?;
         if prior_hash == body_hash {
-            reproject_in_place(tx, record, prior_id, *prior_version, &body_hash, now_ms)?;
-            return idempotent_outcome(record, prior_id, *prior_version, prior_hash);
+            let prior_record_id =
+                RecordId::parse(prior_id.clone()).map_err(|e| StoreError::Invariant {
+                    what: format!("invalid prior record_id `{prior_id}`: {e}"),
+                })?;
+            return Ok(UpsertPlan {
+                outcome_record_id: prior_record_id,
+                target_id: record.target_id.clone(),
+                version: u32::try_from(*prior_version).map_err(|_| StoreError::Invariant {
+                    what: format!("prior version overflows u32: {prior_version}"),
+                })?,
+                content_changed: false,
+                prior_record_id: Some(prior_id.clone()),
+                prior_hash: Some(prior_hash),
+                consent_model: prior_consent_model.clone(),
+            });
         }
+
+        return Ok(UpsertPlan {
+            outcome_record_id: mint_record_id()?,
+            target_id: record.target_id.clone(),
+            version: next_version(*prior_version)?,
+            content_changed: true,
+            prior_record_id: Some(prior_id.clone()),
+            prior_hash: Some(prior_hash),
+            consent_model: prior_consent_model.clone(),
+        });
     }
 
-    let (version, prior_hash, new_record_id, consent_model_to_persist) = if let Some((
-        prior_id,
-        prior_version,
-        prior_hash_str,
-        prior_consent_model,
-    )) = prior.as_ref()
-    {
-        // Body changed: deactivate prior + mint a fresh PK for the new row.
-        tx.execute(
-            "UPDATE records SET active = 0, updated_at = ?1 \
-              WHERE record_id = ?2",
-            params![now_ms, prior_id],
-        )?;
-        let next_version = next_version(*prior_version)?;
-        let prior_hash = body_hash_from_str(prior_hash_str)?;
-        let new_record_id = planned_new_record_id
-            .cloned()
-            .map_or_else(mint_record_id, Ok)?;
-        // Inherit prior consent_model — only the privileged transition
-        // API (Phase-B / #255) can change it.
-        (
-            next_version,
-            Some(prior_hash),
-            Some(new_record_id),
-            prior_consent_model.clone(),
-        )
-    } else {
-        // Fresh insert: always 'legacy_event' until #255's transition
-        // API stamps a different value via a dedicated path.
-        (1u32, None, None, "legacy_event".to_owned())
-    };
-
-    // `record_id` is the version-row PK; supersession requires a fresh one.
-    // The contract docstring on `UpsertOutcome.record_id` ("produced (or
-    // re-used)") explicitly permits the store to synthesize. The first
-    // version of a `target_id` keeps the caller-provided id (matches
-    // `target_id == id` for fresh records, brief §3).
-    //
-    // `consent_model` deliberately does NOT enter `record_json`
-    // (`#[serde(skip)]` on `MemoryRecord::consent_model`): the field
-    // carries store-side authorization metadata, not signed payload.
-    // Persisting it inside the canonical bytes would invalidate any
-    // signature computed before #253 landed. The hot column is the
-    // sole on-disk authority; reads re-hydrate the field from the
-    // column after JSON deserialize.
-    let mut row_record = record.clone();
-    if let Some(ref synthesized) = new_record_id {
-        row_record.id = synthesized.clone();
-    }
-    insert_row(
-        tx,
-        &row_record,
-        version,
-        now_ms,
-        &body_hash,
-        &consent_model_to_persist,
+    let max_version: i64 = tx.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM records WHERE target_id = ?1",
+        params![record.target_id.as_str()],
+        |row| row.get(0),
     )?;
-
-    let outcome_id = new_record_id.unwrap_or_else(|| record.id.clone());
-    Ok(UpsertOutcome {
-        record_id: outcome_id,
+    let version = next_version(max_version)?;
+    let outcome_record_id = if max_version == 0 {
+        record.id.clone()
+    } else {
+        mint_record_id()?
+    };
+    Ok(UpsertPlan {
+        outcome_record_id,
         target_id: record.target_id.clone(),
         version,
         content_changed: true,
-        prior_hash,
+        prior_record_id: None,
+        prior_hash: None,
+        consent_model: "legacy_event".to_owned(),
     })
+}
+
+pub(crate) fn stage_upsert_cow_in_tx(
+    tx: &Transaction<'_>,
+    record: &MemoryRecord,
+    plan: &UpsertPlan,
+) -> Result<(), StoreError> {
+    record.validate()?;
+    let body_hash = BodyHash::compute(&record.body);
+    let now_ms = current_unix_ms();
+
+    if !plan.content_changed {
+        if let Some(prior_id) = plan.prior_record_id.as_deref() {
+            reproject_in_place(
+                tx,
+                record,
+                prior_id,
+                i64::from(plan.version),
+                &body_hash,
+                now_ms,
+            )?;
+        }
+        return Ok(());
+    }
+
+    let mut row_record = record.clone();
+    row_record.id = plan.outcome_record_id.clone();
+    insert_row_with_active(
+        tx,
+        &row_record,
+        plan.version,
+        now_ms,
+        &body_hash,
+        &plan.consent_model,
+        false,
+    )
+}
+
+pub(crate) fn activate_upsert_in_tx(
+    tx: &Transaction<'_>,
+    plan: &UpsertPlan,
+) -> Result<(), StoreError> {
+    if !plan.content_changed {
+        return Ok(());
+    }
+    let now_ms = current_unix_ms();
+    tx.execute(
+        "UPDATE records SET active = 0, updated_at = ?1 \
+          WHERE target_id = ?2 AND active = 1 AND record_id != ?3",
+        params![
+            now_ms,
+            plan.target_id.as_str(),
+            plan.outcome_record_id.as_str()
+        ],
+    )?;
+    tx.execute(
+        "UPDATE records SET active = 1, tombstoned = 0, updated_at = ?1 \
+          WHERE record_id = ?2",
+        params![now_ms, plan.outcome_record_id.as_str()],
+    )?;
+    Ok(())
 }
 
 /// Idempotent re-ingest helper: re-project the row under the current
@@ -391,30 +401,6 @@ fn read_active(tx: &Transaction<'_>, target_id: &str) -> Result<Option<PriorActi
     Ok(row)
 }
 
-/// Build the [`UpsertOutcome`] for the idempotent (no-op) branch. Echoes
-/// the row's actual `record_id` (which may differ from `record.id` if a
-/// prior supersession synthesized a new id).
-fn idempotent_outcome(
-    record: &MemoryRecord,
-    prior_id: &str,
-    prior_version: i64,
-    prior_hash: BodyHash,
-) -> Result<UpsertOutcome, StoreError> {
-    let version = u32::try_from(prior_version).map_err(|_| StoreError::Invariant {
-        what: format!("prior version overflows u32: {prior_version}"),
-    })?;
-    let row_id = RecordId::parse(prior_id.to_owned()).map_err(|e| StoreError::Invariant {
-        what: format!("invalid record_id `{prior_id}`: {e}"),
-    })?;
-    Ok(UpsertOutcome {
-        record_id: row_id,
-        target_id: record.target_id.clone(),
-        version,
-        content_changed: false,
-        prior_hash: Some(prior_hash),
-    })
-}
-
 /// Parse a stored `consent_model` string against the closed enum,
 /// rejecting anything else as `StoreError::Invariant`. Used on both
 /// the prior-row read path and the about-to-write path so schema drift
@@ -455,13 +441,14 @@ fn next_version(prior_version: i64) -> Result<u32, StoreError> {
 
 /// Project + insert one new version row. The caller is responsible for
 /// having deactivated any prior active row in the same transaction.
-fn insert_row(
+fn insert_row_with_active(
     tx: &Transaction<'_>,
     record: &MemoryRecord,
     version: u32,
     now_ms: i64,
     body_hash: &BodyHash,
     consent_model: &str,
+    active: bool,
 ) -> Result<(), StoreError> {
     // Reject anything outside the closed enum *before* projecting, so
     // schema drift / manual SQL corruption cannot ride forward into a
@@ -469,7 +456,7 @@ fn insert_row(
     // strict parse in `upsert_in_tx` for prior rows.
     let _: cairn_core::domain::consent_timeline::ConsentModel = parse_consent_model(consent_model)?;
     let mut row =
-        ProjectedRow::from_record(record, version, now_ms, now_ms, body_hash, true, false)?;
+        ProjectedRow::from_record(record, version, now_ms, now_ms, body_hash, active, false)?;
     // Caller-supplied consent_model overrides the Phase-A default in
     // `from_record` so supersession preserves the prior row's value.
     row.consent_model = match consent_model {
@@ -493,7 +480,9 @@ fn insert_row(
          ) VALUES ( \
             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, \
             ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24 \
-         )",
+         ) \
+         ON CONFLICT(record_id) DO UPDATE SET \
+            updated_at = excluded.updated_at",
         params![
             row.record_id,
             row.target_id,
@@ -922,5 +911,65 @@ mod tests {
             ),
             "idempotent re-ingest must backfill NULL legacy stamp to current",
         );
+    }
+}
+
+#[cfg(test)]
+mod cow_tests {
+    use cairn_core::domain::record::tests_export::sample_record;
+
+    use crate::open_in_memory;
+    use crate::store::upsert::{activate_upsert_in_tx, plan_upsert_in_tx, stage_upsert_cow_in_tx};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cow_stage_inserts_inactive_row() {
+        let store = open_in_memory().await.expect("open");
+        let conn = store.require_conn("test").expect("connected").clone();
+        let record = sample_record();
+
+        conn.call(move |c| {
+            let tx = c.transaction()?;
+            let plan = plan_upsert_in_tx(&tx, &record)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            stage_upsert_cow_in_tx(&tx, &record, &plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let active: i64 = tx.query_row(
+                "SELECT active FROM records WHERE record_id = ?1",
+                rusqlite::params![plan.outcome_record_id.as_str()],
+                |row| row.get(0),
+            )?;
+            assert_eq!(active, 0);
+            tx.rollback()?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("cow stage");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cow_activate_flips_active_pointer_in_one_transaction() {
+        let store = open_in_memory().await.expect("open");
+        let conn = store.require_conn("test").expect("connected").clone();
+        let record = sample_record();
+
+        conn.call(move |c| {
+            let tx = c.transaction()?;
+            let plan = plan_upsert_in_tx(&tx, &record)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            stage_upsert_cow_in_tx(&tx, &record, &plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            activate_upsert_in_tx(&tx, &plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let active: i64 = tx.query_row(
+                "SELECT active FROM records WHERE record_id = ?1",
+                rusqlite::params![plan.outcome_record_id.as_str()],
+                |row| row.get(0),
+            )?;
+            assert_eq!(active, 1);
+            tx.rollback()?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("cow activate");
     }
 }

--- a/crates/cairn-store-sqlite/src/verify.rs
+++ b/crates/cairn-store-sqlite/src/verify.rs
@@ -98,6 +98,10 @@ const EXPECTED_OBJECTS: &[(&str, &str)] = &[
     // sentinel-rejection trigger.
     ("index", "lock_holders_acquisition_ulid_idx"),
     ("trigger", "lock_holders_reject_sentinel_ulid"),
+    // 0053_wal_payloads
+    ("table", "wal_payloads"),
+    ("trigger", "wal_payloads_immutable"),
+    ("trigger", "wal_payloads_no_delete"),
     // 0005_consent
     ("table", "consent_journal"),
     ("index", "consent_journal_subject_scope_idx"),

--- a/crates/cairn-store-sqlite/src/verify.rs
+++ b/crates/cairn-store-sqlite/src/verify.rs
@@ -100,6 +100,7 @@ const EXPECTED_OBJECTS: &[(&str, &str)] = &[
     ("trigger", "lock_holders_reject_sentinel_ulid"),
     // 0053_wal_payloads
     ("table", "wal_payloads"),
+    ("trigger", "wal_payloads_kind_matches_wal"),
     ("trigger", "wal_payloads_immutable"),
     ("trigger", "wal_payloads_no_delete"),
     // 0005_consent

--- a/crates/cairn-store-sqlite/src/wal/recovery.rs
+++ b/crates/cairn-store-sqlite/src/wal/recovery.rs
@@ -47,20 +47,34 @@ impl From<tokio_rusqlite::Error> for RecoveryError {
 
 /// Maps each [`WalKind`] to the [`StepBody`] that should run its steps.
 /// Implementations are owned by sibling issues #57 / #58.
+#[async_trait::async_trait]
 pub trait StepBodyRegistry: Send + Sync {
-    /// Returns the body for the given kind, or `None` if no body is
-    /// registered. `None` causes `Resume` and `AbortAndCompensate` to be
-    /// skipped with a structured warn.
-    fn body_for(&self, kind: WalKind) -> Option<Arc<dyn StepBody>>;
+    /// Returns the body for `kind` and `op_id`.
+    ///
+    /// Recovery registries may load durable payloads and reacquire locks
+    /// before returning a body that can run synchronously inside runner
+    /// transactions.
+    async fn body_for(
+        &self,
+        conn: &Arc<Connection>,
+        kind: WalKind,
+        op_id: &OperationId,
+    ) -> Result<Option<Arc<dyn StepBody>>, RecoveryError>;
 }
 
 /// Empty registry — every kind returns `None`. Used as the default while
 /// #57/#58 are in flight; lets terminal-finalize cases run without a body.
 pub struct EmptyRegistry;
 
+#[async_trait::async_trait]
 impl StepBodyRegistry for EmptyRegistry {
-    fn body_for(&self, _kind: WalKind) -> Option<Arc<dyn StepBody>> {
-        None
+    async fn body_for(
+        &self,
+        _conn: &Arc<Connection>,
+        _kind: WalKind,
+        _op_id: &OperationId,
+    ) -> Result<Option<Arc<dyn StepBody>>, RecoveryError> {
+        Ok(None)
     }
 }
 
@@ -332,7 +346,7 @@ async fn handle_resume(
     config: &RecoveryConfig,
     report: &mut RecoveryReport,
 ) -> Result<(), RecoveryError> {
-    let Some(body) = config.bodies.body_for(snapshot.kind) else {
+    let Some(body) = config.bodies.body_for(conn, snapshot.kind, op_id).await? else {
         warn!(
             op_id = %op_id,
             kind = ?snapshot.kind,

--- a/crates/cairn-store-sqlite/src/wal/runner.rs
+++ b/crates/cairn-store-sqlite/src/wal/runner.rs
@@ -127,23 +127,19 @@ async fn run_one_step(
         return Ok(());
     }
 
-    // 2. Up to MAX_STEP_ATTEMPTS attempts with backoff. Note `attempt` is
-    // a per-invocation loop counter used only to schedule the backoff
-    // sleep; the durable `wal_steps.attempts` column is incremented
-    // inside `try_one_attempt` and is lifetime-cumulative across runner
-    // re-entries (so `decide_recovery` can compare it against
-    // `MAX_STEP_ATTEMPTS`).
-    for attempt in 1..=MAX_STEP_ATTEMPTS {
+    // 2. Retry until the durable, lifetime-cumulative attempts count reaches
+    // MAX_STEP_ATTEMPTS. The loop counter is only for local backoff timing.
+    for attempt in 1.. {
         match try_one_attempt(conn, op_id, step, body).await? {
             AttemptOutcome::Done => return Ok(()),
-            AttemptOutcome::Failed if attempt < MAX_STEP_ATTEMPTS => {
-                tokio::time::sleep(backoff_for(attempt)).await;
-            }
-            AttemptOutcome::Failed => {
+            AttemptOutcome::Failed { attempts } if attempts >= MAX_STEP_ATTEMPTS => {
                 return Err(RunnerError::Exhausted {
                     op_id: op_id.clone(),
                     step_ord: step.ord,
                 });
+            }
+            AttemptOutcome::Failed { .. } => {
+                tokio::time::sleep(backoff_for(attempt)).await;
             }
         }
     }
@@ -157,7 +153,7 @@ async fn run_one_step(
 #[derive(Debug, Clone, Copy)]
 enum AttemptOutcome {
     Done,
-    Failed,
+    Failed { attempts: u32 },
 }
 
 /// Backoff durations per brief §5.6 retry policy: 100 ms / 400 ms / 1600 ms.
@@ -291,7 +287,13 @@ async fn try_one_attempt(
                             finished
                         ],
                     )?;
-                    Ok::<_, tokio_rusqlite::Error>(AttemptOutcome::Failed)
+                    let attempts = c.query_row(
+                        "SELECT attempts FROM wal_steps \
+                         WHERE operation_id = ?1 AND step_ord = ?2",
+                        rusqlite::params![op, step_owned.ord],
+                        |row| row.get::<_, u32>(0),
+                    )?;
+                    Ok::<_, tokio_rusqlite::Error>(AttemptOutcome::Failed { attempts })
                 }
             }
         })

--- a/crates/cairn-store-sqlite/src/wal/runner.rs
+++ b/crates/cairn-store-sqlite/src/wal/runner.rs
@@ -47,7 +47,7 @@ pub trait StepBody: Send + Sync {
     /// schedule a retry (up to [`MAX_STEP_ATTEMPTS`]).
     fn run(
         &self,
-        tx: &Transaction<'_>,
+        tx: &mut Transaction<'_>,
         op_id: &OperationId,
         step: &StepDef,
     ) -> Result<(), StepBodyError>;
@@ -217,7 +217,7 @@ async fn try_one_attempt(
             // Phase 1: open a transaction, upsert the wal_steps row to
             // PENDING, run the body. Commit on Ok; drop (rollback) on Err.
             let body_result: Result<(), StepBodyError> = {
-                let tx = c.transaction()?;
+                let mut tx = c.transaction()?;
                 // `attempts` is lifetime-cumulative across runner re-entries.
                 // For a brand-new row we INSERT with `1`; on conflict we
                 // increment the existing value rather than overwriting with
@@ -237,7 +237,7 @@ async fn try_one_attempt(
                        started_at = COALESCE(wal_steps.started_at, ?4)",
                     rusqlite::params![op, step_owned.ord, step_owned.name, now],
                 )?;
-                let r = body.run(&tx, &op_id_for_body, &step_owned);
+                let r = body.run(&mut tx, &op_id_for_body, &step_owned);
                 if r.is_ok() {
                     let finished = now_ms();
                     tx.execute(

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -203,3 +203,44 @@ async fn upsert_snapshot_stage_records_pre_image_blob() {
     .await
     .expect("snapshot stage");
 }
+
+#[tokio::test]
+async fn upsert_rejects_fresh_target_that_reuses_existing_record_id() {
+    let store = open_in_memory().await.expect("open");
+    let existing = sample();
+    store.upsert(&existing).await.expect("initial upsert");
+
+    let mut colliding = existing.clone();
+    colliding.target_id = TargetId::parse("01HQZX9F5N0000000000000001").expect("valid target id");
+    colliding.body = "different target but same record id".to_owned();
+
+    store
+        .upsert(&colliding)
+        .await
+        .expect_err("record_id collision across targets must fail");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let new_target = colliding.target_id.as_str().to_owned();
+    let old_target = existing.target_id.as_str().to_owned();
+    conn.call(move |c| {
+        let new_active: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records WHERE target_id = ?1 AND active = 1",
+            params![new_target],
+            |row| row.get(0),
+        )?;
+        assert_eq!(
+            new_active, 0,
+            "failed collision must not create an active row for the new target"
+        );
+
+        let old_active: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records WHERE target_id = ?1 AND active = 1",
+            params![old_target],
+            |row| row.get(0),
+        )?;
+        assert_eq!(old_active, 1, "original target remains active");
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("records");
+}

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -1,0 +1,50 @@
+//! Issue #57: COW upsert and expire through body-bearing WAL.
+
+#![allow(missing_docs, unused_imports)]
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::{
+    KeywordSearchArgs, ListArgs, MemoryStore, TombstoneReason,
+};
+use cairn_core::domain::{MemoryRecord, TargetId};
+use cairn_store_sqlite::open_in_memory;
+use rusqlite::params;
+
+fn sample() -> MemoryRecord {
+    cairn_core::domain::record::tests_export::sample_record()
+}
+
+#[tokio::test]
+async fn payload_round_trip_smoke() {
+    let store = open_in_memory().await.expect("open");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let record = sample();
+    let payload = cairn_store_sqlite::record_wal::payload::UpsertPayload::new_for_test(record);
+
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-round-trip', 1, 'upsert', 'ISSUED', '{}', 'issuer', 'target', '{}', 0, 'sig', 1, 1)",
+            [],
+        )?;
+        cairn_store_sqlite::record_wal::payload::save_upsert_payload_for_test(
+            c,
+            "op-round-trip",
+            &payload,
+        )
+        .expect("save upsert payload");
+        let loaded = cairn_store_sqlite::record_wal::payload::load_upsert_payload_for_test(
+            c,
+            "op-round-trip",
+        )
+        .expect("load upsert payload");
+        assert_eq!(loaded.record.target_id, payload.record.target_id);
+        assert_eq!(loaded.record.body, payload.record.body);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("payload round trip");
+}

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use cairn_core::contract::memory_store::{
     KeywordSearchArgs, ListArgs, MemoryStore, TombstoneReason,
 };
-use cairn_core::domain::{MemoryRecord, TargetId};
+use cairn_core::domain::{MemoryRecord, ScopeTuple, TargetId};
 use cairn_core::wal::WalKind;
 use cairn_store_sqlite::{open, open_in_memory};
 use rusqlite::params;
@@ -90,6 +90,127 @@ async fn upsert_commits_wal_operation_and_all_steps() {
     })
     .await
     .expect("wal rows");
+}
+
+#[tokio::test]
+async fn prepared_expire_recovers_with_persisted_scope() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+    let op_id = "op-prepared-expire-scope-recovery";
+    let mut record = sample();
+    record.scope = ScopeTuple {
+        tenant: Some("tenant-review".to_owned()),
+        workspace: Some("workspace-review".to_owned()),
+        session_id: Some("session-review".to_owned()),
+        user: Some("hmn:tafeng".to_owned()),
+        ..ScopeTuple::default()
+    };
+    let target = record.target_id.clone();
+
+    {
+        let store = open(&path).await.expect("open #1");
+        store.upsert(&record).await.expect("seed record");
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let payload_json = serde_json::json!({
+            "type": "expire",
+            "target_id": target.as_str(),
+            "reason": "expire",
+            "scope": record.scope,
+        })
+        .to_string();
+        let target_for_seed = target.clone();
+        let entity_resource = format!(
+            "entity:tenant-review:workspace-review:{}",
+            target_for_seed.as_str()
+        );
+        let session_resource = "session:tenant-review:workspace-review:session-review".to_owned();
+
+        conn.call(move |c| {
+            c.execute(
+                "DELETE FROM lock_holders WHERE resource IN (?1, ?2)",
+                params![entity_resource, session_resource],
+            )?;
+            c.execute(
+                "DELETE FROM locks WHERE resource IN (?1, ?2)",
+                params![entity_resource, session_resource],
+            )?;
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES (?1, 100, 'expire', 'ISSUED', '{}', 'issuer', ?2, '{}', 0, 'sig', 1, 1)",
+                params![op_id, target_for_seed.as_str()],
+            )?;
+            c.execute(
+                "UPDATE wal_ops SET state = 'PREPARED', updated_at = 2 \
+                 WHERE operation_id = ?1",
+                params![op_id],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES (?1, 'expire', ?2, 1)",
+                params![op_id, payload_json],
+            )?;
+            c.execute(
+                "UPDATE records SET scope = '{}' WHERE target_id = ?1",
+                params![target_for_seed.as_str()],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed prepared expire");
+    }
+
+    let store = open(&path).await.expect("open #2");
+    assert!(
+        store
+            .list(&ListArgs::default())
+            .await
+            .expect("list")
+            .records
+            .is_empty()
+    );
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let target_id = target.as_str().to_owned();
+    conn.call(move |c| {
+        let payload_json: String = c.query_row(
+            "SELECT payload_json FROM wal_payloads WHERE operation_id = ?1",
+            params![op_id],
+            |row| row.get(0),
+        )?;
+        let payload: serde_json::Value = serde_json::from_str(&payload_json)
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        assert_eq!(
+            payload
+                .get("scope")
+                .and_then(|scope| scope.get("tenant"))
+                .and_then(serde_json::Value::as_str),
+            Some("tenant-review")
+        );
+
+        let entity_resource = format!("entity:tenant-review:workspace-review:{target_id}");
+        let session_resource = "session:tenant-review:workspace-review:session-review";
+        let non_default_lock_rows: i64 = c.query_row(
+            "SELECT COUNT(*) FROM locks WHERE resource IN (?1, ?2)",
+            params![entity_resource, session_resource],
+            |row| row.get(0),
+        )?;
+        assert_eq!(
+            non_default_lock_rows, 2,
+            "recovery must reacquire locks from durable expire scope"
+        );
+
+        let state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE operation_id = ?1",
+            params![op_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state, "COMMITTED");
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("expire recovery assertions");
 }
 
 #[tokio::test]

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -90,3 +90,52 @@ async fn upsert_commits_wal_operation_and_all_steps() {
     .await
     .expect("wal rows");
 }
+
+#[tokio::test]
+async fn body_changing_upsert_uses_same_record_id_in_outcome_row_and_payload() {
+    let store = open_in_memory().await.expect("open");
+    let mut record = sample();
+    store.upsert(&record).await.expect("initial upsert");
+
+    record.body = "changed body for deterministic wal plan".to_owned();
+    let out = store.upsert(&record).await.expect("body-changing upsert");
+    assert_eq!(out.version, 2);
+    assert!(out.content_changed);
+
+    let target = record.target_id.as_str().to_owned();
+    let returned_id = out.record_id.as_str().to_owned();
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let active_record_id: String = c.query_row(
+            "SELECT record_id FROM records WHERE target_id = ?1 AND active = 1",
+            params![target],
+            |row| row.get(0),
+        )?;
+
+        let payload_json: String = c.query_row(
+            "SELECT wp.payload_json \
+               FROM wal_payloads wp \
+               JOIN wal_ops wo ON wo.operation_id = wp.operation_id \
+              WHERE wo.kind = 'upsert' \
+              ORDER BY wo.issued_seq DESC \
+              LIMIT 1",
+            [],
+            |row| row.get(0),
+        )?;
+        let payload: serde_json::Value = serde_json::from_str(&payload_json)
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        let planned_record_id = payload
+            .get("planned")
+            .and_then(|planned| planned.get("outcome_record_id"))
+            .and_then(serde_json::Value::as_str)
+            .expect("planned outcome_record_id")
+            .to_owned();
+
+        assert_eq!(active_record_id, returned_id);
+        assert_eq!(planned_record_id, returned_id);
+
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("id assertions");
+}

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -495,6 +495,61 @@ async fn expire_retires_target_without_hard_delete() {
 }
 
 #[tokio::test]
+async fn expired_record_is_excluded_from_keyword_search() {
+    let store = open_in_memory().await.expect("open");
+    let mut r = sample();
+    r.body = "body with needle before expire".to_owned();
+    store.upsert(&r).await.expect("upsert");
+
+    store.expire(&r.target_id).await.expect("expire");
+
+    let page = store
+        .search_keyword(&KeywordSearchArgs {
+            query: "needle".into(),
+            filter: None,
+            auth_scope: r.scope.clone(),
+            visibility_allowlist: vec![r.visibility],
+            limit: 10,
+            cursor: None,
+            with_explain: false,
+        })
+        .await
+        .expect("keyword search");
+    assert!(page.candidates.is_empty());
+}
+
+#[tokio::test]
+async fn expire_commits_wal_operation_and_all_steps() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("upsert");
+    store.expire(&r.target_id).await.expect("expire");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(|c| {
+        let state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE kind = 'expire'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state, "COMMITTED");
+
+        let done_count: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps ws \
+              JOIN wal_ops wo ON wo.operation_id = ws.operation_id \
+             WHERE wo.kind = 'expire' AND ws.state = 'DONE'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(done_count, 5);
+
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("expire wal rows");
+}
+
+#[tokio::test]
 async fn expire_preserves_existing_tombstone_reason() {
     let store = open_in_memory().await.expect("open");
     let r = sample();

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -267,3 +267,62 @@ async fn repeated_upsert_steps_do_not_duplicate_derived_rows() {
     .await
     .expect("derived counts");
 }
+
+#[tokio::test]
+async fn expire_retires_target_without_hard_delete() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    let out = store.upsert(&r).await.expect("upsert");
+
+    store.expire(&r.target_id).await.expect("expire");
+
+    assert!(store.get(&out.record_id).await.expect("get").is_none());
+    assert!(
+        store
+            .list(&ListArgs::default())
+            .await
+            .expect("list")
+            .records
+            .is_empty()
+    );
+
+    let versions = store.versions(&r.target_id).await.expect("versions");
+    assert_eq!(versions.len(), 1);
+    assert!(!versions[0].active);
+    assert!(versions[0].tombstoned);
+    assert_eq!(versions[0].tombstone_reason, Some(TombstoneReason::Expire));
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let row_count: i64 = conn
+        .call(|c| {
+            c.query_row("SELECT COUNT(*) FROM records", [], |row| row.get(0))
+                .map_err(Into::into)
+        })
+        .await
+        .expect("record count");
+    assert_eq!(row_count, 1, "expire must not hard-delete records");
+}
+
+#[tokio::test]
+async fn upsert_after_expire_creates_next_visible_version() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("upsert");
+    store.expire(&r.target_id).await.expect("expire");
+
+    let mut replacement = r.clone();
+    replacement.body = "replacement after expire".to_owned();
+    let out = store
+        .upsert(&replacement)
+        .await
+        .expect("replacement upsert");
+
+    assert_eq!(out.version, 2);
+    assert!(store.get(&out.record_id).await.expect("get").is_some());
+
+    let versions = store.versions(&r.target_id).await.expect("versions");
+    assert_eq!(versions.len(), 2);
+    assert!(versions[0].tombstoned);
+    assert!(!versions[1].tombstoned);
+    assert!(versions[1].active);
+}

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -304,6 +304,24 @@ async fn expire_retires_target_without_hard_delete() {
 }
 
 #[tokio::test]
+async fn expire_preserves_existing_tombstone_reason() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    let out = store.upsert(&r).await.expect("upsert");
+
+    store
+        .tombstone(&out.record_id, TombstoneReason::Forget)
+        .await
+        .expect("forget tombstone");
+    store.expire(&r.target_id).await.expect("expire");
+
+    let versions = store.versions(&r.target_id).await.expect("versions");
+    assert_eq!(versions.len(), 1);
+    assert!(versions[0].tombstoned);
+    assert_eq!(versions[0].tombstone_reason, Some(TombstoneReason::Forget));
+}
+
+#[tokio::test]
 async fn upsert_after_expire_creates_next_visible_version() {
     let store = open_in_memory().await.expect("open");
     let r = sample();

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -499,9 +499,7 @@ async fn expired_record_is_excluded_from_keyword_search() {
     let store = open_in_memory().await.expect("open");
     let mut r = sample();
     r.body = "body with needle before expire".to_owned();
-    store.upsert(&r).await.expect("upsert");
-
-    store.expire(&r.target_id).await.expect("expire");
+    let out = store.upsert(&r).await.expect("upsert");
 
     let page = store
         .search_keyword(&KeywordSearchArgs {
@@ -514,7 +512,24 @@ async fn expired_record_is_excluded_from_keyword_search() {
             with_explain: false,
         })
         .await
-        .expect("keyword search");
+        .expect("keyword search before expire");
+    assert_eq!(page.candidates.len(), 1);
+    assert_eq!(page.candidates[0].record_id, out.record_id);
+    assert_eq!(page.candidates[0].target_id, r.target_id);
+
+    store.expire(&r.target_id).await.expect("expire");
+    let page = store
+        .search_keyword(&KeywordSearchArgs {
+            query: "needle".into(),
+            filter: None,
+            auth_scope: r.scope.clone(),
+            visibility_allowlist: vec![r.visibility],
+            limit: 10,
+            cursor: None,
+            with_explain: false,
+        })
+        .await
+        .expect("keyword search after expire");
     assert!(page.candidates.is_empty());
 }
 

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -8,7 +8,8 @@ use cairn_core::contract::memory_store::{
     KeywordSearchArgs, ListArgs, MemoryStore, TombstoneReason,
 };
 use cairn_core::domain::{MemoryRecord, TargetId};
-use cairn_store_sqlite::open_in_memory;
+use cairn_core::wal::WalKind;
+use cairn_store_sqlite::{open, open_in_memory};
 use rusqlite::params;
 
 fn sample() -> MemoryRecord {
@@ -89,6 +90,75 @@ async fn upsert_commits_wal_operation_and_all_steps() {
     })
     .await
     .expect("wal rows");
+}
+
+#[tokio::test]
+async fn prepared_upsert_recovers_from_persisted_payload() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+    let op_id = "op-prepared-upsert-recovery";
+    let record = sample();
+    let record_id = record.id.clone();
+
+    {
+        let store = open(&path).await.expect("open #1");
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let payload =
+            cairn_store_sqlite::record_wal::payload::UpsertPayload::new_for_test(record.clone());
+        let kind = WalKind::Upsert.as_str().to_owned();
+
+        conn.call(move |c| {
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES (?1, 1, ?2, 'ISSUED', '{}', 'issuer', ?3, '{}', 0, 'sig', 1, 1)",
+                params![op_id, kind, record.target_id.as_str()],
+            )?;
+            c.execute(
+                "UPDATE wal_ops SET state = 'PREPARED', updated_at = 2 \
+                 WHERE operation_id = ?1",
+                params![op_id],
+            )?;
+            cairn_store_sqlite::record_wal::payload::save_upsert_payload_for_test(
+                c, op_id, &payload,
+            )
+            .expect("save upsert payload");
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed prepared upsert");
+    }
+
+    let store = open(&path).await.expect("open #2");
+    let recovered = store
+        .get(&record_id)
+        .await
+        .expect("get recovered")
+        .expect("record recovered");
+    assert_eq!(recovered.body, record.body);
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let op = op_id.to_owned();
+    conn.call(move |c| {
+        let state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE operation_id = ?1",
+            params![op],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state, "COMMITTED");
+
+        let done_steps: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps \
+             WHERE operation_id = ?1 AND state = 'DONE'",
+            params![op],
+            |row| row.get(0),
+        )?;
+        assert_eq!(done_steps, 6);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("recovery wal state");
 }
 
 #[tokio::test]

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -244,3 +244,26 @@ async fn upsert_rejects_fresh_target_that_reuses_existing_record_id() {
     .await
     .expect("records");
 }
+
+#[tokio::test]
+async fn repeated_upsert_steps_do_not_duplicate_derived_rows() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("upsert");
+    store.upsert(&r).await.expect("idempotent upsert");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let fts_rows: i64 =
+            c.query_row("SELECT COUNT(*) FROM records_fts", [], |row| row.get(0))?;
+        let active_records: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records WHERE active = 1 AND tombstoned = 0",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(fts_rows, active_records);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("derived counts");
+}

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use cairn_core::contract::memory_store::{
     KeywordSearchArgs, ListArgs, MemoryStore, TombstoneReason,
 };
-use cairn_core::domain::{MemoryRecord, ScopeTuple, TargetId};
+use cairn_core::contract::version::SchemaVersion;
+use cairn_core::domain::{BodyHash, MemoryRecord, ScopeTuple, TargetId};
 use cairn_core::wal::WalKind;
 use cairn_store_sqlite::{open, open_in_memory};
 use rusqlite::params;
@@ -276,6 +277,162 @@ async fn prepared_upsert_recovers_from_persisted_payload() {
             |row| row.get(0),
         )?;
         assert_eq!(done_steps, 6);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("recovery wal state");
+}
+
+#[tokio::test]
+async fn partial_upsert_after_primary_cow_is_hidden_until_recovery_activation() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+    let op_id = "op-partial-upsert-activation-recovery";
+    let record = sample();
+    let record_id = record.id.clone();
+    let target_id = record.target_id.clone();
+
+    {
+        let store = open(&path).await.expect("open #1");
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let payload =
+            cairn_store_sqlite::record_wal::payload::UpsertPayload::new_for_test(record.clone());
+        let staged = record.clone();
+
+        conn.call(move |c| {
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES (?1, 1, 'upsert', 'ISSUED', '{}', 'issuer', ?2, '{}', 0, 'sig', 1, 1)",
+                params![op_id, staged.target_id.as_str()],
+            )?;
+            c.execute(
+                "UPDATE wal_ops SET state = 'PREPARED', updated_at = 2 \
+                 WHERE operation_id = ?1",
+                params![op_id],
+            )?;
+            cairn_store_sqlite::record_wal::payload::save_upsert_payload_for_test(
+                c, op_id, &payload,
+            )
+            .expect("save upsert payload");
+
+            let body_hash = BodyHash::compute(&staged.body);
+            let record_json = serde_json::to_string(&staged)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let scope_json = serde_json::to_string(&staged.scope)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let actor_chain_json = serde_json::to_string(&staged.actor_chain)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let tags_json = serde_json::to_string(&staged.tags)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let schema = SchemaVersion::current();
+            c.execute(
+                "INSERT INTO records ( \
+                    record_id, target_id, version, path, kind, class, visibility, \
+                    scope, actor_chain, body, body_hash, created_at, updated_at, \
+                    active, tombstoned, is_static, record_json, confidence, salience, \
+                    target_id_explicit, tags_json, consent_model, schema_version_major, \
+                    schema_version_minor, cow_staged \
+                 ) VALUES ( \
+                    ?1, ?2, 1, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 1000, 1000, \
+                    0, 0, 0, ?11, ?12, ?13, ?14, ?15, 'legacy_event', ?16, ?17, 1 \
+                 )",
+                params![
+                    staged.id.as_str(),
+                    staged.target_id.as_str(),
+                    format!("vault/{}.md", staged.id.as_str()),
+                    staged.kind.as_str(),
+                    staged.class.as_str(),
+                    staged.visibility.as_str(),
+                    scope_json,
+                    actor_chain_json,
+                    staged.body,
+                    body_hash.as_str(),
+                    record_json,
+                    f64::from(staged.confidence),
+                    f64::from(staged.salience),
+                    staged.target_id.as_str(),
+                    tags_json,
+                    i64::from(schema.major),
+                    i64::from(schema.minor),
+                ],
+            )?;
+            c.execute(
+                "INSERT INTO wal_steps \
+                   (operation_id, step_ord, step_kind, state, attempts, started_at, finished_at) \
+                 VALUES \
+                   (?1, 0, 'snapshot.stage', 'DONE', 1, 2, 3), \
+                   (?1, 1, 'primary.upsert_cow', 'DONE', 1, 3, 4)",
+                params![op_id],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed partial upsert");
+
+        assert!(
+            store.get(&record_id).await.expect("get staged").is_none(),
+            "staged row must stay hidden before recovery activation"
+        );
+        assert!(
+            store
+                .versions(&target_id)
+                .await
+                .expect("versions staged")
+                .is_empty(),
+            "staged row must not appear in committed history"
+        );
+        assert!(
+            store
+                .list(&ListArgs {
+                    limit: 10,
+                    ..ListArgs::default()
+                })
+                .await
+                .expect("list staged")
+                .records
+                .is_empty(),
+            "staged row must not appear in list"
+        );
+    }
+
+    let store = open(&path).await.expect("open #2 recovers partial upsert");
+    let recovered = store
+        .get(&record_id)
+        .await
+        .expect("get recovered")
+        .expect("record recovered");
+    assert_eq!(recovered.body, record.body);
+
+    let versions = store
+        .versions(&target_id)
+        .await
+        .expect("versions recovered");
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].record_id, record_id);
+    assert!(versions[0].active);
+    assert!(!versions[0].tombstoned);
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE operation_id = ?1",
+            params![op_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state, "COMMITTED");
+        let (done_steps, cow_staged, active): (i64, i64, i64) = c.query_row(
+            "SELECT \
+                (SELECT COUNT(*) FROM wal_steps WHERE operation_id = ?1 AND state = 'DONE'), \
+                (SELECT cow_staged FROM records WHERE record_id = ?2), \
+                (SELECT active FROM records WHERE record_id = ?2)",
+            params![op_id, record_id.as_str()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(done_steps, 6);
+        assert_eq!(cow_staged, 0);
+        assert_eq!(active, 1);
         Ok::<_, tokio_rusqlite::Error>(())
     })
     .await

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -139,3 +139,67 @@ async fn body_changing_upsert_uses_same_record_id_in_outcome_row_and_payload() {
     .await
     .expect("id assertions");
 }
+
+#[tokio::test]
+async fn upsert_stages_inactive_row_before_activation() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("initial upsert");
+
+    let mut r2 = r.clone();
+    r2.body = "changed body for cow staging".to_owned();
+
+    let out = store.upsert(&r2).await.expect("second upsert");
+    assert_eq!(out.version, 2);
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let rows: Vec<(String, i64, i64)> = conn
+        .call(move |c| {
+            let mut stmt = c.prepare(
+                "SELECT record_id, active, tombstoned FROM records \
+                 WHERE target_id = ?1 ORDER BY version",
+            )?;
+            let rows = stmt
+                .query_map(params![r.target_id.as_str()], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok::<_, tokio_rusqlite::Error>(rows)
+        })
+        .await
+        .expect("records");
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].1, 0, "prior version inactive after activation");
+    assert_eq!(rows[1].1, 1, "new version active after activation");
+    assert_eq!(rows[0].2, 0, "superseded row is not tombstoned");
+    assert_eq!(rows[1].2, 0, "new row is visible");
+}
+
+#[tokio::test]
+async fn upsert_snapshot_stage_records_pre_image_blob() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("upsert");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(|c| {
+        let count: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps ws \
+              JOIN wal_ops wo ON wo.operation_id = ws.operation_id \
+             WHERE wo.kind = 'upsert' \
+               AND ws.step_kind = 'snapshot.stage' \
+               AND ws.pre_image IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 1);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("snapshot stage");
+}

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -94,6 +94,7 @@ async fn upsert_commits_wal_operation_and_all_steps() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn prepared_expire_recovers_with_persisted_scope() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let path = tmp.path().join("cairn.sqlite");
@@ -284,6 +285,7 @@ async fn prepared_upsert_recovers_from_persisted_payload() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn partial_upsert_after_primary_cow_is_hidden_until_recovery_activation() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let path = tmp.path().join("cairn.sqlite");

--- a/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+++ b/crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
@@ -48,3 +48,45 @@ async fn payload_round_trip_smoke() {
     .await
     .expect("payload round trip");
 }
+
+#[tokio::test]
+async fn upsert_commits_wal_operation_and_all_steps() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+
+    let out = store.upsert(&record).await.expect("upsert through wal");
+    assert_eq!(out.version, 1);
+    assert!(out.content_changed);
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(|c| {
+        let row: (String, i64) = c.query_row(
+            "SELECT state, COUNT(*) FROM wal_ops WHERE kind = 'upsert' GROUP BY state",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(row, ("COMMITTED".to_owned(), 1));
+
+        let done_count: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps ws \
+              JOIN wal_ops wo ON wo.operation_id = ws.operation_id \
+             WHERE wo.kind = 'upsert' AND ws.state = 'DONE'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(done_count, 6);
+
+        let payload_count: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_payloads wp \
+              JOIN wal_ops wo ON wo.operation_id = wp.operation_id \
+             WHERE wo.kind = 'upsert'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(payload_count, 1);
+
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("wal rows");
+}

--- a/crates/cairn-store-sqlite/tests/locks_stale_fence.rs
+++ b/crates/cairn-store-sqlite/tests/locks_stale_fence.rs
@@ -103,3 +103,50 @@ async fn incarnation_change_invalidates_prior_holders() {
         .unwrap_err();
     assert!(matches!(err, LockError::Fenced { .. }));
 }
+
+#[tokio::test]
+async fn assert_live_in_tx_blocks_stale_holder_inside_existing_transaction() {
+    let store = open_in_memory().await.unwrap();
+    let conn = Arc::clone(store.raw_conn_for_admin().unwrap());
+    let inc = store.incarnation().cloned().unwrap();
+    let resource = ResourceKey::entity("t1", "default", "rec-tx");
+
+    let h_a = acquire(
+        &conn,
+        &resource,
+        LockMode::Exclusive,
+        "holder_a_tx",
+        Duration::from_millis(80),
+        &inc,
+        "writer_a_tx",
+    )
+    .await
+    .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let _h_b = acquire(
+        &conn,
+        &resource,
+        LockMode::Exclusive,
+        "holder_b_tx",
+        Duration::from_secs(5),
+        &inc,
+        "writer_b_tx",
+    )
+    .await
+    .unwrap();
+
+    let err = conn
+        .call(move |c| {
+            let tx = c.transaction()?;
+            let result = h_a.assert_live_in_tx(&tx);
+            drop(tx);
+            Ok::<_, tokio_rusqlite::Error>(result)
+        })
+        .await
+        .unwrap()
+        .unwrap_err();
+
+    assert!(matches!(err, LockError::Fenced { .. }));
+}

--- a/crates/cairn-store-sqlite/tests/migrations.rs
+++ b/crates/cairn-store-sqlite/tests/migrations.rs
@@ -15,7 +15,7 @@ fn fresh_in_memory_opens_to_head() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 52);
+    assert_eq!(head, 54);
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn fresh_vault_opens_and_reopens_idempotent() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 52);
+    assert_eq!(head, 54);
 }
 
 #[test]

--- a/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
+++ b/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
@@ -68,3 +68,36 @@ async fn wal_payloads_requires_existing_operation() {
     .await
     .expect("foreign-key assertion");
 }
+
+#[tokio::test]
+async fn wal_payloads_kind_must_match_parent_operation() {
+    let store = open_in_memory().await.expect("open in-memory store");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    conn.call(|c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-expire-payload', 1, ?1, 'ISSUED', '{}', 'issuer', 'target', '{}', 0, 'sig', 1, 1)",
+            params![WalKind::Expire.as_str()],
+        )?;
+
+        let err = c
+            .execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES ('op-expire-payload', 'upsert', '{}', 1)",
+                [],
+            )
+            .expect_err("trigger rejects payload kind mismatch");
+        assert!(
+            err.to_string()
+                .contains("wal_payloads.kind must match wal_ops.kind"),
+            "unexpected mismatch error: {err}"
+        );
+
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("kind-match assertion");
+}

--- a/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
+++ b/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
@@ -1,0 +1,70 @@
+//! Migration 0053 stores body-bearing WAL payloads for record operations.
+
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::wal::WalKind;
+use cairn_store_sqlite::open_in_memory;
+use rusqlite::params;
+
+#[tokio::test]
+async fn wal_payloads_table_is_present_and_immutable() {
+    let store = open_in_memory().await.expect("open in-memory store");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    conn.call(|c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-payload', 1, ?1, 'ISSUED', '{}', 'issuer', 'target', '{}', 0, 'sig', 1, 1)",
+            params![WalKind::Upsert.as_str()],
+        )?;
+        c.execute(
+            "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+             VALUES ('op-payload', 'upsert', '{\"kind\":\"upsert\"}', 1)",
+            [],
+        )?;
+
+        let payload: String = c.query_row(
+            "SELECT payload_json FROM wal_payloads WHERE operation_id = 'op-payload'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(payload, "{\"kind\":\"upsert\"}");
+
+        let update = c.execute(
+            "UPDATE wal_payloads SET payload_json = '{}' WHERE operation_id = 'op-payload'",
+            [],
+        );
+        assert!(update.is_err(), "payload rows must not be updated");
+
+        let delete = c.execute("DELETE FROM wal_payloads WHERE operation_id = 'op-payload'", []);
+        assert!(delete.is_err(), "payload rows must not be deleted");
+
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("schema assertions");
+}
+
+#[tokio::test]
+async fn wal_payloads_requires_existing_operation() {
+    let store = open_in_memory().await.expect("open in-memory store");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    conn.call(|c| {
+        let err = c
+            .execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES ('missing-op', 'upsert', '{}', 1)",
+                [],
+            )
+            .expect_err("foreign key rejects missing wal_ops row");
+        assert!(err.to_string().contains("FOREIGN KEY"));
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("foreign-key assertion");
+}

--- a/crates/cairn-store-sqlite/tests/wal_recovery.rs
+++ b/crates/cairn-store-sqlite/tests/wal_recovery.rs
@@ -434,7 +434,7 @@ async fn recovery_rejects_payload_variant_that_disagrees_with_wal_kind() {
     let record = cairn_core::domain::record::tests_export::sample_record();
     let payload = cairn_store_sqlite::record_wal::payload::UpsertPayload::new_for_test(record);
     let payload_json = serde_json::to_string(
-        &cairn_store_sqlite::record_wal::payload::RecordWalPayload::Upsert(payload),
+        &cairn_store_sqlite::record_wal::payload::RecordWalPayload::Upsert(Box::new(payload)),
     )
     .expect("payload json");
     seed_payload_json(&conn, "op-kind-mismatch", WalKind::Expire, payload_json).await;

--- a/crates/cairn-store-sqlite/tests/wal_recovery.rs
+++ b/crates/cairn-store-sqlite/tests/wal_recovery.rs
@@ -55,7 +55,7 @@ impl StepBody for SyntheticBody {
     #[allow(clippy::match_same_arms)]
     fn run(
         &self,
-        _tx: &Transaction<'_>,
+        _tx: &mut Transaction<'_>,
         _op_id: &OperationId,
         step: &cairn_core::wal::StepDef,
     ) -> Result<(), StepBodyError> {

--- a/crates/cairn-store-sqlite/tests/wal_recovery.rs
+++ b/crates/cairn-store-sqlite/tests/wal_recovery.rs
@@ -74,14 +74,22 @@ impl StepBody for SyntheticBody {
 struct OneKindRegistry {
     kind: WalKind,
     body: Arc<dyn StepBody>,
+    requested_ops: parking_lot::Mutex<Vec<String>>,
 }
 
+#[async_trait::async_trait]
 impl StepBodyRegistry for OneKindRegistry {
-    fn body_for(&self, kind: WalKind) -> Option<Arc<dyn StepBody>> {
+    async fn body_for(
+        &self,
+        _conn: &Arc<Connection>,
+        kind: WalKind,
+        op_id: &OperationId,
+    ) -> Result<Option<Arc<dyn StepBody>>, cairn_store_sqlite::wal::RecoveryError> {
+        self.requested_ops.lock().push(op_id.as_str().to_owned());
         if kind == self.kind {
-            Some(Arc::clone(&self.body))
+            Ok(Some(Arc::clone(&self.body)))
         } else {
-            None
+            Ok(None)
         }
     }
 }
@@ -214,6 +222,7 @@ fn upsert_with_body(body: Arc<dyn StepBody>) -> RecoveryConfig {
         bodies: Box::new(OneKindRegistry {
             kind: WalKind::Upsert,
             body,
+            requested_ops: parking_lot::Mutex::new(Vec::new()),
         }),
     }
 }

--- a/crates/cairn-store-sqlite/tests/wal_recovery.rs
+++ b/crates/cairn-store-sqlite/tests/wal_recovery.rs
@@ -180,6 +180,26 @@ async fn seed_step(
     .expect("seed wal_steps");
 }
 
+async fn seed_payload_json(
+    conn: &Arc<Connection>,
+    op_id: &str,
+    kind: WalKind,
+    payload_json: String,
+) {
+    let op = op_id.to_owned();
+    let kind_str = kind.as_str().to_owned();
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+             VALUES (?1, ?2, ?3, 0)",
+            params![op, kind_str, payload_json],
+        )?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("seed wal_payloads");
+}
+
 async fn read_op_state(conn: &Arc<Connection>, op_id: &str) -> String {
     let op = op_id.to_owned();
     conn.call(move |c| {
@@ -363,6 +383,77 @@ async fn retry_exhaustion_aborts_op() {
     let (state, attempts) = read_step_row(&conn, "op-fail", 1).await;
     assert_eq!(state, "FAILED");
     assert_eq!(attempts, cairn_core::wal::MAX_STEP_ATTEMPTS);
+}
+
+#[tokio::test]
+async fn recovery_stops_at_durable_attempt_ceiling() {
+    let conn = open_db().await;
+    seed_op(&conn, "op-near-ceiling", WalKind::Upsert, "ISSUED", 1).await;
+    forward_to_prepared(&conn, "op-near-ceiling").await;
+    let names = upsert_step_names();
+    seed_step(
+        &conn,
+        "op-near-ceiling",
+        0,
+        names[0],
+        "FAILED",
+        cairn_core::wal::MAX_STEP_ATTEMPTS - 1,
+    )
+    .await;
+
+    let body = SyntheticBody::new(vec![BodyBehavior::AlwaysFail; 6]);
+    let cfg = upsert_with_body(body.clone());
+
+    let report = recover_pending(&conn, &cfg).await.expect("recover");
+
+    assert_eq!(report.aborted.len(), 1);
+    assert_eq!(report.aborted[0].1, 0, "step 0 should hit the ceiling");
+    assert_eq!(read_op_state(&conn, "op-near-ceiling").await, "ABORTED");
+    assert_eq!(
+        body.calls(0),
+        1,
+        "only one additional body invocation is allowed at MAX - 1"
+    );
+    assert_eq!(
+        read_step_row(&conn, "op-near-ceiling", 0).await,
+        ("FAILED".into(), cairn_core::wal::MAX_STEP_ATTEMPTS)
+    );
+}
+
+#[tokio::test]
+async fn recovery_rejects_payload_variant_that_disagrees_with_wal_kind() {
+    let store = open_in_memory().await.expect("open in-memory store");
+    let conn = Arc::clone(
+        store
+            .raw_conn_for_admin()
+            .expect("store has a live connection"),
+    );
+    seed_op(&conn, "op-kind-mismatch", WalKind::Expire, "ISSUED", 1).await;
+    forward_to_prepared(&conn, "op-kind-mismatch").await;
+
+    let record = cairn_core::domain::record::tests_export::sample_record();
+    let payload = cairn_store_sqlite::record_wal::payload::UpsertPayload::new_for_test(record);
+    let payload_json = serde_json::to_string(
+        &cairn_store_sqlite::record_wal::payload::RecordWalPayload::Upsert(payload),
+    )
+    .expect("payload json");
+    seed_payload_json(&conn, "op-kind-mismatch", WalKind::Expire, payload_json).await;
+
+    let cfg = RecoveryConfig {
+        enabled: true,
+        bodies: Box::new(cairn_store_sqlite::record_wal::RecordWalRegistry::new(
+            Arc::clone(store.incarnation().expect("incarnation")),
+        )),
+    };
+
+    let err = recover_pending(&conn, &cfg)
+        .await
+        .expect_err("kind/payload mismatch must fail recovery");
+    assert!(
+        err.to_string().contains("payload"),
+        "error should identify payload mismatch: {err}"
+    );
+    assert_eq!(read_op_state(&conn, "op-kind-mismatch").await, "PREPARED");
 }
 
 #[tokio::test]

--- a/docs/superpowers/plans/2026-05-08-issue-57-cow-upsert-expire.md
+++ b/docs/superpowers/plans/2026-05-08-issue-57-cow-upsert-expire.md
@@ -1,0 +1,2659 @@
+# Issue 57 COW Upsert Expire WAL Apply Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement WAL-driven copy-on-write apply for record upsert and expire so partial writes never expose half-updated records, recovery can replay body-bearing operations, and expired records disappear from default reads and search without hard deletion.
+
+**Architecture:** Add a `record_wal` subsystem inside `cairn-store-sqlite` that owns record-operation payloads, lock acquisition, step bodies, and operation finalization. Public upsert and the new concrete expire API issue a body-bearing `wal_ops` row, persist a durable JSON payload, run the static step graph through the existing runner, and finalize `COMMITTED` only after all steps are `DONE`. Boot recovery initializes the daemon incarnation first, registers record step bodies, reacquires per-operation locks, and resumes `PREPARED` upsert and expire operations from their persisted payloads.
+
+**Tech Stack:** Rust 2024, `tokio_rusqlite`, `rusqlite`, SQLite WAL tables, existing `cairn_core::wal` step graphs, existing `locks` module, serde JSON payloads, integration tests under `crates/cairn-store-sqlite/tests`.
+
+---
+
+## File Structure
+
+- Create: `crates/cairn-store-sqlite/src/migrations/sql/0053_wal_payloads.sql`
+  - Adds durable JSON payload storage keyed by `wal_ops.operation_id`.
+  - Makes payload rows immutable and append-only.
+- Modify: `crates/cairn-store-sqlite/src/migrations/mod.rs`
+  - Registers migration 53 in the manifest and migration list.
+- Create: `crates/cairn-store-sqlite/tests/wal_payloads_migration.rs`
+  - Verifies the schema exists, enforces the foreign key, and blocks update/delete.
+- Modify: `crates/cairn-store-sqlite/src/locks/handle.rs`
+  - Adds synchronous `LockHandle::assert_live_in_tx` for step bodies already running in a `rusqlite::Transaction`.
+- Modify: `crates/cairn-store-sqlite/src/locks/error.rs`
+  - No enum shape change required; reuse `LockError::Db`, `LockError::Clock`, and `LockError::Fenced`.
+- Modify: `crates/cairn-store-sqlite/tests/locks_stale_fence.rs`
+  - Adds coverage for the new transaction-local fencing assertion.
+- Modify: `crates/cairn-store-sqlite/src/wal/recovery.rs`
+  - Changes `StepBodyRegistry` to async and operation-aware so recovery bodies can load payloads and reacquire locks before `runner::run_from`.
+- Modify: `crates/cairn-store-sqlite/tests/wal_recovery.rs`
+  - Updates the synthetic registry to the new `StepBodyRegistry` signature.
+- Create: `crates/cairn-store-sqlite/src/record_wal/mod.rs`
+  - Module root and public-in-crate API for apply and recovery.
+- Create: `crates/cairn-store-sqlite/src/record_wal/payload.rs`
+  - Serializable `UpsertPayload`, `ExpirePayload`, embedding outcome, and payload load/save helpers.
+- Create: `crates/cairn-store-sqlite/src/record_wal/locks.rs`
+  - Shared lock-resource derivation and async acquisition for public apply and recovery.
+- Create: `crates/cairn-store-sqlite/src/record_wal/ops.rs`
+  - WAL issue, prepare, finalize, and payload persistence helpers.
+- Create: `crates/cairn-store-sqlite/src/record_wal/steps.rs`
+  - `StepBody` implementation and all step dispatch for upsert and expire.
+- Create: `crates/cairn-store-sqlite/src/record_wal/recovery.rs`
+  - `RecordWalRegistry` implementation for boot recovery.
+- Create: `crates/cairn-store-sqlite/src/record_wal/upsert.rs`
+  - Public upsert WAL apply orchestration.
+- Create: `crates/cairn-store-sqlite/src/record_wal/expire.rs`
+  - Public expire WAL apply orchestration.
+- Modify: `crates/cairn-store-sqlite/src/store/upsert.rs`
+  - Keeps validation and embedding precompute, then delegates to `record_wal::apply_upsert`.
+  - Exposes sync COW primitives used by WAL step bodies and transaction tests.
+- Create: `crates/cairn-store-sqlite/src/store/expire.rs`
+  - Concrete `SqliteMemoryStore::expire(&TargetId)` API delegating to `record_wal::apply_expire`.
+- Modify: `crates/cairn-store-sqlite/src/store/mod.rs`
+  - Adds the `expire` module.
+- Modify: `crates/cairn-store-sqlite/src/open.rs`
+  - Initializes daemon incarnation before boot recovery and registers `RecordWalRegistry`.
+- Modify: `crates/cairn-store-sqlite/src/lib.rs`
+  - Adds `mod record_wal`.
+- Modify: `crates/cairn-store-sqlite/src/error.rs`
+  - Adds record-WAL lock and apply variants that preserve lock and runner error sources.
+- Create: `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`
+  - End-to-end acceptance tests for WAL conformance, search exclusion, expiry, and retry-safe derived steps.
+
+---
+
+### Task 1: Add Durable WAL Payload Storage
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/migrations/sql/0053_wal_payloads.sql`
+- Modify: `crates/cairn-store-sqlite/src/migrations/mod.rs`
+- Create: `crates/cairn-store-sqlite/tests/wal_payloads_migration.rs`
+
+- [ ] **Step 1: Write the failing migration test**
+
+Add `crates/cairn-store-sqlite/tests/wal_payloads_migration.rs`:
+
+```rust
+//! Migration 0053 stores body-bearing WAL payloads for record operations.
+
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::wal::WalKind;
+use cairn_store_sqlite::open_in_memory;
+use rusqlite::params;
+
+#[tokio::test]
+async fn wal_payloads_table_is_present_and_immutable() {
+    let store = open_in_memory().await.expect("open in-memory store");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    conn.call(|c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-payload', 1, ?1, 'ISSUED', '{}', 'issuer', 'target', '{}', 0, 'sig', 1, 1)",
+            params![WalKind::Upsert.as_str()],
+        )?;
+        c.execute(
+            "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+             VALUES ('op-payload', 'upsert', '{\"kind\":\"upsert\"}', 1)",
+            [],
+        )?;
+
+        let payload: String = c.query_row(
+            "SELECT payload_json FROM wal_payloads WHERE operation_id = 'op-payload'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(payload, "{\"kind\":\"upsert\"}");
+
+        let update = c.execute(
+            "UPDATE wal_payloads SET payload_json = '{}' WHERE operation_id = 'op-payload'",
+            [],
+        );
+        assert!(update.is_err(), "payload rows must not be updated");
+
+        let delete = c.execute("DELETE FROM wal_payloads WHERE operation_id = 'op-payload'", []);
+        assert!(delete.is_err(), "payload rows must not be deleted");
+
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("schema assertions");
+}
+
+#[tokio::test]
+async fn wal_payloads_requires_existing_operation() {
+    let store = open_in_memory().await.expect("open in-memory store");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    conn.call(|c| {
+        let err = c
+            .execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES ('missing-op', 'upsert', '{}', 1)",
+                [],
+            )
+            .expect_err("foreign key rejects missing wal_ops row");
+        assert!(err.to_string().contains("FOREIGN KEY"));
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("foreign-key assertion");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cairn-store-sqlite --test wal_payloads_migration -- --nocapture`
+
+Expected: FAIL with a SQLite message containing `no such table: wal_payloads`.
+
+- [ ] **Step 3: Add the migration SQL**
+
+Create `crates/cairn-store-sqlite/src/migrations/sql/0053_wal_payloads.sql`:
+
+```sql
+-- Migration 0053: durable body-bearing WAL payloads for record operations.
+-- Issue #57: upsert and expire recovery need operation inputs after restart.
+
+CREATE TABLE wal_payloads (
+  operation_id TEXT NOT NULL PRIMARY KEY
+                    REFERENCES wal_ops(operation_id),
+  kind         TEXT NOT NULL CHECK (kind IN ('upsert', 'expire')),
+  payload_json TEXT NOT NULL,
+  created_at   INTEGER NOT NULL
+);
+
+CREATE TRIGGER wal_payloads_immutable
+  BEFORE UPDATE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads rows are immutable');
+END;
+
+CREATE TRIGGER wal_payloads_no_delete
+  BEFORE DELETE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads is append-only');
+END;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (53, '0053_wal_payloads', '', strftime('%s','now') * 1000);
+```
+
+- [ ] **Step 4: Register migration 53**
+
+In `crates/cairn-store-sqlite/src/migrations/mod.rs`, add the const after `M0052_LOCK_ACQUISITION_ULID_UNIQUE`:
+
+```rust
+// Issue #57 — durable body-bearing WAL payloads for upsert/expire recovery.
+const M0053_WAL_PAYLOADS: &str = include_str!("sql/0053_wal_payloads.sql");
+```
+
+Add this tuple after migration 52 in `MIGRATION_SOURCES`:
+
+```rust
+    (53, "0053_wal_payloads", M0053_WAL_PAYLOADS),
+```
+
+Add this migration after `M::up(M0052_LOCK_ACQUISITION_ULID_UNIQUE),`:
+
+```rust
+        M::up(M0053_WAL_PAYLOADS),
+```
+
+- [ ] **Step 5: Run the migration test to verify it passes**
+
+Run: `cargo test -p cairn-store-sqlite --test wal_payloads_migration -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/migrations/mod.rs \
+  crates/cairn-store-sqlite/src/migrations/sql/0053_wal_payloads.sql \
+  crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
+git commit -m "feat: add wal payload storage"
+```
+
+---
+
+### Task 2: Make Recovery Registries Operation-Aware and Add Transaction Fencing
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/wal/recovery.rs`
+- Modify: `crates/cairn-store-sqlite/tests/wal_recovery.rs`
+- Modify: `crates/cairn-store-sqlite/src/locks/handle.rs`
+- Modify: `crates/cairn-store-sqlite/tests/locks_stale_fence.rs`
+
+- [ ] **Step 1: Write the failing lock assertion test**
+
+Add this test to `crates/cairn-store-sqlite/tests/locks_stale_fence.rs`:
+
+```rust
+#[tokio::test]
+async fn assert_live_in_tx_blocks_stale_holder_inside_existing_transaction() {
+    let store = open_in_memory().await.unwrap();
+    let conn = Arc::clone(store.raw_conn_for_admin().unwrap());
+    let inc = store.incarnation().cloned().unwrap();
+    let resource = ResourceKey::entity("t1", "default", "rec-tx");
+
+    let h_a = acquire(
+        &conn,
+        &resource,
+        LockMode::Exclusive,
+        "holder_a_tx",
+        Duration::from_millis(80),
+        &inc,
+        "writer_a_tx",
+    )
+    .await
+    .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let _h_b = acquire(
+        &conn,
+        &resource,
+        LockMode::Exclusive,
+        "holder_b_tx",
+        Duration::from_secs(5),
+        &inc,
+        "writer_b_tx",
+    )
+    .await
+    .unwrap();
+
+    let err = conn
+        .call(move |c| {
+            let tx = c.transaction()?;
+            let result = h_a.assert_live_in_tx(&tx);
+            drop(tx);
+            Ok::<_, tokio_rusqlite::Error>(result)
+        })
+        .await
+        .unwrap()
+        .unwrap_err();
+
+    assert!(matches!(err, LockError::Fenced { .. }));
+}
+```
+
+- [ ] **Step 2: Run the lock test to verify it fails**
+
+Run: `cargo test -p cairn-store-sqlite --test locks_stale_fence assert_live_in_tx_blocks_stale_holder_inside_existing_transaction -- --nocapture`
+
+Expected: FAIL with a compiler error containing `no method named assert_live_in_tx`.
+
+- [ ] **Step 3: Implement transaction-local fencing**
+
+Add this method inside `impl LockHandle` in `crates/cairn-store-sqlite/src/locks/handle.rs`:
+
+```rust
+    /// Assert this lock is still live inside an existing transaction.
+    ///
+    /// Step bodies use this when the WAL runner already opened the
+    /// transaction that will contain the side effect and `wal_steps` update.
+    ///
+    /// # Errors
+    /// - `LockError::Fenced` if the acquisition row expired, was reclaimed,
+    ///   or the resource epoch changed.
+    /// - `LockError::Clock` if system time is before Unix epoch.
+    /// - `LockError::Db` for SQLite failures.
+    pub fn assert_live_in_tx(&self, tx: &rusqlite::Transaction<'_>) -> Result<(), LockError> {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| LockError::Clock)
+            .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))?;
+
+        let (group_epoch, holder_alive): (Option<i64>, i64) = tx
+            .query_row(
+                "SELECT \
+                   (SELECT epoch FROM locks WHERE resource = ?1) AS group_epoch, \
+                   EXISTS (SELECT 1 FROM lock_holders \
+                            WHERE acquisition_ulid = ?2 AND expires_at > ?3) \
+                        AS holder_alive",
+                params![self.resource, self.acquisition_ulid, now_ms],
+                |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .map_err(|e| LockError::Db(tokio_rusqlite::Error::Rusqlite(e)))?;
+
+        let observed = group_epoch.unwrap_or(-1);
+        if observed != self.acquired_epoch || holder_alive == 0 {
+            return Err(LockError::Fenced {
+                resource: self.resource.clone(),
+                expected_epoch: self.acquired_epoch,
+                observed_epoch: observed,
+                retry: default_fenced_retry(),
+            });
+        }
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Run the lock test to verify it passes**
+
+Run: `cargo test -p cairn-store-sqlite --test locks_stale_fence assert_live_in_tx_blocks_stale_holder_inside_existing_transaction -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing recovery registry test update**
+
+In `crates/cairn-store-sqlite/tests/wal_recovery.rs`, change `OneKindRegistry` to count which operation was requested:
+
+```rust
+struct OneKindRegistry {
+    kind: WalKind,
+    body: Arc<dyn StepBody>,
+    requested_ops: parking_lot::Mutex<Vec<String>>,
+}
+```
+
+Update `upsert_with_body`:
+
+```rust
+fn upsert_with_body(body: Arc<dyn StepBody>) -> RecoveryConfig {
+    RecoveryConfig {
+        enabled: true,
+        bodies: Box::new(OneKindRegistry {
+            kind: WalKind::Upsert,
+            body,
+            requested_ops: parking_lot::Mutex::new(Vec::new()),
+        }),
+    }
+}
+```
+
+Replace the `StepBodyRegistry` impl:
+
+```rust
+#[async_trait::async_trait]
+impl StepBodyRegistry for OneKindRegistry {
+    async fn body_for(
+        &self,
+        _conn: &Arc<Connection>,
+        kind: WalKind,
+        op_id: &OperationId,
+    ) -> Result<Option<Arc<dyn StepBody>>, cairn_store_sqlite::wal::RecoveryError> {
+        self.requested_ops.lock().push(op_id.as_str().to_owned());
+        if kind == self.kind {
+            Ok(Some(Arc::clone(&self.body)))
+        } else {
+            Ok(None)
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run WAL recovery tests to verify the signature fails**
+
+Run: `cargo test -p cairn-store-sqlite --test wal_recovery -- --nocapture`
+
+Expected: FAIL with trait signature mismatch errors for `StepBodyRegistry`.
+
+- [ ] **Step 7: Change `StepBodyRegistry` to async operation-aware lookup**
+
+In `crates/cairn-store-sqlite/src/wal/recovery.rs`, replace the trait and empty registry with:
+
+```rust
+#[async_trait::async_trait]
+pub trait StepBodyRegistry: Send + Sync {
+    /// Returns the body for `kind` and `op_id`.
+    ///
+    /// Recovery registries may load durable payloads and reacquire locks
+    /// before returning a body that can run synchronously inside runner
+    /// transactions.
+    async fn body_for(
+        &self,
+        conn: &Arc<Connection>,
+        kind: WalKind,
+        op_id: &OperationId,
+    ) -> Result<Option<Arc<dyn StepBody>>, RecoveryError>;
+}
+
+pub struct EmptyRegistry;
+
+#[async_trait::async_trait]
+impl StepBodyRegistry for EmptyRegistry {
+    async fn body_for(
+        &self,
+        _conn: &Arc<Connection>,
+        _kind: WalKind,
+        _op_id: &OperationId,
+    ) -> Result<Option<Arc<dyn StepBody>>, RecoveryError> {
+        Ok(None)
+    }
+}
+```
+
+In `handle_resume`, replace:
+
+```rust
+    let Some(body) = config.bodies.body_for(snapshot.kind) else {
+```
+
+with:
+
+```rust
+    let Some(body) = config.bodies.body_for(conn, snapshot.kind, op_id).await? else {
+```
+
+- [ ] **Step 8: Run the recovery tests to verify they pass**
+
+Run: `cargo test -p cairn-store-sqlite --test wal_recovery -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/wal/recovery.rs \
+  crates/cairn-store-sqlite/tests/wal_recovery.rs \
+  crates/cairn-store-sqlite/src/locks/handle.rs \
+  crates/cairn-store-sqlite/tests/locks_stale_fence.rs
+git commit -m "feat: make wal recovery bodies operation aware"
+```
+
+---
+
+### Task 3: Add Record WAL Payload and Operation Infrastructure
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/record_wal/mod.rs`
+- Create: `crates/cairn-store-sqlite/src/record_wal/payload.rs`
+- Create: `crates/cairn-store-sqlite/src/record_wal/locks.rs`
+- Create: `crates/cairn-store-sqlite/src/record_wal/ops.rs`
+- Modify: `crates/cairn-store-sqlite/src/lib.rs`
+- Modify: `crates/cairn-store-sqlite/src/error.rs`
+- Create: `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`
+
+- [ ] **Step 1: Write the failing payload round-trip test**
+
+Create `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs` with this initial content:
+
+```rust
+//! Issue #57: COW upsert and expire through body-bearing WAL.
+
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::{
+    KeywordSearchArgs, ListArgs, MemoryStore, TombstoneReason,
+};
+use cairn_core::domain::{MemoryRecord, TargetId};
+use cairn_store_sqlite::open_in_memory;
+use rusqlite::params;
+
+fn sample() -> MemoryRecord {
+    cairn_core::domain::record::tests_export::sample_record()
+}
+
+#[tokio::test]
+async fn payload_round_trip_smoke() {
+    let store = open_in_memory().await.expect("open");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let record = sample();
+    let payload = cairn_store_sqlite::record_wal::payload::UpsertPayload::new_for_test(record);
+
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-round-trip', 1, 'upsert', 'ISSUED', '{}', 'issuer', 'target', '{}', 0, 'sig', 1, 1)",
+            [],
+        )?;
+        cairn_store_sqlite::record_wal::payload::save_upsert_payload_for_test(
+            c,
+            "op-round-trip",
+            &payload,
+        )?;
+        let loaded = cairn_store_sqlite::record_wal::payload::load_upsert_payload_for_test(
+            c,
+            "op-round-trip",
+        )?;
+        assert_eq!(loaded.record.target_id, payload.record.target_id);
+        assert_eq!(loaded.record.body, payload.record.body);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("payload round trip");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire payload_round_trip_smoke -- --nocapture`
+
+Expected: FAIL with an import error for `cairn_store_sqlite::record_wal`.
+
+- [ ] **Step 3: Expose the module inside the crate**
+
+In `crates/cairn-store-sqlite/src/lib.rs`, add:
+
+```rust
+pub mod record_wal;
+```
+
+Use `pub mod` because the integration tests in this task call test-only helper functions gated inside the module. Keep production functions `pub(crate)` unless tests need them.
+
+- [ ] **Step 4: Add record WAL module root**
+
+Create `crates/cairn-store-sqlite/src/record_wal/mod.rs`:
+
+```rust
+//! Body-bearing WAL apply for record upsert and expire operations.
+
+pub mod payload;
+
+pub(crate) mod locks;
+pub(crate) mod ops;
+pub(crate) mod recovery;
+pub(crate) mod steps;
+pub(crate) mod upsert;
+pub(crate) mod expire;
+
+pub(crate) use expire::apply_expire;
+pub(crate) use upsert::apply_upsert;
+pub use recovery::RecordWalRegistry;
+```
+
+- [ ] **Step 5: Add payload types and load/save helpers**
+
+Create `crates/cairn-store-sqlite/src/record_wal/payload.rs`:
+
+```rust
+//! Durable JSON payloads for record WAL operations.
+
+use cairn_core::domain::{MemoryRecord, TargetId};
+use cairn_core::wal::{OperationId, WalKind};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+
+use crate::error::StoreError;
+use crate::store::current_unix_ms;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RecordWalPayload {
+    Upsert(UpsertPayload),
+    Expire(ExpirePayload),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UpsertPayload {
+    pub record: MemoryRecord,
+    pub embed: StoredEmbedOutcome,
+    pub planned: PlannedUpsert,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PlannedUpsert {
+    pub outcome_record_id: String,
+    pub target_id: String,
+    pub version: u32,
+    pub content_changed: bool,
+    pub prior_record_id: Option<String>,
+    pub prior_hash: Option<String>,
+    pub consent_model: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum StoredEmbedOutcome {
+    Succeeded { vector: Vec<u8>, model_label: String },
+    Failed { error: String },
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExpirePayload {
+    pub target_id: TargetId,
+    pub reason: String,
+}
+
+pub(crate) fn save_payload(
+    conn: &Connection,
+    op_id: &OperationId,
+    payload: &RecordWalPayload,
+) -> Result<(), StoreError> {
+    let kind = match payload {
+        RecordWalPayload::Upsert(_) => WalKind::Upsert.as_str(),
+        RecordWalPayload::Expire(_) => WalKind::Expire.as_str(),
+    };
+    let json = serde_json::to_string(payload)?;
+    conn.execute(
+        "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+         VALUES (?1, ?2, ?3, ?4)",
+        params![op_id.as_str(), kind, json, current_unix_ms()],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn load_payload(
+    conn: &Connection,
+    op_id: &OperationId,
+) -> Result<RecordWalPayload, StoreError> {
+    let json: String = conn
+        .query_row(
+            "SELECT payload_json FROM wal_payloads WHERE operation_id = ?1",
+            params![op_id.as_str()],
+            |row| row.get(0),
+        )
+        .optional()?
+        .ok_or_else(|| StoreError::Invariant {
+            what: format!("missing wal_payloads row for operation {}", op_id.as_str()),
+        })?;
+    Ok(serde_json::from_str(&json)?)
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl UpsertPayload {
+    #[must_use]
+    pub fn new_for_test(record: MemoryRecord) -> Self {
+        Self {
+            planned: PlannedUpsert {
+                outcome_record_id: record.id.as_str().to_owned(),
+                target_id: record.target_id.as_str().to_owned(),
+                version: 1,
+                content_changed: true,
+                prior_record_id: None,
+                prior_hash: None,
+                consent_model: "legacy_event".to_owned(),
+            },
+            record,
+            embed: StoredEmbedOutcome::Skipped,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn save_upsert_payload_for_test(
+    conn: &Connection,
+    op_id: &str,
+    payload: &UpsertPayload,
+) -> Result<(), StoreError> {
+    let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
+        what: format!("invalid test op id: {e}"),
+    })?;
+    save_payload(conn, &op, &RecordWalPayload::Upsert(payload.clone()))
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn load_upsert_payload_for_test(
+    conn: &Connection,
+    op_id: &str,
+) -> Result<UpsertPayload, StoreError> {
+    let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
+        what: format!("invalid test op id: {e}"),
+    })?;
+    match load_payload(conn, &op)? {
+        RecordWalPayload::Upsert(payload) => Ok(payload),
+        RecordWalPayload::Expire(_) => Err(StoreError::Invariant {
+            what: "expected upsert payload, found expire payload".to_owned(),
+        }),
+    }
+}
+```
+
+- [ ] **Step 6: Add operation and lock modules with compilable shells**
+
+Create `crates/cairn-store-sqlite/src/record_wal/ops.rs`:
+
+```rust
+//! `wal_ops` issue, prepare, and finalize helpers for record operations.
+
+use cairn_core::wal::{OpState, OperationId, WalKind};
+use rusqlite::{Connection, params};
+
+use crate::error::StoreError;
+use crate::store::current_unix_ms;
+
+#[must_use]
+pub(crate) fn new_operation_id(kind: WalKind) -> OperationId {
+    let raw = format!("{}-{}", kind.as_str(), ulid::Ulid::new());
+    OperationId::parse(raw).expect("operation id built from non-empty kind and ULID")
+}
+
+pub(crate) fn issue_prepared(
+    conn: &Connection,
+    op_id: &OperationId,
+    kind: WalKind,
+    target_hash: &str,
+    scope_json: &str,
+) -> Result<(), StoreError> {
+    let now = current_unix_ms();
+    conn.execute(
+        "INSERT INTO wal_ops \
+           (operation_id, issued_seq, kind, state, envelope, issuer, principal, \
+            target_hash, scope_json, plan_ref, expires_at, signature, issued_at, updated_at) \
+         VALUES (?1, COALESCE((SELECT MAX(issued_seq) FROM wal_ops), 0) + 1, ?2, \
+            'ISSUED', '{}', 'cairn-store-sqlite', NULL, ?3, ?4, NULL, 0, 'local', ?5, ?5)",
+        params![op_id.as_str(), kind.as_str(), target_hash, scope_json, now],
+    )?;
+    conn.execute(
+        "UPDATE wal_ops SET state = 'PREPARED', updated_at = ?1 WHERE operation_id = ?2",
+        params![now, op_id.as_str()],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn finalize(
+    conn: &Connection,
+    op_id: &OperationId,
+    state: OpState,
+    reason: &str,
+) -> Result<(), StoreError> {
+    let now = current_unix_ms();
+    conn.execute(
+        "UPDATE wal_ops SET state = ?1, reason = COALESCE(reason, ?2), updated_at = ?3 \
+         WHERE operation_id = ?4",
+        params![state.as_str(), reason, now, op_id.as_str()],
+    )?;
+    Ok(())
+}
+```
+
+Create `crates/cairn-store-sqlite/src/record_wal/locks.rs`:
+
+```rust
+//! Lock acquisition for record WAL operations.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cairn_core::domain::{ScopeTuple, TargetId};
+use tokio_rusqlite::Connection;
+
+use crate::locks::{LockHandle, LockMode, ResourceKey, acquire};
+
+pub(crate) struct RecordLocks {
+    handles: Vec<LockHandle>,
+}
+
+impl RecordLocks {
+    #[must_use]
+    pub(crate) fn new(handles: Vec<LockHandle>) -> Self {
+        Self { handles }
+    }
+
+    pub(crate) fn assert_live_in_tx(
+        &self,
+        tx: &rusqlite::Transaction<'_>,
+    ) -> Result<(), crate::locks::LockError> {
+        for handle in &self.handles {
+            handle.assert_live_in_tx(tx)?;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) async fn acquire_for_record(
+    conn: &Arc<Connection>,
+    scope: &ScopeTuple,
+    target: &TargetId,
+    incarnation: &Arc<str>,
+    op_id: &str,
+    operation: &'static str,
+) -> Result<RecordLocks, crate::locks::LockError> {
+    let (tenant, workspace) = scope_lock_parts(scope);
+    let mut handles = Vec::with_capacity(2);
+    handles.push(
+        acquire(
+            conn,
+            &ResourceKey::entity(&tenant, &workspace, target.as_str()),
+            LockMode::Exclusive,
+            &format!("{op_id}:entity"),
+            Duration::from_secs(30),
+            incarnation,
+            operation,
+        )
+        .await?,
+    );
+    if let Some(session_id) = scope.session_id.as_deref() {
+        handles.push(
+            acquire(
+                conn,
+                &ResourceKey::session(&tenant, &workspace, session_id),
+                LockMode::Shared,
+                &format!("{op_id}:session"),
+                Duration::from_secs(30),
+                incarnation,
+                operation,
+            )
+            .await?,
+        );
+    }
+    Ok(RecordLocks::new(handles))
+}
+
+fn scope_lock_parts(scope: &ScopeTuple) -> (String, String) {
+    (
+        scope.tenant.as_deref().unwrap_or("default").to_owned(),
+        scope.workspace.as_deref().unwrap_or("default").to_owned(),
+    )
+}
+```
+
+- [ ] **Step 7: Add StoreError variants used by record WAL**
+
+In `crates/cairn-store-sqlite/src/error.rs`, add these variants near `Recovery` and `LockInit`:
+
+```rust
+    /// Record-WAL step runner failed during public apply.
+    #[error("record wal runner")]
+    RecordWalRunner(#[from] crate::wal::RunnerError),
+
+    /// Record-WAL apply could not acquire or assert locks.
+    #[error("record wal lock")]
+    RecordWalLock(#[source] Box<crate::locks::LockError>),
+```
+
+- [ ] **Step 8: Add empty modules named by `mod.rs`**
+
+Create `crates/cairn-store-sqlite/src/record_wal/steps.rs`:
+
+```rust
+//! Record WAL step bodies.
+```
+
+Create `crates/cairn-store-sqlite/src/record_wal/recovery.rs`:
+
+```rust
+//! Record WAL recovery registry.
+```
+
+Create `crates/cairn-store-sqlite/src/record_wal/upsert.rs`:
+
+```rust
+//! Public upsert apply through record WAL.
+```
+
+Create `crates/cairn-store-sqlite/src/record_wal/expire.rs`:
+
+```rust
+//! Public expire apply through record WAL.
+```
+
+- [ ] **Step 9: Run the payload test to verify it passes**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire payload_round_trip_smoke -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/lib.rs \
+  crates/cairn-store-sqlite/src/error.rs \
+  crates/cairn-store-sqlite/src/record_wal \
+  crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+git commit -m "feat: add record wal payload infrastructure"
+```
+
+---
+
+### Task 4: Route Public Upsert Through WAL and Keep Existing Semantics
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/store/upsert.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/upsert.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/steps.rs`
+- Modify: `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`
+- Modify: existing upsert tests remain unchanged and must pass.
+
+- [ ] **Step 1: Add the failing WAL conformance test**
+
+Append to `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`:
+
+```rust
+#[tokio::test]
+async fn upsert_commits_wal_operation_and_all_steps() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+
+    let out = store.upsert(&record).await.expect("upsert through wal");
+    assert_eq!(out.version, 1);
+    assert!(out.content_changed);
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(|c| {
+        let row: (String, i64) = c.query_row(
+            "SELECT state, COUNT(*) FROM wal_ops WHERE kind = 'upsert' GROUP BY state",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(row, ("COMMITTED".to_owned(), 1));
+
+        let done_count: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps ws \
+              JOIN wal_ops wo ON wo.operation_id = ws.operation_id \
+             WHERE wo.kind = 'upsert' AND ws.state = 'DONE'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(done_count, 6);
+
+        let payload_count: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_payloads wp \
+              JOIN wal_ops wo ON wo.operation_id = wp.operation_id \
+             WHERE wo.kind = 'upsert'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(payload_count, 1);
+
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("wal rows");
+}
+```
+
+- [ ] **Step 2: Run the conformance test to verify it fails**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire upsert_commits_wal_operation_and_all_steps -- --nocapture`
+
+Expected: FAIL because `MemoryStore::upsert` writes no `wal_ops` row.
+
+- [ ] **Step 3: Make embedding outcome reusable by WAL payloads**
+
+In `crates/cairn-store-sqlite/src/store/upsert.rs`, change `enum EmbedOutcome` to:
+
+```rust
+pub(crate) enum EmbedOutcome {
+    Succeeded {
+        vector: Vec<u8>,
+        model_label: String,
+    },
+    Failed { error: String },
+    Skipped,
+}
+```
+
+Add this impl below the enum:
+
+```rust
+impl From<EmbedOutcome> for crate::record_wal::payload::StoredEmbedOutcome {
+    fn from(value: EmbedOutcome) -> Self {
+        match value {
+            EmbedOutcome::Succeeded {
+                vector,
+                model_label,
+            } => Self::Succeeded {
+                vector,
+                model_label,
+            },
+            EmbedOutcome::Failed { error } => Self::Failed { error },
+            EmbedOutcome::Skipped => Self::Skipped,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Replace `do_upsert` SQL mutation with WAL apply**
+
+In `crates/cairn-store-sqlite/src/store/upsert.rs`, keep validation and embedding precompute, then replace the `conn.call` block that calls `upsert_in_tx` with:
+
+```rust
+        let payload_embed = crate::record_wal::payload::StoredEmbedOutcome::from(embed_outcome);
+        crate::record_wal::apply_upsert(self, record, payload_embed).await
+```
+
+Remove no longer used imports from `do_upsert`, but keep `upsert_in_tx` and its helpers for current transaction callers until Task 5 splits them into COW primitives.
+
+- [ ] **Step 5: Implement minimal WAL apply using current upsert primitive**
+
+Add to `crates/cairn-store-sqlite/src/record_wal/upsert.rs`:
+
+```rust
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::UpsertOutcome;
+use cairn_core::domain::MemoryRecord;
+use cairn_core::wal::{OpState, WalKind, graph_for};
+
+use crate::error::StoreError;
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::ops::{finalize, issue_prepared, new_operation_id};
+use crate::record_wal::payload::{
+    PlannedUpsert, RecordWalPayload, StoredEmbedOutcome, UpsertPayload, save_payload,
+};
+use crate::record_wal::steps::RecordStepBody;
+use crate::store::SqliteMemoryStore;
+use crate::store::upsert::upsert_in_tx;
+use crate::wal::runner;
+
+pub(crate) async fn apply_upsert(
+    store: &SqliteMemoryStore,
+    record: &MemoryRecord,
+    embed: StoredEmbedOutcome,
+) -> Result<UpsertOutcome, StoreError> {
+    let conn = store.require_conn("upsert")?.clone();
+    let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
+        what: "upsert requires daemon incarnation".to_owned(),
+    })?;
+    let op_id = new_operation_id(WalKind::Upsert);
+    let locks = acquire_for_record(
+        &conn,
+        &record.scope,
+        &record.target_id,
+        &incarnation,
+        op_id.as_str(),
+        "record_wal_upsert",
+    )
+    .await
+    .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
+
+    let record_for_plan = record.clone();
+    let record_for_payload = record.clone();
+    let planned = conn
+        .call(move |c| {
+            let mut tx = c.transaction()?;
+            let out = upsert_in_tx(&mut tx, &record_for_plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            tx.rollback()?;
+            Ok::<_, tokio_rusqlite::Error>(PlannedUpsert {
+                outcome_record_id: out.record_id.as_str().to_owned(),
+                target_id: out.target_id.as_str().to_owned(),
+                version: out.version,
+                content_changed: out.content_changed,
+                prior_record_id: None,
+                prior_hash: out.prior_hash.map(|h| h.to_string()),
+                consent_model: "legacy_event".to_owned(),
+            })
+        })
+        .await?;
+
+    let payload = UpsertPayload {
+        record: record_for_payload,
+        embed,
+        planned,
+    };
+    let payload_for_body = payload.clone();
+    let op_for_issue = op_id.clone();
+    conn.call(move |c| {
+        let tx = c.transaction()?;
+        issue_prepared(
+            &tx,
+            &op_for_issue,
+            WalKind::Upsert,
+            &payload_for_body.planned.target_id,
+            "{}",
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        save_payload(&tx, &op_for_issue, &RecordWalPayload::Upsert(payload_for_body))
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        tx.commit()?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+
+    let planned_for_outcome = payload.planned.clone();
+    let body = Arc::new(RecordStepBody::new_upsert(payload.clone(), locks));
+    runner::run_from(&conn, graph_for(WalKind::Upsert), &op_id, 0, body).await?;
+
+    let op_for_finalize = op_id.clone();
+    conn.call(move |c| {
+        finalize(c, &op_for_finalize, OpState::Committed, "applied")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+
+    Ok(UpsertOutcome {
+        record_id: cairn_core::domain::RecordId::parse(
+            planned_for_outcome.outcome_record_id.clone(),
+        )
+            .map_err(|e| StoreError::Invariant {
+                what: format!("planned record_id invalid: {e}"),
+            })?,
+        target_id: record.target_id.clone(),
+        version: planned_for_outcome.version,
+        content_changed: planned_for_outcome.content_changed,
+        prior_hash: planned_for_outcome
+            .prior_hash
+            .map(cairn_core::domain::BodyHash::parse)
+            .transpose()
+            .map_err(|e| StoreError::Invariant {
+                what: format!("planned prior_hash invalid: {e}"),
+            })?,
+    })
+}
+```
+
+This is a bootstrap implementation. Task 5 replaces the rollback planning call with a true planning helper and replaces the step body with real COW steps.
+
+- [ ] **Step 6: Change the runner body contract to mutable transactions**
+
+In `crates/cairn-store-sqlite/src/wal/runner.rs`, change the `StepBody::run` signature from `&Transaction<'_>` to `&mut Transaction<'_>`:
+
+```rust
+pub trait StepBody: Send + Sync {
+    fn run(
+        &self,
+        tx: &mut Transaction<'_>,
+        op_id: &OperationId,
+        step: &StepDef,
+    ) -> Result<(), StepBodyError>;
+}
+```
+
+In `try_one_attempt`, change:
+
+```rust
+                let tx = c.transaction()?;
+```
+
+to:
+
+```rust
+                let mut tx = c.transaction()?;
+```
+
+and change:
+
+```rust
+                let r = body.run(&tx, &op_id_for_body, &step_owned);
+```
+
+to:
+
+```rust
+                let r = body.run(&mut tx, &op_id_for_body, &step_owned);
+```
+
+Update all test `StepBody` implementations to accept `&mut Transaction<'_>`.
+
+- [ ] **Step 7: Add a step body that delegates to current upsert once**
+
+Add to `crates/cairn-store-sqlite/src/record_wal/steps.rs`:
+
+
+```rust
+use cairn_core::wal::{OperationId, StepDef};
+use rusqlite::Transaction;
+
+use crate::record_wal::locks::RecordLocks;
+use crate::record_wal::payload::{ExpirePayload, UpsertPayload};
+use crate::store::upsert::upsert_in_tx;
+use crate::wal::runner::{StepBody, StepBodyError};
+
+pub(crate) enum RecordStepPayload {
+    Upsert(UpsertPayload),
+    Expire(ExpirePayload),
+}
+
+pub(crate) struct RecordStepBody {
+    payload: RecordStepPayload,
+    locks: RecordLocks,
+}
+
+impl RecordStepBody {
+    #[must_use]
+    pub(crate) fn new_upsert(payload: UpsertPayload, locks: RecordLocks) -> Self {
+        Self {
+            payload: RecordStepPayload::Upsert(payload),
+            locks,
+        }
+    }
+}
+
+impl StepBody for RecordStepBody {
+    fn run(
+        &self,
+        tx: &mut Transaction<'_>,
+        _op_id: &OperationId,
+        step: &StepDef,
+    ) -> Result<(), StepBodyError> {
+        self.locks
+            .assert_live_in_tx(tx)
+            .map_err(|e| StepBodyError::Failed(format!("fenced: {e}")))?;
+
+        match (&self.payload, step.name) {
+            (RecordStepPayload::Upsert(payload), "primary.upsert_cow") => {
+                upsert_in_tx(tx, &payload.record)
+                    .map_err(|e| StepBodyError::Failed(e.to_string()))?;
+                Ok(())
+            }
+            (RecordStepPayload::Upsert(_), _) => Ok(()),
+            (RecordStepPayload::Expire(_), _) => Ok(()),
+        }
+    }
+}
+```
+
+- [ ] **Step 8: Run upsert regression tests**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire upsert_commits_wal_operation_and_all_steps -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-store-sqlite --test upsert_idempotent --test versioning -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/store/upsert.rs \
+  crates/cairn-store-sqlite/src/record_wal/upsert.rs \
+  crates/cairn-store-sqlite/src/record_wal/steps.rs \
+  crates/cairn-store-sqlite/src/wal/runner.rs \
+  crates/cairn-store-sqlite/tests/cow_upsert_expire.rs \
+  crates/cairn-store-sqlite/tests/wal_recovery.rs
+git commit -m "feat: route upsert through wal apply"
+```
+
+---
+
+### Task 5: Replace Direct Upsert with True Copy-On-Write Steps
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/store/upsert.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/payload.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/upsert.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/steps.rs`
+- Modify: `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`
+
+- [ ] **Step 1: Add the failing COW visibility test**
+
+Append this test to `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`:
+
+```rust
+#[tokio::test]
+async fn upsert_stages_inactive_row_before_activation() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("initial upsert");
+
+    let mut r2 = r.clone();
+    r2.body = "changed body for cow staging".to_owned();
+
+    let out = store.upsert(&r2).await.expect("second upsert");
+    assert_eq!(out.version, 2);
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let rows: Vec<(String, i64, i64)> = conn
+        .call(move |c| {
+            let mut stmt = c.prepare(
+                "SELECT record_id, active, tombstoned FROM records \
+                 WHERE target_id = ?1 ORDER BY version",
+            )?;
+            let rows = stmt
+                .query_map(params![r.target_id.as_str()], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok::<_, tokio_rusqlite::Error>(rows)
+        })
+        .await
+        .expect("records");
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].1, 0, "prior version inactive after activation");
+    assert_eq!(rows[1].1, 1, "new version active after activation");
+    assert_eq!(rows[0].2, 0, "superseded row is not tombstoned");
+    assert_eq!(rows[1].2, 0, "new row is visible");
+}
+```
+
+- [ ] **Step 2: Run the test to verify the current bridge is insufficient**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire upsert_stages_inactive_row_before_activation -- --nocapture`
+
+Expected: PASS may occur because direct upsert has the final state. Keep the test; the following unit tests pin the intermediate COW primitives.
+
+- [ ] **Step 3: Add unit tests for planning and staging**
+
+Add a `#[cfg(test)] mod cow_tests` to `crates/cairn-store-sqlite/src/store/upsert.rs`:
+
+```rust
+#[cfg(test)]
+mod cow_tests {
+    use cairn_core::domain::record::tests_export::sample_record;
+
+    use crate::open_in_memory;
+    use crate::store::upsert::{
+        activate_upsert_in_tx, plan_upsert_in_tx, stage_upsert_cow_in_tx,
+    };
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cow_stage_inserts_inactive_row() {
+        let store = open_in_memory().await.expect("open");
+        let conn = store.require_conn("test").expect("connected").clone();
+        let record = sample_record();
+
+        conn.call(move |c| {
+            let mut tx = c.transaction()?;
+            let plan = plan_upsert_in_tx(&tx, &record)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            stage_upsert_cow_in_tx(&tx, &record, &plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let active: i64 = tx.query_row(
+                "SELECT active FROM records WHERE record_id = ?1",
+                rusqlite::params![plan.outcome_record_id.as_str()],
+                |row| row.get(0),
+            )?;
+            assert_eq!(active, 0);
+            tx.rollback()?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("cow stage");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cow_activate_flips_active_pointer_in_one_transaction() {
+        let store = open_in_memory().await.expect("open");
+        let conn = store.require_conn("test").expect("connected").clone();
+        let record = sample_record();
+
+        conn.call(move |c| {
+            let tx = c.transaction()?;
+            let plan = plan_upsert_in_tx(&tx, &record)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            stage_upsert_cow_in_tx(&tx, &record, &plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            activate_upsert_in_tx(&tx, &plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let active: i64 = tx.query_row(
+                "SELECT active FROM records WHERE record_id = ?1",
+                rusqlite::params![plan.outcome_record_id.as_str()],
+                |row| row.get(0),
+            )?;
+            assert_eq!(active, 1);
+            tx.rollback()?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("cow activate");
+    }
+}
+```
+
+- [ ] **Step 4: Run unit tests to verify missing helpers**
+
+Run: `cargo test -p cairn-store-sqlite store::upsert::cow_tests -- --nocapture`
+
+Expected: FAIL with unresolved imports for `plan_upsert_in_tx`, `stage_upsert_cow_in_tx`, and `activate_upsert_in_tx`.
+
+- [ ] **Step 5: Add COW planning and step primitives**
+
+In `crates/cairn-store-sqlite/src/store/upsert.rs`, make `PriorActive` public in crate and add these helpers near `upsert_in_tx`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UpsertPlan {
+    pub outcome_record_id: RecordId,
+    pub target_id: cairn_core::domain::TargetId,
+    pub version: u32,
+    pub content_changed: bool,
+    pub prior_record_id: Option<String>,
+    pub prior_hash: Option<BodyHash>,
+    pub consent_model: String,
+}
+
+pub(crate) fn plan_upsert_in_tx(
+    tx: &Transaction<'_>,
+    record: &MemoryRecord,
+) -> Result<UpsertPlan, StoreError> {
+    record.validate()?;
+    let body_hash = BodyHash::compute(&record.body);
+    let prior = read_active(tx, record.target_id.as_str())?;
+    if let Some((prior_id, prior_version, prior_hash_str, prior_consent_model)) = prior.as_ref() {
+        let _: cairn_core::domain::consent_timeline::ConsentModel =
+            parse_consent_model(prior_consent_model)?;
+        let prior_hash = body_hash_from_str(prior_hash_str)?;
+        if prior_hash == body_hash {
+            let prior_record_id =
+                RecordId::parse(prior_id.clone()).map_err(|e| StoreError::Invariant {
+                    what: format!("invalid prior record_id `{prior_id}`: {e}"),
+                })?;
+            return Ok(UpsertPlan {
+                outcome_record_id: prior_record_id,
+                target_id: record.target_id.clone(),
+                version: u32::try_from(*prior_version).map_err(|_| StoreError::Invariant {
+                    what: format!("prior version overflows u32: {prior_version}"),
+                })?,
+                content_changed: false,
+                prior_record_id: Some(prior_id.clone()),
+                prior_hash: Some(prior_hash),
+                consent_model: prior_consent_model.clone(),
+            });
+        }
+        return Ok(UpsertPlan {
+            outcome_record_id: mint_record_id()?,
+            target_id: record.target_id.clone(),
+            version: next_version(*prior_version)?,
+            content_changed: true,
+            prior_record_id: Some(prior_id.clone()),
+            prior_hash: Some(prior_hash),
+            consent_model: prior_consent_model.clone(),
+        });
+    }
+
+    let max_version: i64 = tx.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM records WHERE target_id = ?1",
+        params![record.target_id.as_str()],
+        |row| row.get(0),
+    )?;
+    let version = next_version(max_version)?;
+    let outcome_record_id = if max_version == 0 {
+        record.id.clone()
+    } else {
+        mint_record_id()?
+    };
+    Ok(UpsertPlan {
+        outcome_record_id,
+        target_id: record.target_id.clone(),
+        version,
+        content_changed: true,
+        prior_record_id: None,
+        prior_hash: None,
+        consent_model: "legacy_event".to_owned(),
+    })
+}
+
+pub(crate) fn stage_upsert_cow_in_tx(
+    tx: &Transaction<'_>,
+    record: &MemoryRecord,
+    plan: &UpsertPlan,
+) -> Result<(), StoreError> {
+    let body_hash = BodyHash::compute(&record.body);
+    let now_ms = current_unix_ms();
+    if !plan.content_changed {
+        if let Some(prior_id) = plan.prior_record_id.as_deref() {
+            reproject_in_place(
+                tx,
+                record,
+                prior_id,
+                i64::from(plan.version),
+                &body_hash,
+                now_ms,
+            )?;
+        }
+        return Ok(());
+    }
+    let mut row_record = record.clone();
+    row_record.id = plan.outcome_record_id.clone();
+    insert_row_with_active(
+        tx,
+        &row_record,
+        plan.version,
+        now_ms,
+        &body_hash,
+        &plan.consent_model,
+        false,
+    )
+}
+
+pub(crate) fn activate_upsert_in_tx(
+    tx: &Transaction<'_>,
+    plan: &UpsertPlan,
+) -> Result<(), StoreError> {
+    if !plan.content_changed {
+        return Ok(());
+    }
+    let now_ms = current_unix_ms();
+    tx.execute(
+        "UPDATE records SET active = 0, updated_at = ?1 \
+          WHERE target_id = ?2 AND active = 1 AND record_id != ?3",
+        params![
+            now_ms,
+            plan.target_id.as_str(),
+            plan.outcome_record_id.as_str()
+        ],
+    )?;
+    tx.execute(
+        "UPDATE records SET active = 1, tombstoned = 0, updated_at = ?1 \
+          WHERE record_id = ?2",
+        params![now_ms, plan.outcome_record_id.as_str()],
+    )?;
+    Ok(())
+}
+```
+
+Rename `insert_row` to call a new internal function:
+
+```rust
+fn insert_row(
+    tx: &Transaction<'_>,
+    record: &MemoryRecord,
+    version: u32,
+    now_ms: i64,
+    body_hash: &BodyHash,
+    consent_model: &str,
+) -> Result<(), StoreError> {
+    insert_row_with_active(tx, record, version, now_ms, body_hash, consent_model, true)
+}
+
+fn insert_row_with_active(
+    tx: &Transaction<'_>,
+    record: &MemoryRecord,
+    version: u32,
+    now_ms: i64,
+    body_hash: &BodyHash,
+    consent_model: &str,
+    active: bool,
+) -> Result<(), StoreError> {
+    let _: cairn_core::domain::consent_timeline::ConsentModel = parse_consent_model(consent_model)?;
+    let mut row =
+        ProjectedRow::from_record(record, version, now_ms, now_ms, body_hash, active, false)?;
+    row.consent_model = match consent_model {
+        "receipt_timeline" => "receipt_timeline",
+        "legacy_event" => "legacy_event",
+        other => {
+            return Err(StoreError::Invariant {
+                what: format!("consent_model `{other}` survived parse_consent_model gate"),
+            });
+        }
+    };
+    tx.execute(
+        "INSERT INTO records ( \
+            record_id, target_id, version, path, kind, class, visibility, \
+            scope, actor_chain, body, body_hash, created_at, updated_at, \
+            active, tombstoned, is_static, record_json, confidence, \
+            salience, target_id_explicit, tags_json, consent_model, \
+            schema_version_major, schema_version_minor \
+         ) VALUES ( \
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, \
+            ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24 \
+         ) \
+         ON CONFLICT(record_id) DO UPDATE SET \
+            updated_at = excluded.updated_at",
+        params![
+            row.record_id,
+            row.target_id,
+            row.version,
+            row.path,
+            row.kind,
+            row.class,
+            row.visibility,
+            row.scope,
+            row.actor_chain,
+            row.body,
+            row.body_hash,
+            row.created_at,
+            row.updated_at,
+            row.active,
+            row.tombstoned,
+            row.is_static,
+            row.record_json,
+            row.confidence,
+            row.salience,
+            row.target_id_explicit,
+            row.tags_json,
+            row.consent_model,
+            row.schema_version_major,
+            row.schema_version_minor,
+        ],
+    )?;
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Persist the real upsert plan in payload**
+
+In `crates/cairn-store-sqlite/src/record_wal/upsert.rs`, replace rollback planning with a read-only transaction:
+
+```rust
+let planned = conn
+    .call({
+        let record_for_plan = record.clone();
+        move |c| {
+            let tx = c.transaction()?;
+            let plan = crate::store::upsert::plan_upsert_in_tx(&tx, &record_for_plan)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            tx.rollback()?;
+            Ok::<_, tokio_rusqlite::Error>(PlannedUpsert {
+                outcome_record_id: plan.outcome_record_id.as_str().to_owned(),
+                target_id: plan.target_id.as_str().to_owned(),
+                version: plan.version,
+                content_changed: plan.content_changed,
+                prior_record_id: plan.prior_record_id,
+                prior_hash: plan.prior_hash.map(|h| h.to_string()),
+                consent_model: plan.consent_model,
+            })
+        }
+    })
+    .await?;
+```
+
+- [ ] **Step 7: Dispatch real COW step bodies**
+
+In `crates/cairn-store-sqlite/src/record_wal/steps.rs`, replace the `primary.upsert_cow` and `primary.activate` branches:
+
+```rust
+            (RecordStepPayload::Upsert(payload), "primary.upsert_cow") => {
+                let plan = payload.planned.to_store_plan()?;
+                crate::store::upsert::stage_upsert_cow_in_tx(tx, &payload.record, &plan)
+                    .map_err(|e| StepBodyError::Failed(e.to_string()))
+            }
+            (RecordStepPayload::Upsert(payload), "primary.activate") => {
+                let plan = payload.planned.to_store_plan()?;
+                crate::store::upsert::activate_upsert_in_tx(tx, &plan)
+                    .map_err(|e| StepBodyError::Failed(e.to_string()))
+            }
+```
+
+Add this conversion in `payload.rs`:
+
+```rust
+impl PlannedUpsert {
+    pub(crate) fn to_store_plan(&self) -> Result<crate::store::upsert::UpsertPlan, StoreError> {
+        Ok(crate::store::upsert::UpsertPlan {
+            outcome_record_id: cairn_core::domain::RecordId::parse(
+                self.outcome_record_id.clone(),
+            )
+            .map_err(|e| StoreError::Invariant {
+                what: format!("planned record id invalid: {e}"),
+            })?,
+            target_id: cairn_core::domain::TargetId::parse(self.target_id.clone()).map_err(
+                |e| StoreError::Invariant {
+                    what: format!("planned target id invalid: {e}"),
+                },
+            )?,
+            version: self.version,
+            content_changed: self.content_changed,
+            prior_record_id: self.prior_record_id.clone(),
+            prior_hash: self
+                .prior_hash
+                .as_ref()
+                .map(|h| cairn_core::domain::BodyHash::parse(h))
+                .transpose()
+                .map_err(|e| StoreError::Invariant {
+                    what: format!("planned prior hash invalid: {e}"),
+                })?,
+            consent_model: self.consent_model.clone(),
+        })
+    }
+}
+```
+
+- [ ] **Step 8: Store snapshot pre-images in `snapshot.stage`**
+
+Append this test to `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`:
+
+```rust
+#[tokio::test]
+async fn upsert_snapshot_stage_records_pre_image_blob() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("upsert");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(|c| {
+        let count: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps ws \
+              JOIN wal_ops wo ON wo.operation_id = ws.operation_id \
+             WHERE wo.kind = 'upsert' \
+               AND ws.step_kind = 'snapshot.stage' \
+               AND ws.pre_image IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 1);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("snapshot stage");
+}
+```
+
+In `RecordStepBody::run`, rename `_op_id` to `op_id`, then add the upsert branch before `primary.upsert_cow`:
+
+```rust
+            (RecordStepPayload::Upsert(payload), "snapshot.stage") => {
+                stage_snapshot(tx, op_id, step, &payload.planned.target_id)
+            }
+```
+
+Add this helper in `crates/cairn-store-sqlite/src/record_wal/steps.rs`:
+
+```rust
+fn stage_snapshot(
+    tx: &rusqlite::Transaction<'_>,
+    op_id: &OperationId,
+    step: &StepDef,
+    target_id: &str,
+) -> Result<(), StepBodyError> {
+    let rows = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT record_id, version, active, tombstoned, tombstone_reason, body_hash \
+                 FROM records WHERE target_id = ?1 ORDER BY version",
+            )
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(rusqlite::params![target_id], |row| {
+            Ok(serde_json::json!({
+                "record_id": row.get::<_, String>(0)?,
+                "version": row.get::<_, i64>(1)?,
+                "active": row.get::<_, i64>(2)?,
+                "tombstoned": row.get::<_, i64>(3)?,
+                "tombstone_reason": row.get::<_, Option<String>>(4)?,
+                "body_hash": row.get::<_, String>(5)?,
+            }))
+        })
+        .map_err(StepBodyError::Storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StepBodyError::Storage)?
+    };
+    let bytes = serde_json::to_vec(&rows)
+        .map_err(|e| StepBodyError::Failed(format!("snapshot json: {e}")))?;
+    tx.execute(
+        "UPDATE wal_steps SET pre_image = ?1 \
+         WHERE operation_id = ?2 AND step_ord = ?3",
+        rusqlite::params![bytes, op_id.as_str(), step.ord],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 9: Run COW and upsert tests**
+
+Run: `cargo test -p cairn-store-sqlite store::upsert::cow_tests -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire upsert_stages_inactive_row_before_activation -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-store-sqlite --test upsert_idempotent --test versioning --test upsert_embed -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/store/upsert.rs \
+  crates/cairn-store-sqlite/src/record_wal/payload.rs \
+  crates/cairn-store-sqlite/src/record_wal/upsert.rs \
+  crates/cairn-store-sqlite/src/record_wal/steps.rs \
+  crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+git commit -m "feat: apply upsert with copy on write steps"
+```
+
+---
+
+### Task 6: Make Derived Upsert Steps Idempotent and Retry-Safe
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/record_wal/steps.rs`
+- Modify: `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`
+- Existing tests: `crates/cairn-store-sqlite/tests/upsert_embed.rs`, `crates/cairn-store-sqlite/tests/search_keyword.rs`
+
+- [ ] **Step 1: Add the failing derived retry test**
+
+Append to `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`:
+
+```rust
+#[tokio::test]
+async fn repeated_upsert_steps_do_not_duplicate_derived_rows() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("upsert");
+    store.upsert(&r).await.expect("idempotent upsert");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let fts_rows: i64 = c.query_row("SELECT COUNT(*) FROM records_fts", [], |row| {
+            row.get(0)
+        })?;
+        let active_records: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records WHERE active = 1 AND tombstoned = 0",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(fts_rows, active_records);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("derived counts");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire repeated_upsert_steps_do_not_duplicate_derived_rows -- --nocapture`
+
+Expected: FAIL if FTS rows duplicate or PASS if triggers masked the gap. Keep the test either way.
+
+- [ ] **Step 3: Add explicit FTS/vector/edges upsert functions**
+
+In `crates/cairn-store-sqlite/src/record_wal/steps.rs`, add:
+
+```rust
+fn upsert_fts(tx: &rusqlite::Transaction<'_>, record_id: &str) -> Result<(), StepBodyError> {
+    let row: (i64, String, String, String, String) = tx
+        .query_row(
+            "SELECT rowid, kind, class, scope, body FROM records WHERE record_id = ?1",
+            rusqlite::params![record_id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            },
+        )
+        .map_err(StepBodyError::Storage)?;
+    tx.execute("DELETE FROM records_fts WHERE rowid = ?1", rusqlite::params![row.0])
+        .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "INSERT INTO records_fts(rowid, kind, class, scope, body) VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![row.0, row.1, row.2, row.3, row.4],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn upsert_vector(
+    tx: &rusqlite::Transaction<'_>,
+    record_id: &str,
+    embed: &crate::record_wal::payload::StoredEmbedOutcome,
+) -> Result<(), StepBodyError> {
+    match embed {
+        crate::record_wal::payload::StoredEmbedOutcome::Succeeded {
+            vector,
+            model_label,
+        } => {
+            tx.execute(
+                "DELETE FROM record_vectors WHERE record_id = ?1",
+                rusqlite::params![record_id],
+            )
+            .map_err(StepBodyError::Storage)?;
+            tx.execute(
+                "INSERT INTO record_vectors(record_id, embedding, model) VALUES (?1, ?2, ?3)",
+                rusqlite::params![record_id, vector, model_label],
+            )
+            .map_err(StepBodyError::Storage)?;
+            tx.execute(
+                "DELETE FROM pending_embeddings WHERE record_id = ?1",
+                rusqlite::params![record_id],
+            )
+            .map_err(StepBodyError::Storage)?;
+            Ok(())
+        }
+        crate::record_wal::payload::StoredEmbedOutcome::Failed { error } => {
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX));
+            tx.execute(
+                "INSERT INTO pending_embeddings \
+                    (record_id, reason, attempt_count, last_error, enqueued_at) \
+                 VALUES (?1, 'embed_failed', 0, ?2, ?3) \
+                 ON CONFLICT(record_id) DO UPDATE SET \
+                    attempt_count = pending_embeddings.attempt_count + 1, \
+                    last_error = excluded.last_error, \
+                    last_attempt_at = ?3",
+                rusqlite::params![record_id, error, now_secs],
+            )
+            .map_err(StepBodyError::Storage)?;
+            Ok(())
+        }
+        crate::record_wal::payload::StoredEmbedOutcome::Skipped => Ok(()),
+    }
+}
+
+fn upsert_edges(_tx: &rusqlite::Transaction<'_>, _record_id: &str) -> Result<(), StepBodyError> {
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Wire the derived step branches**
+
+In `RecordStepBody::run`, add branches before the catch-all:
+
+```rust
+            (RecordStepPayload::Upsert(payload), "vector.upsert") => {
+                upsert_vector(tx, &payload.planned.outcome_record_id, &payload.embed)
+            }
+            (RecordStepPayload::Upsert(payload), "fts.upsert") => {
+                upsert_fts(tx, &payload.planned.outcome_record_id)
+            }
+            (RecordStepPayload::Upsert(payload), "edges.upsert") => {
+                upsert_edges(tx, &payload.planned.outcome_record_id)
+            }
+```
+
+- [ ] **Step 5: Run derived index tests**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire repeated_upsert_steps_do_not_duplicate_derived_rows -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-store-sqlite --test upsert_embed --test search_keyword --test index_stats -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/steps.rs \
+  crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+git commit -m "feat: make record upsert derived steps idempotent"
+```
+
+---
+
+### Task 7: Add Expire Apply With Soft Retirement
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/store/expire.rs`
+- Modify: `crates/cairn-store-sqlite/src/store/mod.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/expire.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/steps.rs`
+- Modify: `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`
+
+- [ ] **Step 1: Add the failing expire acceptance test**
+
+Append to `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`:
+
+```rust
+#[tokio::test]
+async fn expire_retires_target_without_hard_delete() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    let out = store.upsert(&r).await.expect("upsert");
+
+    store.expire(&r.target_id).await.expect("expire");
+
+    assert!(store.get(&out.record_id).await.expect("get").is_none());
+    assert!(store.list(&ListArgs::default()).await.expect("list").records.is_empty());
+
+    let versions = store.versions(&r.target_id).await.expect("versions");
+    assert_eq!(versions.len(), 1);
+    assert!(!versions[0].active);
+    assert!(versions[0].tombstoned);
+    assert_eq!(versions[0].tombstone_reason, Some(TombstoneReason::Expire));
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let row_count: i64 = conn
+        .call(|c| {
+            c.query_row("SELECT COUNT(*) FROM records", [], |row| row.get(0))
+                .map_err(Into::into)
+        })
+        .await
+        .expect("record count");
+    assert_eq!(row_count, 1, "expire must not hard-delete records");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire expire_retires_target_without_hard_delete -- --nocapture`
+
+Expected: FAIL with `no method named expire`.
+
+- [ ] **Step 3: Add store expire module**
+
+Create `crates/cairn-store-sqlite/src/store/expire.rs`:
+
+```rust
+//! Concrete expire API for target-level soft retirement.
+
+use cairn_core::domain::TargetId;
+use tracing::instrument;
+
+use crate::error::StoreError;
+use crate::store::SqliteMemoryStore;
+
+impl SqliteMemoryStore {
+    /// Soft-expire every version in a target lineage through WAL.
+    ///
+    /// Expire removes the target from default read and search results by
+    /// setting `active = 0`, `tombstoned = 1`, and
+    /// `tombstone_reason = 'expire'`. It does not physically delete rows.
+    ///
+    /// # Errors
+    /// Returns store, lock, WAL runner, or recovery-shape errors.
+    #[instrument(skip(self), err, fields(verb = "expire", target_id = %target.as_str()))]
+    pub async fn expire(&self, target: &TargetId) -> Result<(), StoreError> {
+        if self.conn.is_none() {
+            return Err(StoreError::NotInitialized { method: "expire" });
+        }
+        crate::record_wal::apply_expire(self, target).await
+    }
+}
+```
+
+In `crates/cairn-store-sqlite/src/store/mod.rs`, add:
+
+```rust
+pub(crate) mod expire;
+```
+
+- [ ] **Step 4: Implement expire apply**
+
+Create `crates/cairn-store-sqlite/src/record_wal/expire.rs`:
+
+```rust
+use std::sync::Arc;
+
+use cairn_core::domain::{ScopeTuple, TargetId};
+use cairn_core::wal::{OpState, WalKind, graph_for};
+
+use crate::error::StoreError;
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::ops::{finalize, issue_prepared, new_operation_id};
+use crate::record_wal::payload::{ExpirePayload, RecordWalPayload, save_payload};
+use crate::record_wal::steps::RecordStepBody;
+use crate::store::SqliteMemoryStore;
+use crate::wal::runner;
+
+pub(crate) async fn apply_expire(
+    store: &SqliteMemoryStore,
+    target: &TargetId,
+) -> Result<(), StoreError> {
+    let conn = store.require_conn("expire")?.clone();
+    let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
+        what: "expire requires daemon incarnation".to_owned(),
+    })?;
+    let op_id = new_operation_id(WalKind::Expire);
+    let scope = load_scope_for_target(&conn, target).await?;
+    let locks = acquire_for_record(
+        &conn,
+        &scope,
+        target,
+        &incarnation,
+        op_id.as_str(),
+        "record_wal_expire",
+    )
+    .await
+    .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
+
+    let payload = ExpirePayload {
+        target_id: target.clone(),
+        reason: "expire".to_owned(),
+    };
+    let payload_for_body = payload.clone();
+    let op_for_issue = op_id.clone();
+    let target_hash = target.as_str().to_owned();
+    conn.call(move |c| {
+        let tx = c.transaction()?;
+        issue_prepared(&tx, &op_for_issue, WalKind::Expire, &target_hash, "{}")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        save_payload(&tx, &op_for_issue, &RecordWalPayload::Expire(payload_for_body))
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        tx.commit()?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+
+    let body = Arc::new(RecordStepBody::new_expire(payload, locks));
+    runner::run_from(&conn, graph_for(WalKind::Expire), &op_id, 0, body).await?;
+
+    let op_for_finalize = op_id.clone();
+    conn.call(move |c| {
+        finalize(c, &op_for_finalize, OpState::Committed, "applied")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+    Ok(())
+}
+
+async fn load_scope_for_target(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    target: &TargetId,
+) -> Result<ScopeTuple, StoreError> {
+    let target_id = target.as_str().to_owned();
+    conn.call(move |c| {
+        let scope_json: Option<String> = c
+            .query_row(
+                "SELECT scope FROM records WHERE target_id = ?1 ORDER BY version DESC LIMIT 1",
+                rusqlite::params![target_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let scope = match scope_json {
+            Some(json) => serde_json::from_str(&json)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(StoreError::Codec(e))))?,
+            None => ScopeTuple::default(),
+        };
+        Ok::<_, tokio_rusqlite::Error>(scope)
+    })
+    .await
+    .map_err(StoreError::from)
+}
+```
+
+Add `use rusqlite::OptionalExtension;` at the top of `expire.rs`.
+
+- [ ] **Step 5: Add expire step bodies**
+
+In `crates/cairn-store-sqlite/src/record_wal/steps.rs`, add constructor:
+
+```rust
+    #[must_use]
+    pub(crate) fn new_expire(payload: ExpirePayload, locks: RecordLocks) -> Self {
+        Self {
+            payload: RecordStepPayload::Expire(payload),
+            locks,
+        }
+    }
+```
+
+Add branches:
+
+```rust
+            (RecordStepPayload::Expire(payload), "snapshot.stage") => {
+                stage_snapshot(tx, op_id, step, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Expire(payload), "primary.mark_expired") => {
+                mark_expired(tx, payload)
+            }
+            (RecordStepPayload::Expire(payload), "vector.drain") => {
+                drain_vectors(tx, payload)
+            }
+            (RecordStepPayload::Expire(payload), "fts.drain") => {
+                drain_fts(tx, payload)
+            }
+            (RecordStepPayload::Expire(payload), "edges.drain") => {
+                drain_edges(tx, payload)
+            }
+```
+
+Add helpers:
+
+```rust
+fn mark_expired(
+    tx: &rusqlite::Transaction<'_>,
+    payload: &ExpirePayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "UPDATE records \
+            SET active = 0, tombstoned = 1, tombstone_reason = 'expire', updated_at = ?1 \
+          WHERE target_id = ?2",
+        rusqlite::params![crate::store::current_unix_ms(), payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn drain_vectors(
+    tx: &rusqlite::Transaction<'_>,
+    payload: &ExpirePayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM record_vectors \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        rusqlite::params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM pending_embeddings \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        rusqlite::params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn drain_fts(
+    tx: &rusqlite::Transaction<'_>,
+    payload: &ExpirePayload,
+) -> Result<(), StepBodyError> {
+    let rowids = {
+        let mut stmt = tx
+            .prepare("SELECT rowid FROM records WHERE target_id = ?1")
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(rusqlite::params![payload.target_id.as_str()], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(StepBodyError::Storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StepBodyError::Storage)?
+    };
+    for rowid in rowids {
+        tx.execute("DELETE FROM records_fts WHERE rowid = ?1", rusqlite::params![rowid])
+            .map_err(StepBodyError::Storage)?;
+    }
+    Ok(())
+}
+
+fn drain_edges(
+    tx: &rusqlite::Transaction<'_>,
+    payload: &ExpirePayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM edges \
+          WHERE src IN (SELECT record_id FROM records WHERE target_id = ?1) \
+             OR dst IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        rusqlite::params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Run expire acceptance test**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire expire_retires_target_without_hard_delete -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 7: Add and run post-expire upsert version test**
+
+Append:
+
+```rust
+#[tokio::test]
+async fn upsert_after_expire_creates_next_visible_version() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("upsert");
+    store.expire(&r.target_id).await.expect("expire");
+
+    let mut replacement = r.clone();
+    replacement.body = "replacement after expire".to_owned();
+    let out = store.upsert(&replacement).await.expect("replacement upsert");
+
+    assert_eq!(out.version, 2);
+    assert!(store.get(&out.record_id).await.expect("get").is_some());
+
+    let versions = store.versions(&r.target_id).await.expect("versions");
+    assert_eq!(versions.len(), 2);
+    assert!(versions[0].tombstoned);
+    assert!(!versions[1].tombstoned);
+    assert!(versions[1].active);
+}
+```
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire upsert_after_expire_creates_next_visible_version -- --nocapture`
+
+Expected: PASS because Task 5 changed upsert planning to use `MAX(version)` when no active row exists.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/store/mod.rs \
+  crates/cairn-store-sqlite/src/store/expire.rs \
+  crates/cairn-store-sqlite/src/record_wal/expire.rs \
+  crates/cairn-store-sqlite/src/record_wal/steps.rs \
+  crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+git commit -m "feat: apply expire through record wal"
+```
+
+---
+
+### Task 8: Register Record WAL Boot Recovery
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/record_wal/recovery.rs`
+- Modify: `crates/cairn-store-sqlite/src/open.rs`
+- Modify: `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`
+
+- [ ] **Step 1: Add failing recovery test for a prepared upsert**
+
+Append to `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`:
+
+```rust
+#[tokio::test]
+async fn prepared_upsert_recovers_from_persisted_payload() {
+    let store = open_in_memory().await.expect("open");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let inc = store.incarnation().cloned().expect("incarnation");
+    let record = sample();
+    let payload =
+        cairn_store_sqlite::record_wal::payload::UpsertPayload::new_for_test(record.clone());
+
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-recover-upsert', 1, 'upsert', 'ISSUED', '{}', 'issuer', 'target', '{}', 0, 'sig', 1, 1)",
+            [],
+        )?;
+        c.execute(
+            "UPDATE wal_ops SET state = 'PREPARED', updated_at = 2 WHERE operation_id = 'op-recover-upsert'",
+            [],
+        )?;
+        cairn_store_sqlite::record_wal::payload::save_upsert_payload_for_test(
+            c,
+            "op-recover-upsert",
+            &payload,
+        )?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("seed prepared op");
+
+    let cfg = cairn_store_sqlite::wal::RecoveryConfig {
+        enabled: true,
+        bodies: Box::new(cairn_store_sqlite::record_wal::RecordWalRegistry::new(inc)),
+    };
+    let report = cairn_store_sqlite::recover_pending(&conn, &cfg)
+        .await
+        .expect("recover");
+    assert_eq!(report.resumed_committed.len(), 1);
+    assert!(store.get(&record.id).await.expect("get").is_some());
+}
+```
+
+- [ ] **Step 2: Run the recovery test to verify it fails**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire prepared_upsert_recovers_from_persisted_payload -- --nocapture`
+
+Expected: FAIL with missing `RecordWalRegistry`.
+
+- [ ] **Step 3: Implement `RecordWalRegistry`**
+
+Replace `crates/cairn-store-sqlite/src/record_wal/recovery.rs` with:
+
+```rust
+//! Record WAL recovery registry.
+
+use std::sync::Arc;
+
+use cairn_core::wal::{OperationId, WalKind};
+use tokio_rusqlite::Connection;
+
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::payload::{RecordWalPayload, load_payload};
+use crate::record_wal::steps::RecordStepBody;
+use crate::wal::{RecoveryError, StepBody, StepBodyRegistry};
+
+pub struct RecordWalRegistry {
+    incarnation: Arc<str>,
+}
+
+impl RecordWalRegistry {
+    #[must_use]
+    pub fn new(incarnation: Arc<str>) -> Self {
+        Self { incarnation }
+    }
+}
+
+#[async_trait::async_trait]
+impl StepBodyRegistry for RecordWalRegistry {
+    async fn body_for(
+        &self,
+        conn: &Arc<Connection>,
+        kind: WalKind,
+        op_id: &OperationId,
+    ) -> Result<Option<Arc<dyn StepBody>>, RecoveryError> {
+        match kind {
+            WalKind::Upsert | WalKind::Expire => {}
+            WalKind::ForgetRecord => return Ok(None),
+        }
+
+        let op_for_load = op_id.clone();
+        let payload = conn
+            .call(move |c| {
+                load_payload(c, &op_for_load)
+                    .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+            })
+            .await
+            .map_err(RecoveryError::Storage)?;
+
+        match payload {
+            RecordWalPayload::Upsert(payload) => {
+                let locks = acquire_for_record(
+                    conn,
+                    &payload.record.scope,
+                    &payload.record.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_upsert",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_upsert(payload, locks))))
+            }
+            RecordWalPayload::Expire(payload) => {
+                let scope = cairn_core::domain::ScopeTuple::default();
+                let locks = acquire_for_record(
+                    conn,
+                    &scope,
+                    &payload.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_expire",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_expire(payload, locks))))
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run recovery test**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire prepared_upsert_recovers_from_persisted_payload -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 5: Wire boot recovery to record registry**
+
+In `crates/cairn-store-sqlite/src/open.rs`, change `run_boot_recovery` signature:
+
+```rust
+async fn run_boot_recovery(
+    conn: &Arc<AsyncConn>,
+    incarnation: Arc<str>,
+) -> Result<(), StoreError> {
+    let cfg = RecoveryConfig {
+        enabled: true,
+        bodies: Box::new(crate::record_wal::RecordWalRegistry::new(incarnation)),
+    };
+```
+
+In both async open paths, replace:
+
+```rust
+    run_boot_recovery(&conn).await?;
+    let incarnation = crate::locks::init_incarnation(&conn)
+```
+
+with:
+
+```rust
+    let incarnation = crate::locks::init_incarnation(&conn)
+        .await
+        .map_err(|e| StoreError::LockInit(Box::new(e)))?;
+    run_boot_recovery(&conn, Arc::clone(&incarnation)).await?;
+```
+
+Keep the existing `build_store` call unchanged.
+
+- [ ] **Step 6: Run open-path and WAL tests**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire prepared_upsert_recovers_from_persisted_payload -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-store-sqlite --test wal_recovery -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/recovery.rs \
+  crates/cairn-store-sqlite/src/open.rs \
+  crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+git commit -m "feat: recover record wal operations on boot"
+```
+
+---
+
+### Task 9: Pin Expired Search Exclusion and WAL Step Conformance
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/tests/cow_upsert_expire.rs`
+- Existing search modules should already filter `active = 1 AND tombstoned = 0`.
+
+- [ ] **Step 1: Add keyword search exclusion test**
+
+Append:
+
+```rust
+#[tokio::test]
+async fn expired_record_is_excluded_from_keyword_search() {
+    let store = open_in_memory().await.expect("open");
+    let mut r = sample();
+    r.body = "needle unique expired body".to_owned();
+    store.upsert(&r).await.expect("upsert");
+    store.expire(&r.target_id).await.expect("expire");
+
+    let page = store
+        .search_keyword(&KeywordSearchArgs {
+            query: "needle".into(),
+            filter: None,
+            auth_scope: r.scope.clone(),
+            visibility_allowlist: vec![r.visibility],
+            limit: 10,
+            cursor: None,
+            with_explain: false,
+        })
+        .await
+        .expect("keyword search");
+    assert!(page.candidates.is_empty());
+}
+```
+
+- [ ] **Step 2: Add expire WAL conformance test**
+
+Append:
+
+```rust
+#[tokio::test]
+async fn expire_commits_wal_operation_and_all_steps() {
+    let store = open_in_memory().await.expect("open");
+    let r = sample();
+    store.upsert(&r).await.expect("upsert");
+    store.expire(&r.target_id).await.expect("expire");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(|c| {
+        let state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE kind = 'expire'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state, "COMMITTED");
+        let done_count: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps ws \
+              JOIN wal_ops wo ON wo.operation_id = ws.operation_id \
+             WHERE wo.kind = 'expire' AND ws.state = 'DONE'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(done_count, 5);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("expire wal rows");
+}
+```
+
+- [ ] **Step 3: Run search and expire WAL tests**
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire expired_record_is_excluded_from_keyword_search expire_commits_wal_operation_and_all_steps -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run broader read/search regression tests**
+
+Run: `cargo test -p cairn-store-sqlite --test search_keyword --test search_keyword_e2e --test records_latest --test tombstone_reasons -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/tests/cow_upsert_expire.rs
+git commit -m "test: pin expire search exclusion and wal conformance"
+```
+
+---
+
+### Task 10: Final Verification and Cleanup
+
+**Files:**
+- All files touched by Tasks 1 through 9.
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt --all`
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p cairn-store-sqlite --test cow_upsert_expire -- --nocapture
+cargo test -p cairn-store-sqlite --test wal_payloads_migration -- --nocapture
+cargo test -p cairn-store-sqlite --test wal_recovery -- --nocapture
+cargo test -p cairn-store-sqlite --test locks_stale_fence -- --nocapture
+cargo test -p cairn-store-sqlite --test upsert_idempotent --test upsert_embed --test versioning -- --nocapture
+cargo test -p cairn-store-sqlite --test search_keyword --test search_keyword_e2e --test index_stats -- --nocapture
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Run package check**
+
+Run: `cargo check -p cairn-store-sqlite --all-targets`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run diff hygiene**
+
+Run: `git diff --check`
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 5: Inspect WAL state manually**
+
+Run:
+
+```bash
+cargo test -p cairn-store-sqlite --test cow_upsert_expire upsert_commits_wal_operation_and_all_steps expire_commits_wal_operation_and_all_steps -- --nocapture
+```
+
+Expected: PASS, with one committed upsert operation containing 6 done steps and one committed expire operation containing 5 done steps.
+
+- [ ] **Step 6: Final commit**
+
+If formatting changed files after the prior task commits:
+
+```bash
+git add crates/cairn-store-sqlite
+git commit -m "chore: format record wal apply changes"
+```
+
+If `git status --short` is clean, skip this commit.
+
+---
+
+## Spec Coverage
+
+- Upsert creates and updates records with complete version metadata: Tasks 4 and 5 route public upsert through WAL and preserve the existing `UpsertOutcome`, `versions`, schema-version, and consent-model behavior.
+- Expire marks records retired and removes them from default search/retrieve: Tasks 7 and 9 add target-level expire, mark all lineage rows inactive and tombstoned with reason `expire`, and pin `get`, `list`, and keyword search exclusion.
+- Derived FTS/vector/edge updates are retry-safe: Task 6 implements DELETE plus INSERT style idempotent FTS/vector steps and a no-duplicate retry test; expire drains derived rows in Task 7.
+- WAL conformance: Tasks 4, 7, 8, and 9 assert committed operation rows, expected done step counts, durable payloads, and recovery from a prepared operation.
+- No hard delete outside forget flows: Task 7 asserts the record row remains present after expire.

--- a/docs/superpowers/specs/2026-05-08-issue-57-cow-upsert-expire-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-57-cow-upsert-expire-design.md
@@ -1,0 +1,281 @@
+# COW upsert and expire WAL apply — design
+
+- **Issue:** [#57](https://github.com/windoliver/cairn/issues/57)
+- **Parent epic:** [#8](https://github.com/windoliver/cairn/issues/8) WAL, locks, replay, record-level forget
+- **Phase:** v0.1 P0
+- **Brief sections:** §3.0 Atomicity model · §5.6 WAL operations · §10 Continuous Learning
+- **Status:** approved design, awaiting implementation plan
+- **Date:** 2026-05-08
+
+## 1. Goal
+
+Route record upsert and expiration through the §5.6 WAL apply path so every
+record mutation is copy-on-write, replay-safe, and hidden from readers until
+its activation or retirement point commits.
+
+The work completes the `upsert` and `expire` side-effect bodies deferred by
+#55. It must preserve the current `MemoryStore` public behavior while replacing
+the direct-write internals with WAL-backed apply.
+
+## 2. Non-goals
+
+- `forget_record` Phase B purge. This remains a sibling task and must later
+  purge any body-bearing WAL payloads described here.
+- `promote`, `forget_session`, `evolve`, or graph WAL bodies.
+- Distributed P1 Nexus durable messaging. P0 remains one SQLite database.
+- Reworking the CLI `FlushPlan` lifecycle beyond consuming already-persisted
+  plans when a caller provides a `plan_ref`.
+
+## 3. Source-of-truth alignment
+
+| Brief section | Requirement | Design choice |
+|---|---|---|
+| §3.0 Atomicity model | P0 writes land in one SQLite authority; derived indexes are rebuildable | `records` remains authoritative; FTS/vector/edge steps are retryable projections |
+| §5.6 upsert row | Stage version `N+1` inactive, update derived indexes, then activate | `primary.upsert_cow` inserts inactive rows; `primary.activate` flips the active pointer |
+| §5.6 expire row | Expiration retires rows without physical purge | `primary.mark_expired` marks the target lineage tombstoned with reason `expire`; no record rows are deleted |
+| §5.6 read fence | Readers filter inactive/tombstoned rows | Existing `active = 1 AND tombstoned = 0` predicates remain the visibility gate |
+| §10 workflows | Expirer can retry and rebuild indexes | Expire drains derived indexes idempotently and records WAL step completion |
+
+## 4. Architecture
+
+Add a `record_wal` module inside `cairn-store-sqlite`.
+
+```text
+MemoryStore::upsert(record)
+  -> record_wal::apply_upsert(record)
+     -> issue PREPARED wal_ops row
+     -> run UPSERT_STEPS through StepRunner
+     -> finalize COMMITTED
+
+SqliteMemoryStore::expire(target, reason)
+  -> record_wal::apply_expire(target, reason)
+     -> issue PREPARED wal_ops row
+     -> run EXPIRE_STEPS through StepRunner
+     -> finalize COMMITTED
+
+Store::open(...)
+  -> init_incarnation(conn)
+  -> recover_pending(conn, RecoveryConfig { bodies: RecordWalRegistry })
+```
+
+The current direct upsert logic is split into lower-level primitives:
+
+- project a record into an inactive COW row,
+- detect idempotent same-body replays,
+- activate one target version atomically,
+- drain derived rows for a target or record id.
+
+Public API remains stable. `MemoryStore::upsert` still returns
+`UpsertOutcome`; `get`, `list`, `versions`, and search keep their current
+contracts.
+
+## 5. Durable Mutation Payloads
+
+Recovery must be able to resume a `PREPARED` op after process restart. An
+upsert op therefore needs durable access to the planned `MemoryRecord`, and an
+expire op needs durable access to the target and reason.
+
+Add a small SQLite table:
+
+```sql
+CREATE TABLE wal_payloads (
+  operation_id TEXT PRIMARY KEY
+    REFERENCES wal_ops(operation_id),
+  kind         TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  created_at   INTEGER NOT NULL
+);
+```
+
+`payload_json` is body-bearing for upserts. It must never be logged. This is
+acceptable because `.cairn/cairn.db` is the authoritative private store, and
+§5.6 already requires forget flows to purge WAL pre-images. The follow-up
+`forget_record` implementation must also purge matching `wal_payloads` rows or
+replace them with salted-hash audit stubs before a forget op reaches terminal
+commit.
+
+When a caller already has a persisted `FlushPlan`, `wal_ops.plan_ref` points to
+that plan and `wal_payloads.payload_json` stores only the minimal mutation
+payload needed by recovery. Direct `MemoryStore::upsert` calls synthesize the
+same payload in-process.
+
+## 6. Upsert Apply
+
+### 6.1 `snapshot.stage`
+
+Read the active row for `record.target_id`, if any, plus its derived rows. Store
+the pre-image in `wal_steps.pre_image` for ord `0`. For a fresh insert, store an
+explicit absent marker.
+
+This step is non-idempotent in the static graph. Recovery never re-runs it once
+marked `DONE`; later steps read the staged snapshot.
+
+### 6.2 `primary.upsert_cow`
+
+Compute the planned body hash and compare it with the active row:
+
+- no active row: insert version `1` with `active = 0`;
+- active row with same body hash: treat as idempotent, update projection/schema
+  metadata in place if needed, and mark the op as no-content-change;
+- active row with different body hash: insert version `N+1` with `active = 0`
+  and leave version `N` active.
+
+The inserted row uses a deterministic record id for retries:
+
+- first version keeps `record.id`;
+- superseding versions use a stored generated id in the upsert payload or
+  snapshot so retries reuse the same row.
+
+This step never flips the active pointer.
+
+### 6.3 Derived Index Steps
+
+`vector.upsert`, `fts.upsert`, and `edges.upsert` are idempotent.
+
+- FTS is already maintained by triggers on `records`. The WAL step verifies the
+  row exists in `records_fts` for the staged row and can repair it with
+  delete-then-insert if drift is detected.
+- Vector upsert runs only when an embedder is configured. It uses the same
+  delete-then-insert behavior as the current embed-on-write path. If embedding
+  fails, it queues `pending_embeddings` atomically and the WAL step still
+  succeeds because the source record is durable and rebuildable.
+- Edge upsert is a no-op for plain record upsert until the extractor writes
+  explicit edge payloads. The step still records `DONE` so the graph matches
+  §5.6 and recovery has a stable ordinal.
+
+### 6.4 `primary.activate`
+
+Inside one SQLite transaction:
+
+1. assert the staged row exists;
+2. set every row for the target `active = 0`;
+3. set the staged row `active = 1` unless the op was an idempotent no-op;
+4. append the consent journal row if the caller provided consent metadata.
+
+This is the reader-visible linearization point. Before it commits, searches may
+hit staged FTS/vector rows, but the join against `records.active = 1` drops
+them.
+
+After `StepRunner` has marked every step `DONE`, `record_wal` finalizes the
+op to `COMMITTED`. If the process crashes after activation but before that
+final transition, boot recovery reloads the all-`DONE` snapshot and finalizes
+the op without re-running side effects.
+
+## 7. Expire Apply
+
+Expiration targets a `TargetId`, not a single version row.
+
+### 7.1 `snapshot.stage`
+
+Capture the active row and derived rows for the target. Missing or already
+expired targets are idempotent success markers; no hard delete occurs.
+
+### 7.2 `primary.mark_expired`
+
+In one transaction, mark every row in the target lineage:
+
+```sql
+UPDATE records
+   SET tombstoned = 1,
+       tombstone_reason = 'expire',
+       updated_at = :now
+ WHERE target_id = :target_id;
+```
+
+Keeping all historical rows tombstoned prevents superseded versions from
+leaking through audit or graph traversals. A future upsert for the same target
+can create a later non-tombstoned version, which is the brief's un-expire path.
+
+### 7.3 Derived Drains
+
+`vector.drain`, `fts.drain`, and `edges.drain` are idempotent:
+
+- delete `record_vectors` rows for all record ids in the target lineage;
+- delete or verify absence of `records_fts` rows for tombstoned rows;
+- remove non-audit edges whose endpoints are now retired, while preserving
+  append-only WAL and consent data.
+
+Readers already filter `tombstoned = 0`, so stale derived rows must not surface
+even if a drain retry is pending.
+
+## 8. Recovery
+
+`RecordWalRegistry` implements `StepBodyRegistry` for `WalKind::Upsert` and
+`WalKind::Expire`. `open.rs` must initialize the daemon incarnation before
+boot recovery, then pass this registry to `recover_pending`; recovery step
+bodies need a current incarnation so they can reacquire locks and run fenced.
+
+Recovery behavior:
+
+- `ISSUED` without `PREPARED` finalizes to `REJECTED` as today.
+- `PREPARED` resumes at the first missing step.
+- already `DONE` steps are skipped.
+- retry exhaustion marks the op `ABORTED` and runs compensation for pre-activate
+  upsert stages or pre-expire snapshots.
+
+Compensation for #57 is limited:
+
+- upsert before activation: tombstone or remove the inactive staged row and
+  drain its derived rows;
+- expire before `primary.mark_expired`: no-op;
+- expire after `primary.mark_expired`: do not auto-unexpire unless the staged
+  snapshot proves all rows were changed by this op and the op is still
+  `PREPARED`. Otherwise leave tombstones in place and surface a recovery error.
+
+## 9. Locking and Fencing
+
+Every public upsert or expire apply acquires locks using #56's typed lock API:
+
+- entity lock exclusive on `record.target_id` or expire target;
+- session lock shared if the record scope carries a session id.
+
+Step bodies run inside `LockHandle::with_fencing` so a stale holder cannot
+commit authoritative changes after losing ownership. Recovery runs after
+`init_incarnation`, then reacquires fresh locks before resuming bodies.
+
+## 10. Tests
+
+Write tests first.
+
+### 10.1 Upsert conformance
+
+- `upsert_writes_prepared_wal_steps_and_commits`:
+  public `store.upsert(record)` creates one `COMMITTED` `upsert` op with all
+  `UPSERT_STEPS` marked `DONE`.
+- `upsert_stages_inactive_before_activation`:
+  an injected failure after `primary.upsert_cow` leaves the new version
+  inactive and default reads return the previous version.
+- `upsert_supersession_preserves_versions`:
+  two different bodies produce versions `1` and `2`, with exactly one active
+  non-tombstoned row.
+- `upsert_replay_same_operation_is_idempotent`:
+  recovery re-runs a partial op without creating duplicate version rows or
+  duplicate derived rows.
+
+### 10.2 Expire conformance
+
+- `expire_marks_target_retired_without_deleting_history`:
+  `versions(target)` still returns rows, while `get`, `list`, and default
+  search exclude them.
+- `expire_is_idempotent_for_already_expired_target`:
+  repeated expire does not create new record rows or fail.
+- `future_upsert_after_expire_creates_visible_later_version`:
+  upsert after expire writes version `N+1` and makes that version visible.
+
+### 10.3 Derived index retry
+
+- FTS drain can run twice and leaves no searchable expired record.
+- Vector upsert/drain can run twice and leaves at most one vector row for the
+  active version.
+- Recovery from `PREPARED` with partial derived steps finishes to `COMMITTED`.
+
+## 11. Open Risks
+
+- `wal_payloads` is body-bearing. #58 must treat it as a retention surface for
+  forget purge.
+- The existing FTS triggers index inactive rows. This is acceptable because all
+  read paths join back to `records.active = 1`, but tests must prove no staged
+  row leaks through keyword, semantic, hybrid, or graph hydration paths.
+- Current graph edge semantics include append-only audit edges. The expire
+  drain must only remove reader-visible derived edges and must not mutate WAL
+  history or consent journal rows.


### PR DESCRIPTION
## Summary

Implements issue #57: WAL-driven copy-on-write apply for record upsert and expire.

- Adds durable `wal_payloads` storage and operation-aware record WAL recovery bodies.
- Routes upsert through a WAL/COW step graph with idempotent derived vector/FTS/edge steps and activation.
- Routes expire through WAL apply and recovery, preserving lifecycle history and tombstone reasons.
- Adds explicit `records.cow_staged` state so staged COW rows remain hidden from `get`, `list`, `versions`, keyword search, and semantic search until activation.
- Covers recovery after a crash between `primary.upsert_cow` and `primary.activate`.
- Preserves COW replay idempotency while allowing non-`record_id` uniqueness conflicts, such as duplicate trace sequence rows, to surface as typed errors.
- Adds CLI E2E coverage for `cairn ingest` followed by `cairn ingest --resync`, asserting the resync commits through COW/WAL, drains staging, and only exposes the updated active body to keyword search.

## Root Cause Fixed During Final Verification

The final `cairn-store-sqlite` package test exposed that the COW insert used global `INSERT OR IGNORE`, which swallowed all unique-constraint failures. That hid trace sequence conflicts and reported a misleading staged-row invariant instead. The insert now uses `ON CONFLICT(record_id) DO NOTHING`, so primary-key replay remains idempotent while unrelated unique conflicts reach the existing error mapping.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cairn-cli --test ingest_pipeline_e2e ingest_resync_updates_record_through_cow_wal_and_searches_active_body -- --nocapture`
- `cargo test -p cairn-cli --test ingest_pipeline_e2e -- --nocapture`
- `cargo test -p cairn-cli`
- `cargo check -p cairn-cli --all-targets`
- `cargo test -p cairn-store-sqlite --test trace_store upsert_trace_rejects_duplicate_sequence -- --nocapture`
- `cargo test -p cairn-store-sqlite --test cow_upsert_expire --test trace_store -- --nocapture`
- `cargo test -p cairn-store-sqlite`
- `cargo check -p cairn-store-sqlite --all-targets`
- `git diff --check`

## Notes

Opened as draft for CI and maintainer review. Parent epic #8 still has follow-up issue #58 for record-level forget tombstone and purge phases.
