### PR TITLE
feat(store): record-level forget — engine + CLI wire-up (#58)

### DIFF
--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -231,7 +231,10 @@ fn main() -> ExitCode {
             Ok((vault_root, _source)) => verbs::lint::run(sub, Some(vault_root.as_path())),
             Err(_) => verbs::lint::run(sub, None),
         },
-        Some(("forget", sub)) => verbs::forget::run(sub),
+        Some(("forget", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
+            Ok((vault_root, _source, config)) => verbs::forget::run(sub, vault_root, config),
+            Err(code) => code,
+        },
         Some(("hook", sub)) => hooks::run(sub),
         Some(("status", sub)) => run_status(sub, explicit_vault.as_deref()),
         Some(("handshake", sub)) => run_handshake(sub, explicit_vault.as_deref()),

--- a/crates/cairn-cli/src/plugins/verify.rs
+++ b/crates/cairn-cli/src/plugins/verify.rs
@@ -313,7 +313,7 @@ mod tests {
                 &CAPS
             }
             fn supported_contract_versions(&self) -> VersionRange {
-                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0))
             }
             async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
                 Err("stub: upsert not implemented".into())
@@ -413,7 +413,7 @@ mod tests {
                 &CAPS
             }
             fn supported_contract_versions(&self) -> VersionRange {
-                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
+                VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0))
             }
             async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
                 Err("stub: upsert not implemented".into())
@@ -490,7 +490,7 @@ patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 6
+minor = 7
 patch = 0
 "#;
 

--- a/crates/cairn-cli/src/verbs/forget.rs
+++ b/crates/cairn-cli/src/verbs/forget.rs
@@ -11,10 +11,13 @@
 //! `forget --record <ulid>` is wired end-to-end through
 //! [`cairn_store_sqlite::SqliteMemoryStore::forget_record`] (issue #58 — the
 //! engine work landed first; CLI dispatch followed). The actor is taken from
-//! `CAIRN_ISSUER` (or [`DEFAULT_FORGET_ISSUER`] when unset). The local CLI
-//! path bypasses signed-intent verification — the operator has direct
-//! filesystem access to the vault, so a `SignedIntent` admission would not
-//! strengthen the trust boundary; #9 will revisit for cross-host invocations.
+//! `CAIRN_ISSUER` (or [`DEFAULT_FORGET_ISSUER`] when unset) and resolved
+//! against the vault's identity registry before any WAL state is written;
+//! unregistered issuers are rejected with `Unauthorized` and exit
+//! `EX_NOPERM=77`. The local CLI path bypasses signed-intent verification —
+//! the operator has direct filesystem access to the vault, so a
+//! `SignedIntent` admission would not strengthen the trust boundary; #9 will
+//! revisit for cross-host invocations.
 //!
 //! `forget --session` and `forget --scope` still return `CapabilityUnavailable`
 //! until the v0.2 / v0.3 runtime lands.
@@ -23,13 +26,16 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use cairn_core::config::CairnConfig;
+use cairn_core::contract::identity_registry::IdentityVisibility;
 use cairn_core::contract::memory_store::MemoryStore;
-use cairn_core::domain::{Identity, TargetId};
-use cairn_core::generated::envelope::{ResponseData, ResponseVerb};
+use cairn_core::domain::identity::{keys::IdentityRevision, provision::ProvisionInput};
+use cairn_core::domain::{DomainError, Identity, TargetId};
+use cairn_core::generated::envelope::{Response, ResponseData, ResponseVerb};
 use cairn_core::generated::verbs::forget::ForgetData;
 use clap::ArgMatches;
 
 use crate::identity::{guard::refuse_if_degraded, status::ReconciliationReport};
+use crate::llm::EX_NOPERM;
 
 use super::envelope::{
     EX_UNAVAILABLE, capability_unavailable_response, emit_json, human_error, invalid_args_response,
@@ -194,6 +200,34 @@ async fn run_async_record(
         }
     };
 
+    // Resolve the actor against the durable identity registry BEFORE
+    // writing the destructive WAL op. Without this gate any string a
+    // shell happens to set in `CAIRN_ISSUER` would land verbatim as
+    // `consent_journal.actor` for an unrecoverable delete. The local
+    // CLI path still bypasses signed-intent verification (operator has
+    // filesystem access to the vault), but a registered issuer is a
+    // strictly stronger gate than "any env-var string."
+    if let Err(resp) = ensure_forget_issuer(&ctx, &actor).await {
+        if json {
+            emit_json(&resp);
+        } else {
+            let code = super::signed::response_error_code(&resp).unwrap_or("Unauthorized");
+            let message = resp
+                .error
+                .as_ref()
+                .and_then(|e| e.get("message"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("issuer not registered");
+            human_error("forget", code, message, &resp.operation_id);
+        }
+        // EX_NOPERM=77 for Rejected/Unauthorized; EX_CONFIG=78 for
+        // backend-side aborts (registry lookup error / provision error).
+        return match resp.status {
+            cairn_core::generated::envelope::ResponseStatus::Aborted => ExitCode::from(78),
+            _ => ExitCode::from(EX_NOPERM),
+        };
+    }
+
     let receipt = match ctx.store.forget_record(&target, &actor).await {
         Ok(r) => r,
         Err(e) => {
@@ -219,9 +253,16 @@ async fn run_async_record(
     // ULIDs here without changing the contract surface. Set tombstones
     // to None — the deleted_count and committed status already prove
     // the operation took effect.
-    let _ = receipt; // explicitly drop the body-free receipt
+    //
+    // `deleted_count` is the live-version count captured engine-side
+    // before locks were taken. Idempotent re-forgets and forgets
+    // against never-existing target ids report `0` here (status still
+    // `committed` — the WAL op did execute, idempotently, per
+    // brief §5.6). Operators reading `deleted_count: 0` get the signal
+    // they need to debug stale IDs / typos / repeat forgets without
+    // us promoting the no-op into a hard failure.
     let data = ForgetData {
-        deleted_count: 1,
+        deleted_count: receipt.deleted_count,
         plan_ref: None,
         tombstones: None,
     };
@@ -237,6 +278,66 @@ async fn run_async_record(
         println!("cairn forget: committed deletion of target {raw_id}");
     }
     ExitCode::SUCCESS
+}
+
+/// Reject the forget call when the actor is not registered in the
+/// vault's identity registry.
+///
+/// Mirrors `ingest::ensure_ingest_issuer`: when the operator's
+/// `CAIRN_ISSUER` is the default ([`DEFAULT_FORGET_ISSUER`]), the helper
+/// auto-provisions it on first use — operators with vault filesystem
+/// access can already write any record they like, so requiring an
+/// explicit handshake step before the very first `forget` would be
+/// CLI-unfriendly noise. Custom `CAIRN_ISSUER` values that are not in
+/// the registry are rejected with `Unauthorized` and the CLI exits
+/// `EX_NOPERM=77`. Brief §14: the registered issuer is what lands in
+/// `consent_journal.actor` for the destructive op.
+async fn ensure_forget_issuer(
+    ctx: &super::signed::OpenedVerbContext,
+    issuer: &Identity,
+) -> Result<(), Response> {
+    let existing = ctx
+        .identity
+        .registry
+        .get_identity(issuer, IdentityVisibility::Operational)
+        .await
+        .map_err(|e| {
+            super::signed::aborted(ResponseVerb::Forget, format!("identity lookup: {e}"))
+        })?;
+    if existing.is_some() {
+        return Ok(());
+    }
+    if issuer.as_str() != DEFAULT_FORGET_ISSUER {
+        return Err(super::signed::rejected_from_domain(
+            ResponseVerb::Forget,
+            DomainError::Unauthorized {
+                message: format!(
+                    "issuer {issuer} is not active in this vault — \
+                     run `cairn handshake --issuer {issuer}` to register it before forgetting"
+                ),
+            },
+        ));
+    }
+
+    // Auto-provision the default forget issuer on first use. Mirrors
+    // `ingest::ensure_ingest_issuer`'s default-only auto-provision.
+    let mut rng = rand_core::OsRng;
+    let input = ProvisionInput {
+        vault_id: ctx.identity.vault_id.clone(),
+        id: issuer.clone(),
+        kind: issuer.kind(),
+        revision: IdentityRevision::FIRST,
+    };
+    ctx.identity
+        .provision(issuer.kind(), input, &mut rng)
+        .await
+        .map_err(|e| {
+            super::signed::aborted(
+                ResponseVerb::Forget,
+                format!("default issuer provision: {e}"),
+            )
+        })?;
+    Ok(())
 }
 
 fn require_bound_vault(json: bool, vault_root: &std::path::Path) -> Option<ExitCode> {

--- a/crates/cairn-cli/src/verbs/forget.rs
+++ b/crates/cairn-cli/src/verbs/forget.rs
@@ -304,8 +304,25 @@ async fn ensure_forget_issuer(
         .map_err(|e| {
             super::signed::aborted(ResponseVerb::Forget, format!("identity lookup: {e}"))
         })?;
-    if existing.is_some() {
-        return Ok(());
+    if let Some(record) = existing {
+        // §3.10 / §3.5: only `Active` identities can author a destructive
+        // op. `Operational` visibility includes `Revoked`, `RevokePending`,
+        // `Pending`, etc. — checking presence alone would let a revoked
+        // CAIRN_ISSUER land as `consent_journal.actor`, defeating the
+        // signed-tombstone audit posture.
+        if record.provisioning_state.can_sign() {
+            return Ok(());
+        }
+        return Err(super::signed::rejected_from_domain(
+            ResponseVerb::Forget,
+            DomainError::Unauthorized {
+                message: format!(
+                    "issuer {issuer} is registered but not Active \
+                     (state: {:?}); only Active issuers may forget",
+                    record.provisioning_state
+                ),
+            },
+        ));
     }
     if issuer.as_str() != DEFAULT_FORGET_ISSUER {
         return Err(super::signed::rejected_from_domain(

--- a/crates/cairn-cli/src/verbs/forget.rs
+++ b/crates/cairn-cli/src/verbs/forget.rs
@@ -3,22 +3,45 @@
 //! # Trust boundary (spec §3.5)
 //!
 //! `forget` is an issuer-dependent verb: it produces a signed tombstone record
-//! once the store is wired (#9).  The guard call below enforces the
+//! once the store is wired.  The guard call below enforces the
 //! `VaultDegraded → EX_TEMPFAIL=75` contract even in the stub path.
 //!
-//! **Deferred**: full async wiring (calling [`open_for_signed_verb`] against the
-//! resolved vault path) is deferred to issue #9 when this verb becomes async.
+//! # Dispatch state
 //!
-//! [`open_for_signed_verb`]: crate::identity::guard::open_for_signed_verb
+//! `forget --record <ulid>` is wired end-to-end through
+//! [`cairn_store_sqlite::SqliteMemoryStore::forget_record`] (issue #58 — the
+//! engine work landed first; CLI dispatch followed). The actor is taken from
+//! `CAIRN_ISSUER` (or [`DEFAULT_FORGET_ISSUER`] when unset). The local CLI
+//! path bypasses signed-intent verification — the operator has direct
+//! filesystem access to the vault, so a `SignedIntent` admission would not
+//! strengthen the trust boundary; #9 will revisit for cross-host invocations.
+//!
+//! `forget --session` and `forget --scope` still return `CapabilityUnavailable`
+//! until the v0.2 / v0.3 runtime lands.
 
+use std::path::PathBuf;
 use std::process::ExitCode;
 
-use cairn_core::generated::envelope::ResponseVerb;
+use cairn_core::config::CairnConfig;
+use cairn_core::contract::memory_store::MemoryStore;
+use cairn_core::domain::{Identity, TargetId};
+use cairn_core::generated::envelope::{ResponseData, ResponseVerb};
+use cairn_core::generated::verbs::forget::ForgetData;
 use clap::ArgMatches;
 
 use crate::identity::{guard::refuse_if_degraded, status::ReconciliationReport};
 
-use super::envelope::{EX_UNAVAILABLE, capability_unavailable_response, emit_json, human_error};
+use super::envelope::{
+    EX_UNAVAILABLE, capability_unavailable_response, emit_json, human_error, invalid_args_response,
+    new_operation_id, not_found_response,
+};
+use super::status;
+
+/// Default issuer used when `CAIRN_ISSUER` is unset. The local CLI path
+/// authors the consent journal entry with this principal — the operator has
+/// direct filesystem access to the vault, so the value records intent rather
+/// than enforcing it.
+const DEFAULT_FORGET_ISSUER: &str = "hmn:cairn-cli:v1";
 
 fn requested_capability(sub: &ArgMatches) -> &'static str {
     if sub.get_one::<String>("session_id").is_some() {
@@ -32,7 +55,7 @@ fn requested_capability(sub: &ArgMatches) -> &'static str {
 
 /// Run `cairn forget`.
 #[must_use]
-pub fn run(sub: &ArgMatches) -> ExitCode {
+pub fn run(sub: &ArgMatches, vault_root: PathBuf, config: CairnConfig) -> ExitCode {
     let json = sub.get_flag("json");
 
     let dry_run = sub.get_flag("dry-run");
@@ -45,30 +68,202 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
             cairn_core::domain::flush_plan::FlushMode::HumanReview
         };
         // Reuse the same stub planner — for the stub, the ingest/forget
-        // distinction collapses to "produce a placeholder plan." #9 will
-        // split them into real builders.
+        // distinction collapses to "produce a placeholder plan."
         return crate::verbs::ingest_plan_stub(sub, mode, no_diff, json);
     }
 
     // §3.5 trust-boundary guard: refuse if the vault is degraded.
-    // In this P0 stub the report is always clean (no store is open); full async
-    // wiring against the resolved vault path is deferred to issue #9.
+    // In this P0 path the report is built against a clean default — full
+    // reconciliation would require opening the identity store first.
     if let Err(e) = refuse_if_degraded(&ReconciliationReport::default(), vec![]) {
         eprintln!("cairn forget: VaultDegraded — {e}");
         return ExitCode::from(75); // EX_TEMPFAIL
     }
 
-    let capability = requested_capability(sub);
-    let resp = capability_unavailable_response(ResponseVerb::Forget, capability);
+    // --session / --scope still fail-closed: capability is not advertised.
+    if sub.get_one::<String>("session_id").is_some() || sub.get_one::<String>("scope").is_some() {
+        let capability = requested_capability(sub);
+        let resp = capability_unavailable_response(ResponseVerb::Forget, capability);
+        if json {
+            emit_json(&resp);
+        } else {
+            human_error(
+                "forget",
+                "CapabilityUnavailable",
+                "capability is not advertised in this build",
+                &resp.operation_id,
+            );
+        }
+        return ExitCode::from(EX_UNAVAILABLE);
+    }
+
+    // --record path: real dispatch.
+    if let Some(exit) = require_bound_vault(json, vault_root.as_path()) {
+        return exit;
+    }
+
+    let raw_id = if let Some(s) = sub.get_one::<String>("record_id") {
+        s.clone()
+    } else {
+        // clap's ArgGroup(required=true) should prevent this; treat as
+        // a clap-style usage failure if it ever fires.
+        let reason = "exactly one of --record / --session / --scope is required";
+        let resp = invalid_args_response(ResponseVerb::Forget, "record_id", reason);
+        if json {
+            emit_json(&resp);
+        } else {
+            human_error("forget", "InvalidArgs", reason, &resp.operation_id);
+        }
+        return ExitCode::from(64);
+    };
+
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            let resp = super::envelope::internal_error_response(
+                ResponseVerb::Forget,
+                &format!("runtime build: {e}"),
+            );
+            if json {
+                emit_json(&resp);
+            } else {
+                human_error("forget", "Internal", &format!("{e}"), &resp.operation_id);
+            }
+            return ExitCode::FAILURE;
+        }
+    };
+    rt.block_on(run_async_record(vault_root, config, json, raw_id))
+}
+
+#[tracing::instrument(
+    skip(vault_root, config, raw_id),
+    fields(verb = "forget", target_id = %raw_id),
+)]
+async fn run_async_record(
+    vault_root: PathBuf,
+    config: CairnConfig,
+    json: bool,
+    raw_id: String,
+) -> ExitCode {
+    let target = match TargetId::parse(raw_id.clone()) {
+        Ok(t) => t,
+        Err(e) => {
+            let reason = e.to_string();
+            let resp = invalid_args_response(ResponseVerb::Forget, "record_id", &reason);
+            if json {
+                emit_json(&resp);
+            } else {
+                human_error("forget", "InvalidArgs", &reason, &resp.operation_id);
+            }
+            return ExitCode::from(64);
+        }
+    };
+
+    let ctx = match super::signed::open_context(ResponseVerb::Forget, &vault_root, config).await {
+        Ok(ctx) => ctx,
+        Err(resp) => {
+            if json {
+                emit_json(&resp);
+            } else {
+                human_error(
+                    "forget",
+                    "Internal",
+                    "vault open failed",
+                    &resp.operation_id,
+                );
+            }
+            return ExitCode::from(78);
+        }
+    };
+
+    let issuer_wire =
+        std::env::var("CAIRN_ISSUER").unwrap_or_else(|_| DEFAULT_FORGET_ISSUER.to_owned());
+    let actor = match Identity::parse(issuer_wire) {
+        Ok(id) => id,
+        Err(e) => {
+            let resp = invalid_args_response(ResponseVerb::Forget, "CAIRN_ISSUER", &e.to_string());
+            if json {
+                emit_json(&resp);
+            } else {
+                human_error("forget", "InvalidArgs", &e.to_string(), &resp.operation_id);
+            }
+            return ExitCode::from(64);
+        }
+    };
+
+    let receipt = match ctx.store.forget_record(&target, &actor).await {
+        Ok(r) => r,
+        Err(e) => {
+            let resp =
+                super::signed::aborted(ResponseVerb::Forget, format!("store forget_record: {e}"));
+            if json {
+                emit_json(&resp);
+            } else {
+                human_error(
+                    "forget",
+                    "Internal",
+                    &format!("store forget_record: {e}"),
+                    &resp.operation_id,
+                );
+            }
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // ForgetData.tombstones carries the deleted record ULID list. The
+    // ForgetReceipt only retains the salted target_id hash (brief §14
+    // forget-receipt allowlist), so we cannot leak the original record
+    // ULIDs here without changing the contract surface. Set tombstones
+    // to None — the deleted_count and committed status already prove
+    // the operation took effect.
+    let _ = receipt; // explicitly drop the body-free receipt
+    let data = ForgetData {
+        deleted_count: 1,
+        plan_ref: None,
+        tombstones: None,
+    };
+    let resp = super::signed::committed(
+        ResponseVerb::Forget,
+        new_operation_id(),
+        ResponseData::Forget(data),
+        Vec::new(),
+    );
     if json {
         emit_json(&resp);
     } else {
-        human_error(
-            "forget",
-            "CapabilityUnavailable",
-            "capability is not advertised in this build",
-            &resp.operation_id,
-        );
+        println!("cairn forget: committed deletion of target {raw_id}");
     }
-    ExitCode::from(EX_UNAVAILABLE)
+    ExitCode::SUCCESS
+}
+
+fn require_bound_vault(json: bool, vault_root: &std::path::Path) -> Option<ExitCode> {
+    match status::probe_vault_binding(vault_root) {
+        status::VaultBinding::Bound => None,
+        status::VaultBinding::Unbound => {
+            let msg = format!(
+                "no Cairn vault at {} — run `cairn bootstrap` first",
+                vault_root.display()
+            );
+            let resp = not_found_response(ResponseVerb::Forget, "vault", &msg);
+            if json {
+                emit_json(&resp);
+            } else {
+                human_error("forget", "NotFound", &msg, &resp.operation_id);
+            }
+            Some(ExitCode::from(78))
+        }
+        status::VaultBinding::Invalid(reason) => {
+            let msg = format!("vault binding error — {reason}");
+            let resp = super::envelope::internal_error_response(ResponseVerb::Forget, &msg);
+            if json {
+                emit_json(&resp);
+            } else {
+                human_error("forget", "Internal", &msg, &resp.operation_id);
+            }
+            Some(ExitCode::from(78))
+        }
+    }
 }

--- a/crates/cairn-cli/src/verbs/status.rs
+++ b/crates/cairn-cli/src/verbs/status.rs
@@ -291,6 +291,7 @@ fn compute_capabilities(
         embedding_provider_ready,
         llm_configured: false,
         contract_phase: cairn_core::status::Phase::V0_1,
+        surface: cairn_core::status::Surface::Cli,
     })
 }
 
@@ -402,6 +403,7 @@ fn capabilities_for_config(config: &CairnConfig, model_present: bool) -> Vec<Cap
         embedding_provider_ready,
         llm_configured: false,
         contract_phase: cairn_core::status::Phase::V0_1,
+        surface: cairn_core::status::Surface::Cli,
     })
 }
 

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -541,10 +541,18 @@ fn capture_trace_rejects_session_arg_until_scoped_import_supported() {
 }
 
 #[test]
-fn forget_record_returns_capability_unavailable() {
+fn forget_session_returns_capability_unavailable() {
+    // `forget --record` is now wired through SqliteMemoryStore::forget_record
+    // (issue #58); the negative-path coverage moved to `--session`, which
+    // still gates on a v0.2 runtime that has not landed.
     assert_rejected_capability_unavailable(
-        &["forget", "--record", "01JXXXXXXXXXXXXXXXXXXXXXXX", "--json"],
-        "cairn.mcp.v1.forget.record",
+        &[
+            "forget",
+            "--session",
+            "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            "--json",
+        ],
+        "cairn.mcp.v1.forget.session",
     );
 }
 
@@ -636,10 +644,14 @@ fn status_in_bound_vault_advertises_search_and_policy_trace() {
         "hybrid must NOT be advertised when no embedding model is on disk \
          (runtime resolves an embedder for hybrid mode); got {caps:?}"
     );
+    // `cairn.mcp.v1.forget.record` was previously in this stub-only list;
+    // it's now end-to-end wired (issue #58) and lives in the positive
+    // assertion in `assert_status_capabilities_are_deterministic` over in
+    // `issue7_cli_e2e.rs`. `forget.session` stays here — it remains
+    // unwired until the v0.2 runtime lands.
     for stub_cap in [
         "cairn.mcp.v1.retrieve.session",
         "cairn.mcp.v1.retrieve.full",
-        "cairn.mcp.v1.forget.record",
         "cairn.mcp.v1.forget.session",
     ] {
         assert!(
@@ -647,6 +659,11 @@ fn status_in_bound_vault_advertises_search_and_policy_trace() {
             "stub-only capability {stub_cap} must NOT be advertised; got {caps:?}"
         );
     }
+    assert!(
+        caps.contains("cairn.mcp.v1.forget.record"),
+        "forget.record must be advertised in a bound vault now that the CLI \
+         dispatch is wired (issue #58); got {caps:?}"
+    );
 }
 
 #[test]

--- a/crates/cairn-cli/tests/forget_record_cli.rs
+++ b/crates/cairn-cli/tests/forget_record_cli.rs
@@ -5,6 +5,12 @@
 //! 1. The committed envelope shape (status=committed, verb=forget,
 //!    `deleted_count=1`).
 //! 2. The record disappears from `cairn search` afterwards.
+//! 3. A second forget against the same target reports `deleted_count=0`
+//!    with status=committed (idempotent re-forget; brief §5.6).
+//! 4. A forget against a never-existing target id reports
+//!    `deleted_count=0` with status=committed.
+//! 5. A forget invoked with an unregistered `CAIRN_ISSUER` is rejected
+//!    with `Unauthorized` and exit code `EX_NOPERM=77`.
 //!
 //! Bypasses the binary-level `cairn bootstrap` to avoid the BGE embedding
 //! model download that the CLI bootstrap triggers when
@@ -117,5 +123,182 @@ fn forget_record_commits_and_search_no_longer_returns_record() {
     assert!(
         hits.is_empty(),
         "search after forget must return no hits, got {hits:?}"
+    );
+}
+
+/// Repeat-forget against the same target reports `deleted_count: 0` and
+/// stays `committed`. Brief §5.6: forget is idempotent — the WAL op
+/// executes and tombstones zero new rows because the canonical row
+/// was already tombstoned + purged on the first call. Operators reading
+/// `deleted_count: 0` get the signal they need to debug stale IDs /
+/// repeat forgets without us promoting the no-op into a hard failure.
+#[test]
+fn forget_record_idempotent_re_forget_reports_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: dir.path().to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+
+    let _ = cli()
+        .current_dir(dir.path())
+        .args([
+            "ingest",
+            "--kind",
+            "reference",
+            "--body",
+            "second forget",
+            "--json",
+        ])
+        .output()
+        .expect("ingest");
+    let db_path = dir.path().join(".cairn").join("cairn.db");
+    let conn = rusqlite::Connection::open(&db_path).expect("open cairn.db");
+    let target_id: String = conn
+        .query_row("SELECT target_id FROM records LIMIT 1", [], |row| {
+            row.get(0)
+        })
+        .expect("read target_id");
+    drop(conn);
+
+    // First forget — should succeed with deleted_count=1.
+    let first = cli()
+        .current_dir(dir.path())
+        .args(["forget", "--record", target_id.as_str(), "--json"])
+        .output()
+        .expect("first forget");
+    assert_eq!(first.status.code(), Some(0), "first forget must succeed");
+    let first_json: serde_json::Value =
+        serde_json::from_slice(&first.stdout).expect("first forget JSON");
+    assert_eq!(first_json["data"]["deleted_count"], 1);
+
+    // Repeat forget — must commit with deleted_count=0.
+    let second = cli()
+        .current_dir(dir.path())
+        .args(["forget", "--record", target_id.as_str(), "--json"])
+        .output()
+        .expect("second forget");
+    assert_eq!(
+        second.status.code(),
+        Some(0),
+        "idempotent re-forget must exit 0; stderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&second.stderr),
+        String::from_utf8_lossy(&second.stdout)
+    );
+    let second_json: serde_json::Value =
+        serde_json::from_slice(&second.stdout).expect("second forget JSON");
+    assert_eq!(second_json["status"], "committed");
+    assert_eq!(
+        second_json["data"]["deleted_count"], 0,
+        "repeat forget against an already-tombstoned target must report deleted_count=0"
+    );
+}
+
+/// Forget against a target that never existed reports `deleted_count: 0`
+/// with `status: committed`. The WAL op still executes — that is the
+/// brief §5.6 idempotency contract — but the response envelope tells
+/// operators no live rows were tombstoned so they can investigate
+/// stale IDs / typos without us conflating the no-op with a hard error.
+#[test]
+fn forget_record_against_never_existing_target_reports_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: dir.path().to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+
+    // Need at least one ingest so the default issuer auto-provisions
+    // before we exercise forget on a never-seen target. Without it the
+    // forget would still auto-provision the default issuer, but pinning
+    // the order here keeps the test focused on `deleted_count`, not the
+    // issuer-resolution side-effect.
+    let _ = cli()
+        .current_dir(dir.path())
+        .args([
+            "ingest",
+            "--kind",
+            "reference",
+            "--body",
+            "anchor row",
+            "--json",
+        ])
+        .output()
+        .expect("ingest");
+
+    let phantom = "01HZZZZZZZZZZZZZZZZZZZZZZZ";
+    let out = cli()
+        .current_dir(dir.path())
+        .args(["forget", "--record", phantom, "--json"])
+        .output()
+        .expect("forget phantom");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "forget against a never-existing target must exit 0; stderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("forget JSON parse");
+    assert_eq!(json["status"], "committed");
+    assert_eq!(
+        json["data"]["deleted_count"], 0,
+        "phantom-target forget must report deleted_count=0"
+    );
+}
+
+/// `CAIRN_ISSUER=hmn:never-registered:v1` must be rejected with
+/// `Unauthorized`. Without this gate any string an environment
+/// variable holds would land verbatim as `consent_journal.actor` for
+/// the destructive WAL op. Mirrors `ingest`'s issuer-resolution
+/// contract — only the default issuer auto-provisions; every custom
+/// issuer must be registered first via `cairn handshake --issuer ...`.
+#[test]
+fn forget_record_rejects_unregistered_custom_issuer() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: dir.path().to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+
+    let _ = cli()
+        .current_dir(dir.path())
+        .args([
+            "ingest",
+            "--kind",
+            "reference",
+            "--body",
+            "auth-gate target",
+            "--json",
+        ])
+        .output()
+        .expect("ingest");
+    // Use a syntactically-valid placeholder ULID. The Unauthorized
+    // gate runs BEFORE the engine reads the target row — no live row
+    // is required for the assertion. (Pinning a placeholder removes
+    // an unrelated SELECT-target_id failure mode from the test.)
+    let target_id = "01HZZZZZZZZZZZZZZZZZZZZZZZ";
+
+    let mut forge_cmd = cli();
+    forge_cmd
+        .current_dir(dir.path())
+        .env("CAIRN_ISSUER", "hmn:never-registered:v1")
+        .args(["forget", "--record", target_id, "--json"]);
+    let out = forge_cmd.output().expect("forget with unregistered issuer");
+    assert_eq!(
+        out.status.code(),
+        Some(77),
+        "unregistered custom issuer must exit EX_NOPERM=77; stderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).expect("rejected JSON parse");
+    assert_eq!(json["status"], "rejected");
+    assert_eq!(json["verb"], "forget");
+    assert_eq!(
+        json["error"]["code"], "Unauthorized",
+        "unregistered issuer must surface Unauthorized; got {json:?}"
     );
 }

--- a/crates/cairn-cli/tests/forget_record_cli.rs
+++ b/crates/cairn-cli/tests/forget_record_cli.rs
@@ -1,0 +1,121 @@
+//! End-to-end smoke for `cairn forget --record <ulid>` (issue #58).
+//!
+//! Bootstraps a vault, ingests a fact, then runs `forget --record` against
+//! the stored `target_id` and asserts:
+//! 1. The committed envelope shape (status=committed, verb=forget,
+//!    `deleted_count=1`).
+//! 2. The record disappears from `cairn search` afterwards.
+//!
+//! Bypasses the binary-level `cairn bootstrap` to avoid the BGE embedding
+//! model download that the CLI bootstrap triggers when
+//! `search.local_embeddings: true`. The library helper
+//! `cairn_cli::vault::bootstrap` performs the same vault layout creation
+//! without fetching the model.
+
+use std::process::Command;
+
+fn cli() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cairn"));
+    cmd.env_remove("CAIRN_VAULT");
+    cmd.env_remove("CAIRN_REGISTRY");
+    cmd.env_remove("CAIRN_ISSUER");
+    cmd
+}
+
+#[test]
+fn forget_record_commits_and_search_no_longer_returns_record() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: dir.path().to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+
+    // 1. Ingest a record.
+    let ingest_out = cli()
+        .current_dir(dir.path())
+        .args([
+            "ingest",
+            "--kind",
+            "reference",
+            "--body",
+            "hello forget",
+            "--json",
+        ])
+        .output()
+        .expect("cairn ingest --json");
+    assert_eq!(
+        ingest_out.status.code(),
+        Some(0),
+        "ingest must succeed; stderr: {}",
+        String::from_utf8_lossy(&ingest_out.stderr)
+    );
+    let ingest_stdout = String::from_utf8(ingest_out.stdout).expect("utf-8");
+    let ingest_json: serde_json::Value = serde_json::from_str(ingest_stdout.trim())
+        .unwrap_or_else(|e| panic!("ingest JSON parse failed: {e}\nstdout: {ingest_stdout:?}"));
+    assert_eq!(ingest_json["status"], "committed");
+
+    // Resolve the target_id by reading directly from the SQLite DB. The
+    // ingest envelope only carries the version-specific record_id; the
+    // forget verb takes the supersession lineage key (target_id) which
+    // are independent ULIDs (brief §3 / §3.0).
+    let db_path = dir.path().join(".cairn").join("cairn.db");
+    let conn = rusqlite::Connection::open(&db_path).expect("open cairn.db");
+    let target_id: String = conn
+        .query_row("SELECT target_id FROM records LIMIT 1", [], |row| {
+            row.get(0)
+        })
+        .expect("read target_id from records table");
+    drop(conn);
+    assert_eq!(target_id.len(), 26, "target_id must be a 26-char ULID");
+
+    // 2. Forget the record by target_id.
+    let forget_out = cli()
+        .current_dir(dir.path())
+        .args(["forget", "--record", target_id.as_str(), "--json"])
+        .output()
+        .expect("cairn forget --record --json");
+    assert_eq!(
+        forget_out.status.code(),
+        Some(0),
+        "forget must succeed; stderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&forget_out.stderr),
+        String::from_utf8_lossy(&forget_out.stdout)
+    );
+    let forget_stdout = String::from_utf8(forget_out.stdout).expect("utf-8");
+    let forget_json: serde_json::Value = serde_json::from_str(forget_stdout.trim())
+        .unwrap_or_else(|e| panic!("forget JSON parse failed: {e}\nstdout: {forget_stdout:?}"));
+    assert_eq!(forget_json["contract"], "cairn.mcp.v1");
+    assert_eq!(forget_json["status"], "committed");
+    assert_eq!(forget_json["verb"], "forget");
+    assert!(forget_json["error"].is_null(), "no error on success");
+    assert_eq!(
+        forget_json["data"]["deleted_count"], 1,
+        "deleted_count must be 1 after committing a single forget"
+    );
+    assert!(forget_json["operation_id"].is_string());
+    assert!(forget_json["policy_trace"].is_array());
+
+    // 3. Confirm the record is gone via `cairn search --mode keyword`.
+    let search_out = cli()
+        .current_dir(dir.path())
+        .args(["search", "--mode", "keyword", "hello forget", "--json"])
+        .output()
+        .expect("cairn search --json");
+    assert_eq!(
+        search_out.status.code(),
+        Some(0),
+        "search must exit 0; stderr: {}",
+        String::from_utf8_lossy(&search_out.stderr)
+    );
+    let search_stdout = String::from_utf8(search_out.stdout).expect("utf-8");
+    let search_json: serde_json::Value = serde_json::from_str(search_stdout.trim())
+        .unwrap_or_else(|e| panic!("search JSON parse failed: {e}\nstdout: {search_stdout:?}"));
+    let hits = search_json["data"]["hits"]
+        .as_array()
+        .expect("search must return data.hits array");
+    assert!(
+        hits.is_empty(),
+        "search after forget must return no hits, got {hits:?}"
+    );
+}

--- a/crates/cairn-cli/tests/issue7_cli_e2e.rs
+++ b/crates/cairn-cli/tests/issue7_cli_e2e.rs
@@ -93,8 +93,9 @@ fn assert_status_capabilities_are_deterministic(vault_path: &str) {
         "retrieve.record must not be advertised until runtime can honor it: {caps_one:?}"
     );
     assert!(
-        !caps_one.contains(&"cairn.mcp.v1.forget.record".to_owned()),
-        "forget.record must not be advertised until runtime can honor it: {caps_one:?}"
+        caps_one.contains(&"cairn.mcp.v1.forget.record".to_owned()),
+        "forget.record must be advertised in a bound vault now that the CLI \
+         dispatch is wired to SqliteMemoryStore::forget_record (issue #58): {caps_one:?}"
     );
 }
 
@@ -145,6 +146,11 @@ fn assert_sensitive_verb_rejection(out: &Output, args: &[&str], verb: &str, capa
 }
 
 fn assert_unadvertised_sensitive_verbs_fail_closed(vault_path: &str) {
+    // `forget --record` was previously here as the second arm; it's been
+    // removed because the CLI now wires the dispatch path through
+    // `SqliteMemoryStore::forget_record` (issue #58). Negative-path coverage
+    // for forget is preserved by `forget --session` which still returns
+    // CapabilityUnavailable until the v0.2 runtime lands.
     for (args, verb, capability) in [
         (
             vec![
@@ -162,12 +168,12 @@ fn assert_unadvertised_sensitive_verbs_fail_closed(vault_path: &str) {
                 "--vault",
                 vault_path,
                 "forget",
-                "--record",
+                "--session",
                 "01JXXXXXXXXXXXXXXXXXXXXXXX",
                 "--json",
             ],
             "forget",
-            "cairn.mcp.v1.forget.record",
+            "cairn.mcp.v1.forget.session",
         ),
     ] {
         let out = run(&args);

--- a/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_human.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_human.snap
@@ -6,5 +6,5 @@ expression: text
 NAME                  CONTRACT              VERSION-RANGE     SOURCE
 cairn-mcp             MCPServer             [0.1.0, 0.2.0)    bundled:cairn-mcp
 cairn-sensors-local   SensorIngress         [0.1.0, 0.2.0)    bundled:cairn-sensors-local
-cairn-store-sqlite    MemoryStore           [0.5.0, 0.6.0)    bundled:cairn-store-sqlite
+cairn-store-sqlite    MemoryStore           [0.5.0, 0.7.0)    bundled:cairn-store-sqlite
 cairn-workflows       WorkflowOrchestrator  [0.1.0, 0.2.0)    bundled:cairn-workflows

--- a/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
@@ -44,7 +44,7 @@ expression: json
       },
       "contract": "MemoryStore",
       "contract_version_range": {
-        "max_exclusive": "0.6.0",
+        "max_exclusive": "0.7.0",
         "min": "0.5.0"
       },
       "name": "cairn-store-sqlite",

--- a/crates/cairn-cli/tests/snapshots/status_snapshot_insta__default_p0_bound_vault.snap
+++ b/crates/cairn-cli/tests/snapshots/status_snapshot_insta__default_p0_bound_vault.snap
@@ -5,7 +5,8 @@ expression: v
 {
   "capabilities": [
     "cairn.mcp.v1.search.keyword",
-    "cairn.mcp.v1.policy_trace"
+    "cairn.mcp.v1.policy_trace",
+    "cairn.mcp.v1.forget.record"
   ],
   "contract": "cairn.mcp.v1",
   "extensions": [],

--- a/crates/cairn-cli/tests/snapshots/status_snapshot_insta__local_embeddings_off.snap
+++ b/crates/cairn-cli/tests/snapshots/status_snapshot_insta__local_embeddings_off.snap
@@ -5,7 +5,8 @@ expression: v
 {
   "capabilities": [
     "cairn.mcp.v1.search.keyword",
-    "cairn.mcp.v1.policy_trace"
+    "cairn.mcp.v1.policy_trace",
+    "cairn.mcp.v1.forget.record"
   ],
   "contract": "cairn.mcp.v1",
   "extensions": [],

--- a/crates/cairn-core/src/contract/macros.rs
+++ b/crates/cairn-core/src/contract/macros.rs
@@ -79,7 +79,7 @@
 ///     const NAME: &'static str = "acme-store";
 ///     const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
 ///         ContractVersion::new(0, 1, 0),
-///         ContractVersion::new(0, 6, 0),
+///         ContractVersion::new(0, 7, 0),
 ///     );
 /// }
 ///
@@ -114,7 +114,7 @@
 ///
 /// [contract_version_range.max_exclusive]
 /// major = 0
-/// minor = 6
+/// minor = 7
 /// patch = 0
 /// "#;
 ///
@@ -155,7 +155,7 @@
 ///     const NAME: &'static str = "acme-store";
 ///     const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
 ///         ContractVersion::new(0, 1, 0),
-///         ContractVersion::new(0, 6, 0),
+///         ContractVersion::new(0, 7, 0),
 ///     );
 /// }
 ///
@@ -434,7 +434,7 @@ macro_rules! __register_plugin_with_manifest_helper {
 ///     const NAME: &'static str = "config-store";
 ///     const SUPPORTED_VERSIONS: VersionRange = VersionRange::new(
 ///         ContractVersion::new(0, 1, 0),
-///         ContractVersion::new(0, 6, 0),
+///         ContractVersion::new(0, 7, 0),
 ///     );
 /// }
 ///

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -585,7 +585,10 @@ pub struct ForgetReceipt {
     pub target_id_hash: String,
     /// WAL operation id that committed the forget.
     pub op_id: String,
-    /// Unix milliseconds when Phase B step 5 (`primary.purge`) committed.
+    /// Unix milliseconds captured immediately after Phase B's seven-step
+    /// graph reached COMMITTED. The gap from `primary.purge` (step 5) to
+    /// here is the bounded duration of `wal.purge_pre_images` (step 6)
+    /// and `snapshot.purge` (step 7) — single-digit ms in P0.
     pub purged_at: i64,
 }
 

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -32,7 +32,14 @@ use crate::search::ScoreExplain;
 /// `MemoryStoreCapabilities::graph_search` flag and the
 /// `search_graph_neighbors` trait method (default impl returns
 /// `CapabilityUnavailable`) ship in the same bump.
-pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 5, 0);
+/// Bumped 0.5 → 0.6 in #58 when `MemoryStore::forget_record` and
+/// `ForgetReceipt` landed for the §5.6 record-level forget pipeline.
+/// Adding a new required trait method is a structural break for any
+/// downstream adapter that does not provide its own implementation —
+/// the default impl returns `"capability unavailable: forget_record"`
+/// so trait-object consumers compile, but the trait surface itself
+/// has grown.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 6, 0);
 
 /// Errors raised by `MemoryStore` implementations. Adapters define their
 /// own concrete type (e.g. `cairn_store_sqlite::StoreError`); this is the
@@ -153,6 +160,32 @@ pub trait MemoryStore: Send + Sync {
     /// Mark a specific record version as tombstoned with the given reason.
     /// Idempotent — already-tombstoned rows return `Ok(())`.
     async fn tombstone(&self, id: &RecordId, reason: TombstoneReason) -> Result<(), StoreError>;
+
+    /// Record-level forget (brief §5.6 row 2, §14 audit invariant).
+    ///
+    /// Phase A tombstones every version of `target` with reason `Forget`
+    /// and fuses a body-free [`crate::domain::ConsentEvent`] receipt into
+    /// the same `SQLite` transaction. Phase B physically purges record rows,
+    /// derived indexes, and any WAL pre-image blob that referenced
+    /// the forgotten content. Idempotent and crash-safe at every step.
+    ///
+    /// `actor` is the resolved principal authoring the forget — the
+    /// engine writes it into `consent_journal.actor` for audit-keyed
+    /// queries. CLI/MCP/SDK callers (issue #9) pass the principal
+    /// resolved by the signed-envelope guard.
+    ///
+    /// Returns the body-free [`ForgetReceipt`] proving deletion.
+    ///
+    /// # Errors
+    /// Default impl returns `"capability unavailable: forget_record"`.
+    async fn forget_record(
+        &self,
+        target: &TargetId,
+        actor: &crate::domain::Identity,
+    ) -> Result<ForgetReceipt, StoreError> {
+        let _ = (target, actor);
+        Err("capability unavailable: forget_record".into())
+    }
 
     /// Full version history for a target, oldest → newest. Includes
     /// active and inactive rows.
@@ -538,6 +571,22 @@ impl TombstoneReason {
             _ => None,
         }
     }
+}
+
+/// Outcome of a `forget_record` call (brief §14 forget-receipt allowlist).
+///
+/// Body-free by construction: only the salted target hash, the WAL op id,
+/// and the purge timestamp survive. The corresponding row in
+/// `consent_journal` carries the same `target_id_hash` and `op_id` so
+/// audits can join the two without exposing forgotten content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgetReceipt {
+    /// `sha256:<hex>` of the forgotten `target_id`.
+    pub target_id_hash: String,
+    /// WAL operation id that committed the forget.
+    pub op_id: String,
+    /// Unix milliseconds when Phase B step 5 (`primary.purge`) committed.
+    pub purged_at: i64,
 }
 
 /// Outcome of an `upsert` call. `content_changed = false` indicates the
@@ -1002,7 +1051,7 @@ mod tests {
     impl MemoryStorePlugin for StubStore {
         const NAME: &'static str = "stub";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 5, 0), ContractVersion::new(0, 6, 0));
+            VersionRange::new(ContractVersion::new(0, 6, 0), ContractVersion::new(0, 7, 0));
     }
 
     #[tokio::test]
@@ -1136,11 +1185,12 @@ mod tests {
         assert!(err.to_string().contains("bitemporal_graph"));
     }
 
-    /// `CONTRACT_VERSION` for the `MemoryStore` trait is locked to 0.5.0.
+    /// `CONTRACT_VERSION` for the `MemoryStore` trait is locked to 0.6.0.
     /// #258 bumped 0.3→0.4 (per-row `schema_version`). #191 bumped 0.4→0.5
-    /// (`auth_scope`, `graph_search` capability + trait method).
+    /// (`auth_scope`, `graph_search` capability + trait method). #58 bumped
+    /// 0.5→0.6 (`forget_record` trait method + `ForgetReceipt`).
     #[test]
-    fn contract_version_locked_to_0_5_0() {
-        assert_eq!(CONTRACT_VERSION, ContractVersion::new(0, 5, 0));
+    fn contract_version_locked_to_0_6_0() {
+        assert_eq!(CONTRACT_VERSION, ContractVersion::new(0, 6, 0));
     }
 }

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -580,9 +580,22 @@ impl TombstoneReason {
 ///
 /// Body-free by construction: only the salted target hash, the WAL op id,
 /// the purge timestamp, and the count of active rows that were
-/// tombstoned survive. The corresponding row in `consent_journal` carries
-/// the same `target_id_hash` and `op_id` so audits can join the two
-/// without exposing forgotten content.
+/// tombstoned survive.
+///
+/// **Consent-journal join contract.** When the forget op had something
+/// to destroy (any record rows existed for the target at admission
+/// time, including already-expired ones), the corresponding row in
+/// `consent_journal` carries the same `target_id_hash` and `op_id` so
+/// audits can join the two without exposing forgotten content. When
+/// the target had NO rows at all (truly already-purged idempotent
+/// re-forget), the receipt still returns with a fresh `op_id` and
+/// `deleted_count = 0`, but no consent row is appended — the
+/// authoritative receipt is the one the original destructive forget
+/// wrote, and adding a no-rows duplicate would dilute the audit
+/// trail with `ScopeTuple::default()` + `MemoryVisibility::Private`
+/// post-purge defaults. Round-6 review (Codex). Auditors join via
+/// `query_by_op(receipt.op_id)` and treat zero rows as the "already
+/// purged" marker.
 ///
 /// `#[non_exhaustive]` so adding new audit-allowlisted fields (e.g. a
 /// post-Phase-B integrity hash) is a non-breaking change for downstream

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -38,7 +38,10 @@ use crate::search::ScoreExplain;
 /// downstream adapter that does not provide its own implementation —
 /// the default impl returns `"capability unavailable: forget_record"`
 /// so trait-object consumers compile, but the trait surface itself
-/// has grown.
+/// has grown. Co-evolved within 0.6 in the #58 forget-receipt-fidelity
+/// follow-up by adding `ForgetReceipt::deleted_count` and marking
+/// `ForgetReceipt` `#[non_exhaustive]` with a [`ForgetReceipt::new`]
+/// constructor — additive, gated by `non_exhaustive`, no version bump.
 pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 6, 0);
 
 /// Errors raised by `MemoryStore` implementations. Adapters define their
@@ -576,10 +579,16 @@ impl TombstoneReason {
 /// Outcome of a `forget_record` call (brief §14 forget-receipt allowlist).
 ///
 /// Body-free by construction: only the salted target hash, the WAL op id,
-/// and the purge timestamp survive. The corresponding row in
-/// `consent_journal` carries the same `target_id_hash` and `op_id` so
-/// audits can join the two without exposing forgotten content.
+/// the purge timestamp, and the count of active rows that were
+/// tombstoned survive. The corresponding row in `consent_journal` carries
+/// the same `target_id_hash` and `op_id` so audits can join the two
+/// without exposing forgotten content.
+///
+/// `#[non_exhaustive]` so adding new audit-allowlisted fields (e.g. a
+/// post-Phase-B integrity hash) is a non-breaking change for downstream
+/// trait implementors. Use [`ForgetReceipt::new`] to construct.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ForgetReceipt {
     /// `sha256:<hex>` of the forgotten `target_id`.
     pub target_id_hash: String,
@@ -590,6 +599,33 @@ pub struct ForgetReceipt {
     /// here is the bounded duration of `wal.purge_pre_images` (step 6)
     /// and `snapshot.purge` (step 7) — single-digit ms in P0.
     pub purged_at: i64,
+    /// Number of active record rows that were live for `target_id` at
+    /// the moment the forget was admitted. Captured via
+    /// `SELECT COUNT(*) FROM records WHERE target_id = ?1 AND active = 1`
+    /// before any locks are taken so an idempotent re-forget reports `0`
+    /// (the rows are already tombstoned + purged) while the first forget
+    /// reports the live-version count. Operators reading `deleted_count: 0`
+    /// in the response envelope get the signal they need to debug stale
+    /// IDs / typos / repeat forgets without polluting it as a hard error
+    /// — the WAL op did execute, idempotently (brief §5.6).
+    pub deleted_count: u64,
+}
+
+impl ForgetReceipt {
+    /// Construct a [`ForgetReceipt`].
+    ///
+    /// Provided so adapter crates outside `cairn-core` can build the struct
+    /// despite the `#[non_exhaustive]` attribute. Mirrors the [`IndexStats`]
+    /// constructor pattern.
+    #[must_use]
+    pub fn new(target_id_hash: String, op_id: String, purged_at: i64, deleted_count: u64) -> Self {
+        Self {
+            target_id_hash,
+            op_id,
+            purged_at,
+            deleted_count,
+        }
+    }
 }
 
 /// Outcome of an `upsert` call. `content_changed = false` indicates the

--- a/crates/cairn-core/src/contract/registry.rs
+++ b/crates/cairn-core/src/contract/registry.rs
@@ -655,15 +655,15 @@ mod tests {
     impl MemoryStorePlugin for StubStore {
         const NAME: &'static str = "stub-store";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0));
     }
 
     fn compatible() -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0))
     }
 
     fn incompatible() -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 6, 0), ContractVersion::new(0, 7, 0))
+        VersionRange::new(ContractVersion::new(0, 7, 0), ContractVersion::new(0, 8, 0))
     }
 
     #[test]
@@ -765,7 +765,7 @@ patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 6
+minor = 7
 patch = 0
 "#
     }

--- a/crates/cairn-core/src/status/mod.rs
+++ b/crates/cairn-core/src/status/mod.rs
@@ -62,6 +62,28 @@ pub struct StoreCaps {
     pub vector: bool,
 }
 
+/// Which Cairn surface is asking for a capability advertisement.
+///
+/// Brief §15 fail-closed: a capability appears in `status.capabilities`
+/// only when the calling surface can honor every call against it. When a
+/// dispatch path lands on the CLI ahead of the SDK transport / MCP handler,
+/// `advertise()` consults the per-surface wiring flag (e.g.
+/// [`wiring::FORGET_RECORD_WIRED_CLI`] vs `WIRED_SDK` / `WIRED_MCP`) so the
+/// lagging surfaces do not over-advertise.
+///
+/// `#[non_exhaustive]` so adding a future surface (e.g. a remote-RPC
+/// adapter, the in-tree skill) is non-breaking for downstream callers.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Surface {
+    /// `cairn` binary verbs.
+    Cli,
+    /// In-process typed SDK (`cairn-sdk`).
+    Sdk,
+    /// MCP adapter (`cairn-mcp`) — stdio + http transports.
+    Mcp,
+}
+
 /// Inputs for the per-capability decision rules in `advertise()`.
 // Four boolean fields (vault_bound, model_present, embedding_provider_ready,
 // llm_configured) represent orthogonal binary-state runtime probes. Each bool
@@ -124,6 +146,11 @@ pub struct CapabilityGates {
     pub llm_configured: bool,
     /// Contract-version phase the runtime is operating at.
     pub contract_phase: Phase,
+    /// Calling surface — selects per-surface wiring flags for
+    /// capabilities whose dispatch landed on some surfaces but not
+    /// others. See [`Surface`] and the per-surface wiring constants
+    /// in [`wiring`].
+    pub surface: Surface,
 }
 
 impl CapabilityGates {
@@ -174,7 +201,7 @@ pub fn advertise(gates: &CapabilityGates) -> Vec<Capabilities> {
     }
 
     // ── forget (capability surfaces; runtime wiring still all-false) ──────
-    if phase >= Phase::V0_1 && wiring::FORGET_RECORD_WIRED {
+    if phase >= Phase::V0_1 && forget_record_wired_for(gates.surface) {
         out.push(Capabilities::CairnMcpV1ForgetRecord);
     }
     if phase >= Phase::V0_2 && wiring::FORGET_SESSION_WIRED {
@@ -213,6 +240,20 @@ pub fn advertise(gates: &CapabilityGates) -> Vec<Capabilities> {
     }
 
     out
+}
+
+/// Per-surface lookup for `cairn.mcp.v1.forget.record` wiring.
+///
+/// Brief §15 fail-closed: the CLI dispatch landed in #58 ahead of the SDK
+/// transport and the MCP handler. Until those surfaces dispatch end-to-end,
+/// only the CLI advertises `forget.record` in `status`.
+#[must_use]
+fn forget_record_wired_for(surface: Surface) -> bool {
+    match surface {
+        Surface::Cli => wiring::FORGET_RECORD_WIRED_CLI,
+        Surface::Sdk => wiring::FORGET_RECORD_WIRED_SDK,
+        Surface::Mcp => wiring::FORGET_RECORD_WIRED_MCP,
+    }
 }
 
 #[cfg(test)]

--- a/crates/cairn-core/src/status/tests.rs
+++ b/crates/cairn-core/src/status/tests.rs
@@ -29,6 +29,11 @@ fn gates(bound: bool, model_present: bool, store: Option<StoreCaps>) -> Capabili
         embedding_provider_ready: model_present,
         llm_configured: false,
         contract_phase: Phase::V0_1,
+        // Default to the CLI surface — the surface where today's wiring
+        // flags are flipped on. Tests that exercise SDK/MCP surfaces
+        // construct gates directly with `surface: Surface::Sdk` /
+        // `Surface::Mcp` (see `forget_record_*` tests below).
+        surface: Surface::Cli,
     }
 }
 
@@ -100,15 +105,46 @@ fn local_embeddings_off_drops_semantic_and_hybrid() {
 }
 
 #[test]
-fn forget_record_advertised_after_wiring_flipped() {
-    // `wiring::FORGET_RECORD_WIRED` was flipped to true once the CLI dispatch
-    // landed (issue #58 dispatch extension). The brief §15 fail-closed
-    // contract is now satisfied because the runtime can honor the call.
+fn forget_record_advertised_on_cli_surface_after_wiring_flipped() {
+    // `wiring::FORGET_RECORD_WIRED_CLI` was flipped to true once the CLI
+    // dispatch landed (issue #58 dispatch extension). The brief §15
+    // fail-closed contract is satisfied because the CLI runtime honors
+    // every call against `cairn.mcp.v1.forget.record`.
     let g = gates(true, true, None);
     let caps = advertise(&g);
     assert!(
         caps.contains(&Capabilities::CairnMcpV1ForgetRecord),
-        "forget.record must be advertised once runtime is wired (brief §15)"
+        "forget.record must be advertised on the CLI surface (brief §15)"
+    );
+}
+
+#[test]
+fn forget_record_not_advertised_on_sdk_surface_until_wired() {
+    // `Sdk::forget` still returns `unimplemented` — brief §15 fail-closed
+    // forbids advertising `cairn.mcp.v1.forget.record` from `Sdk::status`
+    // until the SDK transport calls into `MemoryStore::forget_record`.
+    let mut g = gates(true, true, None);
+    g.surface = Surface::Sdk;
+    let caps = advertise(&g);
+    assert!(
+        !caps.contains(&Capabilities::CairnMcpV1ForgetRecord),
+        "forget.record must NOT be advertised on the SDK surface while \
+         `Sdk::forget` returns unimplemented (brief §15); got {caps:?}"
+    );
+}
+
+#[test]
+fn forget_record_not_advertised_on_mcp_surface_until_wired() {
+    // The MCP `tools/call` handler still falls through to `dispatch_stub`
+    // for forget — brief §15 fail-closed forbids advertising
+    // `cairn.mcp.v1.forget.record` until that path lands.
+    let mut g = gates(true, true, None);
+    g.surface = Surface::Mcp;
+    let caps = advertise(&g);
+    assert!(
+        !caps.contains(&Capabilities::CairnMcpV1ForgetRecord),
+        "forget.record must NOT be advertised on the MCP surface while \
+         the handler falls through to dispatch_stub (brief §15); got {caps:?}"
     );
 }
 
@@ -215,6 +251,7 @@ mod remediation_tests {
             embedding_provider_ready: true,
             llm_configured: false,
             contract_phase: Phase::V0_1,
+            surface: Surface::Cli,
         };
 
         for cap in advertise(&gates) {
@@ -268,6 +305,10 @@ mod prop_tests {
         )
     }
 
+    fn arb_surface() -> impl Strategy<Value = Surface> {
+        prop_oneof![Just(Surface::Cli), Just(Surface::Sdk), Just(Surface::Mcp)]
+    }
+
     fn arb_gates() -> impl Strategy<Value = CapabilityGates> {
         (
             arb_cap_set(),
@@ -277,9 +318,10 @@ mod prop_tests {
             any::<bool>(),
             any::<bool>(),
             arb_phase(),
+            arb_surface(),
         )
-            .prop_map(|(config, store, bound, model, embed_ready, llm, phase)| {
-                CapabilityGates {
+            .prop_map(
+                |(config, store, bound, model, embed_ready, llm, phase, surface)| CapabilityGates {
                     config,
                     store,
                     vault_bound: bound,
@@ -287,8 +329,9 @@ mod prop_tests {
                     embedding_provider_ready: embed_ready,
                     llm_configured: llm,
                     contract_phase: phase,
-                }
-            })
+                    surface,
+                },
+            )
     }
 
     // Turning a capability gate ON never removes capabilities. Catches
@@ -361,6 +404,7 @@ fn openai_provider_without_key_drops_semantic_and_hybrid() {
         embedding_provider_ready: false,
         llm_configured: false,
         contract_phase: Phase::V0_1,
+        surface: Surface::Cli,
     };
     let caps = advertise(&g);
     assert!(

--- a/crates/cairn-core/src/status/tests.rs
+++ b/crates/cairn-core/src/status/tests.rs
@@ -100,13 +100,15 @@ fn local_embeddings_off_drops_semantic_and_hybrid() {
 }
 
 #[test]
-fn forget_record_held_back_until_wiring_flips() {
-    // wiring::FORGET_RECORD_WIRED = false today.
+fn forget_record_advertised_after_wiring_flipped() {
+    // `wiring::FORGET_RECORD_WIRED` was flipped to true once the CLI dispatch
+    // landed (issue #58 dispatch extension). The brief §15 fail-closed
+    // contract is now satisfied because the runtime can honor the call.
     let g = gates(true, true, None);
     let caps = advertise(&g);
     assert!(
-        !caps.contains(&Capabilities::CairnMcpV1ForgetRecord),
-        "forget.record advertised before runtime wired (brief §15)"
+        caps.contains(&Capabilities::CairnMcpV1ForgetRecord),
+        "forget.record must be advertised once runtime is wired (brief §15)"
     );
 }
 

--- a/crates/cairn-core/src/status/wiring.rs
+++ b/crates/cairn-core/src/status/wiring.rs
@@ -3,16 +3,49 @@
 //! Brief §15 / §8.0.a forbid over-advertising: a capability appears in
 //! `status.capabilities` only when the runtime can honor every call against
 //! it. The flags below start `false`; the issue that lands a verb's dispatch
-//! flips the matching flag to `true`. CLI, SDK, and MCP all read these
-//! through `cairn_core::status::advertise()` so flipping one constant
-//! propagates to every surface.
+//! flips the matching flag to `true`.
+//!
+//! ## Surface granularity
+//!
+//! Capabilities can land on different surfaces at different times — the
+//! CLI verb often arrives ahead of the SDK transport and the MCP handler,
+//! and a global flag would over-advertise on the lagging surfaces. For
+//! capabilities that have arrived on at least one but not all surfaces,
+//! split the flag per-surface and have `advertise()` consult the gate for
+//! the calling [`crate::status::Surface`]. Once every surface honors the
+//! call, fold the per-surface flags back into a single global constant.
+//!
+//! `forget.record` is currently in this split state: the CLI path is wired
+//! through `SqliteMemoryStore::forget_record`, but the SDK transport and
+//! MCP handler still fall through to `unimplemented!` / `dispatch_stub`.
+//! Brief §15 fail-closed therefore forbids advertising
+//! `cairn.mcp.v1.forget.record` from the SDK or MCP `status` until those
+//! dispatch paths land.
 
-/// `forget --record` end-to-end dispatch path is wired (issue family #54+).
+/// `forget --record` end-to-end dispatch path on the CLI surface.
 ///
 /// Flipped to `true` once `cairn forget --record <id>` was wired through
-/// `SqliteMemoryStore::forget_record` in the CLI (issue #58 dispatch
-/// extension; the engine landed earlier in #58).
-pub const FORGET_RECORD_WIRED: bool = true;
+/// `SqliteMemoryStore::forget_record` (issue #58 dispatch extension; the
+/// engine landed earlier in #58).
+pub const FORGET_RECORD_WIRED_CLI: bool = true;
+
+/// `forget --record` end-to-end dispatch path on the SDK surface.
+///
+/// `false` until `Sdk::forget` calls into `MemoryStore::forget_record`
+/// instead of returning `unimplemented`. Brief §15 fail-closed: SDK
+/// callers must not see `cairn.mcp.v1.forget.record` in `status` while
+/// `Sdk::forget` rejects with `Unimplemented`. Wiring lands in a
+/// follow-up PR; flip this constant and merge with
+/// [`FORGET_RECORD_WIRED_MCP`] + [`FORGET_RECORD_WIRED_CLI`] back into a
+/// single global flag once every surface honors the call.
+pub const FORGET_RECORD_WIRED_SDK: bool = false;
+
+/// `forget --record` end-to-end dispatch path on the MCP surface.
+///
+/// `false` until the MCP `tools/call` handler dispatches `forget` against
+/// the wired store instead of falling through to `dispatch_stub`. Brief
+/// §15 fail-closed: same rationale as [`FORGET_RECORD_WIRED_SDK`].
+pub const FORGET_RECORD_WIRED_MCP: bool = false;
 
 /// `forget --session` (v0.2+ runtime).
 pub const FORGET_SESSION_WIRED: bool = false;

--- a/crates/cairn-core/src/status/wiring.rs
+++ b/crates/cairn-core/src/status/wiring.rs
@@ -8,7 +8,11 @@
 //! propagates to every surface.
 
 /// `forget --record` end-to-end dispatch path is wired (issue family #54+).
-pub const FORGET_RECORD_WIRED: bool = false;
+///
+/// Flipped to `true` once `cairn forget --record <id>` was wired through
+/// `SqliteMemoryStore::forget_record` in the CLI (issue #58 dispatch
+/// extension; the engine landed earlier in #58).
+pub const FORGET_RECORD_WIRED: bool = true;
 
 /// `forget --session` (v0.2+ runtime).
 pub const FORGET_SESSION_WIRED: bool = false;

--- a/crates/cairn-core/tests/conformance_tier1.rs
+++ b/crates/cairn-core/tests/conformance_tier1.rs
@@ -32,7 +32,7 @@ patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 6
+minor = 7
 patch = 0
 
 [features]
@@ -64,7 +64,7 @@ impl MemoryStore for StubStore {
         &CAPS
     }
     fn supported_contract_versions(&self) -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0))
     }
     async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
         Err("stub: upsert not implemented".into())

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -56,7 +56,7 @@ mod compatible_plugin {
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0))
         }
         async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
             Err("stub: upsert not implemented".into())
@@ -96,7 +96,7 @@ mod compatible_plugin {
     impl MemoryStorePlugin for FakeStore {
         const NAME: &'static str = "fake-compat";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0));
     }
 
     register_plugin!(MemoryStore, FakeStore, "fake-compat");
@@ -232,7 +232,7 @@ patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 6
+minor = 7
 patch = 0
 "#;
 
@@ -257,7 +257,7 @@ patch = 0
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0))
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0))
         }
         async fn upsert(&self, _r: &MemoryRecord) -> Result<UpsertOutcome, StoreError> {
             Err("stub: upsert not implemented".into())
@@ -297,7 +297,7 @@ patch = 0
     impl MemoryStorePlugin for FakeStore {
         const NAME: &'static str = "fake-with-manifest";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0));
     }
 
     register_plugin!(MemoryStore, FakeStore, "fake-with-manifest", MANIFEST_TOML);
@@ -458,7 +458,7 @@ mod config_driven_plugin {
     impl MemoryStorePlugin for PathStore {
         const NAME: &'static str = "path-store";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0));
     }
 
     register_plugin_with!(
@@ -533,7 +533,7 @@ mod name_mismatch_plugin {
     impl MemoryStorePlugin for BadNameStore {
         const NAME: &'static str = "actual-name";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0));
     }
 
     // NAME const = "actual-name" but macro literal = "wrong-name"
@@ -875,7 +875,7 @@ mod factory_error_plugin {
     impl MemoryStorePlugin for FailingStore {
         const NAME: &'static str = "failing-store";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 6, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 7, 0));
     }
 
     register_plugin_with!(

--- a/crates/cairn-core/tests/status_phase_pinning.rs
+++ b/crates/cairn-core/tests/status_phase_pinning.rs
@@ -5,7 +5,7 @@
 
 use cairn_core::config::CapabilitySet;
 use cairn_core::generated::common::Capabilities;
-use cairn_core::status::{CapabilityGates, Phase, StoreCaps, advertise};
+use cairn_core::status::{CapabilityGates, Phase, StoreCaps, Surface, advertise};
 
 fn full_caps_set() -> CapabilitySet {
     CapabilitySet {
@@ -33,6 +33,10 @@ fn full_gates(phase: Phase) -> CapabilityGates {
         embedding_provider_ready: true,
         llm_configured: false,
         contract_phase: phase,
+        // Phase-pinning rules in §8.0.a are surface-independent — exercise
+        // the CLI surface here; per-surface gating gets its own test in
+        // `cairn_core::status::tests`.
+        surface: Surface::Cli,
     }
 }
 

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -308,6 +308,12 @@ impl CairnMcpHandler {
             embedding_provider_ready,
             llm_configured: false,
             contract_phase: cairn_core::status::Phase::V0_1,
+            // Brief §15: MCP-surface capability advertisement consults the
+            // MCP-specific wiring flags. `cairn.mcp.v1.forget.record` stays
+            // off here while `tools/call` falls through to `dispatch_stub`
+            // for forget; the CLI surface advertises it because its
+            // dispatch is wired.
+            surface: cairn_core::status::Surface::Mcp,
         };
 
         // Post-filter replay capabilities to keep status advertisement and

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -247,6 +247,11 @@ impl<T: Transport> Sdk<T> {
             embedding_provider_ready,
             llm_configured: false,
             contract_phase: cairn_core::status::Phase::V0_1,
+            // Brief §15: SDK-surface capability advertisement consults the
+            // SDK-specific wiring flags. `cairn.mcp.v1.forget.record` stays
+            // off here while `Sdk::forget` returns `unimplemented`; the
+            // CLI surface advertises it because its dispatch is wired.
+            surface: cairn_core::status::Surface::Sdk,
         }
     }
 

--- a/crates/cairn-store-sqlite/plugin.toml
+++ b/crates/cairn-store-sqlite/plugin.toml
@@ -8,7 +8,7 @@ patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 6
+minor = 7
 patch = 0
 
 [features]

--- a/crates/cairn-store-sqlite/src/lib.rs
+++ b/crates/cairn-store-sqlite/src/lib.rs
@@ -52,7 +52,7 @@ pub const PLUGIN_NAME: &str = "cairn-store-sqlite";
 /// Plugin capability manifest TOML (parsed at registration time).
 pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
 
-/// Contract-version range this crate accepts (`[0.4.0, 0.5.0)`). Shared
+/// Contract-version range this crate accepts (`[0.5.0, 0.7.0)`). Shared
 /// by the trait impl and the compile-time guard below so the manifest
 /// range and the trait surface derive from one binding. Lower bound
 /// raised to 0.3.0 in #253 (`per_record_consent_model`), and to 0.4.0
@@ -60,9 +60,11 @@ pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
 /// `RecordVersion` — adding required public fields is a struct-
 /// construction break). Raised to 0.5.0 in #191 (`auth_scope` on
 /// `*SearchArgs`, `MemoryStoreCapabilities::graph_search`,
-/// `search_graph_neighbors` trait method).
+/// `search_graph_neighbors` trait method). Upper bound widened to
+/// 0.7.0 in #58 (`MemoryStore::forget_record` trait method bumped
+/// host `CONTRACT_VERSION` to 0.6.0).
 pub const ACCEPTED_RANGE: VersionRange =
-    VersionRange::new(ContractVersion::new(0, 5, 0), ContractVersion::new(0, 6, 0));
+    VersionRange::new(ContractVersion::new(0, 5, 0), ContractVersion::new(0, 7, 0));
 
 // Compile-time guard: this crate's accepted range must include the host
 // CONTRACT_VERSION. If we ever bump CONTRACT_VERSION without bumping the

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -95,6 +95,9 @@ const M0052_LOCK_ACQUISITION_ULID_UNIQUE: &str =
 const M0053_WAL_PAYLOADS: &str = include_str!("sql/0053_wal_payloads.sql");
 // Issue #57 round-2 — internal marker for pre-activation COW rows.
 const M0054_RECORDS_COW_STAGING: &str = include_str!("sql/0054_records_cow_staging.sql");
+// Issue #58 — widen wal_payloads.kind to admit 'forget_record' for
+// record-level forget durable payloads.
+const M0055_WAL_PAYLOADS_FORGET: &str = include_str!("sql/0055_wal_payloads_forget.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -247,6 +250,7 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
     ),
     (53, "0053_wal_payloads", M0053_WAL_PAYLOADS),
     (54, "0054_records_cow_staging", M0054_RECORDS_COW_STAGING),
+    (55, "0055_wal_payloads_forget", M0055_WAL_PAYLOADS_FORGET),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -302,5 +306,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0052_LOCK_ACQUISITION_ULID_UNIQUE),
         M::up(M0053_WAL_PAYLOADS),
         M::up(M0054_RECORDS_COW_STAGING),
+        M::up(M0055_WAL_PAYLOADS_FORGET),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/sql/0055_wal_payloads_forget.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0055_wal_payloads_forget.sql
@@ -1,0 +1,50 @@
+-- Migration 0055: widen wal_payloads.kind to allow forget_record.
+-- Issue #58: record-level forget needs a durable payload row keyed by
+-- operation_id, just like upsert and expire (added in 0053).
+
+-- SQLite cannot ALTER a CHECK constraint in place; recreate the table.
+CREATE TABLE wal_payloads_new (
+  operation_id TEXT NOT NULL PRIMARY KEY
+                    REFERENCES wal_ops(operation_id),
+  kind         TEXT NOT NULL CHECK (kind IN ('upsert', 'expire', 'forget_record')),
+  payload_json TEXT NOT NULL,
+  created_at   INTEGER NOT NULL
+);
+
+INSERT INTO wal_payloads_new SELECT * FROM wal_payloads;
+
+DROP TRIGGER IF EXISTS wal_payloads_kind_matches_wal;
+DROP TRIGGER IF EXISTS wal_payloads_immutable;
+DROP TRIGGER IF EXISTS wal_payloads_no_delete;
+DROP TABLE wal_payloads;
+ALTER TABLE wal_payloads_new RENAME TO wal_payloads;
+
+CREATE TRIGGER wal_payloads_kind_matches_wal
+  BEFORE INSERT ON wal_payloads
+  FOR EACH ROW
+  WHEN EXISTS (
+    SELECT 1
+      FROM wal_ops
+     WHERE operation_id = NEW.operation_id
+       AND kind IS NOT NEW.kind
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads.kind must match wal_ops.kind');
+END;
+
+CREATE TRIGGER wal_payloads_immutable
+  BEFORE UPDATE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads rows are immutable');
+END;
+
+CREATE TRIGGER wal_payloads_no_delete
+  BEFORE DELETE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads is append-only');
+END;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (55, '0055_wal_payloads_forget', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/record_wal/forget.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/forget.rs
@@ -28,6 +28,15 @@ pub(crate) async fn apply_forget_record(
     })?;
     let op_id = new_operation_id(WalKind::ForgetRecord)?;
 
+    // Capture the live-version count BEFORE acquiring locks so an
+    // idempotent re-forget reports `deleted_count = 0` (rows already
+    // tombstoned + purged) while the first call reports the active
+    // row count. Operators reading `deleted_count: 0` get the signal
+    // they need to debug stale IDs / typos without us conflating it
+    // with a hard failure — the WAL op still executes, idempotently
+    // (brief §5.6 row 2). See `ForgetReceipt::deleted_count`.
+    let deleted_count = count_active_rows(&conn, target).await?;
+
     let (scope, scope_tier) = load_scope_and_tier(&conn, target).await?;
 
     let locks = acquire_for_record(
@@ -89,11 +98,33 @@ pub(crate) async fn apply_forget_record(
     hasher.update(target.as_str().as_bytes());
     let target_id_hash = format!("sha256:{:x}", hasher.finalize());
 
-    Ok(ForgetReceipt {
+    Ok(ForgetReceipt::new(
         target_id_hash,
-        op_id: op_id.as_str().to_owned(),
+        op_id.as_str().to_owned(),
         purged_at,
-    })
+        deleted_count,
+    ))
+}
+
+/// Read the count of active record rows for `target` without taking
+/// the record-WAL locks. Called before `acquire_for_record` so an
+/// idempotent re-forget — where every row is already tombstoned —
+/// reports `0` rather than the historical version count.
+async fn count_active_rows(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    target: &TargetId,
+) -> Result<u64, StoreError> {
+    let target_id = target.as_str().to_owned();
+    Ok(conn
+        .call(move |c| {
+            let count: i64 = c.query_row(
+                "SELECT COUNT(*) FROM records WHERE target_id = ?1 AND active = 1",
+                rusqlite::params![target_id],
+                |row| row.get(0),
+            )?;
+            Ok(u64::try_from(count).unwrap_or(0))
+        })
+        .await?)
 }
 
 async fn load_scope_and_tier(

--- a/crates/cairn-store-sqlite/src/record_wal/forget.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/forget.rs
@@ -1,6 +1,7 @@
 //! Public `forget_record` apply through record WAL.
 
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use cairn_core::contract::memory_store::ForgetReceipt;
 use cairn_core::domain::taxonomy::MemoryVisibility;
@@ -27,15 +28,6 @@ pub(crate) async fn apply_forget_record(
         what: "forget_record requires daemon incarnation".to_owned(),
     })?;
     let op_id = new_operation_id(WalKind::ForgetRecord)?;
-
-    // Capture the live-version count BEFORE acquiring locks so an
-    // idempotent re-forget reports `deleted_count = 0` (rows already
-    // tombstoned + purged) while the first call reports the active
-    // row count. Operators reading `deleted_count: 0` get the signal
-    // they need to debug stale IDs / typos without us conflating it
-    // with a hard failure — the WAL op still executes, idempotently
-    // (brief §5.6 row 2). See `ForgetReceipt::deleted_count`.
-    let deleted_count = count_active_rows(&conn, target).await?;
 
     let (scope, scope_tier) = load_scope_and_tier(&conn, target).await?;
 
@@ -82,8 +74,17 @@ pub(crate) async fn apply_forget_record(
     })
     .await?;
 
-    let body: Arc<dyn StepBody> = Arc::new(RecordStepBody::new_forget(payload, locks));
+    // Build the step body and stash a handle to its in-txn deleted-count
+    // cell BEFORE handing the body to the runner. The cell is written by
+    // `mark_tombstone_and_emit_receipt` inside the Phase A transaction
+    // (under the record-WAL locks), so two concurrent forgets cannot both
+    // observe the target as live — the second runs after the first has
+    // already flipped active=0 and reads 0.
+    let step_body = RecordStepBody::new_forget(payload, locks);
+    let deleted_count_cell = step_body.deleted_count_handle();
+    let body: Arc<dyn StepBody> = Arc::new(step_body);
     runner::run_from(&conn, graph_for(WalKind::ForgetRecord), &op_id, 0, body).await?;
+    let deleted_count = deleted_count_cell.load(Ordering::SeqCst);
 
     let purged_at = crate::store::current_unix_ms();
     let op_for_finalize = op_id.clone();
@@ -104,27 +105,6 @@ pub(crate) async fn apply_forget_record(
         purged_at,
         deleted_count,
     ))
-}
-
-/// Read the count of active record rows for `target` without taking
-/// the record-WAL locks. Called before `acquire_for_record` so an
-/// idempotent re-forget — where every row is already tombstoned —
-/// reports `0` rather than the historical version count.
-async fn count_active_rows(
-    conn: &Arc<tokio_rusqlite::Connection>,
-    target: &TargetId,
-) -> Result<u64, StoreError> {
-    let target_id = target.as_str().to_owned();
-    Ok(conn
-        .call(move |c| {
-            let count: i64 = c.query_row(
-                "SELECT COUNT(*) FROM records WHERE target_id = ?1 AND active = 1",
-                rusqlite::params![target_id],
-                |row| row.get(0),
-            )?;
-            Ok(u64::try_from(count).unwrap_or(0))
-        })
-        .await?)
 }
 
 async fn load_scope_and_tier(

--- a/crates/cairn-store-sqlite/src/record_wal/forget.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/forget.rs
@@ -1,0 +1,125 @@
+//! Public `forget_record` apply through record WAL.
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::ForgetReceipt;
+use cairn_core::domain::taxonomy::MemoryVisibility;
+use cairn_core::domain::{Identity, ScopeTuple, TargetId};
+use cairn_core::wal::{OpState, WalKind, graph_for};
+use rusqlite::OptionalExtension;
+use sha2::{Digest, Sha256};
+
+use crate::error::StoreError;
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::ops::{finalize, issue_prepared, new_operation_id};
+use crate::record_wal::payload::{ForgetPayload, RecordWalPayload, save_payload};
+use crate::record_wal::steps::RecordStepBody;
+use crate::store::SqliteMemoryStore;
+use crate::wal::runner::{self, StepBody};
+
+pub(crate) async fn apply_forget_record(
+    store: &SqliteMemoryStore,
+    target: &TargetId,
+    actor: &Identity,
+) -> Result<ForgetReceipt, StoreError> {
+    let conn = Arc::clone(store.require_conn("forget_record")?);
+    let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
+        what: "forget_record requires daemon incarnation".to_owned(),
+    })?;
+    let op_id = new_operation_id(WalKind::ForgetRecord)?;
+
+    let (scope, scope_tier) = load_scope_and_tier(&conn, target).await?;
+
+    let locks = acquire_for_record(
+        &conn,
+        &scope,
+        target,
+        &incarnation,
+        op_id.as_str(),
+        "record_wal_forget_record",
+    )
+    .await
+    .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
+
+    let payload = ForgetPayload {
+        target_id: target.clone(),
+        scope: scope.clone(),
+        reason_code: "user_command".to_owned(),
+        actor: actor.clone(),
+        scope_tier,
+    };
+    let payload_for_body = payload.clone();
+    let op_for_issue = op_id.clone();
+    let target_hash = target.as_str().to_owned();
+
+    conn.call(move |c| {
+        let tx = c.transaction()?;
+        issue_prepared(
+            &tx,
+            &op_for_issue,
+            WalKind::ForgetRecord,
+            &target_hash,
+            "{}",
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        save_payload(
+            &tx,
+            &op_for_issue,
+            &RecordWalPayload::Forget(Box::new(payload_for_body)),
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        tx.commit()?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+
+    let body: Arc<dyn StepBody> = Arc::new(RecordStepBody::new_forget(payload, locks));
+    runner::run_from(&conn, graph_for(WalKind::ForgetRecord), &op_id, 0, body).await?;
+
+    let purged_at = crate::store::current_unix_ms();
+    let op_for_finalize = op_id.clone();
+    conn.call(move |c| {
+        finalize(c, &op_for_finalize, OpState::Committed, "applied")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(target.as_str().as_bytes());
+    let target_id_hash = format!("sha256:{:x}", hasher.finalize());
+
+    Ok(ForgetReceipt {
+        target_id_hash,
+        op_id: op_id.as_str().to_owned(),
+        purged_at,
+    })
+}
+
+async fn load_scope_and_tier(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    target: &TargetId,
+) -> Result<(ScopeTuple, MemoryVisibility), StoreError> {
+    let target_id = target.as_str().to_owned();
+    Ok(conn
+        .call(move |c| {
+            let row: Option<(String, String)> = c
+                .query_row(
+                    "SELECT scope, visibility FROM records \
+                       WHERE target_id = ?1 \
+                       ORDER BY version DESC LIMIT 1",
+                    rusqlite::params![target_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()?;
+            let Some((scope_json, visibility)) = row else {
+                return Ok((ScopeTuple::default(), MemoryVisibility::Private));
+            };
+            let scope: ScopeTuple = serde_json::from_str(&scope_json)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let tier: MemoryVisibility =
+                MemoryVisibility::parse(&visibility).unwrap_or(MemoryVisibility::Private);
+            Ok((scope, tier))
+        })
+        .await?)
+}

--- a/crates/cairn-store-sqlite/src/record_wal/mod.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/mod.rs
@@ -10,6 +10,7 @@
 pub mod payload;
 
 pub(crate) mod expire;
+pub(crate) mod forget;
 pub(crate) mod locks;
 pub(crate) mod ops;
 pub(crate) mod recovery;
@@ -17,5 +18,6 @@ pub(crate) mod steps;
 pub(crate) mod upsert;
 
 pub(crate) use expire::apply_expire;
+pub(crate) use forget::apply_forget_record;
 pub use recovery::RecordWalRegistry;
 pub(crate) use upsert::apply_upsert;

--- a/crates/cairn-store-sqlite/src/record_wal/payload.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/payload.rs
@@ -13,6 +13,7 @@ use crate::store::current_unix_ms;
 pub enum RecordWalPayload {
     Upsert(Box<UpsertPayload>),
     Expire(Box<ExpirePayload>),
+    Forget(Box<ForgetPayload>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -83,6 +84,16 @@ pub struct ExpirePayload {
     pub scope: ScopeTuple,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ForgetPayload {
+    pub target_id: TargetId,
+    #[serde(default)]
+    pub scope: ScopeTuple,
+    pub reason_code: String,
+    pub actor: cairn_core::domain::Identity,
+    pub scope_tier: cairn_core::domain::taxonomy::MemoryVisibility,
+}
+
 pub(crate) fn save_payload(
     conn: &Connection,
     op_id: &OperationId,
@@ -91,6 +102,7 @@ pub(crate) fn save_payload(
     let kind = match payload {
         RecordWalPayload::Upsert(_) => WalKind::Upsert.as_str(),
         RecordWalPayload::Expire(_) => WalKind::Expire.as_str(),
+        RecordWalPayload::Forget(_) => WalKind::ForgetRecord.as_str(),
     };
     let json = serde_json::to_string(payload)?;
     conn.execute(
@@ -167,5 +179,40 @@ pub fn load_upsert_payload_for_test(
         RecordWalPayload::Expire(_) => Err(StoreError::Invariant {
             what: "expected upsert payload, found expire payload".to_owned(),
         }),
+        RecordWalPayload::Forget(_) => Err(StoreError::Invariant {
+            what: "expected upsert payload, found forget payload".to_owned(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod forget_payload_tests {
+    use super::*;
+    use cairn_core::domain::{Identity, MemoryVisibility, ScopeTuple, TargetId};
+
+    #[test]
+    fn forget_payload_round_trips_through_record_wal_payload() {
+        let target =
+            TargetId::parse("01HQZX9F5N0000000000000000".to_owned()).expect("valid target id");
+        let actor = Identity::parse("hmn:alice:v1".to_owned()).expect("valid identity");
+        let payload = ForgetPayload {
+            target_id: target.clone(),
+            scope: ScopeTuple::default(),
+            reason_code: "user_command".to_owned(),
+            actor: actor.clone(),
+            scope_tier: MemoryVisibility::Private,
+        };
+        let wrapped = RecordWalPayload::Forget(Box::new(payload.clone()));
+        let json = serde_json::to_string(&wrapped).expect("serialize");
+        let decoded: RecordWalPayload = serde_json::from_str(&json).expect("deserialize");
+        match decoded {
+            RecordWalPayload::Forget(p) => {
+                assert_eq!(p.target_id, target);
+                assert_eq!(p.actor, actor);
+                assert_eq!(p.scope_tier, MemoryVisibility::Private);
+                assert_eq!(p.reason_code, "user_command");
+            }
+            _ => panic!("expected Forget variant after round trip"),
+        }
     }
 }

--- a/crates/cairn-store-sqlite/src/record_wal/payload.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/payload.rs
@@ -1,6 +1,8 @@
 //! Durable JSON payloads for record WAL operations.
 
-use cairn_core::domain::{BodyHash, MemoryRecord, RecordId, ScopeTuple, TargetId};
+use cairn_core::domain::{
+    BodyHash, Identity, MemoryRecord, MemoryVisibility, RecordId, ScopeTuple, TargetId,
+};
 use cairn_core::wal::{OperationId, WalKind};
 use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
@@ -13,6 +15,7 @@ use crate::store::current_unix_ms;
 pub enum RecordWalPayload {
     Upsert(Box<UpsertPayload>),
     Expire(Box<ExpirePayload>),
+    #[serde(rename = "forget_record")]
     Forget(Box<ForgetPayload>),
 }
 
@@ -90,8 +93,8 @@ pub struct ForgetPayload {
     #[serde(default)]
     pub scope: ScopeTuple,
     pub reason_code: String,
-    pub actor: cairn_core::domain::Identity,
-    pub scope_tier: cairn_core::domain::taxonomy::MemoryVisibility,
+    pub actor: Identity,
+    pub scope_tier: MemoryVisibility,
 }
 
 pub(crate) fn save_payload(
@@ -188,7 +191,6 @@ pub fn load_upsert_payload_for_test(
 #[cfg(test)]
 mod forget_payload_tests {
     use super::*;
-    use cairn_core::domain::{Identity, MemoryVisibility, ScopeTuple, TargetId};
 
     #[test]
     fn forget_payload_round_trips_through_record_wal_payload() {
@@ -204,6 +206,10 @@ mod forget_payload_tests {
         };
         let wrapped = RecordWalPayload::Forget(Box::new(payload.clone()));
         let json = serde_json::to_string(&wrapped).expect("serialize");
+        assert!(
+            json.contains("\"type\":\"forget_record\""),
+            "wire tag should match wal_payloads.kind"
+        );
         let decoded: RecordWalPayload = serde_json::from_str(&json).expect("deserialize");
         match decoded {
             RecordWalPayload::Forget(p) => {

--- a/crates/cairn-store-sqlite/src/record_wal/recovery.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/recovery.rs
@@ -36,7 +36,7 @@ impl StepBodyRegistry for RecordWalRegistry {
         op_id: &OperationId,
     ) -> Result<Option<Arc<dyn StepBody>>, RecoveryError> {
         match kind {
-            WalKind::Upsert | WalKind::Expire => {}
+            WalKind::Upsert | WalKind::Expire | WalKind::ForgetRecord => {}
             _ => return Ok(None),
         }
 
@@ -75,11 +75,38 @@ impl StepBodyRegistry for RecordWalRegistry {
                 .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
                 Ok(Some(Arc::new(RecordStepBody::new_expire(*payload, locks))))
             }
+            (WalKind::ForgetRecord, RecordWalPayload::Forget(payload)) => {
+                let locks = acquire_for_record(
+                    conn,
+                    &payload.scope,
+                    &payload.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_forget_record",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_forget(*payload, locks))))
+            }
             (WalKind::Upsert, RecordWalPayload::Expire(_)) => Err(RecoveryError::Invariant(
                 "record wal payload variant expire does not match wal kind upsert".to_owned(),
             )),
             (WalKind::Expire, RecordWalPayload::Upsert(_)) => Err(RecoveryError::Invariant(
                 "record wal payload variant upsert does not match wal kind expire".to_owned(),
+            )),
+            (WalKind::Upsert, RecordWalPayload::Forget(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant forget does not match wal kind upsert".to_owned(),
+            )),
+            (WalKind::Expire, RecordWalPayload::Forget(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant forget does not match wal kind expire".to_owned(),
+            )),
+            (WalKind::ForgetRecord, RecordWalPayload::Upsert(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant upsert does not match wal kind forget_record"
+                    .to_owned(),
+            )),
+            (WalKind::ForgetRecord, RecordWalPayload::Expire(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant expire does not match wal kind forget_record"
+                    .to_owned(),
             )),
             _ => Ok(None),
         }

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -1,5 +1,8 @@
 //! Record WAL step bodies.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use cairn_core::wal::{OperationId, StepDef};
 use rusqlite::{Transaction, params};
 
@@ -16,6 +19,13 @@ pub(crate) enum RecordStepPayload {
 pub(crate) struct RecordStepBody {
     payload: RecordStepPayload,
     locks: RecordLocks,
+    /// Live-version count captured inside the Phase A transaction by the
+    /// `primary.mark_tombstone` step body for `forget_record`. `0` for
+    /// other op kinds. Read by `apply_forget_record` after the runner
+    /// returns to populate `ForgetReceipt::deleted_count` with a value
+    /// that reflects what THIS op actually tombstoned, not a pre-lock
+    /// snapshot that two concurrent forgets could both read as `1`.
+    deleted_count: Arc<AtomicU64>,
 }
 
 impl RecordStepBody {
@@ -24,6 +34,7 @@ impl RecordStepBody {
         Self {
             payload: RecordStepPayload::Upsert(Box::new(payload)),
             locks,
+            deleted_count: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -32,6 +43,7 @@ impl RecordStepBody {
         Self {
             payload: RecordStepPayload::Expire(Box::new(payload)),
             locks,
+            deleted_count: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -40,7 +52,14 @@ impl RecordStepBody {
         Self {
             payload: RecordStepPayload::Forget(Box::new(payload)),
             locks,
+            deleted_count: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Handle that the caller stashes before `runner::run_from` so it can
+    /// observe the in-txn count after the runner returns.
+    pub(crate) fn deleted_count_handle(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.deleted_count)
     }
 }
 
@@ -101,7 +120,7 @@ impl StepBody for RecordStepBody {
                 drain_edges_for_target(tx, payload.target_id.as_str())
             }
             (RecordStepPayload::Forget(payload), "primary.mark_tombstone") => {
-                mark_tombstone_and_emit_receipt(tx, op_id, payload)
+                mark_tombstone_and_emit_receipt(tx, op_id, payload, &self.deleted_count)
             }
             (RecordStepPayload::Forget(payload), "vector.drain") => {
                 drain_vectors_for_target(tx, payload.target_id.as_str())
@@ -328,11 +347,26 @@ fn mark_tombstone_and_emit_receipt(
     tx: &Transaction<'_>,
     op_id: &OperationId,
     payload: &ForgetPayload,
+    deleted_count: &AtomicU64,
 ) -> Result<(), StepBodyError> {
     use cairn_core::domain::{ConsentEvent, ConsentKind, ConsentPayload};
     use sha2::{Digest, Sha256};
 
     let now_ms = crate::store::current_unix_ms();
+
+    // Capture the live-version count INSIDE the Phase A transaction so
+    // two concurrent forgets cannot both report deleted_count=1. The
+    // record-WAL locks serialize the SELECT against the matching
+    // tombstone UPDATE on the same target — the second forget runs
+    // after the first has already flipped active=0 and reads 0.
+    let live_count: i64 = tx
+        .query_row(
+            "SELECT COUNT(*) FROM records WHERE target_id = ?1 AND active = 1",
+            params![payload.target_id.as_str()],
+            |row| row.get(0),
+        )
+        .map_err(StepBodyError::Storage)?;
+    deleted_count.store(u64::try_from(live_count).unwrap_or(0), Ordering::SeqCst);
 
     // Brief §5.6 Phase A: tombstone every version of the target with
     // reason='forget' and active=0.

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -343,6 +343,16 @@ fn now_secs() -> i64 {
 /// replay produces exactly one receipt per successful Phase-A commit.
 /// The `UPDATE` itself is idempotent — re-running over already-tombstoned
 /// rows is a no-op.
+///
+/// **No-op forgets do not append a consent receipt.** When the in-txn
+/// count observes zero live rows (idempotent re-forget after the
+/// records were already purged), the helper records `deleted_count = 0`
+/// in the cell and returns without writing to `consent_journal`. The
+/// authoritative receipt is the one the *original* forget wrote with
+/// the real scope/tier; appending another receipt with the post-purge
+/// `ScopeTuple::default()` + `MemoryVisibility::Private` defaults
+/// would dilute the audit trail and misclassify a previously
+/// team/org/public scoped record. Round-5 review (Codex).
 fn mark_tombstone_and_emit_receipt(
     tx: &Transaction<'_>,
     op_id: &OperationId,
@@ -366,7 +376,8 @@ fn mark_tombstone_and_emit_receipt(
             |row| row.get(0),
         )
         .map_err(StepBodyError::Storage)?;
-    deleted_count.store(u64::try_from(live_count).unwrap_or(0), Ordering::SeqCst);
+    let live_count_u64 = u64::try_from(live_count).unwrap_or(0);
+    deleted_count.store(live_count_u64, Ordering::SeqCst);
 
     // Brief §5.6 Phase A: tombstone every version of the target with
     // reason='forget' and active=0.
@@ -380,6 +391,12 @@ fn mark_tombstone_and_emit_receipt(
         params![now_ms, payload.target_id.as_str()],
     )
     .map_err(StepBodyError::Storage)?;
+
+    // No-op forget (records already purged): skip the receipt.
+    // See doc comment above for the audit-invariant rationale.
+    if live_count_u64 == 0 {
+        return Ok(());
+    }
 
     // sha256 of the raw target id. P1 follow-up (brief §14) introduces a
     // per-user salt; the receipt schema does not change.

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -4,12 +4,15 @@ use cairn_core::wal::{OperationId, StepDef};
 use rusqlite::{Transaction, params};
 
 use crate::record_wal::locks::RecordLocks;
-use crate::record_wal::payload::{ExpirePayload, StoredEmbedOutcome, UpsertPayload};
+use crate::record_wal::payload::{
+    ExpirePayload, ForgetPayload, StoredEmbedOutcome, UpsertPayload,
+};
 use crate::wal::runner::{StepBody, StepBodyError};
 
 pub(crate) enum RecordStepPayload {
     Upsert(Box<UpsertPayload>),
     Expire(Box<ExpirePayload>),
+    Forget(Box<ForgetPayload>),
 }
 
 pub(crate) struct RecordStepBody {
@@ -30,6 +33,14 @@ impl RecordStepBody {
     pub(crate) fn new_expire(payload: ExpirePayload, locks: RecordLocks) -> Self {
         Self {
             payload: RecordStepPayload::Expire(Box::new(payload)),
+            locks,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn new_forget(payload: ForgetPayload, locks: RecordLocks) -> Self {
+        Self {
+            payload: RecordStepPayload::Forget(Box::new(payload)),
             locks,
         }
     }
@@ -82,10 +93,45 @@ impl StepBody for RecordStepBody {
             (RecordStepPayload::Expire(payload), "primary.mark_expired") => {
                 mark_expired(tx, payload)
             }
-            (RecordStepPayload::Expire(payload), "vector.drain") => drain_vectors(tx, payload),
-            (RecordStepPayload::Expire(payload), "fts.drain") => drain_fts(tx, payload),
-            (RecordStepPayload::Expire(payload), "edges.drain") => drain_edges(tx, payload),
-            (RecordStepPayload::Upsert(_) | RecordStepPayload::Expire(_), _) => Ok(()),
+            (RecordStepPayload::Expire(payload), "vector.drain") => {
+                drain_vectors_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Expire(payload), "fts.drain") => {
+                drain_fts_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Expire(payload), "edges.drain") => {
+                drain_edges_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Forget(payload), "primary.mark_tombstone") => {
+                mark_tombstone_and_emit_receipt(tx, op_id, payload)
+            }
+            (RecordStepPayload::Forget(payload), "vector.drain") => {
+                drain_vectors_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Forget(payload), "fts.drain") => {
+                drain_fts_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Forget(payload), "edges.drain") => {
+                drain_edges_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Forget(payload), "primary.purge") => {
+                primary_purge_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Forget(payload), "wal.purge_pre_images") => {
+                purge_wal_pre_images_for_target(tx, op_id, payload)
+            }
+            (RecordStepPayload::Forget(_), "snapshot.purge") => {
+                // P0: no `.cairn/snapshots/` or `nexus-data/` mirror exists
+                // (issue #109 lands the cold-storage layer). The bundle
+                // rewrite is a no-op until the snapshot registry exists.
+                Ok(())
+            }
+            (
+                RecordStepPayload::Upsert(_)
+                | RecordStepPayload::Expire(_)
+                | RecordStepPayload::Forget(_),
+                _,
+            ) => Ok(()),
         }
     }
 }
@@ -218,33 +264,31 @@ fn mark_expired(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), Ste
     Ok(())
 }
 
-fn drain_vectors(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError> {
+fn drain_vectors_for_target(tx: &Transaction<'_>, target: &str) -> Result<(), StepBodyError> {
     tx.execute(
         "DELETE FROM record_vectors \
           WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
-        params![payload.target_id.as_str()],
+        params![target],
     )
     .map_err(StepBodyError::Storage)?;
     tx.execute(
         "DELETE FROM pending_embeddings \
           WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
-        params![payload.target_id.as_str()],
+        params![target],
     )
     .map_err(StepBodyError::Storage)?;
     Ok(())
 }
 
-fn drain_fts(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError> {
+fn drain_fts_for_target(tx: &Transaction<'_>, target: &str) -> Result<(), StepBodyError> {
     let rowids = {
         let mut stmt = tx
             .prepare("SELECT rowid FROM records WHERE target_id = ?1")
             .map_err(StepBodyError::Storage)?;
-        stmt.query_map(params![payload.target_id.as_str()], |row| {
-            row.get::<_, i64>(0)
-        })
-        .map_err(StepBodyError::Storage)?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(StepBodyError::Storage)?
+        stmt.query_map(params![target], |row| row.get::<_, i64>(0))
+            .map_err(StepBodyError::Storage)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(StepBodyError::Storage)?
     };
     for rowid in rowids {
         tx.execute("DELETE FROM records_fts WHERE rowid = ?1", params![rowid])
@@ -253,12 +297,12 @@ fn drain_fts(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBo
     Ok(())
 }
 
-fn drain_edges(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError> {
+fn drain_edges_for_target(tx: &Transaction<'_>, target: &str) -> Result<(), StepBodyError> {
     tx.execute(
         "DELETE FROM edges \
           WHERE src IN (SELECT record_id FROM records WHERE target_id = ?1) \
              OR dst IN (SELECT record_id FROM records WHERE target_id = ?1)",
-        params![payload.target_id.as_str()],
+        params![target],
     )
     .map_err(StepBodyError::Storage)?;
     Ok(())
@@ -268,6 +312,188 @@ fn now_secs() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(i64::MAX))
+}
+
+/// Phase A of `forget_record` (brief §5.6 row 2). Tombstones every version
+/// of the target with `reason='forget'` and emits a body-free
+/// `ForgetIntent` consent receipt in the same transaction. The fusion is
+/// what makes the receipt atomic with the tombstone — neither half can be
+/// observed without the other.
+///
+/// Idempotent: re-running after a Phase-A crash re-applies the same
+/// `UPDATE` (no-op if rows are already in the target state) and inserts a
+/// fresh receipt with the same `op_id`. The journal allows multiple rows
+/// per `op_id`; the materializer keeps them all.
+fn mark_tombstone_and_emit_receipt(
+    tx: &mut Transaction<'_>,
+    op_id: &OperationId,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    use cairn_core::domain::{ConsentEvent, ConsentKind, ConsentPayload};
+    use sha2::{Digest, Sha256};
+
+    let now_ms = crate::store::current_unix_ms();
+
+    // Brief §5.6 Phase A: tombstone every version of the target with
+    // reason='forget' and active=0.
+    tx.execute(
+        "UPDATE records \
+            SET active = 0, \
+                tombstoned = 1, \
+                tombstone_reason = 'forget', \
+                updated_at = ?1 \
+          WHERE target_id = ?2",
+        params![now_ms, payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+
+    // sha256 of the raw target id. P1 follow-up (brief §14) introduces a
+    // per-user salt; the receipt schema does not change.
+    let mut hasher = Sha256::new();
+    hasher.update(payload.target_id.as_str().as_bytes());
+    let hex = format!("{:x}", hasher.finalize());
+    let target_id_hash = format!("sha256:{hex}");
+    let subject_hash = format!("sha256:{hex}");
+
+    let event = ConsentEvent {
+        consent_id: format!("CNS{}", ulid::Ulid::new()),
+        kind: ConsentKind::ForgetIntent,
+        actor: payload.actor.clone(),
+        subject: subject_hash,
+        scope: scope_canonical_wire(&payload.scope, payload.scope_tier),
+        op_id: Some(op_id.as_str().to_owned()),
+        sensor_id: None,
+        payload: ConsentPayload::IntentReceipt {
+            target_id_hash,
+            scope_tier: payload.scope_tier,
+            reason_code: payload.reason_code.clone(),
+        },
+        decided_at: now_rfc3339_from_ms(now_ms)?,
+        expires_at: None,
+    };
+
+    crate::consent::append(&*tx, &event)
+        .map_err(|e| StepBodyError::Failed(format!("consent append: {e}")))?;
+    Ok(())
+}
+
+/// Render a `ScopeTuple` into the consent journal `scope` slot. Defaults
+/// (no IDL-addressable dimension set) fall back to the visibility tier
+/// wire form so the slot is non-empty — `validate_scope` rejects empty.
+fn scope_canonical_wire(
+    scope: &cairn_core::domain::ScopeTuple,
+    tier: cairn_core::domain::MemoryVisibility,
+) -> String {
+    let wire = scope.canonical_wire();
+    if wire.is_empty() {
+        tier.as_str().to_owned()
+    } else {
+        wire
+    }
+}
+
+/// Build a UTC `Rfc3339Timestamp` from a Unix-millis instant. Matches
+/// the `from_unix_secs` constructor by truncating sub-second precision —
+/// `decided_at_iso` writers in this crate use second precision.
+///
+/// `current_unix_ms` saturates negative values to `0`, but we still clamp
+/// here (`max(0)`) so a future caller passing a degraded clock value
+/// cannot push us into the `from_unix_secs` error path. Errors are
+/// surfaced as [`StepBodyError::Failed`] so the WAL marks the step
+/// failed rather than the helper crashing.
+fn now_rfc3339_from_ms(
+    unix_ms: i64,
+) -> Result<cairn_core::domain::Rfc3339Timestamp, StepBodyError> {
+    let secs = unix_ms.div_euclid(1_000).max(0);
+    cairn_core::domain::Rfc3339Timestamp::from_unix_secs(secs)
+        .map_err(|e| StepBodyError::Failed(format!("rfc3339 from_unix_secs: {e}")))
+}
+
+/// Phase B step 4: collapse all body-bearing rows for the target. Re-runs
+/// the index drains defensively — vector.drain / fts.drain / edges.drain
+/// may have completed in a prior crash window, but the `idempotent: false`
+/// `primary.purge` step is the audit-invariant boundary so we make sure
+/// nothing survives.
+fn primary_purge_for_target(tx: &Transaction<'_>, target: &str) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM record_vectors \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![target],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM pending_embeddings \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![target],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute("DELETE FROM records WHERE target_id = ?1", params![target])
+        .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+/// Phase B step 5: scrub WAL pre-image blobs that mention the forgotten
+/// target id, replacing them with a `{purged, target_id_hash, op_id,
+/// purged_at}` stub. The audit invariant (brief §5.6) is that no
+/// post-forget reader can recover the original record body from a WAL
+/// snapshot.
+///
+/// LIKE prefilter: target ids are ULIDs (`[0-9A-Z]{26}`) so they cannot
+/// contain `%` or `_` — no escaping needed. We treat the prefilter as
+/// authoritative: any `wal_steps.pre_image` whose CAST-to-TEXT contains
+/// the literal target id substring is rewritten in place. Snapshot bodies
+/// are JSON arrays of `{record_id, …}` produced by `stage_snapshot`, so a
+/// substring hit is a real reference (`record_id` values embed the
+/// `target_id`).
+fn purge_wal_pre_images_for_target(
+    tx: &mut Transaction<'_>,
+    self_op_id: &OperationId,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    use sha2::{Digest, Sha256};
+
+    let target = payload.target_id.as_str();
+    let needle = format!("%{target}%");
+    let rows: Vec<(String, u32)> = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT operation_id, step_ord \
+                   FROM wal_steps \
+                  WHERE pre_image IS NOT NULL \
+                    AND CAST(pre_image AS TEXT) LIKE ?1",
+            )
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(params![needle], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+        })
+        .map_err(StepBodyError::Storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StepBodyError::Storage)?
+    };
+
+    let now_ms = crate::store::current_unix_ms();
+    let mut hasher = Sha256::new();
+    hasher.update(target.as_bytes());
+    let target_id_hash = format!("sha256:{:x}", hasher.finalize());
+
+    for (op_id, step_ord) in rows {
+        let stub = serde_json::json!({
+            "purged": true,
+            "target_id_hash": target_id_hash,
+            "op_id": self_op_id.as_str(),
+            "purged_at": now_ms,
+        });
+        let bytes = serde_json::to_vec(&stub)
+            .map_err(|e| StepBodyError::Failed(format!("stub json: {e}")))?;
+        tx.execute(
+            "UPDATE wal_steps \
+                SET pre_image = ?1 \
+              WHERE operation_id = ?2 AND step_ord = ?3",
+            params![bytes, op_id, step_ord],
+        )
+        .map_err(StepBodyError::Storage)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -320,12 +320,14 @@ fn now_secs() -> i64 {
 /// what makes the receipt atomic with the tombstone — neither half can be
 /// observed without the other.
 ///
-/// Idempotent: re-running after a Phase-A crash re-applies the same
-/// `UPDATE` (no-op if rows are already in the target state) and inserts a
-/// fresh receipt with the same `op_id`. The journal allows multiple rows
-/// per `op_id`; the materializer keeps them all.
+/// Phase A is atomic: the runner wraps this body in one `SQLite` txn, so
+/// the tombstone `UPDATE` and the `consent_journal` append commit
+/// together or not at all. A crashed Phase A leaves neither side effect;
+/// replay produces exactly one receipt per successful Phase-A commit.
+/// The `UPDATE` itself is idempotent — re-running over already-tombstoned
+/// rows is a no-op.
 fn mark_tombstone_and_emit_receipt(
-    tx: &mut Transaction<'_>,
+    tx: &Transaction<'_>,
     op_id: &OperationId,
     payload: &ForgetPayload,
 ) -> Result<(), StepBodyError> {
@@ -372,7 +374,7 @@ fn mark_tombstone_and_emit_receipt(
         expires_at: None,
     };
 
-    crate::consent::append(&*tx, &event)
+    crate::consent::append(tx, &event)
         .map_err(|e| StepBodyError::Failed(format!("consent append: {e}")))?;
     Ok(())
 }
@@ -439,14 +441,34 @@ fn primary_purge_for_target(tx: &Transaction<'_>, target: &str) -> Result<(), St
 /// snapshot.
 ///
 /// LIKE prefilter: target ids are ULIDs (`[0-9A-Z]{26}`) so they cannot
-/// contain `%` or `_` — no escaping needed. We treat the prefilter as
-/// authoritative: any `wal_steps.pre_image` whose CAST-to-TEXT contains
-/// the literal target id substring is rewritten in place. Snapshot bodies
-/// are JSON arrays of `{record_id, …}` produced by `stage_snapshot`, so a
-/// substring hit is a real reference (`record_id` values embed the
-/// `target_id`).
+/// contain `%` or `_` — no escaping needed. Any `wal_steps.pre_image`
+/// whose CAST-to-TEXT contains the literal target id substring is
+/// rewritten in place.
+///
+/// **Coverage in P0 is forward-defense.** `stage_snapshot` (the only
+/// step that currently writes `pre_image` blobs) projects
+/// `{record_id, version, active, tombstoned, tombstone_reason,
+/// body_hash}` — none of which carry body bytes and none of which
+/// embed the target id (`RecordId` and `TargetId` are independent
+/// ULIDs per
+/// `cairn_core::domain::record::tests::target_id_independent_of_id`).
+/// So the body-leakage invariant is already satisfied by construction
+/// for current snapshot `pre_image`s, and the LIKE prefilter on the raw
+/// target-id substring will not match any of them in practice.
+///
+/// This step body still runs because:
+/// 1. Future step bodies that stage `target_id`-bearing `pre_image`s
+///    will be caught.
+/// 2. It documents intent — the audit-invariant test (#58 Task 10)
+///    can grep for the target id substring with confidence that any
+///    matches would have been stubbed.
+///
+/// A follow-up (filed when issue #58 closes) may extend this to scrub
+/// `pre_image`s that reference any of the target's purged `record_id`s,
+/// but that requires capturing the record-id list at Phase A before
+/// `primary.purge` deletes the records — out of scope here.
 fn purge_wal_pre_images_for_target(
-    tx: &mut Transaction<'_>,
+    tx: &Transaction<'_>,
     self_op_id: &OperationId,
     payload: &ForgetPayload,
 ) -> Result<(), StepBodyError> {

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -383,11 +383,36 @@ fn mark_tombstone_and_emit_receipt(
             |row| row.get(0),
         )
         .map_err(StepBodyError::Storage)?;
-    let total_rows: i64 = tx
+    // Snapshot scope + visibility from the latest record version
+    // INSIDE the Phase A transaction. The pre-lock read in
+    // `apply_forget_record` populates the payload's `scope` /
+    // `scope_tier` for lock-acquisition purposes (entity + session
+    // legs), but a same-target upsert that committed between that
+    // pre-lock read and the record-WAL lock acquisition could have
+    // moved the record to a different scope/tier. Brief §14 audit
+    // invariant: the consent receipt must record the scope/tier of
+    // the rows actually destroyed by THIS op.
+    //
+    // `total_rows` discriminates "truly already purged" (no
+    // receipt) from "rows present" (receipt with in-txn tier).
+    // Single-row scalar SELECT: always returns one row even when the
+    // subqueries are NULL (COALESCE -> '').
+    let (total_rows, in_txn_scope_json, in_txn_visibility): (i64, String, String) = tx
         .query_row(
-            "SELECT COUNT(*) FROM records WHERE target_id = ?1",
+            "SELECT \
+                (SELECT COUNT(*) FROM records WHERE target_id = ?1), \
+                COALESCE( \
+                    (SELECT scope FROM records WHERE target_id = ?1 \
+                       ORDER BY version DESC LIMIT 1), \
+                    '' \
+                ), \
+                COALESCE( \
+                    (SELECT visibility FROM records WHERE target_id = ?1 \
+                       ORDER BY version DESC LIMIT 1), \
+                    '' \
+                )",
             params![payload.target_id.as_str()],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .map_err(StepBodyError::Storage)?;
     let live_count_u64 = u64::try_from(live_count).unwrap_or(0);
@@ -413,6 +438,21 @@ fn mark_tombstone_and_emit_receipt(
         return Ok(());
     }
 
+    // Resolve the in-txn scope/tier; fall back to the payload values
+    // only if the snapshot SELECT returned NULLs (defensive — should
+    // not happen when total_rows > 0).
+    let in_txn_scope = if in_txn_scope_json.is_empty() {
+        payload.scope.clone()
+    } else {
+        serde_json::from_str(&in_txn_scope_json).unwrap_or_else(|_| payload.scope.clone())
+    };
+    let in_txn_tier = if in_txn_visibility.is_empty() {
+        payload.scope_tier
+    } else {
+        cairn_core::domain::MemoryVisibility::parse(&in_txn_visibility)
+            .unwrap_or(payload.scope_tier)
+    };
+
     // sha256 of the raw target id. P1 follow-up (brief §14) introduces a
     // per-user salt; the receipt schema does not change.
     let mut hasher = Sha256::new();
@@ -426,12 +466,12 @@ fn mark_tombstone_and_emit_receipt(
         kind: ConsentKind::ForgetIntent,
         actor: payload.actor.clone(),
         subject: subject_hash,
-        scope: scope_canonical_wire(&payload.scope, payload.scope_tier),
+        scope: scope_canonical_wire(&in_txn_scope, in_txn_tier),
         op_id: Some(op_id.as_str().to_owned()),
         sensor_id: None,
         payload: ConsentPayload::IntentReceipt {
             target_id_hash,
-            scope_tier: payload.scope_tier,
+            scope_tier: in_txn_tier,
             reason_code: payload.reason_code.clone(),
         },
         decided_at: now_rfc3339_from_ms(now_ms)?,

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -4,9 +4,7 @@ use cairn_core::wal::{OperationId, StepDef};
 use rusqlite::{Transaction, params};
 
 use crate::record_wal::locks::RecordLocks;
-use crate::record_wal::payload::{
-    ExpirePayload, ForgetPayload, StoredEmbedOutcome, UpsertPayload,
-};
+use crate::record_wal::payload::{ExpirePayload, ForgetPayload, StoredEmbedOutcome, UpsertPayload};
 use crate::wal::runner::{StepBody, StepBodyError};
 
 pub(crate) enum RecordStepPayload {

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -438,20 +438,51 @@ fn mark_tombstone_and_emit_receipt(
         return Ok(());
     }
 
-    // Resolve the in-txn scope/tier; fall back to the payload values
-    // only if the snapshot SELECT returned NULLs (defensive — should
-    // not happen when total_rows > 0).
-    let in_txn_scope = if in_txn_scope_json.is_empty() {
-        payload.scope.clone()
-    } else {
-        serde_json::from_str(&in_txn_scope_json).unwrap_or_else(|_| payload.scope.clone())
-    };
-    let in_txn_tier = if in_txn_visibility.is_empty() {
-        payload.scope_tier
-    } else {
-        cairn_core::domain::MemoryVisibility::parse(&in_txn_visibility)
-            .unwrap_or(payload.scope_tier)
-    };
+    // Round-8 review (Codex): for `total_rows > 0` we MUST resolve the
+    // in-txn scope/tier from the records table — falling back to
+    // `payload.scope` / `payload.scope_tier` would let stale pre-lock
+    // values leak into the audit receipt. Treat any parse failure or
+    // empty-string snapshot as a storage invariant break and abort
+    // Phase A; the WAL marks the step Failed and recovery surfaces it.
+    if in_txn_scope_json.is_empty() {
+        return Err(StepBodyError::Failed(format!(
+            "records.scope is NULL/empty for target {} despite total_rows > 0",
+            payload.target_id.as_str()
+        )));
+    }
+    if in_txn_visibility.is_empty() {
+        return Err(StepBodyError::Failed(format!(
+            "records.visibility is NULL/empty for target {} despite total_rows > 0",
+            payload.target_id.as_str()
+        )));
+    }
+    let in_txn_scope: cairn_core::domain::ScopeTuple = serde_json::from_str(&in_txn_scope_json)
+        .map_err(|e| {
+            StepBodyError::Failed(format!(
+                "records.scope is not valid JSON for target {}: {e}",
+                payload.target_id.as_str()
+            ))
+        })?;
+    let in_txn_tier =
+        cairn_core::domain::MemoryVisibility::parse(&in_txn_visibility).map_err(|e| {
+            StepBodyError::Failed(format!(
+                "records.visibility {in_txn_visibility:?} not parseable for target {}: {e}",
+                payload.target_id.as_str()
+            ))
+        })?;
+
+    // Known limitation (Round-8 review): the receipt records the scope
+    // and tier of the LATEST version only. A target lineage can in
+    // principle hold versions at different visibility tiers (an upsert
+    // that promoted Private → Public), and Phase B purges every
+    // version's body bytes. The receipt's single tier is therefore an
+    // incomplete summary of what was destroyed when the lineage spans
+    // tiers. Brief §14 forget-receipt allowlist does not yet model a
+    // multi-tier list; a follow-up should either extend the receipt
+    // schema or enforce per-target tier immutability at upsert time.
+    // For now we record the latest tier — better than the original
+    // pre-lock payload value and matches the most-recent reader-visible
+    // classification.
 
     // sha256 of the raw target id. P1 follow-up (brief §14) introduces a
     // per-user salt; the receipt schema does not change.
@@ -728,5 +759,146 @@ mod tests {
              commit purged active=1. A pre-lock SELECT (captured \
              before this function ran) would leak its stale `1` here."
         );
+    }
+
+    /// Round-8 review (Codex): the integration-level race regression
+    /// test cannot construct a real "stale payload after a same-target
+    /// upsert" interleaving — apply_forget_record's pre-lock read sees
+    /// whatever is committed when it runs. Pin the in-txn scope/tier
+    /// invariant at the unit-test layer instead: build a payload that
+    /// asserts a Private tier (the `stale` value), upsert a Public v2
+    /// AFTER the payload is built, then call the helper directly. The
+    /// emitted consent row's payload_json must say `"public"` — proving
+    /// the helper read the in-txn snapshot, not the payload.
+    #[test]
+    fn mark_tombstone_uses_in_txn_scope_tier_not_stale_payload() {
+        use std::sync::atomic::AtomicU64;
+
+        use cairn_core::domain::Identity;
+        use cairn_core::domain::taxonomy::MemoryVisibility;
+        use cairn_core::wal::{OperationId, WalKind};
+
+        use crate::record_wal::ops::new_operation_id;
+        use crate::record_wal::payload::ForgetPayload;
+
+        let mut conn = crate::open::open_in_memory_sync().expect("open");
+        let mut record = cairn_core::domain::record::tests_export::sample_record();
+        record.visibility = MemoryVisibility::Private;
+        let target = record.target_id.clone();
+
+        // v1 Private — what the simulated pre-lock read would observe.
+        let tx = conn.transaction().expect("tx v1");
+        let plan_v1 = crate::store::upsert::plan_upsert_in_tx(&tx, &record).expect("plan v1");
+        crate::store::upsert::stage_upsert_cow_in_tx(&tx, &record, &plan_v1).expect("stage v1");
+        crate::store::upsert::activate_upsert_in_tx(&tx, &plan_v1).expect("activate v1");
+        tx.commit().expect("commit v1");
+
+        // Build the "stale" payload that an apply_forget_record running
+        // in the race window would have constructed.
+        let payload = ForgetPayload {
+            target_id: target.clone(),
+            scope: record.scope.clone(),
+            reason_code: "user_command".to_owned(),
+            actor: Identity::parse("hmn:test:v1").expect("identity"),
+            scope_tier: MemoryVisibility::Private,
+        };
+
+        // Simulated race: a competing upsert commits Public v2 AFTER the
+        // payload was built, BEFORE the helper runs.
+        let mut v2 = record.clone();
+        v2.visibility = MemoryVisibility::Public;
+        v2.body = format!("{}-public", record.body);
+        let tx = conn.transaction().expect("tx v2");
+        let plan_v2 = crate::store::upsert::plan_upsert_in_tx(&tx, &v2).expect("plan v2");
+        crate::store::upsert::stage_upsert_cow_in_tx(&tx, &v2, &plan_v2).expect("stage v2");
+        crate::store::upsert::activate_upsert_in_tx(&tx, &plan_v2).expect("activate v2");
+        tx.commit().expect("commit v2");
+
+        // Run the helper with the stale (Private) payload against the
+        // database where Public v2 is now the latest version.
+        let op_id: OperationId = new_operation_id(WalKind::ForgetRecord).expect("op id");
+        let cell = AtomicU64::new(0);
+        let tx = conn.transaction().expect("tx forget");
+        mark_tombstone_and_emit_receipt(&tx, &op_id, &payload, &cell).expect("phase A");
+        tx.commit().expect("commit phase A");
+
+        // The consent_journal row written under op_id MUST carry the
+        // in-txn (Public) tier, not the payload's stale Private.
+        let payload_json: String = conn
+            .query_row(
+                "SELECT payload_json FROM consent_journal \
+                  WHERE kind = 'forget_intent' AND op_id = ?1",
+                params![op_id.as_str()],
+                |row| row.get(0),
+            )
+            .expect("consent row");
+        assert!(
+            payload_json.contains("\"scope_tier\":\"public\""),
+            "receipt scope_tier must come from the in-txn snapshot of the \
+             latest version (Public). A regression that read from \
+             payload.scope_tier (Private) would dilute the audit trail. \
+             Got: {payload_json}"
+        );
+        assert!(
+            !payload_json.contains("\"scope_tier\":\"private\""),
+            "receipt must NOT echo the stale payload's Private tier. \
+             Got: {payload_json}"
+        );
+    }
+
+    /// Round-8 review (Codex): when `total_rows > 0` but the in-txn
+    /// `records.visibility` is unparseable (corrupt row / schema drift),
+    /// the helper MUST fail closed instead of falling back to the
+    /// stale payload tier. This test inserts a row with a garbage
+    /// visibility string and asserts the helper rejects with
+    /// `StepBodyError::Failed`.
+    #[test]
+    fn mark_tombstone_fails_closed_on_unparseable_visibility() {
+        use std::sync::atomic::AtomicU64;
+
+        use cairn_core::domain::Identity;
+        use cairn_core::domain::taxonomy::MemoryVisibility;
+        use cairn_core::wal::{OperationId, WalKind};
+
+        use crate::record_wal::ops::new_operation_id;
+        use crate::record_wal::payload::ForgetPayload;
+
+        let mut conn = crate::open::open_in_memory_sync().expect("open");
+        let record = cairn_core::domain::record::tests_export::sample_record();
+
+        let tx = conn.transaction().expect("tx upsert");
+        let plan = crate::store::upsert::plan_upsert_in_tx(&tx, &record).expect("plan");
+        crate::store::upsert::stage_upsert_cow_in_tx(&tx, &record, &plan).expect("stage");
+        crate::store::upsert::activate_upsert_in_tx(&tx, &plan).expect("activate");
+        // Stomp the visibility column with an invalid value.
+        tx.execute(
+            "UPDATE records SET visibility = 'not_a_real_tier' WHERE target_id = ?1",
+            params![record.target_id.as_str()],
+        )
+        .expect("stomp visibility");
+        tx.commit().expect("commit");
+
+        let payload = ForgetPayload {
+            target_id: record.target_id.clone(),
+            scope: record.scope.clone(),
+            reason_code: "user_command".to_owned(),
+            actor: Identity::parse("hmn:test:v1").expect("identity"),
+            scope_tier: MemoryVisibility::Private,
+        };
+        let op_id: OperationId = new_operation_id(WalKind::ForgetRecord).expect("op id");
+        let cell = AtomicU64::new(0);
+        let tx = conn.transaction().expect("tx forget");
+        let result = mark_tombstone_and_emit_receipt(&tx, &op_id, &payload, &cell);
+        match result {
+            Err(StepBodyError::Failed(msg)) => {
+                assert!(
+                    msg.contains("visibility") && msg.contains("not_a_real_tier"),
+                    "error must name the bad column + value; got: {msg}"
+                );
+            }
+            other => {
+                panic!("expected StepBodyError::Failed for unparseable visibility, got {other:?}")
+            }
+        }
     }
 }

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -582,4 +582,79 @@ mod tests {
         assert_eq!(row.1, "embed unavailable");
         assert_eq!(row.2, None);
     }
+
+    /// Round-3 review (Codex): integration tests cannot distinguish a
+    /// pre-lock SELECT from the in-txn SELECT because the record-WAL
+    /// locks are fail-fast — the contender never reaches Phase A. Pin
+    /// the in-txn semantic at the unit-test layer instead: call
+    /// `mark_tombstone_and_emit_receipt` directly against a transaction
+    /// where rows have been mutated AFTER the helper would otherwise
+    /// have captured a count, and assert the `AtomicU64` reflects the
+    /// post-mutation state. A regression to a pre-lock SELECT (count
+    /// captured outside this function) would not write through this
+    /// `AtomicU64` at all and the assertion would fail closed.
+    #[test]
+    fn mark_tombstone_count_is_captured_inside_transaction() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        use cairn_core::domain::Identity;
+        use cairn_core::domain::taxonomy::MemoryVisibility;
+        use cairn_core::wal::{OperationId, WalKind};
+
+        use crate::record_wal::ops::new_operation_id;
+        use crate::record_wal::payload::ForgetPayload;
+
+        let mut conn = crate::open::open_in_memory_sync().expect("open");
+        let record = cairn_core::domain::record::tests_export::sample_record();
+
+        // Stage one active record + one already-tombstoned superseded
+        // version of the same target. The helper must count only the
+        // single live row.
+        let tx = conn.transaction().expect("tx");
+        let plan = crate::store::upsert::plan_upsert_in_tx(&tx, &record).expect("plan");
+        crate::store::upsert::stage_upsert_cow_in_tx(&tx, &record, &plan).expect("stage");
+        crate::store::upsert::activate_upsert_in_tx(&tx, &plan).expect("activate");
+        tx.commit().expect("commit upsert");
+
+        let payload = ForgetPayload {
+            target_id: record.target_id.clone(),
+            scope: record.scope.clone(),
+            reason_code: "user_command".to_owned(),
+            actor: Identity::parse("hmn:test:v1").expect("identity"),
+            scope_tier: MemoryVisibility::Private,
+        };
+        let op_id: OperationId = new_operation_id(WalKind::ForgetRecord).expect("op id");
+        let cell = AtomicU64::new(0);
+
+        // First call inside its own transaction: live count = 1.
+        let tx = conn.transaction().expect("tx 1");
+        mark_tombstone_and_emit_receipt(&tx, &op_id, &payload, &cell).expect("first phase A");
+        assert_eq!(
+            cell.load(Ordering::SeqCst),
+            1,
+            "first Phase A inside the transaction must observe the one live row"
+        );
+        tx.commit().expect("commit first phase A");
+
+        // Reset the cell so the assertion below cannot be satisfied by
+        // the previous write surviving. Then run again on the now-
+        // tombstoned target: in-txn count = 0. A pre-lock SELECT
+        // regression would never write to this cell at all (the helper
+        // wouldn't take it as a parameter), so the test would fail at
+        // compile time — but for any future implementation that DOES
+        // capture the count outside the transaction, this catches the
+        // stale-count regression.
+        cell.store(99, Ordering::SeqCst);
+        let op_id_2: OperationId = new_operation_id(WalKind::ForgetRecord).expect("op id 2");
+        let tx = conn.transaction().expect("tx 2");
+        mark_tombstone_and_emit_receipt(&tx, &op_id_2, &payload, &cell).expect("second phase A");
+        assert_eq!(
+            cell.load(Ordering::SeqCst),
+            0,
+            "second Phase A must observe zero live rows — its SELECT \
+             happens INSIDE the transaction, AFTER the previous \
+             commit purged active=1. A pre-lock SELECT (captured \
+             before this function ran) would leak its stale `1` here."
+        );
+    }
 }

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -463,6 +463,18 @@ fn mark_tombstone_and_emit_receipt(
                 payload.target_id.as_str()
             ))
         })?;
+    // Round-9 review (Codex): semantic validation. JSON-syntactic
+    // success is not enough — `{}` deserializes fine but is an invalid
+    // domain value (no IDL-addressable dimension). Reject corrupt
+    // domain shapes too; otherwise schema drift could let an
+    // irreversible forget commit a receipt with the original
+    // tenant/session/entity erased.
+    in_txn_scope.validate().map_err(|e| {
+        StepBodyError::Failed(format!(
+            "records.scope failed domain validation for target {}: {e}",
+            payload.target_id.as_str()
+        ))
+    })?;
     let in_txn_tier =
         cairn_core::domain::MemoryVisibility::parse(&in_txn_visibility).map_err(|e| {
             StepBodyError::Failed(format!(
@@ -899,6 +911,62 @@ mod tests {
             other => {
                 panic!("expected StepBodyError::Failed for unparseable visibility, got {other:?}")
             }
+        }
+    }
+
+    /// Round-9 review (Codex): the parse step accepts any JSON that
+    /// deserializes to `ScopeTuple`, but `{}` and `{"tenant":""}` etc.
+    /// are syntactically valid yet domain-invalid (no IDL-addressable
+    /// dimension; empty value). Without `ScopeTuple::validate()`,
+    /// schema drift could let an irreversible forget commit with a
+    /// receipt that lost the original scope. Pin the validation gate.
+    #[test]
+    fn mark_tombstone_fails_closed_on_invalid_scope_shape() {
+        use std::sync::atomic::AtomicU64;
+
+        use cairn_core::domain::Identity;
+        use cairn_core::domain::taxonomy::MemoryVisibility;
+        use cairn_core::wal::{OperationId, WalKind};
+
+        use crate::record_wal::ops::new_operation_id;
+        use crate::record_wal::payload::ForgetPayload;
+
+        let mut conn = crate::open::open_in_memory_sync().expect("open");
+        let record = cairn_core::domain::record::tests_export::sample_record();
+
+        let tx = conn.transaction().expect("tx upsert");
+        let plan = crate::store::upsert::plan_upsert_in_tx(&tx, &record).expect("plan");
+        crate::store::upsert::stage_upsert_cow_in_tx(&tx, &record, &plan).expect("stage");
+        crate::store::upsert::activate_upsert_in_tx(&tx, &plan).expect("activate");
+        // Stomp scope with valid JSON but invalid domain shape: `{}`
+        // deserializes to ScopeTuple::default() which has zero
+        // IDL-addressable dimensions → ScopeTuple::validate() rejects.
+        tx.execute(
+            "UPDATE records SET scope = '{}' WHERE target_id = ?1",
+            params![record.target_id.as_str()],
+        )
+        .expect("stomp scope");
+        tx.commit().expect("commit");
+
+        let payload = ForgetPayload {
+            target_id: record.target_id.clone(),
+            scope: record.scope.clone(),
+            reason_code: "user_command".to_owned(),
+            actor: Identity::parse("hmn:test:v1").expect("identity"),
+            scope_tier: MemoryVisibility::Private,
+        };
+        let op_id: OperationId = new_operation_id(WalKind::ForgetRecord).expect("op id");
+        let cell = AtomicU64::new(0);
+        let tx = conn.transaction().expect("tx forget");
+        let result = mark_tombstone_and_emit_receipt(&tx, &op_id, &payload, &cell);
+        match result {
+            Err(StepBodyError::Failed(msg)) => {
+                assert!(
+                    msg.contains("scope") && msg.contains("domain validation"),
+                    "error must name scope + domain validation; got: {msg}"
+                );
+            }
+            other => panic!("expected StepBodyError::Failed for invalid scope, got {other:?}"),
         }
     }
 }

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -344,15 +344,23 @@ fn now_secs() -> i64 {
 /// The `UPDATE` itself is idempotent — re-running over already-tombstoned
 /// rows is a no-op.
 ///
-/// **No-op forgets do not append a consent receipt.** When the in-txn
-/// count observes zero live rows (idempotent re-forget after the
-/// records were already purged), the helper records `deleted_count = 0`
-/// in the cell and returns without writing to `consent_journal`. The
-/// authoritative receipt is the one the *original* forget wrote with
-/// the real scope/tier; appending another receipt with the post-purge
+/// **Truly-purged forgets do not append a consent receipt.** When the
+/// in-txn `SELECT COUNT(*)` observes zero rows for the target (records
+/// table holds nothing), the helper records `deleted_count = 0` and
+/// returns without writing to `consent_journal`. The authoritative
+/// receipt is the one the original forget wrote with the real
+/// scope/tier; appending another receipt with the post-purge
 /// `ScopeTuple::default()` + `MemoryVisibility::Private` defaults
-/// would dilute the audit trail and misclassify a previously
-/// team/org/public scoped record. Round-5 review (Codex).
+/// would dilute the audit trail. Round-5 review (Codex).
+///
+/// **Already-expired targets DO get a receipt.** A target whose rows
+/// exist but are `active = 0` (e.g. previously expired by the
+/// expiration workflow) still has body-bearing data on disk. Phase B
+/// will purge those rows; the receipt records WHO authorized the
+/// destructive op. The scope/tier comes from `load_scope_and_tier`'s
+/// `ORDER BY version DESC` which reads the latest row regardless of
+/// active status, so the receipt preserves the original tier even
+/// when no live row exists. Round-6 review (Codex).
 fn mark_tombstone_and_emit_receipt(
     tx: &Transaction<'_>,
     op_id: &OperationId,
@@ -364,14 +372,20 @@ fn mark_tombstone_and_emit_receipt(
 
     let now_ms = crate::store::current_unix_ms();
 
-    // Capture the live-version count INSIDE the Phase A transaction so
-    // two concurrent forgets cannot both report deleted_count=1. The
-    // record-WAL locks serialize the SELECT against the matching
-    // tombstone UPDATE on the same target — the second forget runs
-    // after the first has already flipped active=0 and reads 0.
+    // In-txn counts under the record-WAL lock: `live_count` populates
+    // `ForgetReceipt::deleted_count` (the count THIS op tombstoned);
+    // `total_rows` discriminates "truly already purged" (no receipt)
+    // from "rows present but inactive" (receipt with original tier).
     let live_count: i64 = tx
         .query_row(
             "SELECT COUNT(*) FROM records WHERE target_id = ?1 AND active = 1",
+            params![payload.target_id.as_str()],
+            |row| row.get(0),
+        )
+        .map_err(StepBodyError::Storage)?;
+    let total_rows: i64 = tx
+        .query_row(
+            "SELECT COUNT(*) FROM records WHERE target_id = ?1",
             params![payload.target_id.as_str()],
             |row| row.get(0),
         )
@@ -392,9 +406,10 @@ fn mark_tombstone_and_emit_receipt(
     )
     .map_err(StepBodyError::Storage)?;
 
-    // No-op forget (records already purged): skip the receipt.
-    // See doc comment above for the audit-invariant rationale.
-    if live_count_u64 == 0 {
+    // Truly already-purged target: no rows exist. Skip the receipt
+    // (the original forget wrote the authoritative one). See doc
+    // comment above for the audit-invariant rationale.
+    if total_rows == 0 {
         return Ok(());
     }
 

--- a/crates/cairn-store-sqlite/src/store/forget.rs
+++ b/crates/cairn-store-sqlite/src/store/forget.rs
@@ -1,0 +1,41 @@
+//! Concrete `forget_record` API for record-level forget through the record WAL.
+
+use cairn_core::contract::memory_store::ForgetReceipt;
+use cairn_core::domain::{Identity, TargetId};
+use tracing::instrument;
+
+use crate::error::StoreError;
+use crate::store::SqliteMemoryStore;
+
+impl SqliteMemoryStore {
+    /// Inherent `forget_record` implementation; the trait method
+    /// [`MemoryStore::forget_record`] guards `self.conn` then delegates here.
+    ///
+    /// Phase A tombstones the lineage and emits the body-free receipt; Phase
+    /// B physically purges vectors, FTS, edges, primary rows, and WAL
+    /// pre-images. Idempotent and crash-safe; returns the §14 forget-receipt
+    /// allowlist {`target_id_hash`, `op_id`, `purged_at`}.
+    ///
+    /// [`MemoryStore::forget_record`]: cairn_core::contract::memory_store::MemoryStore::forget_record
+    ///
+    /// # Errors
+    ///
+    /// Returns store, lock, WAL runner, or recovery-shape errors.
+    #[instrument(
+        skip(self),
+        err,
+        fields(verb = "forget_record", target_id = %target.as_str(), actor = %actor.as_str()),
+    )]
+    pub(crate) async fn do_forget_record(
+        &self,
+        target: &TargetId,
+        actor: &Identity,
+    ) -> Result<ForgetReceipt, StoreError> {
+        if self.conn.is_none() {
+            return Err(StoreError::NotInitialized {
+                method: "forget_record",
+            });
+        }
+        crate::record_wal::apply_forget_record(self, target, actor).await
+    }
+}

--- a/crates/cairn-store-sqlite/src/store/mod.rs
+++ b/crates/cairn-store-sqlite/src/store/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod edges;
 pub(crate) mod expire;
+pub(crate) mod forget;
 pub(crate) mod graph_search;
 pub(crate) mod hybrid;
 pub(crate) mod projection;

--- a/crates/cairn-store-sqlite/src/store/trait_impl.rs
+++ b/crates/cairn-store-sqlite/src/store/trait_impl.rs
@@ -8,14 +8,14 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use cairn_core::contract::memory_store::{
-    Edge, EdgeDir, EdgeKey, GraphNeighborsArgs, HybridSearchArgs, HybridSearchPage, IndexStats,
-    KeywordSearchArgs, KeywordSearchPage, ListArgs, ListPage, MemoryStore, MemoryStoreCapabilities,
-    RecordVersion, SemanticSearchArgs, SemanticSearchPage, StoreError, TombstoneReason,
-    UpsertOutcome,
+    Edge, EdgeDir, EdgeKey, ForgetReceipt, GraphNeighborsArgs, HybridSearchArgs, HybridSearchPage,
+    IndexStats, KeywordSearchArgs, KeywordSearchPage, ListArgs, ListPage, MemoryStore,
+    MemoryStoreCapabilities, RecordVersion, SemanticSearchArgs, SemanticSearchPage, StoreError,
+    TombstoneReason, UpsertOutcome,
 };
 use cairn_core::contract::version::VersionRange;
 use cairn_core::domain::consent_timeline::ConsentModel;
-use cairn_core::domain::{MemoryRecord, RecordId, TargetId};
+use cairn_core::domain::{Identity, MemoryRecord, RecordId, TargetId};
 use cairn_core::search::GraphCandidate;
 
 use crate::error::StoreError as ConcreteError;
@@ -66,6 +66,19 @@ impl MemoryStore for SqliteMemoryStore {
             return not_initialized("tombstone");
         }
         self.do_tombstone(id, reason).await.map_err(Into::into)
+    }
+
+    async fn forget_record(
+        &self,
+        target: &TargetId,
+        actor: &Identity,
+    ) -> Result<ForgetReceipt, StoreError> {
+        if self.conn.is_none() {
+            return not_initialized("forget_record");
+        }
+        self.do_forget_record(target, actor)
+            .await
+            .map_err(Into::into)
     }
 
     async fn versions(&self, target: &TargetId) -> Result<Vec<RecordVersion>, StoreError> {

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use cairn_core::contract::memory_store::{ForgetReceipt, KeywordSearchArgs, ListArgs, MemoryStore};
 use cairn_core::domain::{Identity, MemoryRecord};
-use cairn_store_sqlite::open_in_memory;
+use cairn_store_sqlite::{open, open_in_memory};
 
 fn sample() -> MemoryRecord {
     cairn_core::domain::record::tests_export::sample_record()
@@ -270,3 +270,84 @@ fn collect_json_keys(value: &serde_json::Value, out: &mut std::collections::BTre
         _ => {}
     }
 }
+
+// ── Task 12 ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn forget_record_phase_a_crash_leaves_no_state() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+
+    let seed = sample();
+    let target = seed.target_id.clone();
+
+    {
+        let store = open(&path).await.expect("open");
+        store.upsert(&seed).await.expect("upsert seed");
+
+        // Stage a PREPARED forget_record op + payload but skip the step
+        // runner so Phase A never commits its tombstone.
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let target_str = target.as_str().to_owned();
+        let payload_json = serde_json::to_string(
+            &cairn_store_sqlite::record_wal::payload::RecordWalPayload::Forget(Box::new(
+                cairn_store_sqlite::record_wal::payload::ForgetPayload {
+                    target_id: target.clone(),
+                    scope: seed.scope.clone(),
+                    reason_code: "user_command".to_owned(),
+                    actor: alice(),
+                    scope_tier: cairn_core::domain::taxonomy::MemoryVisibility::Private,
+                },
+            )),
+        )
+        .expect("serialize");
+        conn.call(move |c| {
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES ('op-crash-58', \
+                         COALESCE((SELECT MAX(issued_seq) FROM wal_ops),0)+1, \
+                         'forget_record','PREPARED','{}','test', \
+                         ?1, '{}', 0, 'sig', 1, 1)",
+                rusqlite::params![target_str],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES ('op-crash-58', 'forget_record', ?1, 1)",
+                rusqlite::params![payload_json],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed PREPARED op");
+    } // drop store — simulates crash before Phase A txn could commit
+
+    // Reopen and assert recovery completes the prepared op.
+    let store = open(&path).await.expect("reopen");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let state: String = conn
+        .call(|c| {
+            c.query_row(
+                "SELECT state FROM wal_ops WHERE operation_id = 'op-crash-58'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("read op state");
+    assert_eq!(
+        state, "COMMITTED",
+        "boot-time recovery resumed the prepared forget op to COMMITTED"
+    );
+
+    // The seed record must be gone from every reader after recovery.
+    let post = store
+        .get_active_by_target(&target)
+        .await
+        .expect("post lookup");
+    assert!(post.is_none(), "recovered forget purges the target");
+}
+

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -723,3 +723,60 @@ async fn forget_after_expire_writes_receipt_with_original_tier() {
         "Phase B primary.purge ran for the expired target"
     );
 }
+
+// ── Round 7 review: in-txn scope/tier read defeats pre-lock-read race ──
+
+#[tokio::test]
+async fn forget_records_post_upsert_visibility_in_consent_receipt() {
+    use cairn_core::domain::taxonomy::MemoryVisibility;
+
+    // Round-7 review (Codex): apply_forget_record reads scope+tier
+    // BEFORE acquiring the record-WAL lock (the values feed the
+    // entity/session lock legs). A same-target upsert could commit
+    // between that pre-lock read and the lock acquisition, leaving
+    // the receipt with stale tier metadata.
+    //
+    // Fix: mark_tombstone_and_emit_receipt re-reads scope+tier INSIDE
+    // the Phase A transaction. This test simulates the race by
+    // upserting a Private v1, then a Public v2 (BEFORE the forget),
+    // then forgetting. The receipt MUST reflect Public — the latest
+    // version's tier — not whatever the apply path read first.
+    let store = open_in_memory().await.expect("open");
+    let mut record = sample();
+    record.visibility = MemoryVisibility::Private;
+    let target = record.target_id.clone();
+    store.upsert(&record).await.expect("upsert v1 private");
+
+    // Bump visibility on the same target.
+    let mut v2 = record.clone();
+    v2.visibility = MemoryVisibility::Public;
+    v2.body = format!("{}-public", record.body);
+    store.upsert(&v2).await.expect("upsert v2 public");
+
+    let receipt = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("forget");
+    assert_eq!(receipt.deleted_count, 1, "v2 was the live row");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let receipt_op_id = receipt.op_id.clone();
+    let payload_json: String = conn
+        .call(move |c| {
+            c.query_row(
+                "SELECT payload_json FROM consent_journal \
+                  WHERE kind = 'forget_intent' AND op_id = ?1",
+                rusqlite::params![receipt_op_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("query consent");
+    assert!(
+        payload_json.contains("\"scope_tier\":\"public\""),
+        "receipt scope_tier must come from the in-txn read of the latest \
+         version (Public), not a stale pre-lock snapshot of v1 (Private). \
+         Got: {payload_json}"
+    );
+}

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -552,3 +552,88 @@ async fn concurrent_forgets_serialize_via_record_wal_lock() {
 // outside it). Integration-level tests can't distinguish those two
 // implementations because the record-WAL locks fail-fast — no contender
 // reaches Phase A.
+
+// ── Round 5 review: receipt fidelity for non-private repeat forget ─────
+
+#[tokio::test]
+async fn repeat_forget_after_purge_does_not_dilute_consent_audit_trail() {
+    use cairn_core::domain::taxonomy::MemoryVisibility;
+
+    // Round-5 review (Codex): a repeat forget against an already-purged
+    // target previously appended a SECOND consent_journal row using
+    // `ScopeTuple::default()` and `MemoryVisibility::Private` — the
+    // post-purge `load_scope_and_tier` defaults. For a record that
+    // started life as `Team`/`Org`/`Public`, this misclassified the
+    // audit trail.
+    //
+    // Fix: skip the consent receipt when the in-txn count observes
+    // zero live rows. Brief §14: the authoritative receipt is the one
+    // bound to the destructive Phase A; a no-op forget has nothing to
+    // audit beyond what the original receipt already captured.
+    let store = open_in_memory().await.expect("open");
+    let mut record = sample();
+    // Force a non-default tier so the regression — defaulting to
+    // Private on the second receipt — would visibly demote it.
+    record.visibility = MemoryVisibility::Team;
+    let target = record.target_id.clone();
+    store.upsert(&record).await.expect("upsert");
+
+    let r1 = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("first forget");
+    assert_eq!(r1.deleted_count, 1, "first forget tombstones the live row");
+
+    let r2 = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("second forget");
+    assert_eq!(
+        r2.deleted_count, 0,
+        "repeat forget after purge observes zero live rows in-txn"
+    );
+
+    // Inspect consent_journal: exactly one ForgetIntent for this
+    // target_id_hash; its scope_tier reflects the original Team
+    // visibility (no diluted Private receipt from the second call).
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let target_id_hash = r1.target_id_hash.clone();
+    let receipts: Vec<(String, String)> = conn
+        .call(move |c| {
+            let mut stmt = c.prepare(
+                "SELECT op_id, payload_json FROM consent_journal \
+                  WHERE kind = 'forget_intent' \
+                    AND payload_json LIKE '%' || ?1 || '%'",
+            )?;
+            let rows = stmt
+                .query_map(rusqlite::params![target_id_hash], |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?.unwrap_or_default(),
+                        row.get::<_, String>(1)?,
+                    ))
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(rows)
+        })
+        .await
+        .expect("query consent");
+
+    assert_eq!(
+        receipts.len(),
+        1,
+        "exactly one ForgetIntent receipt per target — repeat forget \
+         must not append a duplicate. Got: {receipts:?}"
+    );
+    let (op_id, payload_json) = &receipts[0];
+    assert_eq!(
+        op_id, &r1.op_id,
+        "the surviving receipt must be the one written by the *real* \
+         destructive op, not the no-op"
+    );
+    assert!(
+        payload_json.contains("\"scope_tier\":\"team\""),
+        "receipt scope_tier must preserve the original Team visibility \
+         — a regression to default-Private would record \"private\". \
+         Got payload: {payload_json}"
+    );
+}

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -1,9 +1,10 @@
 //! Issue #58: record-level forget through body-bearing WAL.
 //!
-//! Engine-level integration coverage. The CLI/MCP/SDK dispatch wiring
-//! and the `wiring::FORGET_RECORD_WIRED` constant flip are deferred
-//! to issue #9; these tests call `SqliteMemoryStore::forget_record`
-//! directly to exercise the WAL apply path end-to-end.
+//! Engine-level integration coverage. The CLI dispatch wiring and the
+//! `wiring::FORGET_RECORD_WIRED_CLI` constant flip landed in #58; SDK and
+//! MCP wiring (`FORGET_RECORD_WIRED_SDK` / `_MCP`) are deferred to #9.
+//! These tests call `SqliteMemoryStore::forget_record` directly to
+//! exercise the WAL apply path end-to-end.
 
 #![allow(missing_docs)]
 

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -467,3 +467,68 @@ async fn forget_record_phase_b_crash_resumes_from_last_done_step() {
         .expect("scan records");
     assert_eq!(row_count, 0, "Phase B primary.purge ran during recovery");
 }
+
+// ── Round 2 review: deleted_count is captured under the lock ───────────
+
+#[tokio::test]
+async fn concurrent_forgets_serialize_via_record_wal_lock() {
+    use std::sync::Arc as StdArc;
+
+    // In-process concurrency: two tokio tasks call forget_record on the
+    // same target through the same SqliteMemoryStore. The record-WAL
+    // entity-exclusive lock (brief §10.1 single-writer ordering)
+    // serializes them — exactly one acquires the lock and reports
+    // `deleted_count = 1`; the other fails fast with `RecordWalLock`.
+    //
+    // Round-2 review concern: a pre-lock SELECT could let two
+    // concurrent forgets both observe `active = 1` and both report
+    // `deleted_count = 1`. The fix moves the count read INSIDE the
+    // Phase A transaction (under the same lock), so the second forget
+    // — even if it eventually retried past the lock — would see
+    // `active = 0` and report `0`.
+    let store = StdArc::new(open_in_memory().await.expect("open"));
+    let record = sample();
+    let target = record.target_id.clone();
+    store.upsert(&record).await.expect("upsert");
+
+    let s1 = StdArc::clone(&store);
+    let s2 = StdArc::clone(&store);
+    let t1 = target.clone();
+    let t2 = target.clone();
+    let h1 = tokio::spawn(async move { s1.forget_record(&t1, &alice()).await });
+    let h2 = tokio::spawn(async move { s2.forget_record(&t2, &alice()).await });
+
+    let r1 = h1.await.expect("task1 join");
+    let r2 = h2.await.expect("task2 join");
+
+    let outcomes: Vec<Result<u64, String>> = [r1, r2]
+        .into_iter()
+        .map(|r| match r {
+            Ok(receipt) => Ok(receipt.deleted_count),
+            Err(e) => Err(e.to_string()),
+        })
+        .collect();
+
+    let successes: Vec<u64> = outcomes
+        .iter()
+        .filter_map(|o| o.as_ref().ok().copied())
+        .collect();
+    let failures: Vec<&String> = outcomes.iter().filter_map(|o| o.as_ref().err()).collect();
+
+    assert_eq!(
+        successes,
+        vec![1u64],
+        "exactly one concurrent forget must succeed with deleted_count=1; \
+         successes={successes:?} failures={failures:?}"
+    );
+    assert_eq!(
+        failures.len(),
+        1,
+        "the other concurrent forget must fail-fast on lock contention; got {failures:?}"
+    );
+    assert!(
+        failures[0].contains("record wal lock") || failures[0].contains("RecordWalLock"),
+        "loser must surface the typed RecordWalLock error; got {:?}",
+        failures[0]
+    );
+}

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -130,6 +130,22 @@ async fn forget_record_is_idempotent_under_repeat() {
 
     assert_eq!(r1.target_id_hash, r2.target_id_hash);
     assert_ne!(r1.op_id, r2.op_id, "every call mints a fresh op_id");
+    // Round-2 review: the in-txn `SELECT COUNT(*) WHERE active = 1`
+    // captures the live-version count under the record-WAL lock. The
+    // first forget tombstones one live row → `deleted_count = 1`; the
+    // second runs after Phase A purged the records table → reads 0.
+    // A regression to a pre-lock SELECT would still report `1` here
+    // because the second call's pre-lock read could observe the same
+    // active row before locking.
+    assert_eq!(
+        r1.deleted_count, 1,
+        "first forget should report exactly one tombstoned row"
+    );
+    assert_eq!(
+        r2.deleted_count, 0,
+        "post-contention re-forget must report deleted_count=0 — would \
+         regress to 1 if the count moved back to a pre-lock SELECT"
+    );
 
     // Verify two COMMITTED forget_record ops landed in wal_ops.
     let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
@@ -474,18 +490,12 @@ async fn forget_record_phase_b_crash_resumes_from_last_done_step() {
 async fn concurrent_forgets_serialize_via_record_wal_lock() {
     use std::sync::Arc as StdArc;
 
-    // In-process concurrency: two tokio tasks call forget_record on the
-    // same target through the same SqliteMemoryStore. The record-WAL
-    // entity-exclusive lock (brief §10.1 single-writer ordering)
-    // serializes them — exactly one acquires the lock and reports
-    // `deleted_count = 1`; the other fails fast with `RecordWalLock`.
-    //
-    // Round-2 review concern: a pre-lock SELECT could let two
-    // concurrent forgets both observe `active = 1` and both report
-    // `deleted_count = 1`. The fix moves the count read INSIDE the
-    // Phase A transaction (under the same lock), so the second forget
-    // — even if it eventually retried past the lock — would see
-    // `active = 0` and report `0`.
+    // Brief §10.1 single-writer ordering: the record-WAL
+    // entity-exclusive lock makes two same-target forgets fail-fast
+    // contend — exactly one acquires the lock and reports
+    // `deleted_count = 1`; the other surfaces the typed `RecordWalLock`
+    // error. This test pins the surfaced error type so a future
+    // change to a wait-and-retry policy gets a deliberate review.
     let store = StdArc::new(open_in_memory().await.expect("open"));
     let record = sample();
     let target = record.target_id.clone();
@@ -530,5 +540,72 @@ async fn concurrent_forgets_serialize_via_record_wal_lock() {
         failures[0].contains("record wal lock") || failures[0].contains("RecordWalLock"),
         "loser must surface the typed RecordWalLock error; got {:?}",
         failures[0]
+    );
+}
+
+#[tokio::test]
+async fn contended_forget_retried_after_lock_release_reports_zero() {
+    use std::sync::Arc as StdArc;
+    use std::time::Duration;
+
+    // Round-2 review (Codex): the fail-fast concurrent test above does
+    // NOT exercise the in-txn deleted_count fix — the loser never runs
+    // Phase A, so a regressed pre-lock SELECT would still satisfy "one
+    // dc=1, one error." This test fills that gap: spawn the contender,
+    // catch the RecordWalLock error, retry once the incumbent committed
+    // and released the lock, then assert the retry reports `0`.
+    //
+    // Behaviour invariant: after the first forget tombstoned the live
+    // row, ANY subsequent successful forget on the same target must
+    // observe zero live rows inside its own Phase A transaction. A
+    // regression to a pre-lock SELECT would let the contender stash
+    // its own pre-lock count of `1` and falsely report `deleted_count
+    // = 1` even after the incumbent already drained everything.
+    let store = StdArc::new(open_in_memory().await.expect("open"));
+    let record = sample();
+    let target = record.target_id.clone();
+    store.upsert(&record).await.expect("upsert");
+
+    let s1 = StdArc::clone(&store);
+    let s2 = StdArc::clone(&store);
+    let t1 = target.clone();
+    let t2 = target.clone();
+    let h1 = tokio::spawn(async move { s1.forget_record(&t1, &alice()).await });
+    let h2 = tokio::spawn(async move { s2.forget_record(&t2, &alice()).await });
+
+    let r1 = h1.await.expect("task1 join");
+    let r2 = h2.await.expect("task2 join");
+
+    let (winner, loser) = match (r1, r2) {
+        (Ok(w), Err(e)) | (Err(e), Ok(w)) => (w, e.to_string()),
+        (Ok(_), Ok(_)) => panic!("both succeeded — locks should serialize"),
+        (Err(e1), Err(e2)) => panic!("both failed: {e1}, {e2}"),
+    };
+    assert_eq!(
+        winner.deleted_count, 1,
+        "incumbent that acquired the lock must report dc=1"
+    );
+    assert!(
+        loser.contains("record wal lock") || loser.contains("RecordWalLock"),
+        "loser must surface RecordWalLock; got {loser:?}"
+    );
+
+    // Wait long enough for the incumbent's lock to fully release. The
+    // record-WAL locks unwind after `runner::run_from` returns and
+    // `finalize` commits — single-digit ms in tests, but give it 100ms
+    // for headroom.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let retry = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("retry after lock released should succeed");
+    assert_eq!(
+        retry.deleted_count, 0,
+        "after the incumbent purged the records, the retry's in-txn \
+         SELECT must observe zero live rows. A regression to a pre-lock \
+         SELECT would let this still report `1` (the pre-lock count \
+         captured before the second forget could see the effect of the \
+         first)."
     );
 }

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -351,3 +351,118 @@ async fn forget_record_phase_a_crash_leaves_no_state() {
     assert!(post.is_none(), "recovered forget purges the target");
 }
 
+// ── Task 13 ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn forget_record_phase_b_crash_resumes_from_last_done_step() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+
+    let seed = sample();
+    let target = seed.target_id.clone();
+
+    {
+        let store = open(&path).await.expect("open");
+        store.upsert(&seed).await.expect("upsert seed");
+
+        // Stage a PREPARED forget op + payload + a wal_steps row
+        // marking step 0 (primary.mark_tombstone) DONE. Apply the
+        // tombstone effect manually so the on-disk state matches
+        // "Phase A commit succeeded, crashed before step 1."
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let target_str = target.as_str().to_owned();
+        let payload_json = serde_json::to_string(
+            &cairn_store_sqlite::record_wal::payload::RecordWalPayload::Forget(Box::new(
+                cairn_store_sqlite::record_wal::payload::ForgetPayload {
+                    target_id: target.clone(),
+                    scope: seed.scope.clone(),
+                    reason_code: "user_command".to_owned(),
+                    actor: alice(),
+                    scope_tier: cairn_core::domain::taxonomy::MemoryVisibility::Private,
+                },
+            )),
+        )
+        .expect("serialize");
+        let target_for_tx = target_str.clone();
+        conn.call(move |c| {
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES ('op-phaseb-58', \
+                         COALESCE((SELECT MAX(issued_seq) FROM wal_ops),0)+1, \
+                         'forget_record','PREPARED','{}','test', \
+                         ?1, '{}', 0, 'sig', 1, 1)",
+                rusqlite::params![target_for_tx],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES ('op-phaseb-58', 'forget_record', ?1, 1)",
+                rusqlite::params![payload_json],
+            )?;
+            // Mark step 0 DONE so recovery resumes from step 1.
+            c.execute(
+                "INSERT INTO wal_steps \
+                   (operation_id, step_ord, step_kind, state, attempts, \
+                    started_at, finished_at) \
+                 VALUES ('op-phaseb-58', 0, 'primary.mark_tombstone', 'DONE', 1, 1, 2)",
+                [],
+            )?;
+            // Apply the tombstone effect of step 0 directly.
+            c.execute(
+                "UPDATE records \
+                    SET active = 0, tombstoned = 1, tombstone_reason = 'forget' \
+                  WHERE target_id = ?1",
+                rusqlite::params![target_for_tx],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed half-run state");
+    }
+
+    // Reopen — recovery picks up the prepared op and runs steps 1-6.
+    let store = open(&path).await.expect("reopen");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let (state, done_steps): (String, i64) = conn
+        .call(|c| {
+            let s: String = c.query_row(
+                "SELECT state FROM wal_ops WHERE operation_id = 'op-phaseb-58'",
+                [],
+                |row| row.get(0),
+            )?;
+            let n: i64 = c.query_row(
+                "SELECT COUNT(*) FROM wal_steps \
+                  WHERE operation_id = 'op-phaseb-58' AND state = 'DONE'",
+                [],
+                |row| row.get(0),
+            )?;
+            Ok((s, n))
+        })
+        .await
+        .expect("query state");
+
+    assert_eq!(
+        state, "COMMITTED",
+        "recovery drove the prepared op to COMMITTED"
+    );
+    assert_eq!(
+        done_steps, 7,
+        "every step in FORGET_RECORD_STEPS reached DONE during recovery"
+    );
+
+    let target_for_count = target.as_str().to_owned();
+    let row_count: i64 = conn
+        .call(move |c| {
+            c.query_row(
+                "SELECT COUNT(*) FROM records WHERE target_id = ?1",
+                rusqlite::params![target_for_count],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("scan records");
+    assert_eq!(row_count, 0, "Phase B primary.purge ran during recovery");
+}

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -7,6 +7,8 @@
 
 #![allow(missing_docs)]
 
+use std::sync::Arc;
+
 use cairn_core::contract::memory_store::{ForgetReceipt, KeywordSearchArgs, ListArgs, MemoryStore};
 use cairn_core::domain::{Identity, MemoryRecord};
 use cairn_store_sqlite::open_in_memory;
@@ -99,4 +101,48 @@ async fn forget_record_removes_content_from_every_reader() {
     );
     assert!(receipt.op_id.starts_with("forget_record-"));
     assert!(receipt.purged_at > 0);
+}
+
+// ── Task 9 ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn forget_record_is_idempotent_under_repeat() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+    let target = record.target_id.clone();
+
+    store.upsert(&record).await.expect("upsert");
+
+    let r1 = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("first forget");
+
+    // Second call against the already-forgotten target. Records table is
+    // empty, but the WAL apply path should still succeed: tombstone +
+    // drains + purge are all no-ops, snapshot.purge stays no-op, and the
+    // receipt comes back with the same target_id_hash.
+    let r2 = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("second forget");
+
+    assert_eq!(r1.target_id_hash, r2.target_id_hash);
+    assert_ne!(r1.op_id, r2.op_id, "every call mints a fresh op_id");
+
+    // Verify two COMMITTED forget_record ops landed in wal_ops.
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let count: i64 = conn
+        .call(|c| {
+            c.query_row(
+                "SELECT COUNT(*) FROM wal_ops \
+                  WHERE kind = 'forget_record' AND state = 'COMMITTED'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("wal count");
+    assert_eq!(count, 2, "both forget calls reach COMMITTED");
 }

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -637,3 +637,89 @@ async fn repeat_forget_after_purge_does_not_dilute_consent_audit_trail() {
          Got payload: {payload_json}"
     );
 }
+
+// ── Round 6 review: expire-then-forget preserves audit receipt ─────────
+
+#[tokio::test]
+async fn forget_after_expire_writes_receipt_with_original_tier() {
+    use cairn_core::domain::taxonomy::MemoryVisibility;
+
+    // Round-6 review (Codex): the no-op-skip predicate must NOT fire on
+    // already-expired targets. An expired record has `active = 0` rows
+    // present (live_count = 0) but body bytes still on disk; the
+    // forget op WILL purge them in Phase B and therefore MUST record
+    // the actor/scope/tier in consent_journal.
+    //
+    // The fix uses `total_rows == 0` (not `live_count == 0`) as the
+    // skip predicate so this case writes a receipt with the original
+    // Org tier — `load_scope_and_tier`'s `ORDER BY version DESC`
+    // reads inactive rows too.
+    let store = open_in_memory().await.expect("open");
+    let mut record = sample();
+    record.visibility = MemoryVisibility::Org;
+    let target = record.target_id.clone();
+    store.upsert(&record).await.expect("upsert");
+
+    // Soft-expire the record: rows remain with active=0, tombstoned=1,
+    // tombstone_reason='expire' (no body purge yet).
+    store.expire(&target).await.expect("expire");
+
+    let receipt = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("forget after expire");
+    assert_eq!(
+        receipt.deleted_count, 0,
+        "no live rows at admission — but rows existed, so forget still purges"
+    );
+
+    // The expire-then-forget op MUST have written a consent receipt
+    // (the destructive Phase B purge needs an audited actor).
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let receipt_op_id = receipt.op_id.clone();
+    let row: Option<String> = conn
+        .call(move |c| {
+            let result: Result<String, rusqlite::Error> = c.query_row(
+                "SELECT payload_json FROM consent_journal \
+                  WHERE kind = 'forget_intent' AND op_id = ?1",
+                rusqlite::params![receipt_op_id],
+                |row| row.get(0),
+            );
+            match result {
+                Ok(s) => Ok(Some(s)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(tokio_rusqlite::Error::Other(Box::new(e))),
+            }
+        })
+        .await
+        .expect("query consent");
+    let payload_json = row.expect(
+        "expire-then-forget MUST append a ForgetIntent receipt — \
+         the no-op skip predicate must use `total_rows == 0`, not \
+         `live_count == 0`",
+    );
+    assert!(
+        payload_json.contains("\"scope_tier\":\"org\""),
+        "receipt must preserve the original Org visibility (read from \
+         the inactive row via load_scope_and_tier ORDER BY version DESC). \
+         Got: {payload_json}"
+    );
+
+    // Records table physically empty after Phase B.
+    let target_str = target.as_str().to_owned();
+    let row_count: i64 = conn
+        .call(move |c| {
+            c.query_row(
+                "SELECT COUNT(*) FROM records WHERE target_id = ?1",
+                rusqlite::params![target_str],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("count");
+    assert_eq!(
+        row_count, 0,
+        "Phase B primary.purge ran for the expired target"
+    );
+}

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -543,69 +543,12 @@ async fn concurrent_forgets_serialize_via_record_wal_lock() {
     );
 }
 
-#[tokio::test]
-async fn contended_forget_retried_after_lock_release_reports_zero() {
-    use std::sync::Arc as StdArc;
-    use std::time::Duration;
-
-    // Round-2 review (Codex): the fail-fast concurrent test above does
-    // NOT exercise the in-txn deleted_count fix — the loser never runs
-    // Phase A, so a regressed pre-lock SELECT would still satisfy "one
-    // dc=1, one error." This test fills that gap: spawn the contender,
-    // catch the RecordWalLock error, retry once the incumbent committed
-    // and released the lock, then assert the retry reports `0`.
-    //
-    // Behaviour invariant: after the first forget tombstoned the live
-    // row, ANY subsequent successful forget on the same target must
-    // observe zero live rows inside its own Phase A transaction. A
-    // regression to a pre-lock SELECT would let the contender stash
-    // its own pre-lock count of `1` and falsely report `deleted_count
-    // = 1` even after the incumbent already drained everything.
-    let store = StdArc::new(open_in_memory().await.expect("open"));
-    let record = sample();
-    let target = record.target_id.clone();
-    store.upsert(&record).await.expect("upsert");
-
-    let s1 = StdArc::clone(&store);
-    let s2 = StdArc::clone(&store);
-    let t1 = target.clone();
-    let t2 = target.clone();
-    let h1 = tokio::spawn(async move { s1.forget_record(&t1, &alice()).await });
-    let h2 = tokio::spawn(async move { s2.forget_record(&t2, &alice()).await });
-
-    let r1 = h1.await.expect("task1 join");
-    let r2 = h2.await.expect("task2 join");
-
-    let (winner, loser) = match (r1, r2) {
-        (Ok(w), Err(e)) | (Err(e), Ok(w)) => (w, e.to_string()),
-        (Ok(_), Ok(_)) => panic!("both succeeded — locks should serialize"),
-        (Err(e1), Err(e2)) => panic!("both failed: {e1}, {e2}"),
-    };
-    assert_eq!(
-        winner.deleted_count, 1,
-        "incumbent that acquired the lock must report dc=1"
-    );
-    assert!(
-        loser.contains("record wal lock") || loser.contains("RecordWalLock"),
-        "loser must surface RecordWalLock; got {loser:?}"
-    );
-
-    // Wait long enough for the incumbent's lock to fully release. The
-    // record-WAL locks unwind after `runner::run_from` returns and
-    // `finalize` commits — single-digit ms in tests, but give it 100ms
-    // for headroom.
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    let retry = store
-        .forget_record(&target, &alice())
-        .await
-        .expect("retry after lock released should succeed");
-    assert_eq!(
-        retry.deleted_count, 0,
-        "after the incumbent purged the records, the retry's in-txn \
-         SELECT must observe zero live rows. A regression to a pre-lock \
-         SELECT would let this still report `1` (the pre-lock count \
-         captured before the second forget could see the effect of the \
-         first)."
-    );
-}
+// Note on the deleted_count race fix: the strongest regression coverage
+// for the in-txn SELECT lives at the unit-test layer in
+// `record_wal/steps.rs::tests::mark_tombstone_count_is_captured_inside_transaction`.
+// That test calls `mark_tombstone_and_emit_receipt` directly against
+// transactions interleaved with an external commit, proving the count
+// is captured INSIDE the transaction (not via a pre-lock SELECT cached
+// outside it). Integration-level tests can't distinguish those two
+// implementations because the record-WAL locks fail-fast — no contender
+// reaches Phase A.

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -194,3 +194,79 @@ async fn forget_record_scrubs_wal_pre_image_blobs() {
         "no wal_steps.pre_image blob may reference the forgotten target id or body"
     );
 }
+
+// ── Task 11 ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn forget_record_emits_body_free_consent_receipt() {
+    use cairn_core::domain::{ConsentEvent, ConsentKind, ConsentPayload};
+
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+    let target = record.target_id.clone();
+
+    store.upsert(&record).await.expect("upsert");
+    let receipt = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("forget");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let op_id = receipt.op_id.clone();
+
+    let events: Vec<ConsentEvent> = conn
+        .call(move |c| {
+            cairn_store_sqlite::consent::query_by_op(c, &op_id)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("query consent");
+
+    assert_eq!(events.len(), 1, "exactly one ForgetIntent receipt per op");
+    let event = &events[0];
+    assert!(matches!(event.kind, ConsentKind::ForgetIntent));
+    match &event.payload {
+        ConsentPayload::IntentReceipt {
+            target_id_hash,
+            reason_code,
+            ..
+        } => {
+            assert_eq!(target_id_hash, &receipt.target_id_hash);
+            assert_eq!(reason_code, "user_command");
+        }
+        other => panic!("expected IntentReceipt payload, got {other:?}"),
+    }
+
+    // Defense-in-depth: the JSON wire form must not contain any body-bearing
+    // field NAME. Substring matching would false-positive on legitimate
+    // values (e.g. reason_code "user_command" contains "command"), so
+    // recurse the JSON value tree and check key names only — mirroring the
+    // canonical `forbids_body_bearing_field_names_anywhere` test in
+    // `cairn_core::domain::consent`.
+    let value = serde_json::to_value(event).expect("serialize event");
+    let mut keys = std::collections::BTreeSet::new();
+    collect_json_keys(&value, &mut keys);
+    for banned in ConsentEvent::BANNED_FIELDS {
+        assert!(
+            !keys.contains(*banned),
+            "consent event JSON must not contain banned field {banned}; saw keys {keys:?}"
+        );
+    }
+}
+
+fn collect_json_keys(value: &serde_json::Value, out: &mut std::collections::BTreeSet<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (k, v) in map {
+                out.insert(k.clone());
+                collect_json_keys(v, out);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_json_keys(item, out);
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -146,3 +146,51 @@ async fn forget_record_is_idempotent_under_repeat() {
         .expect("wal count");
     assert_eq!(count, 2, "both forget calls reach COMMITTED");
 }
+
+// ── Task 10 ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn forget_record_scrubs_wal_pre_image_blobs() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+    let target = record.target_id.clone();
+    let body = record.body.clone();
+
+    // First upsert seeds the row. Second upsert (with a mutated body)
+    // forces snapshot.stage to capture a pre_image referencing the
+    // target's lineage — the very blob we want to verify is body-free
+    // post-forget.
+    store.upsert(&record).await.expect("upsert v1");
+    let mut v2 = record.clone();
+    v2.body = format!("{body}-revised");
+    store.upsert(&v2).await.expect("upsert v2");
+
+    store
+        .forget_record(&target, &alice())
+        .await
+        .expect("forget");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let target_str = target.as_str().to_owned();
+    let body_str = body.clone();
+    let leaks: i64 = conn
+        .call(move |c| {
+            c.query_row(
+                "SELECT COUNT(*) FROM wal_steps \
+                  WHERE pre_image IS NOT NULL \
+                    AND ( \
+                          CAST(pre_image AS TEXT) LIKE '%' || ?1 || '%' \
+                       OR CAST(pre_image AS TEXT) LIKE '%' || ?2 || '%' \
+                    )",
+                rusqlite::params![target_str, body_str],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("scan");
+    assert_eq!(
+        leaks, 0,
+        "no wal_steps.pre_image blob may reference the forgotten target id or body"
+    );
+}

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -1,0 +1,102 @@
+//! Issue #58: record-level forget through body-bearing WAL.
+//!
+//! Engine-level integration coverage. The CLI/MCP/SDK dispatch wiring
+//! and the `wiring::FORGET_RECORD_WIRED` constant flip are deferred
+//! to issue #9; these tests call `SqliteMemoryStore::forget_record`
+//! directly to exercise the WAL apply path end-to-end.
+
+#![allow(missing_docs)]
+
+use cairn_core::contract::memory_store::{ForgetReceipt, KeywordSearchArgs, ListArgs, MemoryStore};
+use cairn_core::domain::{Identity, MemoryRecord};
+use cairn_store_sqlite::open_in_memory;
+
+fn sample() -> MemoryRecord {
+    cairn_core::domain::record::tests_export::sample_record()
+}
+
+fn alice() -> Identity {
+    Identity::parse("hmn:alice:v1").expect("identity")
+}
+
+fn make_keyword_args(query: &str, record: &MemoryRecord) -> KeywordSearchArgs<'static> {
+    KeywordSearchArgs {
+        query: query.to_owned(),
+        filter: None,
+        auth_scope: record.scope.clone(),
+        visibility_allowlist: vec![record.visibility],
+        limit: 10,
+        cursor: None,
+        with_explain: false,
+    }
+}
+
+// ── Task 8 ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn forget_record_removes_content_from_every_reader() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+    let target = record.target_id.clone();
+    let body = record.body.clone();
+
+    store.upsert(&record).await.expect("upsert seed record");
+
+    // Pre-condition: the seeded record is visible.
+    let pre_list = store
+        .list(&ListArgs {
+            limit: 10,
+            ..ListArgs::default()
+        })
+        .await
+        .expect("list pre");
+    assert_eq!(
+        pre_list.records.len(),
+        1,
+        "list returns the seeded record before forget"
+    );
+
+    let receipt: ForgetReceipt = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("forget_record");
+
+    // Post-condition 1: list / get_active_by_target return nothing.
+    let post_list = store
+        .list(&ListArgs {
+            limit: 10,
+            ..ListArgs::default()
+        })
+        .await
+        .expect("list post");
+    assert!(
+        post_list.records.is_empty(),
+        "list returns no rows after forget"
+    );
+
+    let post_active = store
+        .get_active_by_target(&target)
+        .await
+        .expect("get_active_by_target post");
+    assert!(post_active.is_none(), "no active record after forget");
+
+    // Post-condition 2: keyword search misses every body token.
+    let body_substr = body.split_whitespace().next().unwrap_or("user");
+    let kw_args = make_keyword_args(body_substr, &record);
+    let kw_page = store
+        .search_keyword(&kw_args)
+        .await
+        .expect("keyword search");
+    assert!(
+        kw_page.candidates.is_empty(),
+        "keyword search misses the forgotten body"
+    );
+
+    // Post-condition 3: receipt is body-free and well-shaped.
+    assert!(
+        receipt.target_id_hash.starts_with("sha256:"),
+        "receipt carries sha256-prefixed hash, not raw target id"
+    );
+    assert!(receipt.op_id.starts_with("forget_record-"));
+    assert!(receipt.purged_at > 0);
+}

--- a/crates/cairn-store-sqlite/tests/migrations.rs
+++ b/crates/cairn-store-sqlite/tests/migrations.rs
@@ -15,7 +15,7 @@ fn fresh_in_memory_opens_to_head() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 54);
+    assert_eq!(head, 55);
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn fresh_vault_opens_and_reopens_idempotent() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 54);
+    assert_eq!(head, 55);
 }
 
 #[test]

--- a/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
+++ b/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
@@ -101,3 +101,31 @@ async fn wal_payloads_kind_must_match_parent_operation() {
     .await
     .expect("kind-match assertion");
 }
+
+#[tokio::test]
+async fn migration_0055_widens_wal_payloads_kind_to_include_forget_record() {
+    let store = open_in_memory().await.expect("open in-memory store");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    // Insert a sentinel wal_ops row with kind=forget_record so the FK +
+    // trigger constraints are satisfied, then insert the matching payload
+    // under the widened CHECK introduced by migration 0055.
+    conn.call(|c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-mig-55', 1, 'forget_record', 'ISSUED', '{}', 'test', \
+                     'target', '{}', 0, 'sig', 1, 1)",
+            [],
+        )?;
+        c.execute(
+            "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+             VALUES ('op-mig-55', 'forget_record', '{}', 1)",
+            [],
+        )?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("forget_record payload insert succeeds under widened CHECK");
+}

--- a/docs/site/src/reference/generated/plugins.md
+++ b/docs/site/src/reference/generated/plugins.md
@@ -8,5 +8,5 @@ Generated from the bundled plugin registry.
 |---|---|---|---|---|
 | `cairn-mcp` | `MCPServer` | `[0.1.0, 0.2.0)` | `bundled:cairn-mcp` | `{"extensions":false,"http_streamable":false,"sse":false,"stdio":true}` |
 | `cairn-sensors-local` | `SensorIngress` | `[0.1.0, 0.2.0)` | `bundled:cairn-sensors-local` | `{"batches":false,"consent_aware":false,"streaming":false}` |
-| `cairn-store-sqlite` | `MemoryStore` | `[0.5.0, 0.6.0)` | `bundled:cairn-store-sqlite` | `{"fts":true,"graph_edges":true,"per_record_consent_model":true,"transactions":true,"vector":false}` |
+| `cairn-store-sqlite` | `MemoryStore` | `[0.5.0, 0.7.0)` | `bundled:cairn-store-sqlite` | `{"fts":true,"graph_edges":true,"per_record_consent_model":true,"transactions":true,"vector":false}` |
 | `cairn-workflows` | `WorkflowOrchestrator` | `[0.1.0, 0.2.0)` | `bundled:cairn-workflows` | `{"crash_safe":false,"cron_schedules":false,"durable":false}` |

--- a/docs/superpowers/plans/2026-05-09-issue-58-record-forget.md
+++ b/docs/superpowers/plans/2026-05-09-issue-58-record-forget.md
@@ -1,0 +1,1893 @@
+# Issue #58 — Record-level forget Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land record-level forget through the §5.6 WAL apply path so an engine-level call removes the target from records, FTS, vectors, edges, and WAL pre-images atomically (Phase A) and physically purges every body-bearing copy (Phase B) — leaving only a body-free `ForgetIntent` consent receipt.
+
+**Architecture:** Reuse the `record_wal` scaffold #57 added for upsert/expire. New `apply_forget_record` issues a `WalKind::ForgetRecord` op, acquires the same entity-exclusive / session-shared `RecordLocks`, persists a body-free `ForgetPayload`, then drives the seven-step `FORGET_RECORD_STEPS` graph (already declared in `cairn-core::wal::step_graph`). Phase A fuses tombstone + consent-journal append in one SQLite transaction; Phase B drains derived indexes, deletes records, scrubs `wal_steps.pre_image` blobs, and no-ops the cold-snapshot purge (no snapshot registry in P0).
+
+**Tech Stack:** Rust 1.95, `tokio_rusqlite`, `serde_json`, `sha2`, `tracing`, `cairn-core::wal::step_graph`, `cairn-core::domain::consent::{ConsentEvent, ConsentKind, ConsentPayload}`, existing `record_wal::{ops, locks, payload, steps, recovery}` module.
+
+**Out of scope (deferred):** CLI/MCP/SDK/skill dispatch wiring and the `wiring::FORGET_RECORD_WIRED` flip — those land in issue #9. The engine here is invoked directly by tests; production callers stay on the `CapabilityUnavailable` stub until #9 lands.
+
+---
+
+## File map
+
+**Create:**
+- `crates/cairn-store-sqlite/src/record_wal/forget.rs` — public `apply_forget_record` async entry.
+- `crates/cairn-store-sqlite/src/migrations/sql/0055_wal_payloads_forget.sql` — widen `wal_payloads.kind` CHECK constraint.
+- `crates/cairn-store-sqlite/src/store/forget.rs` — `SqliteMemoryStore::forget_record` inherent method.
+- `crates/cairn-store-sqlite/tests/forget_record.rs` — integration tests for happy path, idempotency, crash recovery, leakage, body-free receipt.
+
+**Modify:**
+- `crates/cairn-core/src/contract/memory_store.rs` — add `forget_record` trait method, `ForgetReceipt` struct, bump `CONTRACT_VERSION` to `0.6.0`.
+- `crates/cairn-store-sqlite/src/record_wal/payload.rs` — add `ForgetPayload`, `RecordWalPayload::Forget` variant, widen `save_payload` kind matcher.
+- `crates/cairn-store-sqlite/src/record_wal/steps.rs` — add `RecordStepBody::new_forget` constructor + six new step bodies.
+- `crates/cairn-store-sqlite/src/record_wal/recovery.rs` — handle `WalKind::ForgetRecord` in `RecordWalRegistry::body_for`.
+- `crates/cairn-store-sqlite/src/record_wal/mod.rs` — re-export `apply_forget_record`.
+- `crates/cairn-store-sqlite/src/store/mod.rs` — add `pub(crate) mod forget;` alongside `expire`.
+- `crates/cairn-store-sqlite/src/store/trait_impl.rs` — wire `MemoryStore::forget_record` onto `SqliteMemoryStore::forget_record`.
+- `crates/cairn-store-sqlite/src/migrations/loader.rs` (or wherever the migration list lives) — register `0055_wal_payloads_forget`.
+
+---
+
+## Task 1: Add `ForgetReceipt` and `forget_record` to the `MemoryStore` trait
+
+**Files:**
+- Modify: `crates/cairn-core/src/contract/memory_store.rs`
+
+**Why:** Define the contract surface the SQLite adapter implements. Default impl returns the not-supported sentinel so existing `FixtureStore` and registry stubs compile unchanged.
+
+- [ ] **Step 1: Read the current `CONTRACT_VERSION` doc comment**
+
+```bash
+sed -n '1,40p' crates/cairn-core/src/contract/memory_store.rs
+```
+
+Expected: see the version-bump narrative ending with `pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 5, 0);`
+
+- [ ] **Step 2: Bump the version constant and append a bump narrative paragraph**
+
+In `crates/cairn-core/src/contract/memory_store.rs`, replace `pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 5, 0);` with:
+
+```rust
+/// Bumped 0.5 → 0.6 in #58 when `MemoryStore::forget_record` and
+/// `ForgetReceipt` landed for the §5.6 record-level forget pipeline.
+/// Adding a new required trait method is a structural break for any
+/// downstream adapter that does not provide its own implementation —
+/// the default impl returns `"capability unavailable: forget_record"`
+/// so trait-object consumers compile, but the trait surface itself
+/// has grown.
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 6, 0);
+```
+
+(The existing 0.5 narrative paragraph stays above; this new paragraph immediately precedes the `pub const` line.)
+
+- [ ] **Step 3: Add `ForgetReceipt` immediately above `UpsertOutcome`**
+
+Locate `pub struct UpsertOutcome` (search for `/// Outcome of an `upsert` call`). Insert directly above it:
+
+```rust
+/// Outcome of a `forget_record` call (brief §14 forget-receipt allowlist).
+///
+/// Body-free by construction: only the salted target hash, the WAL op id,
+/// and the purge timestamp survive. The corresponding row in
+/// `consent_journal` carries the same `target_id_hash` and `op_id` so
+/// audits can join the two without exposing forgotten content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgetReceipt {
+    /// `sha256:<hex>` of the forgotten `target_id`.
+    pub target_id_hash: String,
+    /// WAL operation id that committed the forget.
+    pub op_id: String,
+    /// Unix milliseconds when Phase B step 5 (`primary.purge`) committed.
+    pub purged_at: i64,
+}
+```
+
+- [ ] **Step 4: Add the trait method with default impl**
+
+In the `impl MemoryStore for ...` trait (find `async fn tombstone(&self, id: &RecordId, reason: TombstoneReason) -> Result<(), StoreError>;`), insert immediately after that method:
+
+```rust
+    /// Record-level forget (brief §5.6 row 2, §14 audit invariant).
+    ///
+    /// Phase A tombstones every version of `target` with reason `Forget`
+    /// and fuses a body-free [`ConsentEvent`] receipt into the same
+    /// SQLite transaction. Phase B physically purges record rows,
+    /// derived indexes, and any WAL pre-image blob that referenced
+    /// the forgotten content. Idempotent and crash-safe at every step.
+    ///
+    /// `actor` is the resolved principal authoring the forget — the
+    /// engine writes it into `consent_journal.actor` for audit-keyed
+    /// queries. CLI/MCP/SDK callers (issue #9) pass the principal
+    /// resolved by the signed-envelope guard.
+    ///
+    /// Returns the body-free [`ForgetReceipt`] proving deletion.
+    ///
+    /// # Errors
+    /// Default impl returns `"capability unavailable: forget_record"`.
+    async fn forget_record(
+        &self,
+        target: &TargetId,
+        actor: &crate::domain::Identity,
+    ) -> Result<ForgetReceipt, StoreError> {
+        let _ = (target, actor);
+        Err("capability unavailable: forget_record".into())
+    }
+```
+
+Verify the `Identity` import path: `cairn_core::domain::Identity` is exported from `domain::mod`. If the existing module-level `use crate::domain::{...}` doesn't already include `Identity`, the fully-qualified `crate::domain::Identity` (as used above) compiles without imports churn.
+
+- [ ] **Step 5: Add `ForgetReceipt` to the in-file `StubStore` test**
+
+The file has a `#[cfg(test)] mod tests { ... }` block that uses a `StubStore` to verify trait shape (search for `impl MemoryStore for StubStore`). Default impl is fine — `StubStore` does not need to override `forget_record`. Confirm by:
+
+```bash
+grep -n "impl MemoryStore for StubStore" crates/cairn-core/src/contract/memory_store.rs
+```
+
+No edit required; the trait default carries `StubStore` through.
+
+- [ ] **Step 6: Update the contract-version assertion test**
+
+Find:
+
+```bash
+grep -n "CONTRACT_VERSION.*0.*5.*0\|CONTRACT_VERSION.*locked to 0\\.5" crates/cairn-core/src/contract/memory_store.rs
+```
+
+Expected output includes `/// `CONTRACT_VERSION` for the `MemoryStore` trait is locked to 0.5.0.` — change `0.5.0` to `0.6.0` in that doc comment, and update the assertion below it (the test calls `assert_eq!(CONTRACT_VERSION, ContractVersion::new(0, 5, 0))` or similar). Edit both to `0, 6, 0`.
+
+- [ ] **Step 7: Run `cairn-core` build to verify the trait compiles**
+
+```bash
+cargo check -p cairn-core --locked
+```
+
+Expected: `Finished` with no errors. Warnings about unused `actor` in the default impl are silenced by the `let _ = (target, actor);` line.
+
+- [ ] **Step 8: Run the contract-version unit test**
+
+```bash
+cargo nextest run -p cairn-core --locked contract::memory_store::tests
+```
+
+Expected: PASS (the version assertion now matches `0.6.0`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/cairn-core/src/contract/memory_store.rs
+git commit -m "feat(core): add MemoryStore::forget_record trait method (#58)
+
+Adds the engine-level contract for record-level forget per brief §5.6.
+Default impl returns the not-supported sentinel so existing adapters
+and trait-object consumers compile unchanged. ForgetReceipt is the
+body-free audit receipt {target_id_hash, op_id, purged_at} matching
+the §14 forget-receipt allowlist. Bumps CONTRACT_VERSION 0.5 → 0.6."
+```
+
+---
+
+## Task 2: Add migration `0055_wal_payloads_forget` widening the kind CHECK
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/migrations/sql/0055_wal_payloads_forget.sql`
+- Modify: `crates/cairn-store-sqlite/src/migrations/` (whichever file enumerates migrations)
+
+**Why:** `wal_payloads.kind` is currently `CHECK (kind IN ('upsert', 'expire'))`. The new `ForgetPayload` rows need `'forget_record'` to satisfy the constraint.
+
+- [ ] **Step 1: Find the migrations registration site**
+
+```bash
+grep -rn "0053_wal_payloads\|0054_records_cow_staging" crates/cairn-store-sqlite/src/migrations/ --include="*.rs"
+```
+
+Expected: locates the Rust list (likely `crates/cairn-store-sqlite/src/migrations/mod.rs` or `loader.rs`) where each `.sql` file is registered with its migration id.
+
+- [ ] **Step 2: Write the migration file**
+
+Create `crates/cairn-store-sqlite/src/migrations/sql/0055_wal_payloads_forget.sql`:
+
+```sql
+-- Migration 0055: widen wal_payloads.kind to allow forget_record.
+-- Issue #58: record-level forget needs a durable payload row keyed by
+-- operation_id, just like upsert and expire (added in 0053).
+
+-- SQLite cannot ALTER a CHECK constraint in place; recreate the table.
+CREATE TABLE wal_payloads_new (
+  operation_id TEXT NOT NULL PRIMARY KEY
+                    REFERENCES wal_ops(operation_id),
+  kind         TEXT NOT NULL CHECK (kind IN ('upsert', 'expire', 'forget_record')),
+  payload_json TEXT NOT NULL,
+  created_at   INTEGER NOT NULL
+);
+
+INSERT INTO wal_payloads_new SELECT * FROM wal_payloads;
+
+DROP TRIGGER IF EXISTS wal_payloads_kind_matches_wal;
+DROP TRIGGER IF EXISTS wal_payloads_immutable;
+DROP TRIGGER IF EXISTS wal_payloads_no_delete;
+DROP TABLE wal_payloads;
+ALTER TABLE wal_payloads_new RENAME TO wal_payloads;
+
+CREATE TRIGGER wal_payloads_kind_matches_wal
+  BEFORE INSERT ON wal_payloads
+  FOR EACH ROW
+  WHEN EXISTS (
+    SELECT 1
+      FROM wal_ops
+     WHERE operation_id = NEW.operation_id
+       AND kind IS NOT NEW.kind
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads.kind must match wal_ops.kind');
+END;
+
+CREATE TRIGGER wal_payloads_immutable
+  BEFORE UPDATE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads rows are immutable');
+END;
+
+CREATE TRIGGER wal_payloads_no_delete
+  BEFORE DELETE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads is append-only');
+END;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (55, '0055_wal_payloads_forget', '', strftime('%s','now') * 1000);
+```
+
+- [ ] **Step 3: Register the migration in the loader**
+
+Open the file located in Step 1. Find the existing `0054_records_cow_staging` line (search for `0054`) and append immediately after it the same shape of entry, e.g.:
+
+```rust
+include_migration!(55, "0055_wal_payloads_forget"),
+```
+
+Match the surrounding macro/struct exactly — if the project uses a `&[Migration { ... }]` slice, copy the prior entry's pattern verbatim with id `55` and the new file basename.
+
+- [ ] **Step 4: Run the migrations smoke test**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked migration_smoke
+```
+
+Expected: PASS. The smoke test opens an in-memory store, runs every migration in order, and asserts the final schema has no surprises. If the loader entry is wrong the test fails with a missing-migration error.
+
+- [ ] **Step 5: Verify the kind constraint was widened**
+
+Add an inline assertion in the migrations test file. Open `crates/cairn-store-sqlite/tests/migrations.rs`, find the existing `wal_payloads` assertions (search for `wal_payloads`), and append:
+
+```rust
+#[tokio::test]
+async fn migration_0055_widens_wal_payloads_kind_to_include_forget_record() {
+    let store = cairn_store_sqlite::open_in_memory().await.expect("open");
+    let conn = std::sync::Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    // Insert a sentinel wal_ops row with kind=forget_record so the FK +
+    // trigger constraints are satisfied, then insert the matching payload.
+    conn.call(|c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-mig-55', 1, 'forget_record', 'ISSUED', '{}', 'test', \
+                     'target', '{}', 0, 'sig', 1, 1)",
+            [],
+        )?;
+        c.execute(
+            "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+             VALUES ('op-mig-55', 'forget_record', '{}', 1)",
+            [],
+        )?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("forget_record payload insert succeeds under widened CHECK");
+}
+```
+
+- [ ] **Step 6: Run the new test**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked --test migrations migration_0055_widens_wal_payloads_kind_to_include_forget_record
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/migrations/sql/0055_wal_payloads_forget.sql \
+        crates/cairn-store-sqlite/src/migrations/ \
+        crates/cairn-store-sqlite/tests/migrations.rs
+git commit -m "feat(store): widen wal_payloads.kind for forget_record (#58)
+
+Adds migration 0055 recreating wal_payloads with the kind CHECK
+expanded to include 'forget_record'. Triggers are recreated unchanged.
+Existing rows are copied through the rename. Test exercises the new
+kind value end-to-end."
+```
+
+---
+
+## Task 3: Define `ForgetPayload` and the `RecordWalPayload::Forget` variant
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/record_wal/payload.rs`
+
+**Why:** Phase A and recovery both need a durable, body-free payload describing the forget op. Mirrors `ExpirePayload` shape.
+
+- [ ] **Step 1: Write the failing payload-shape test**
+
+Append to `crates/cairn-store-sqlite/src/record_wal/payload.rs` inside the existing `#[cfg(any(test, feature = "test-helpers"))]` test region (or append a new `#[cfg(test)] mod tests` block at the bottom if no test region exists yet):
+
+```rust
+#[cfg(test)]
+mod forget_payload_tests {
+    use super::*;
+    use cairn_core::domain::{Identity, MemoryVisibility, ScopeTuple, TargetId};
+
+    #[test]
+    fn forget_payload_round_trips_through_record_wal_payload() {
+        let target = TargetId::parse("01HQZX9F5N0000000000000000".to_owned())
+            .expect("valid target id");
+        let actor = Identity::parse("hmn:alice:v1".to_owned()).expect("valid identity");
+        let payload = ForgetPayload {
+            target_id: target.clone(),
+            scope: ScopeTuple::default(),
+            reason_code: "user_command".to_owned(),
+            actor: actor.clone(),
+            scope_tier: MemoryVisibility::Private,
+        };
+        let wrapped = RecordWalPayload::Forget(Box::new(payload.clone()));
+        let json = serde_json::to_string(&wrapped).expect("serialize");
+        let decoded: RecordWalPayload = serde_json::from_str(&json).expect("deserialize");
+        match decoded {
+            RecordWalPayload::Forget(p) => {
+                assert_eq!(p.target_id, target);
+                assert_eq!(p.actor, actor);
+                assert_eq!(p.scope_tier, MemoryVisibility::Private);
+                assert_eq!(p.reason_code, "user_command");
+            }
+            _ => panic!("expected Forget variant after round trip"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked record_wal::payload::forget_payload_tests
+```
+
+Expected: compile error — `ForgetPayload` undefined and `RecordWalPayload::Forget` variant missing.
+
+- [ ] **Step 3: Add `ForgetPayload` and the enum variant**
+
+In `crates/cairn-store-sqlite/src/record_wal/payload.rs`, locate the `pub enum RecordWalPayload` block:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RecordWalPayload {
+    Upsert(Box<UpsertPayload>),
+    Expire(Box<ExpirePayload>),
+}
+```
+
+Add the `Forget` variant:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RecordWalPayload {
+    Upsert(Box<UpsertPayload>),
+    Expire(Box<ExpirePayload>),
+    Forget(Box<ForgetPayload>),
+}
+```
+
+Below `pub struct ExpirePayload`, add:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ForgetPayload {
+    pub target_id: TargetId,
+    #[serde(default)]
+    pub scope: ScopeTuple,
+    pub reason_code: String,
+    pub actor: cairn_core::domain::Identity,
+    pub scope_tier: cairn_core::domain::taxonomy::MemoryVisibility,
+}
+```
+
+- [ ] **Step 4: Update `save_payload`'s kind-discrimination match**
+
+In the same file, find `pub(crate) fn save_payload(...)`. The match currently reads:
+
+```rust
+let kind = match payload {
+    RecordWalPayload::Upsert(_) => WalKind::Upsert.as_str(),
+    RecordWalPayload::Expire(_) => WalKind::Expire.as_str(),
+};
+```
+
+Change to:
+
+```rust
+let kind = match payload {
+    RecordWalPayload::Upsert(_) => WalKind::Upsert.as_str(),
+    RecordWalPayload::Expire(_) => WalKind::Expire.as_str(),
+    RecordWalPayload::Forget(_) => WalKind::ForgetRecord.as_str(),
+};
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked record_wal::payload::forget_payload_tests
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/payload.rs
+git commit -m "feat(store): add ForgetPayload and RecordWalPayload::Forget variant (#58)
+
+Body-free durable payload for record-level forget. Round-trip test
+verifies serde shape; save_payload now writes kind='forget_record'
+matching the widened CHECK constraint from migration 0055."
+```
+
+---
+
+## Task 4: Implement the six `forget_record` step bodies
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/record_wal/steps.rs`
+
+**Why:** The runner already drives `FORGET_RECORD_STEPS` once `RecordStepBody` knows how to dispatch each step name. This task adds the bodies — Phase A fuses tombstone + consent receipt; Phase B drains, deletes, scrubs pre-images, and no-ops the cold-snapshot purge.
+
+- [ ] **Step 1: Add a constructor for the forget variant**
+
+In `crates/cairn-store-sqlite/src/record_wal/steps.rs`, find:
+
+```rust
+pub(crate) enum RecordStepPayload {
+    Upsert(Box<UpsertPayload>),
+    Expire(Box<ExpirePayload>),
+}
+```
+
+Add the `Forget` variant:
+
+```rust
+pub(crate) enum RecordStepPayload {
+    Upsert(Box<UpsertPayload>),
+    Expire(Box<ExpirePayload>),
+    Forget(Box<ForgetPayload>),
+}
+```
+
+Update the `use` line at the top:
+
+```rust
+use crate::record_wal::payload::{ExpirePayload, ForgetPayload, StoredEmbedOutcome, UpsertPayload};
+```
+
+Add the constructor on `RecordStepBody`:
+
+```rust
+    #[must_use]
+    pub(crate) fn new_forget(payload: ForgetPayload, locks: RecordLocks) -> Self {
+        Self {
+            payload: RecordStepPayload::Forget(Box::new(payload)),
+            locks,
+        }
+    }
+```
+
+- [ ] **Step 2: Extend the dispatch match in `StepBody::run`**
+
+Find the `match (&self.payload, step.name) { ... }` block. Add the seven new arms (the snapshot.purge body is a no-op DONE) immediately before the catch-all `(RecordStepPayload::Upsert(_) | RecordStepPayload::Expire(_), _) => Ok(())` branch, and widen that catch-all to include `Forget`:
+
+```rust
+            (RecordStepPayload::Forget(payload), "primary.mark_tombstone") => {
+                mark_tombstone_and_emit_receipt(tx, op_id, payload)
+            }
+            (RecordStepPayload::Forget(payload), "vector.drain") => {
+                drain_vectors_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Forget(payload), "fts.drain") => {
+                drain_fts_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Forget(payload), "edges.drain") => {
+                drain_edges_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Forget(payload), "primary.purge") => {
+                primary_purge_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Forget(payload), "wal.purge_pre_images") => {
+                purge_wal_pre_images_for_target(tx, op_id, payload)
+            }
+            (RecordStepPayload::Forget(_), "snapshot.purge") => {
+                // P0: no .cairn/snapshots/ or nexus-data/ mirror exists
+                // (issue #109 lands the cold-storage layer). The bundle
+                // rewrite is a no-op until the snapshot registry exists.
+                Ok(())
+            }
+            (
+                RecordStepPayload::Upsert(_)
+                | RecordStepPayload::Expire(_)
+                | RecordStepPayload::Forget(_),
+                _,
+            ) => Ok(()),
+```
+
+- [ ] **Step 3: Refactor `expire`'s drain helpers into shared free functions**
+
+The existing `drain_vectors`, `drain_fts`, `drain_edges` take `&ExpirePayload`. Replace each with a target-id-keyed variant (so both expire and forget call the same code) and update the expire call sites.
+
+Locate `fn drain_vectors(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), StepBodyError>`. Rename and re-shape:
+
+```rust
+fn drain_vectors_for_target(tx: &Transaction<'_>, target: &str) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM record_vectors \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![target],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM pending_embeddings \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![target],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+```
+
+Do the same for `drain_fts` → `drain_fts_for_target(tx, target: &str)` and `drain_edges` → `drain_edges_for_target(tx, target: &str)`. Inline the logic from the existing helpers verbatim, swapping `payload.target_id.as_str()` for the new `target` parameter.
+
+Update the existing expire arms to call the renamed helpers:
+
+```rust
+            (RecordStepPayload::Expire(payload), "vector.drain") => {
+                drain_vectors_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Expire(payload), "fts.drain") => {
+                drain_fts_for_target(tx, payload.target_id.as_str())
+            }
+            (RecordStepPayload::Expire(payload), "edges.drain") => {
+                drain_edges_for_target(tx, payload.target_id.as_str())
+            }
+```
+
+Delete the original `drain_vectors`, `drain_fts`, `drain_edges` definitions.
+
+- [ ] **Step 4: Add `mark_tombstone_and_emit_receipt`**
+
+Append below the existing helpers in `steps.rs`:
+
+```rust
+fn mark_tombstone_and_emit_receipt(
+    tx: &mut Transaction<'_>,
+    op_id: &OperationId,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    use cairn_core::domain::{
+        ConsentEvent, ConsentKind, ConsentPayload, Rfc3339Timestamp,
+    };
+    use sha2::{Digest, Sha256};
+
+    let now_ms = crate::store::current_unix_ms();
+
+    // Brief §5.6 Phase A: tombstone every version of the target with
+    // reason='forget' and active=0. Idempotent — re-running after a
+    // crash re-applies the same UPDATE, no-op if rows are already in
+    // the target state.
+    tx.execute(
+        "UPDATE records \
+            SET active = 0, \
+                tombstoned = 1, \
+                tombstone_reason = 'forget', \
+                updated_at = ?1 \
+          WHERE target_id = ?2",
+        params![now_ms, payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+
+    // sha256 of the raw target id. P1 follow-up (brief §14) introduces
+    // a per-user salt; the receipt schema does not change.
+    let mut hasher = Sha256::new();
+    hasher.update(payload.target_id.as_str().as_bytes());
+    let hex = format!("{:x}", hasher.finalize());
+    let target_id_hash = format!("sha256:{hex}");
+    let subject_hash = format!("hash:{hex}");
+
+    let event = ConsentEvent {
+        consent_id: format!("CNS{}", ulid::Ulid::new()),
+        kind: ConsentKind::ForgetIntent,
+        actor: payload.actor.clone(),
+        subject: subject_hash,
+        scope: scope_canonical_wire(&payload.scope),
+        op_id: Some(op_id.as_str().to_owned()),
+        sensor_id: None,
+        payload: ConsentPayload::IntentReceipt {
+            target_id_hash,
+            scope_tier: payload.scope_tier,
+            reason_code: payload.reason_code.clone(),
+        },
+        decided_at: now_rfc3339_ms(now_ms),
+        expires_at: None,
+    };
+
+    crate::consent::append(&*tx, &event)
+        .map_err(|e| StepBodyError::Failed(format!("consent append: {e}")))?;
+    Ok(())
+}
+
+fn scope_canonical_wire(scope: &cairn_core::domain::ScopeTuple) -> String {
+    serde_json::to_string(scope).unwrap_or_else(|_| "{}".to_owned())
+}
+
+fn now_rfc3339_ms(unix_ms: i64) -> cairn_core::domain::Rfc3339Timestamp {
+    // Build "YYYY-MM-DDTHH:MM:SS.mmmZ" without pulling chrono. The
+    // pipeline::time module exposes a helper; reuse it.
+    cairn_core::time::rfc3339_from_unix_ms(unix_ms)
+        .expect("unix_ms always renders to a valid RFC3339 timestamp")
+}
+```
+
+If `cairn_core::time::rfc3339_from_unix_ms` does not exist (verify with `grep -n "rfc3339_from_unix_ms\|pub fn.*rfc3339" crates/cairn-core/src/time.rs`), inline a minimal builder:
+
+```rust
+fn now_rfc3339_ms(unix_ms: i64) -> cairn_core::domain::Rfc3339Timestamp {
+    let secs = unix_ms / 1000;
+    let millis = (unix_ms % 1000).max(0);
+    let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, (millis * 1_000_000) as u32)
+        .unwrap_or_else(|| chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).expect("epoch"));
+    let s = dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    cairn_core::domain::Rfc3339Timestamp::parse(s).expect("rfc3339 from chrono is valid")
+}
+```
+
+(Only add the `chrono` fallback if `cairn-store-sqlite` already depends on `chrono`. Run `grep -n '^chrono' crates/cairn-store-sqlite/Cargo.toml` — if absent, prefer the `cairn_core::time::*` path or add a tiny hand-rolled UTC builder mirroring `consent.rs::days_from_civil`.)
+
+- [ ] **Step 5: Add the `sha2` dep if not present**
+
+```bash
+grep -n '^sha2\|sha2 = ' crates/cairn-store-sqlite/Cargo.toml
+```
+
+If absent, add under `[dependencies]`:
+
+```toml
+sha2 = { workspace = true }
+```
+
+Verify the workspace already declares `sha2`:
+
+```bash
+grep -n 'sha2' Cargo.toml
+```
+
+If neither has it, add to the workspace `[workspace.dependencies]` first:
+
+```toml
+sha2 = "0.10"
+```
+
+then reference it from `cairn-store-sqlite/Cargo.toml`.
+
+- [ ] **Step 6: Add `primary_purge_for_target` and `purge_wal_pre_images_for_target`**
+
+Append to `steps.rs`:
+
+```rust
+fn primary_purge_for_target(tx: &Transaction<'_>, target: &str) -> Result<(), StepBodyError> {
+    // Re-run the index drains defensively — vector.drain / fts.drain /
+    // edges.drain may have completed in a prior crash window but the
+    // `idempotent: false` primary.purge step is the audit-invariant
+    // boundary, so we collapse all body-bearing rows here.
+    tx.execute(
+        "DELETE FROM record_vectors \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![target],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM pending_embeddings \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![target],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM records WHERE target_id = ?1",
+        params![target],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn purge_wal_pre_images_for_target(
+    tx: &mut Transaction<'_>,
+    self_op_id: &OperationId,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    use sha2::{Digest, Sha256};
+
+    let target = payload.target_id.as_str();
+
+    // Coarse prefilter: pull every wal_steps row whose pre_image blob
+    // mentions the target id. JSON parse below confirms containment so
+    // unrelated rows are not stubbed.
+    let needle = format!("%{target}%");
+    let rows: Vec<(String, u32, Vec<u8>)> = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT operation_id, step_ord, pre_image \
+                   FROM wal_steps \
+                  WHERE pre_image IS NOT NULL \
+                    AND CAST(pre_image AS TEXT) LIKE ?1",
+            )
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(params![needle], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, u32>(1)?,
+                row.get::<_, Vec<u8>>(2)?,
+            ))
+        })
+        .map_err(StepBodyError::Storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StepBodyError::Storage)?
+    };
+
+    let now_ms = crate::store::current_unix_ms();
+    let mut hasher = Sha256::new();
+    hasher.update(target.as_bytes());
+    let target_id_hash = format!("sha256:{:x}", hasher.finalize());
+
+    for (op_id, step_ord, pre_image) in rows {
+        // Confirm containment via JSON parse. The pre_image is a JSON
+        // array of {record_id, version, ...} entries (see
+        // `stage_snapshot`); we look for any entry whose record_id row
+        // belongs to this target. Cheaper proxy: the raw bytes contain
+        // the literal target id — the LIKE prefilter already verified
+        // this; no further parse needed.
+        let _ = serde_json::from_slice::<serde_json::Value>(&pre_image);
+        let stub = serde_json::json!({
+            "purged": true,
+            "target_id_hash": target_id_hash,
+            "op_id": self_op_id.as_str(),
+            "purged_at": now_ms,
+        });
+        let bytes = serde_json::to_vec(&stub)
+            .map_err(|e| StepBodyError::Failed(format!("stub json: {e}")))?;
+        tx.execute(
+            "UPDATE wal_steps \
+                SET pre_image = ?1 \
+              WHERE operation_id = ?2 AND step_ord = ?3",
+            params![bytes, op_id, step_ord],
+        )
+        .map_err(StepBodyError::Storage)?;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 7: Build to verify all helpers compile**
+
+```bash
+cargo check -p cairn-store-sqlite --locked
+```
+
+Expected: `Finished`. Fix any missing imports (likely `cairn_core::domain::{ConsentEvent, ConsentKind, ConsentPayload, Rfc3339Timestamp, ScopeTuple}` and `sha2::{Digest, Sha256}`).
+
+- [ ] **Step 8: Run existing expire tests to confirm refactor preserved behavior**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked cow_upsert_expire
+```
+
+Expected: every existing test still passes — the rename of `drain_*` → `drain_*_for_target` is a pure refactor.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/steps.rs \
+        crates/cairn-store-sqlite/Cargo.toml Cargo.toml
+git commit -m "feat(store): implement six forget_record step bodies (#58)
+
+Adds Phase A (mark_tombstone fused with body-free ForgetIntent receipt)
+and Phase B (vector/fts/edges drain, primary.purge, wal.purge_pre_images,
+snapshot.purge no-op). Refactors drain helpers shared with expire to
+take a target id directly. snapshot.purge stays a no-op until cold
+storage lands in #109. WAL pre-image scrub replaces matching blobs
+with a {target_id_hash, op_id, purged_at} stub satisfying the §5.6
+audit invariant."
+```
+
+---
+
+## Task 5: Implement `apply_forget_record` async entry
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/record_wal/forget.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/mod.rs`
+
+**Why:** Public entry point that issues the WAL op, locks, persists the payload, drives the runner, and returns the body-free receipt.
+
+- [ ] **Step 1: Create `forget.rs`**
+
+Write `crates/cairn-store-sqlite/src/record_wal/forget.rs`:
+
+```rust
+//! Public forget_record apply through record WAL.
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::ForgetReceipt;
+use cairn_core::domain::taxonomy::MemoryVisibility;
+use cairn_core::domain::{Identity, ScopeTuple, TargetId};
+use cairn_core::wal::{OpState, WalKind, graph_for};
+use rusqlite::OptionalExtension;
+use sha2::{Digest, Sha256};
+
+use crate::error::StoreError;
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::ops::{finalize, issue_prepared, new_operation_id};
+use crate::record_wal::payload::{ForgetPayload, RecordWalPayload, save_payload};
+use crate::record_wal::steps::RecordStepBody;
+use crate::store::SqliteMemoryStore;
+use crate::wal::runner::{self, StepBody};
+
+pub(crate) async fn apply_forget_record(
+    store: &SqliteMemoryStore,
+    target: &TargetId,
+    actor: &Identity,
+) -> Result<ForgetReceipt, StoreError> {
+    let conn = Arc::clone(store.require_conn("forget_record")?);
+    let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
+        what: "forget_record requires daemon incarnation".to_owned(),
+    })?;
+    let op_id = new_operation_id(WalKind::ForgetRecord)?;
+
+    let (scope, scope_tier) = load_scope_and_tier(&conn, target).await?;
+
+    let locks = acquire_for_record(
+        &conn,
+        &scope,
+        target,
+        &incarnation,
+        op_id.as_str(),
+        "record_wal_forget_record",
+    )
+    .await
+    .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
+
+    let payload = ForgetPayload {
+        target_id: target.clone(),
+        scope: scope.clone(),
+        reason_code: "user_command".to_owned(),
+        actor: actor.clone(),
+        scope_tier,
+    };
+    let payload_for_body = payload.clone();
+    let op_for_issue = op_id.clone();
+    let target_hash = target.as_str().to_owned();
+
+    conn.call(move |c| {
+        let tx = c.transaction()?;
+        issue_prepared(&tx, &op_for_issue, WalKind::ForgetRecord, &target_hash, "{}")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        save_payload(
+            &tx,
+            &op_for_issue,
+            &RecordWalPayload::Forget(Box::new(payload_for_body)),
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        tx.commit()?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+
+    let body: Arc<dyn StepBody> = Arc::new(RecordStepBody::new_forget(payload, locks));
+    runner::run_from(&conn, graph_for(WalKind::ForgetRecord), &op_id, 0, body).await?;
+
+    let purged_at = crate::store::current_unix_ms();
+    let op_for_finalize = op_id.clone();
+    conn.call(move |c| {
+        finalize(c, &op_for_finalize, OpState::Committed, "applied")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(target.as_str().as_bytes());
+    let target_id_hash = format!("sha256:{:x}", hasher.finalize());
+
+    Ok(ForgetReceipt {
+        target_id_hash,
+        op_id: op_id.as_str().to_owned(),
+        purged_at,
+    })
+}
+
+async fn load_scope_and_tier(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    target: &TargetId,
+) -> Result<(ScopeTuple, MemoryVisibility), StoreError> {
+    let target_id = target.as_str().to_owned();
+    Ok(conn
+        .call(move |c| {
+            let row: Option<(String, String)> = c
+                .query_row(
+                    "SELECT scope, visibility FROM records \
+                       WHERE target_id = ?1 \
+                       ORDER BY version DESC LIMIT 1",
+                    rusqlite::params![target_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()?;
+            let Some((scope_json, visibility)) = row else {
+                return Ok((ScopeTuple::default(), MemoryVisibility::Private));
+            };
+            let scope: ScopeTuple = serde_json::from_str(&scope_json)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            let tier: MemoryVisibility = MemoryVisibility::parse(&visibility)
+                .unwrap_or(MemoryVisibility::Private);
+            Ok((scope, tier))
+        })
+        .await?)
+}
+```
+
+(If `MemoryVisibility::parse` does not exist, replace with whichever from-string constructor the type exposes. Verify with `grep -n "fn parse\|fn from_str\|impl FromStr" crates/cairn-core/src/domain/taxonomy.rs`.)
+
+- [ ] **Step 2: Re-export from `record_wal/mod.rs`**
+
+In `crates/cairn-store-sqlite/src/record_wal/mod.rs`, add:
+
+```rust
+pub(crate) mod forget;
+```
+
+next to the existing `pub(crate) mod expire;`, and:
+
+```rust
+pub(crate) use forget::apply_forget_record;
+```
+
+next to the existing `pub(crate) use expire::apply_expire;`.
+
+- [ ] **Step 3: Build**
+
+```bash
+cargo check -p cairn-store-sqlite --locked
+```
+
+Expected: `Finished`. Common errors:
+- `MemoryVisibility::parse` missing → swap for whatever the type exposes (often `MemoryVisibility::from_str_lower` or `serde_json::from_str` against the JSON form).
+- `Identity` vs `Identity::parse` import — make sure `cairn_core::domain::Identity` is the alias.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/forget.rs \
+        crates/cairn-store-sqlite/src/record_wal/mod.rs
+git commit -m "feat(store): apply_forget_record async entry through record WAL (#58)
+
+Issues a WalKind::ForgetRecord op, acquires the same lineage/entity/
+session locks as upsert and expire, persists a body-free ForgetPayload,
+runs the seven-step graph, and returns a ForgetReceipt. Reads the
+active record's scope and visibility tier inside the WAL prep so
+recovery can rebuild the receipt from the persisted payload."
+```
+
+---
+
+## Task 6: Wire `apply_forget_record` into `SqliteMemoryStore` and the `MemoryStore` trait
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/store/forget.rs`
+- Modify: `crates/cairn-store-sqlite/src/store/mod.rs`
+- Modify: `crates/cairn-store-sqlite/src/store/trait_impl.rs`
+
+**Why:** Adapters expose verbs through inherent methods (`do_*` or directly named); the trait impl thin-wraps them. This task connects the WAL apply to the public surface.
+
+- [ ] **Step 1: Create `store/forget.rs`**
+
+Write `crates/cairn-store-sqlite/src/store/forget.rs`:
+
+```rust
+//! Concrete forget_record API for record-level forget through the record WAL.
+
+use cairn_core::contract::memory_store::ForgetReceipt;
+use cairn_core::domain::{Identity, TargetId};
+use tracing::instrument;
+
+use crate::error::StoreError;
+use crate::store::SqliteMemoryStore;
+
+impl SqliteMemoryStore {
+    /// Phase A tombstone + body-free receipt, then Phase B physical purge
+    /// across vectors, FTS, edges, primary rows, and WAL pre-images.
+    /// Idempotent and crash-safe; returns the §14 forget-receipt
+    /// allowlist {`target_id_hash`, `op_id`, `purged_at`}.
+    ///
+    /// # Errors
+    ///
+    /// Returns store, lock, WAL runner, or recovery-shape errors.
+    #[instrument(
+        skip(self, actor),
+        err,
+        fields(verb = "forget_record", target_id = %target.as_str(), actor = %actor.as_str()),
+    )]
+    pub async fn forget_record(
+        &self,
+        target: &TargetId,
+        actor: &Identity,
+    ) -> Result<ForgetReceipt, StoreError> {
+        if self.conn.is_none() {
+            return Err(StoreError::NotInitialized {
+                method: "forget_record",
+            });
+        }
+        crate::record_wal::apply_forget_record(self, target, actor).await
+    }
+}
+```
+
+- [ ] **Step 2: Register the new module**
+
+In `crates/cairn-store-sqlite/src/store/mod.rs`, add:
+
+```rust
+pub(crate) mod forget;
+```
+
+immediately after `pub(crate) mod expire;`.
+
+- [ ] **Step 3: Wire the trait method**
+
+In `crates/cairn-store-sqlite/src/store/trait_impl.rs`, find the `async fn tombstone(...)` impl. Insert immediately after it:
+
+```rust
+    async fn forget_record(
+        &self,
+        target: &TargetId,
+        actor: &cairn_core::domain::Identity,
+    ) -> Result<cairn_core::contract::memory_store::ForgetReceipt, StoreError> {
+        if self.conn.is_none() {
+            return not_initialized("forget_record");
+        }
+        self.forget_record(target, actor).await.map_err(Into::into)
+    }
+```
+
+Update the `use cairn_core::contract::memory_store::{ ... }` import block at the top to add `ForgetReceipt` to the brace list.
+
+- [ ] **Step 4: Build**
+
+```bash
+cargo check -p cairn-store-sqlite --locked
+```
+
+Expected: `Finished`.
+
+- [ ] **Step 5: Run the full store test suite to verify nothing regressed**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked
+```
+
+Expected: PASS — no test in this crate exercises `forget_record` yet, so existing coverage is unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/store/forget.rs \
+        crates/cairn-store-sqlite/src/store/mod.rs \
+        crates/cairn-store-sqlite/src/store/trait_impl.rs
+git commit -m "feat(store): wire SqliteMemoryStore::forget_record (#58)
+
+Inherent SqliteMemoryStore::forget_record delegates to the record WAL
+apply path; trait impl thin-wraps it. NotInitialized guard mirrors
+the upsert and expire pattern."
+```
+
+---
+
+## Task 7: Recovery shim — handle `WalKind::ForgetRecord` in `RecordWalRegistry`
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/record_wal/recovery.rs`
+
+**Why:** Boot-time WAL recovery walks every PREPARED op and resumes step execution from the last DONE step. Without a registry entry, a crashed `forget_record` op would never recover.
+
+- [ ] **Step 1: Extend the kind matcher**
+
+In `crates/cairn-store-sqlite/src/record_wal/recovery.rs`, find:
+
+```rust
+        match kind {
+            WalKind::Upsert | WalKind::Expire => {}
+            _ => return Ok(None),
+        }
+```
+
+Change to:
+
+```rust
+        match kind {
+            WalKind::Upsert | WalKind::Expire | WalKind::ForgetRecord => {}
+            _ => return Ok(None),
+        }
+```
+
+- [ ] **Step 2: Add the dispatch arm**
+
+In the same function, find the `match (kind, payload) { ... }` block. Add the forget arm after the existing upsert and expire arms (before the mismatch error arms):
+
+```rust
+            (WalKind::ForgetRecord, RecordWalPayload::Forget(payload)) => {
+                let locks = acquire_for_record(
+                    conn,
+                    &payload.scope,
+                    &payload.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_forget_record",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_forget(*payload, locks))))
+            }
+```
+
+Add three new mismatch arms so a payload/kind mismatch fails closed instead of falling through:
+
+```rust
+            (WalKind::Upsert, RecordWalPayload::Forget(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant forget does not match wal kind upsert".to_owned(),
+            )),
+            (WalKind::Expire, RecordWalPayload::Forget(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant forget does not match wal kind expire".to_owned(),
+            )),
+            (WalKind::ForgetRecord, RecordWalPayload::Upsert(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant upsert does not match wal kind forget_record".to_owned(),
+            )),
+            (WalKind::ForgetRecord, RecordWalPayload::Expire(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant expire does not match wal kind forget_record".to_owned(),
+            )),
+```
+
+(The trailing `_ => Ok(None)` arm stays as the catch-all for kinds returning `None` at the top filter.)
+
+- [ ] **Step 3: Build**
+
+```bash
+cargo check -p cairn-store-sqlite --locked
+```
+
+Expected: `Finished`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/recovery.rs
+git commit -m "feat(store): recover prepared forget_record ops (#58)
+
+RecordWalRegistry now resolves a step body for WalKind::ForgetRecord
+during boot-time WAL recovery. Locks reacquire under the recovery
+holder name; mismatched payload variants fail closed via Invariant."
+```
+
+---
+
+## Task 8: Integration test — happy-path forget removes content from every reader
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+**Why:** The acceptance criteria require that record-level forget removes content from retrieve / search / markdown / derived indexes. This test exercises the full Phase A + Phase B pipeline against a real schema and verifies every reader misses.
+
+- [ ] **Step 1: Write the failing happy-path test**
+
+Create `crates/cairn-store-sqlite/tests/forget_record.rs`:
+
+```rust
+//! Issue #58: record-level forget through body-bearing WAL.
+
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::{ForgetReceipt, KeywordSearchArgs, ListArgs, MemoryStore};
+use cairn_core::domain::{Identity, MemoryRecord, TargetId};
+use cairn_store_sqlite::open_in_memory;
+
+fn sample() -> MemoryRecord {
+    cairn_core::domain::record::tests_export::sample_record()
+}
+
+fn alice() -> Identity {
+    Identity::parse("hmn:alice:v1".to_owned()).expect("identity")
+}
+
+#[tokio::test]
+async fn forget_record_removes_content_from_every_reader() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+    let target = record.target_id.clone();
+    let body = record.body.clone();
+
+    store.upsert(&record).await.expect("upsert seed record");
+
+    // Pre-condition: every reader sees the record.
+    let pre_list = store
+        .list(&ListArgs {
+            limit: 10,
+            ..ListArgs::default()
+        })
+        .await
+        .expect("list pre");
+    assert_eq!(
+        pre_list.records.len(),
+        1,
+        "list returns the seeded record before forget"
+    );
+
+    let receipt: ForgetReceipt = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("forget_record");
+
+    // Post-condition 1: list, get_active_by_target return nothing.
+    let post_list = store
+        .list(&ListArgs {
+            limit: 10,
+            ..ListArgs::default()
+        })
+        .await
+        .expect("list post");
+    assert!(post_list.records.is_empty(), "list returns no rows after forget");
+
+    let post_active = store
+        .get_active_by_target(&target)
+        .await
+        .expect("get_active_by_target post");
+    assert!(post_active.is_none(), "no active record after forget");
+
+    // Post-condition 2: keyword search misses every body token.
+    let body_substr = body.split_whitespace().next().unwrap_or("hello");
+    let kw_args = KeywordSearchArgs::default_for_query(body_substr);
+    let kw_page = store.search_keyword(&kw_args).await.expect("keyword search");
+    assert!(
+        kw_page.candidates.is_empty(),
+        "keyword search misses the forgotten body"
+    );
+
+    // Post-condition 3: receipt is body-free and well-shaped.
+    assert!(
+        receipt.target_id_hash.starts_with("sha256:"),
+        "receipt carries sha256-prefixed hash, not raw target id"
+    );
+    assert!(receipt.op_id.starts_with("forget_record-"));
+    assert!(receipt.purged_at > 0);
+}
+```
+
+(If `KeywordSearchArgs::default_for_query` does not exist, build it inline — search the existing tests for `KeywordSearchArgs {` to find the canonical construction shape.)
+
+- [ ] **Step 2: Run the test to verify it fails for the right reason**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked --test forget_record forget_record_removes_content_from_every_reader
+```
+
+Expected: PASS (Tasks 1–7 already implement the engine). If it fails, the failure should be in the post-condition assertions, not in compilation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "test(store): forget_record clears every reader (#58)
+
+End-to-end smoke test seeds a record, calls forget_record, and asserts
+that list, get_active_by_target, and keyword search all miss while
+the body-free ForgetReceipt is well-shaped."
+```
+
+---
+
+## Task 9: Integration test — idempotent re-forget is safe
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+- [ ] **Step 1: Append the idempotency test**
+
+Append to `crates/cairn-store-sqlite/tests/forget_record.rs`:
+
+```rust
+#[tokio::test]
+async fn forget_record_is_idempotent_under_repeat() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+    let target = record.target_id.clone();
+
+    store.upsert(&record).await.expect("upsert");
+
+    let r1 = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("first forget");
+
+    // Second call against the already-forgotten target. Records table is
+    // empty, but the WAL apply path should still succeed: tombstone +
+    // drains + purge are all no-ops, snapshot.purge stays no-op, and the
+    // receipt comes back with the same target_id_hash.
+    let r2 = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("second forget");
+
+    assert_eq!(r1.target_id_hash, r2.target_id_hash);
+    assert_ne!(r1.op_id, r2.op_id, "every call mints a fresh op_id");
+
+    // Verify two COMMITTED forget_record ops landed in wal_ops.
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let count: i64 = conn
+        .call(|c| {
+            c.query_row(
+                "SELECT COUNT(*) FROM wal_ops \
+                  WHERE kind = 'forget_record' AND state = 'COMMITTED'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("wal count");
+    assert_eq!(count, 2, "both forget calls reach COMMITTED");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked --test forget_record forget_record_is_idempotent_under_repeat
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "test(store): idempotent re-forget commits a second WAL op (#58)
+
+Calling forget_record twice on the same target returns matching
+target_id_hash and lands two distinct COMMITTED wal_ops rows. Confirms
+Phase A and Phase B step bodies behave as no-ops on already-purged
+state."
+```
+
+---
+
+## Task 10: Integration test — WAL pre-image scrub leaves no body bytes
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+- [ ] **Step 1: Append the leakage test**
+
+Append:
+
+```rust
+#[tokio::test]
+async fn forget_record_scrubs_wal_pre_image_blobs() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+    let target = record.target_id.clone();
+    let body = record.body.clone();
+
+    // First upsert seeds the row. Second upsert (with a mutated body)
+    // forces the snapshot.stage step to capture a pre_image referencing
+    // the target id — the very blob we need to verify is scrubbed.
+    store.upsert(&record).await.expect("upsert v1");
+    let mut v2 = record.clone();
+    v2.body = format!("{body}-revised");
+    store.upsert(&v2).await.expect("upsert v2");
+
+    store
+        .forget_record(&target, &alice())
+        .await
+        .expect("forget");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let target_str = target.as_str().to_owned();
+    let body_str = body.clone();
+    let leaks: i64 = conn
+        .call(move |c| {
+            c.query_row(
+                "SELECT COUNT(*) FROM wal_steps \
+                  WHERE pre_image IS NOT NULL \
+                    AND ( \
+                          CAST(pre_image AS TEXT) LIKE '%' || ?1 || '%' \
+                       OR CAST(pre_image AS TEXT) LIKE '%' || ?2 || '%' \
+                    )",
+                rusqlite::params![target_str, body_str],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("scan");
+    assert_eq!(
+        leaks, 0,
+        "no wal_steps.pre_image blob may reference the forgotten target id or body"
+    );
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked --test forget_record forget_record_scrubs_wal_pre_image_blobs
+```
+
+Expected: PASS. If it fails because pre_image rows still contain the target id, the `purge_wal_pre_images_for_target` body's LIKE prefilter or stub-write SQL needs investigation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "test(store): forget scrubs every wal_steps.pre_image referencing target (#58)
+
+Brief §5.6 audit invariant: after Phase B step 5, no wal_steps row may
+contain the forgotten body or target id. Test stages two upserts (so
+the second's snapshot.stage captures a v1 pre_image), then forgets and
+greps the pre_image blobs for either the target id or any body bytes."
+```
+
+---
+
+## Task 11: Integration test — body-free `ForgetIntent` consent receipt
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+- [ ] **Step 1: Append the receipt-shape test**
+
+Append:
+
+```rust
+#[tokio::test]
+async fn forget_record_emits_body_free_consent_receipt() {
+    use cairn_core::domain::{ConsentEvent, ConsentKind, ConsentPayload};
+
+    let store = open_in_memory().await.expect("open");
+    let record = sample();
+    let target = record.target_id.clone();
+
+    store.upsert(&record).await.expect("upsert");
+    let receipt = store
+        .forget_record(&target, &alice())
+        .await
+        .expect("forget");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let op_id = receipt.op_id.clone();
+
+    let events: Vec<ConsentEvent> = conn
+        .call(move |c| {
+            cairn_store_sqlite::consent::query_by_op(c, &op_id)
+                .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("query consent");
+
+    assert_eq!(events.len(), 1, "exactly one ForgetIntent receipt per op");
+    let event = &events[0];
+    assert!(matches!(event.kind, ConsentKind::ForgetIntent));
+    match &event.payload {
+        ConsentPayload::IntentReceipt {
+            target_id_hash,
+            reason_code,
+            ..
+        } => {
+            assert_eq!(target_id_hash, &receipt.target_id_hash);
+            assert_eq!(reason_code, "user_command");
+        }
+        other => panic!("expected IntentReceipt payload, got {other:?}"),
+    }
+
+    // Defense-in-depth: the JSON wire form may not contain any of the
+    // banned body-bearing field names.
+    let json = serde_json::to_string(event).expect("serialize event");
+    for banned in ConsentEvent::BANNED_FIELDS {
+        assert!(
+            !json.contains(banned),
+            "consent event JSON must not contain banned field {banned}"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked --test forget_record forget_record_emits_body_free_consent_receipt
+```
+
+Expected: PASS. A failure typically means either the consent insert in `mark_tombstone_and_emit_receipt` did not commit, or the payload field shape diverged from `ConsentPayload::IntentReceipt`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "test(store): ForgetIntent receipt is body-free and joinable to op (#58)
+
+Verifies (1) exactly one ConsentKind::ForgetIntent row lands per
+forget op, (2) the payload's target_id_hash matches the receipt's,
+(3) the JSON wire form contains none of ConsentEvent::BANNED_FIELDS."
+```
+
+---
+
+## Task 12: Integration test — crash recovery during Phase A is all-or-nothing
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+**Why:** Phase A is a single SQLite transaction (tombstone + consent receipt). A crash before commit must leave no observable state.
+
+- [ ] **Step 1: Read the existing crash-recovery test patterns from the expire suite**
+
+```bash
+grep -n "prepared_expire_recovers\|tempfile::tempdir\|let path =" crates/cairn-store-sqlite/tests/cow_upsert_expire.rs | head -20
+```
+
+Expected: locates the pattern of opening a file-backed store, persisting a PREPARED row out of band, dropping the connection, reopening, and asserting recovery behavior.
+
+- [ ] **Step 2: Append the Phase A recovery test**
+
+Append to `crates/cairn-store-sqlite/tests/forget_record.rs`:
+
+```rust
+#[tokio::test]
+async fn forget_record_phase_a_crash_leaves_no_state() {
+    use cairn_core::wal::{OperationId, WalKind};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+
+    {
+        let store = cairn_store_sqlite::open(&path).await.expect("open");
+        store.upsert(&sample()).await.expect("upsert seed");
+
+        // Stage a PREPARED forget_record op + payload but skip the step
+        // runner so Phase A never commits its tombstone.
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let target_str = sample().target_id.as_str().to_owned();
+        let payload_json = serde_json::to_string(
+            &cairn_store_sqlite::record_wal::payload::RecordWalPayload::Forget(Box::new(
+                cairn_store_sqlite::record_wal::payload::ForgetPayload {
+                    target_id: sample().target_id,
+                    scope: sample().scope,
+                    reason_code: "user_command".to_owned(),
+                    actor: alice(),
+                    scope_tier: cairn_core::domain::taxonomy::MemoryVisibility::Private,
+                },
+            )),
+        )
+        .expect("serialize");
+        conn.call(move |c| {
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES ('op-crash-58', \
+                         COALESCE((SELECT MAX(issued_seq) FROM wal_ops),0)+1, \
+                         'forget_record','PREPARED','{}','test', \
+                         ?1, '{}', 0, 'sig', 1, 1)",
+                rusqlite::params![target_str],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES ('op-crash-58', 'forget_record', ?1, 1)",
+                rusqlite::params![payload_json],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed PREPARED op");
+    } // drop store — simulates crash before Phase A txn could commit on its own
+
+    // Reopen and assert recovery completes the prepared op.
+    let store = cairn_store_sqlite::open(&path).await.expect("reopen");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let state: String = conn
+        .call(|c| {
+            c.query_row(
+                "SELECT state FROM wal_ops WHERE operation_id = 'op-crash-58'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("read op state");
+    assert_eq!(
+        state, "COMMITTED",
+        "boot-time recovery resumed the prepared forget op to COMMITTED"
+    );
+
+    // The seed record must be gone from every reader after recovery.
+    let post = store
+        .get_active_by_target(&sample().target_id)
+        .await
+        .expect("post lookup");
+    assert!(post.is_none(), "recovered forget purges the target");
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked --test forget_record forget_record_phase_a_crash_leaves_no_state
+```
+
+Expected: PASS. If it fails on the recovery state assertion, check that `RecordWalRegistry` is registered in the boot path (open.rs or the migration applier — search for `RecordWalRegistry` to confirm it's plugged in).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "test(store): boot recovery completes a prepared forget_record (#58)
+
+Stages a PREPARED forget_record op with payload, drops the store
+without running Phase A, reopens, and asserts boot-time recovery
+drives the op to COMMITTED and purges the target from every reader."
+```
+
+---
+
+## Task 13: Integration test — Phase B crash recovery resumes from last DONE step
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+**Why:** Spec §8 test #4 — Phase A may have committed the tombstone + receipt, then a crash leaves Phase B half-run. Recovery must resume from the next PENDING step and reach COMMITTED.
+
+- [ ] **Step 1: Append the Phase B recovery test**
+
+Append:
+
+```rust
+#[tokio::test]
+async fn forget_record_phase_b_crash_resumes_from_last_done_step() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+
+    let target = sample().target_id.clone();
+
+    {
+        let store = cairn_store_sqlite::open(&path).await.expect("open");
+        store.upsert(&sample()).await.expect("upsert seed");
+
+        // Stage a PREPARED forget op + payload + a wal_steps row
+        // marking step 0 (primary.mark_tombstone) DONE. Apply the
+        // tombstone manually so the on-disk state matches "Phase A
+        // commit succeeded, crashed before step 1."
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let target_str = target.as_str().to_owned();
+        let payload_json = serde_json::to_string(
+            &cairn_store_sqlite::record_wal::payload::RecordWalPayload::Forget(Box::new(
+                cairn_store_sqlite::record_wal::payload::ForgetPayload {
+                    target_id: target.clone(),
+                    scope: sample().scope,
+                    reason_code: "user_command".to_owned(),
+                    actor: alice(),
+                    scope_tier: cairn_core::domain::taxonomy::MemoryVisibility::Private,
+                },
+            )),
+        )
+        .expect("serialize");
+        let target_for_tx = target_str.clone();
+        conn.call(move |c| {
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES ('op-phaseb-58', \
+                         COALESCE((SELECT MAX(issued_seq) FROM wal_ops),0)+1, \
+                         'forget_record','PREPARED','{}','test', \
+                         ?1, '{}', 0, 'sig', 1, 1)",
+                rusqlite::params![target_for_tx],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES ('op-phaseb-58', 'forget_record', ?1, 1)",
+                rusqlite::params![payload_json],
+            )?;
+            // Mark step 0 DONE so recovery resumes from step 1.
+            c.execute(
+                "INSERT INTO wal_steps \
+                   (operation_id, step_ord, step_kind, state, attempts, \
+                    started_at, finished_at) \
+                 VALUES ('op-phaseb-58', 0, 'primary.mark_tombstone', 'DONE', 1, 1, 2)",
+                [],
+            )?;
+            // Apply the tombstone effect of step 0 directly.
+            c.execute(
+                "UPDATE records \
+                    SET active = 0, tombstoned = 1, tombstone_reason = 'forget' \
+                  WHERE target_id = ?1",
+                rusqlite::params![target_for_tx],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed half-run state");
+    }
+
+    // Reopen — recovery picks up the prepared op and runs steps 1–6.
+    let store = cairn_store_sqlite::open(&path).await.expect("reopen");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let (state, done_steps): (String, i64) = conn
+        .call(|c| {
+            let s: String = c.query_row(
+                "SELECT state FROM wal_ops WHERE operation_id = 'op-phaseb-58'",
+                [],
+                |row| row.get(0),
+            )?;
+            let n: i64 = c.query_row(
+                "SELECT COUNT(*) FROM wal_steps \
+                  WHERE operation_id = 'op-phaseb-58' AND state = 'DONE'",
+                [],
+                |row| row.get(0),
+            )?;
+            Ok((s, n))
+        })
+        .await
+        .expect("query state");
+
+    assert_eq!(state, "COMMITTED", "recovery drove the prepared op to COMMITTED");
+    assert_eq!(
+        done_steps, 7,
+        "every step in FORGET_RECORD_STEPS reached DONE during recovery"
+    );
+
+    // Records are physically gone after Phase B completes.
+    let row_count: i64 = conn
+        .call(move |c| {
+            c.query_row(
+                "SELECT COUNT(*) FROM records WHERE target_id = ?1",
+                rusqlite::params![target.as_str().to_owned()],
+                |row| row.get(0),
+            )
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
+        })
+        .await
+        .expect("scan records");
+    assert_eq!(row_count, 0, "Phase B primary.purge ran during recovery");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+cargo nextest run -p cairn-store-sqlite --locked --test forget_record forget_record_phase_b_crash_resumes_from_last_done_step
+```
+
+Expected: PASS. Common failure mode: the recovery boot path does not register `RecordWalRegistry`. Find where `RecordWalRegistry::new` is wired (likely `crates/cairn-store-sqlite/src/open.rs`) and confirm it is constructed before the recovery scan runs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "test(store): forget Phase B recovery resumes from last DONE step (#58)
+
+Seeds an op-phaseb-58 row with primary.mark_tombstone marked DONE and
+the tombstone effect applied, mimicking a crash mid-Phase-B. After
+reopen, all seven steps reach DONE, the op commits, and the records
+table is physically empty for the target."
+```
+
+---
+
+## Task 14: Run the full verification checklist before opening the PR
+
+**Files:** None — verification only.
+
+**Why:** CLAUDE.md §8 specifies the commands CI runs. Run them locally so the PR doesn't bounce.
+
+- [ ] **Step 1: Format and clippy**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+```
+
+Expected: both succeed. If clippy flags `pedantic` issues in the new code, fix them inline (no local `#[allow]` without a one-line justification per CLAUDE.md §6.8).
+
+- [ ] **Step 2: Workspace check + test run**
+
+```bash
+cargo check --workspace --all-targets --locked
+cargo nextest run --workspace --locked --no-fail-fast
+cargo test --doc --workspace --locked
+```
+
+Expected: all green. If a `cairn-core` doctest references the old contract version, update it to `0.6.0`.
+
+- [ ] **Step 3: Core boundary check**
+
+```bash
+./scripts/check-core-boundary.sh
+```
+
+Expected: passes. `cairn-core` only added types and a trait method — no new dependencies on adapter crates.
+
+- [ ] **Step 4: IDL codegen no-diff check**
+
+```bash
+cargo run -p cairn-idl --bin cairn-codegen --locked -- --check
+```
+
+Expected: no diff. The IDL was not touched (the wire schema for `forget` already exists from prior work).
+
+- [ ] **Step 5: Docs**
+
+```bash
+cargo run -p cairn-cli --bin cairn-docgen --locked -- --check
+RUSTDOCFLAGS="-D warnings -D rustdoc::broken-intra-doc-links" \
+  cargo doc --workspace --no-deps --document-private-items --locked
+```
+
+Expected: no diff for docgen, no warnings from rustdoc. New doc comments on `ForgetReceipt` and `MemoryStore::forget_record` need to be intra-doc-link safe.
+
+- [ ] **Step 6: Supply chain**
+
+```bash
+cargo deny check
+cargo audit --deny warnings
+cargo machete
+```
+
+Expected: pass. `sha2` is the only potential new dep; if `cargo machete` flags it as unused, recheck the import in `steps.rs::mark_tombstone_and_emit_receipt`.
+
+- [ ] **Step 7: Done — open the PR**
+
+When every check above is green, open the PR with:
+- Title: `feat(store): record-level forget engine through WAL apply (#58)`
+- Body: link issue #58, cite brief sections §5.6, §14, §15, §18.c US8; list invariants 5 (WAL two-phase apply) and 9 (privacy by construction) as the two touched; paste the green output of Step 2.
+
+---
+
+## Self-review notes (informational, not part of execution)
+
+- **Spec coverage:** Tasks 1–11 cover spec §§5–8 directly. Spec §9 (migration safety) is exercised by Task 2's `migration_smoke` rerun and the new `migration_0055_widens...` test. Spec §10 (open follow-ups) is correctly out of scope.
+- **Type consistency:** `ForgetReceipt` (Task 1), `ForgetPayload` (Task 3), `RecordStepBody::new_forget` (Task 4), `apply_forget_record` (Task 5), `SqliteMemoryStore::forget_record` (Task 6), trait method (Task 6), and registry arm (Task 7) all use the same `target: &TargetId, actor: &Identity` shape and the same `target_id_hash = "sha256:" + hex(sha256(target_id))` derivation.
+- **No CLI/MCP/SDK churn:** Per the spec rescope, no surface tests are touched. `wiring::FORGET_RECORD_WIRED` stays `false`. Issue #9 owns the surface flip.

--- a/docs/superpowers/specs/2026-05-09-issue-58-record-forget-design.md
+++ b/docs/superpowers/specs/2026-05-09-issue-58-record-forget-design.md
@@ -1,0 +1,213 @@
+# Record-level forget — design
+
+- **Issue:** [#58](https://github.com/windoliver/cairn/issues/58)
+- **Parent epic:** [#8](https://github.com/windoliver/cairn/issues/8) WAL, locks, replay, record-level forget
+- **Phase:** v0.1 P0
+- **Brief sections:** §5.6 forget_record · §14 Privacy and Consent · §15 audit invariants · §18.c US8
+- **Depends on:** #57 COW upsert + expire WAL apply (landed in commit 3f9c46f8)
+- **Date:** 2026-05-09
+
+## 1. Goal
+
+Run record-level forget through the §5.6 WAL apply path so the engine removes the target from every reader surface (records, FTS, vectors, edges, snapshots) atomically at Phase A and physically purges all body-bearing copies in Phase B, leaving only a body-free audit receipt in `consent_journal`.
+
+This issue lands the engine — the `MemoryStore::forget_record` trait method, its `SqliteMemoryStore` implementation, the WAL apply path, the recovery shim, and the migration. The four-surface dispatch wiring (CLI / MCP / SDK / skill calling into `forget_record`) and the `wiring::FORGET_RECORD_WIRED` constant flip are deferred to issue #9 (`Implement eight core verbs in CLI and SDK`), per the existing `// deferred to issue #9` comment in `crates/cairn-cli/src/verbs/forget.rs:9`. Keeping the wiring flag at `false` until #9 lands the CLI/MCP/SDK dispatch preserves the §15 fail-closed invariant ("a capability appears in `status.capabilities` only when the runtime can honor every call against it").
+
+## 2. Non-goals
+
+- `forget --session` (v0.2, issue #108) and `forget --scope` (v0.3) fan-out. Both keep returning `CapabilityUnavailable` with the existing remediation hint.
+- Cold-storage snapshot rewrite. v0.1 has no `nexus-data/` mirror nor `.cairn/snapshots/` directory; the `snapshot.purge` step is a no-op until issue #109 lands the cold layer.
+- Per-user salt for `target_id_hash`. v0.1 ships `sha256:<hex>` of the raw target id; the brief §14 per-user salt rotation is a P1 follow-up that swaps the hash function without changing the receipt schema.
+- Markdown projector and consent-log materializer integration. The §5.6 markdown projection drains itself when `records` rows are deleted (the projector reads the active set); the consent.log materializer tails `consent_journal` rowids and picks up the new `ForgetIntent` row automatically.
+
+## 3. Source-of-truth alignment
+
+| Brief section | Requirement | Design choice |
+|---|---|---|
+| §5.6 forget_record Phase A | One SQLite txn flips `tombstoned = 1` on every version of `target_id`, appends `consent_journal` row | `primary.mark_tombstone` step body fuses both writes inside the same `Transaction` the runner opens |
+| §5.6 forget_record Phase B | Physical purge across vectors, FTS, edges, primary rows, WAL pre-images, snapshots | Step bodies 2–7 in `FORGET_RECORD_STEPS` (already declared in `cairn-core::wal::step_graph`) |
+| §5.6 audit invariant | "no original body, frontmatter, index entry, graph edge, pre-image, or bundle copy" survives step 7 | `wal.purge_pre_images` zeroes any `wal_steps.pre_image` blob whose JSON references this `target_id` and replaces it with a `{target_id_hash, op_id, purged_at}` stub |
+| §5.6 retry policy | Idempotent steps backoff 100/400/1600 ms, non-idempotent run once | Reuses existing `StepRunner` + `MAX_STEP_ATTEMPTS`; `primary.purge` is the only `idempotent: false` step in the graph |
+| §5.6 lock model | Record-level forget = exclusive on entity, shared on session | Reuses `record_wal::locks::acquire_for_record` (same shape as upsert/expire) |
+| §14 body-free receipt | `forget_intent` payload allowlist `{target_id_hash, op_id, purged_at}` | Emits `ConsentEvent { kind: ForgetIntent, payload: IntentReceipt { target_id_hash: sha256(target_id), scope_tier, reason_code: "user_command" } }` — already validated by `ConsentEvent::validate` and the `consent_journal_forget_receipt_body_free` trigger |
+| §15 fail-closed advertise | Cap appears in `status` only when wiring constant is `true` | Flip `FORGET_RECORD_WIRED` from `false` to `true` in `cairn-core/src/status/wiring.rs` |
+| §18.c US8 | "forget what I said about Y" → record disappears from retrieve / search / markdown | New integration test asserts post-forget `get`, `list`, `search_keyword`, `search_semantic` (when vector wired), `versions`, and edge endpoints all miss |
+
+## 4. Architecture
+
+Extend the `record_wal` module that #57 added.
+
+```text
+MemoryStore::forget_record(target)
+  -> record_wal::apply_forget_record(target)
+     -> issue PREPARED wal_ops row + persist ForgetPayload to wal_payloads
+     -> run FORGET_RECORD_STEPS through StepRunner
+        step 0  primary.mark_tombstone   [idem, fused: tombstone + consent receipt]
+        step 1  vector.drain             [idem]
+        step 2  fts.drain                [idem]
+        step 3  edges.drain              [idem]
+        step 4  primary.purge            [non-idem]
+        step 5  wal.purge_pre_images     [idem]
+        step 6  snapshot.purge           [idem, P0 no-op]
+     -> finalize COMMITTED, return ForgetReceipt { target_id_hash, op_id, purged_at }
+```
+
+Recovery picks up after the last `DONE` step. Phase A (step 0) is a single SQLite transaction so a crash before commit leaves no tombstone and no consent row; a crash after commit leaves both, and Phase B retries idempotently from step 1. Step 4 (`primary.purge`) is `idempotent: false` because it is a destructive `DELETE`; once it succeeds the recovery shim never re-runs it, but the same `target_id` can be re-purged across operations because the `wal_payloads.kind` row is keyed by `operation_id`.
+
+## 5. Module changes
+
+### 5.1 `cairn-core` (additive)
+
+- `wal::step_graph` already declares `FORGET_RECORD_STEPS` and `WalKind::ForgetRecord`. No changes here.
+- `contract::memory_store`:
+  - Add `async fn forget_record(&self, target: &TargetId, actor: &Identity) -> Result<ForgetReceipt, StoreError>` with a default impl returning `"capability unavailable: forget_record"`. Adapters that ship Phase A+B opt in; v0.1 fixture stores keep the default. The `actor` parameter is the resolved principal that authored the forget intent (passed in by issue #9's CLI/MCP/SDK dispatch); the engine writes it into the `consent_journal.actor` column on the receipt row.
+  - Add `pub struct ForgetReceipt { target_id_hash: String, op_id: String, purged_at: i64 }` (body-free; matches the brief §14 forget-receipt allowlist).
+  - Bump `CONTRACT_VERSION` 0.5.0 → 0.6.0 with a doc comment explaining the structural addition.
+- `status::wiring::FORGET_RECORD_WIRED` stays `false` — flipped to `true` by issue #9 once the CLI/MCP/SDK dispatch lands.
+- `status::REMEDIATION` for `cairn.mcp.v1.forget.record` is unchanged.
+
+### 5.2 `cairn-store-sqlite` (additive)
+
+- New `record_wal/forget.rs` mirroring `record_wal/expire.rs`:
+  - `apply_forget_record(store, target, actor) -> Result<ForgetReceipt, StoreError>` constructs the op id, acquires `RecordLocks`, persists the `ForgetPayload`, runs the step graph, finalizes COMMITTED.
+- `record_wal/payload.rs` adds:
+  - `ForgetPayload { target_id: TargetId, scope: ScopeTuple, reason_code: String, actor: Identity, scope_tier: MemoryVisibility }` and a new `RecordWalPayload::Forget` variant. (The `scope_tier` is captured at issue time inside Phase A's read so recovery uses the same value the original call would have.)
+  - `wal_payloads.kind` CHECK widening from `('upsert', 'expire')` to `('upsert', 'expire', 'forget_record')` via migration `0055_wal_payloads_forget.sql`.
+- `record_wal/steps.rs` adds the six new step bodies. Bodies reuse existing helpers where possible (`drain_vectors`, `drain_fts`, `drain_edges` from expire; `current_unix_ms` for timestamps).
+- `record_wal/recovery.rs` (`RecordWalRegistry`) routes `WalKind::ForgetRecord` to a `RecordStepBody::new_forget(payload, locks)`.
+- `record_wal/mod.rs` re-exports `apply_forget_record`.
+- New `store/forget.rs` exposes `SqliteMemoryStore::forget_record(target)` (parallel to `expire`); `trait_impl.rs` wires it onto the trait.
+- `consent.rs::append` is unchanged — the call site inside `primary.mark_tombstone` builds the `ConsentEvent` and invokes `append` against the same `Transaction`. (`append` already takes a `&Connection`; we pass the txn's underlying connection through the standard `&*tx` deref pattern that existing fused writes use.)
+
+### 5.3 `cairn-cli` (no changes in this issue)
+
+`verbs/forget.rs` keeps its existing stub: dry-run / human-review still flow through the placeholder planner, and the `record_id` / `session_id` / `scope` branches all return `CapabilityUnavailable`. Issue #9 will replace the stub with a real call into `store.forget_record(target).await` and flip `FORGET_RECORD_WIRED` to `true` once the matching MCP and SDK dispatchers land.
+
+### 5.4 Migration `0055_wal_payloads_forget.sql`
+
+```sql
+-- Migration 0055: widen wal_payloads.kind to allow forget_record.
+-- Issue #58: record-level forget needs a durable payload like upsert/expire.
+
+-- SQLite cannot ALTER a CHECK constraint in place; recreate the table.
+CREATE TABLE wal_payloads_new (
+  operation_id TEXT NOT NULL PRIMARY KEY
+                    REFERENCES wal_ops(operation_id),
+  kind         TEXT NOT NULL CHECK (kind IN ('upsert', 'expire', 'forget_record')),
+  payload_json TEXT NOT NULL,
+  created_at   INTEGER NOT NULL
+);
+
+INSERT INTO wal_payloads_new SELECT * FROM wal_payloads;
+
+DROP TRIGGER IF EXISTS wal_payloads_kind_matches_wal;
+DROP TRIGGER IF EXISTS wal_payloads_immutable;
+DROP TRIGGER IF EXISTS wal_payloads_no_delete;
+DROP TABLE wal_payloads;
+ALTER TABLE wal_payloads_new RENAME TO wal_payloads;
+
+-- Recreate the three triggers from 0053 unchanged.
+CREATE TRIGGER wal_payloads_kind_matches_wal ...;
+CREATE TRIGGER wal_payloads_immutable ...;
+CREATE TRIGGER wal_payloads_no_delete ...;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (55, '0055_wal_payloads_forget', '', strftime('%s','now') * 1000);
+```
+
+## 6. Step body details
+
+### 6.1 `primary.mark_tombstone` (Phase A — fused atomic)
+
+```sql
+UPDATE records
+   SET active = 0,
+       tombstoned = 1,
+       tombstone_reason = 'forget',
+       updated_at = ?ms
+ WHERE target_id = ?target;
+```
+
+Same transaction inserts a `consent_journal` row via `consent::append` with:
+
+```rust
+ConsentEvent {
+    consent_id: ulid(),
+    kind: ConsentKind::ForgetIntent,
+    actor: store_actor(),                // identity of the caller; from incarnation
+    subject: format!("hash:{sha256_hex}"), // same hash as payload.target_id_hash
+    scope: scope_canonical_wire(&scope),
+    op_id: Some(op_id.to_string()),
+    sensor_id: None,
+    payload: ConsentPayload::IntentReceipt {
+        target_id_hash: format!("sha256:{sha256_hex}"),
+        scope_tier: visibility_for_target(&target)?,
+        reason_code: "user_command".to_owned(),
+    },
+    decided_at: now_rfc3339(),
+    expires_at: None,
+}
+```
+
+`scope_tier` is read from the active record's visibility column inside the same SELECT before the UPDATE so the receipt records the tier the row carried at forget time.
+
+### 6.2 `vector.drain` / `fts.drain` / `edges.drain`
+
+Identical SQL to the expire bodies in `record_wal/steps.rs`. Refactor those into shared free functions (`drain_vectors_for_target`, etc.) so both kinds call the same code.
+
+### 6.3 `primary.purge` (Phase B step 4 — destructive)
+
+```sql
+DELETE FROM record_vectors WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?);
+DELETE FROM pending_embeddings WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?);
+DELETE FROM records WHERE target_id = ?;
+```
+
+The vector / pending DELETE statements are repeated here even though `vector.drain` already ran them — `vector.drain` could have failed and been retried, and the audit invariant test treats this step as the final guarantee. Both deletes are idempotent.
+
+### 6.4 `wal.purge_pre_images`
+
+```sql
+SELECT operation_id, step_ord, pre_image
+  FROM wal_steps
+ WHERE pre_image IS NOT NULL
+   AND pre_image LIKE '%' || ?target || '%';
+```
+
+For each row, parse the `pre_image` JSON, replace it with `{"purged": true, "target_id_hash": "sha256:...", "op_id": "...", "purged_at": ms}`, and `UPDATE wal_steps SET pre_image = ?stub WHERE operation_id = ? AND step_ord = ?`. The `wal_steps_state_transition` trigger does not fire on `pre_image` updates; the `wal_steps_identity_immutable` trigger guards `operation_id`/`step_ord`/`step_kind` only — `pre_image` is intentionally mutable for exactly this reason.
+
+`LIKE '%target%'` is a coarse prefilter; the JSON parse step verifies actual containment so unrelated rows are not stubbed. The stub blob is JSON so a future replay validator can recognize it.
+
+### 6.5 `snapshot.purge`
+
+P0 has no `.cairn/snapshots/` directory and no `nexus-data/` mirror. Body checks for any registered cold-snapshot path (currently always empty) and marks DONE. When issue #109 introduces the snapshot registry, this step body grows the bundle-rewrite logic; the FORGET_RECORD_STEPS graph does not change.
+
+## 7. Wire and capability surface
+
+The CLI / MCP / SDK / skill behavior is **unchanged** by this issue. `status.capabilities` does **not** list `cairn.mcp.v1.forget.record` yet — the `wiring::FORGET_RECORD_WIRED` constant stays `false`. All four surfaces continue to return `CapabilityUnavailable` for `forget --record`. Issue #9 lands the dispatch wiring and the wiring-flag flip in one PR so the §15 fail-closed invariant is preserved.
+
+## 8. Tests
+
+Add `crates/cairn-store-sqlite/tests/forget_record.rs` (mirroring `cow_upsert_expire.rs`):
+
+1. **Happy path** — upsert + forget; assert `get`, `list`, `versions`, keyword search, edges all miss; assert `wal_ops` has one COMMITTED `forget_record` row with seven DONE steps; assert one `consent_journal` row with `kind = forget_intent`, body-free payload, matching `op_id`.
+2. **Idempotent re-forget** — call `forget_record` twice on the same target; second call returns `Ok(receipt)` with the same `target_id_hash` and a fresh `op_id` (the `wal_payloads` row is per-op, not per-target) and the SQL state stays identical (no-op tombstones, no-op deletes).
+3. **Crash during Phase A** — abort before the txn commits (drop the connection mid-step); reopen, run `record_wal::recovery`; assert no tombstone and no consent row exist (Phase A is all-or-nothing).
+4. **Crash during Phase B** — leave the WAL in `PREPARED` after `primary.mark_tombstone` DONE; reopen, run recovery; assert all seven steps land DONE and the op transitions to COMMITTED.
+5. **WAL pre-image scrub** — perform an upsert that stages a pre_image referencing `target`, then forget; assert no `wal_steps.pre_image` blob contains the original target body bytes after step 5.
+6. **Receipt body-free** — load the `consent_journal` row; assert `ConsentEvent::validate()` passes, the JSON form has no field from `ConsentEvent::BANNED_FIELDS`, and `payload.target_id_hash` matches `sha256(target_id)`.
+7. **Status capability still unwired** — `cairn-core/src/status/tests.rs` continues to assert that `cairn.mcp.v1.forget.record` does not appear when `FORGET_RECORD_WIRED` is `false`; no snapshot churn from this issue.
+8. **CLI/MCP/SDK still return CapabilityUnavailable** — existing snapshot tests for `cairn forget --record`, the MCP forget tool, and the SDK forget call stay green. Issue #9 will rewrite those snapshots when it flips the wiring flag.
+
+## 9. Migration safety
+
+- `0055_wal_payloads_forget.sql` recreates the `wal_payloads` table inside one transaction; existing rows survive the copy. The migration smoke test exercises this on a populated DB to catch any FK or trigger drift.
+- The new `MemoryStore::forget_record` default impl returns the not-supported sentinel, so dyn-only consumers compile without changes. Adapters that opt in implement the method; the contract version bump (0.5 → 0.6) ensures the handshake refuses adapters built against the old surface.
+- `FORGET_RECORD_WIRED` is checked by `cairn-core::status::advertise()`; flipping it to `true` requires the dispatch path to honor every call. The CI `status::tests::wired_caps_appear` test already encodes this invariant.
+
+## 10. Open follow-ups (out of scope)
+
+- Per-user salt rotation for `target_id_hash` (P1, brief §14).
+- Cold-snapshot bundle rewrite for `snapshot.purge` (issue #109).
+- `forget_session` Phase A fence + per-child Phase B fan-out (issue #108).
+- Markdown projector reaction to `forget` (currently passive — projector reads active set, so deleted rows vanish; but a `--fix-markdown` lint pass should explicitly exercise this after #58 lands).


### PR DESCRIPTION
## Summary

Implements the record-level forget pipeline for issue #58 end-to-end: the §5.6 `forget_record` engine + the `cairn forget --record <id>` CLI surface that drives it.

**Engine** (Tasks 1–13): `MemoryStore::forget_record` trait method (default returns `CapabilityUnavailable`), `SqliteMemoryStore::forget_record` overrides through the seven-step WAL graph — Phase A atomic tombstone + body-free `ForgetIntent` consent receipt; Phase B drain → primary.purge → wal pre-image scrub → snapshot.purge no-op (cold storage lands in #109).

**CLI wire-up** (post-Task 14, scope-extended on user request): `verbs/forget::run` promoted to async, `--record` mode dispatches through `signed::open_context` to `store.forget_record(&target, &actor)`. `wiring::FORGET_RECORD_WIRED` flipped to `true`. `--session` and `--scope` keep returning `CapabilityUnavailable`.

## Brief sections

- §5.6 forget_record fan-out (Phase A + Phase B)
- §14 Privacy and Consent (body-free receipt, IntentReceipt payload allowlist)
- §15 fail-closed advertise (now honored end-to-end)
- §18.c US8 record-level forget acceptance criteria

## Invariants touched

- 5 (WAL two-phase apply for every mutation) — forget joins upsert and expire on the same `record_wal::apply_*` pattern.
- 6 (fail closed on capability) — wiring flag flips only after every surface honors the call.
- 9 (privacy by construction) — receipt body-free, validated by `ConsentEvent::validate` and the existing trigger.

## Out of scope (deferred)

- `forget --session` (issue #108, v0.2 fan-out) and `--scope` (v0.3) — both still `CapabilityUnavailable`.
- Cold-storage `snapshot.purge` (issue #109) — step body is a no-op until the snapshot registry exists.
- Per-user salt for `target_id_hash` — sha256 of raw target id today; P1 swaps the hash function without changing the receipt schema.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo nextest run --workspace --locked --no-fail-fast` — 3612 pass (2 pre-existing `/tmp/.cairn`-pollution flakes unrelated to this branch; CI clean env passes them)
- [x] `cargo test --doc --workspace --locked`
- [x] `./scripts/check-core-boundary.sh`
- [x] `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
- [x] `cargo run -p cairn-cli --bin cairn-docgen --locked -- --check`
- [x] Six new integration tests in `crates/cairn-store-sqlite/tests/forget_record.rs`: happy path, idempotency, pre-image scrub, body-free receipt, Phase A + Phase B crash recovery
- [x] New `crates/cairn-cli/tests/forget_record_cli.rs` end-to-end test
- [x] Live smoke: bootstrap → ingest → status (forget.record advertised) → forget --record → search (record gone) all green against the built binary

Closes #58.