### PR TITLE
[codex] Implement record-level forget with tombstone and purge phases

### DIFF
--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -231,7 +231,10 @@ fn main() -> ExitCode {
             Ok((vault_root, _source)) => verbs::lint::run(sub, Some(vault_root.as_path())),
             Err(_) => verbs::lint::run(sub, None),
         },
-        Some(("forget", sub)) => verbs::forget::run(sub),
+        Some(("forget", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
+            Ok((vault_root, _source, config)) => verbs::forget::run(sub, vault_root, config),
+            Err(code) => code,
+        },
         Some(("hook", sub)) => hooks::run(sub),
         Some(("status", sub)) => run_status(sub, explicit_vault.as_deref()),
         Some(("handshake", sub)) => run_handshake(sub, explicit_vault.as_deref()),

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -231,10 +231,18 @@ fn main() -> ExitCode {
             Ok((vault_root, _source)) => verbs::lint::run(sub, Some(vault_root.as_path())),
             Err(_) => verbs::lint::run(sub, None),
         },
-        Some(("forget", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
-            Ok((vault_root, _source, config)) => verbs::forget::run(sub, vault_root, config),
-            Err(code) => code,
-        },
+        Some(("forget", sub)) => {
+            if verbs::forget::requires_vault_context(sub) {
+                match resolve_vault_and_config(explicit_vault.as_deref()) {
+                    Ok((vault_root, _source, config)) => {
+                        verbs::forget::run(sub, vault_root, config)
+                    }
+                    Err(code) => code,
+                }
+            } else {
+                verbs::forget::run_without_context(sub)
+            }
+        }
         Some(("hook", sub)) => hooks::run(sub),
         Some(("status", sub)) => run_status(sub, explicit_vault.as_deref()),
         Some(("handshake", sub)) => run_handshake(sub, explicit_vault.as_deref()),

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -116,7 +116,13 @@ fn resolve_vault_or_cwd(
     }
 }
 
-fn subcommand_needs_vault_guard(active_subcommand: &str) -> bool {
+fn subcommand_needs_vault_guard(subcommand: Option<(&str, &ArgMatches)>) -> bool {
+    let Some((active_subcommand, sub)) = subcommand else {
+        return false;
+    };
+    if active_subcommand == "forget" {
+        return verbs::forget::requires_vault_context(sub);
+    }
     !matches!(
         active_subcommand,
         "vault"
@@ -156,12 +162,11 @@ fn main() -> ExitCode {
         .cloned()
         .or_else(|| std::env::var("CAIRN_VAULT").ok());
 
-    let active_subcommand = matches.subcommand_name().unwrap_or("");
     // admin verbs resolve their own vault path from CAIRN_VAULT / CWD; the
     // registry guard here would reject them when no vault is registered.
     // `identity` manages vault-path internally for each subcommand; exclude
     // from the top-level vault registry guard (which requires a named vault).
-    let needs_vault_guard = subcommand_needs_vault_guard(active_subcommand);
+    let needs_vault_guard = subcommand_needs_vault_guard(matches.subcommand());
 
     if needs_vault_guard {
         let store = match registry_store() {

--- a/crates/cairn-cli/src/verbs/forget.rs
+++ b/crates/cairn-cli/src/verbs/forget.rs
@@ -33,6 +33,42 @@ fn requested_capability(sub: &ArgMatches) -> &'static str {
 /// Run `cairn forget`.
 #[must_use]
 pub fn run(sub: &ArgMatches, vault_root: PathBuf, config: CairnConfig) -> ExitCode {
+    if !requires_vault_context(sub) {
+        return run_without_context(sub);
+    }
+
+    let json = sub.get_flag("json");
+
+    let Some(record_id) = sub.get_one::<String>("record_id") else {
+        return run_without_context(sub);
+    };
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            let resp = super::signed::aborted(ResponseVerb::Forget, format!("runtime build: {e}"));
+            emit_response(&resp, json, record_id);
+            return ExitCode::FAILURE;
+        }
+    };
+    let resp = rt.block_on(run_record(record_id.clone(), vault_root, config));
+    emit_response(&resp, json, record_id);
+    response_exit_code(&resp)
+}
+
+/// Whether this invocation needs the resolved vault path and config.
+#[must_use]
+pub fn requires_vault_context(sub: &ArgMatches) -> bool {
+    !sub.get_flag("dry-run")
+        && !sub.get_flag("human-review")
+        && sub.get_one::<String>("record_id").is_some()
+}
+
+/// Run `cairn forget` modes that do not open the vault store.
+#[must_use]
+pub fn run_without_context(sub: &ArgMatches) -> ExitCode {
     let json = sub.get_flag("json");
 
     let dry_run = sub.get_flag("dry-run");
@@ -48,24 +84,6 @@ pub fn run(sub: &ArgMatches, vault_root: PathBuf, config: CairnConfig) -> ExitCo
         // distinction collapses to "produce a placeholder plan." #9 will
         // split them into real builders.
         return crate::verbs::ingest_plan_stub(sub, mode, no_diff, json);
-    }
-
-    if let Some(record_id) = sub.get_one::<String>("record_id") {
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                let resp =
-                    super::signed::aborted(ResponseVerb::Forget, format!("runtime build: {e}"));
-                emit_response(&resp, json, record_id);
-                return ExitCode::FAILURE;
-            }
-        };
-        let resp = rt.block_on(run_record(record_id.clone(), vault_root, config));
-        emit_response(&resp, json, record_id);
-        return response_exit_code(&resp);
     }
 
     let capability = requested_capability(sub);
@@ -94,6 +112,10 @@ async fn run_record(record_id_raw: String, vault_root: PathBuf, config: CairnCon
     };
     match ctx.store.forget_record(&record_id).await {
         Ok(outcome) => {
+            let operation_id = match response_operation_id(&outcome.operation_id) {
+                Ok(operation_id) => operation_id,
+                Err(message) => return super::signed::aborted(ResponseVerb::Forget, message),
+            };
             let data = ForgetData {
                 deleted_count: outcome.deleted_count,
                 plan_ref: None,
@@ -107,7 +129,7 @@ async fn run_record(record_id_raw: String, vault_root: PathBuf, config: CairnCon
             };
             super::signed::committed(
                 ResponseVerb::Forget,
-                super::envelope::new_operation_id(),
+                operation_id,
                 ResponseData::Forget(data),
                 Vec::new(),
             )
@@ -119,6 +141,17 @@ async fn run_record(record_id_raw: String, vault_root: PathBuf, config: CairnCon
         ),
         Err(e) => super::signed::aborted(ResponseVerb::Forget, format!("store forget: {e}")),
     }
+}
+
+fn response_operation_id(operation_id: &cairn_core::wal::OperationId) -> Result<Ulid, String> {
+    const PREFIX: &str = "forget_record-";
+    let raw = operation_id.as_str();
+    let Some(ulid) = raw.strip_prefix(PREFIX) else {
+        return Err(format!("unexpected forget wal operation id: {raw}"));
+    };
+    RecordId::parse(ulid.to_owned())
+        .map_err(|e| format!("invalid forget wal operation id `{raw}`: {e}"))?;
+    Ok(Ulid(ulid.to_owned()))
 }
 
 fn emit_response(resp: &Response, json: bool, requested_record_id: &str) {

--- a/crates/cairn-cli/src/verbs/forget.rs
+++ b/crates/cairn-cli/src/verbs/forget.rs
@@ -3,22 +3,22 @@
 //! # Trust boundary (spec §3.5)
 //!
 //! `forget` is an issuer-dependent verb: it produces a signed tombstone record
-//! once the store is wired (#9).  The guard call below enforces the
-//! `VaultDegraded → EX_TEMPFAIL=75` contract even in the stub path.
-//!
-//! **Deferred**: full async wiring (calling [`open_for_signed_verb`] against the
-//! resolved vault path) is deferred to issue #9 when this verb becomes async.
-//!
-//! [`open_for_signed_verb`]: crate::identity::guard::open_for_signed_verb
+//! through the signed-verb context before mutating the selected vault store.
 
+use std::path::PathBuf;
 use std::process::ExitCode;
 
+use cairn_core::config::CairnConfig;
+use cairn_core::domain::RecordId;
+use cairn_core::generated::common::Ulid;
 use cairn_core::generated::envelope::ResponseVerb;
+use cairn_core::generated::envelope::{Response, ResponseData, ResponseStatus};
+use cairn_core::generated::verbs::forget::ForgetData;
 use clap::ArgMatches;
 
-use crate::identity::{guard::refuse_if_degraded, status::ReconciliationReport};
-
-use super::envelope::{EX_UNAVAILABLE, capability_unavailable_response, emit_json, human_error};
+use super::envelope::{
+    EX_UNAVAILABLE, capability_unavailable_response, emit_json, human_error, not_found_response,
+};
 
 fn requested_capability(sub: &ArgMatches) -> &'static str {
     if sub.get_one::<String>("session_id").is_some() {
@@ -32,7 +32,7 @@ fn requested_capability(sub: &ArgMatches) -> &'static str {
 
 /// Run `cairn forget`.
 #[must_use]
-pub fn run(sub: &ArgMatches) -> ExitCode {
+pub fn run(sub: &ArgMatches, vault_root: PathBuf, config: CairnConfig) -> ExitCode {
     let json = sub.get_flag("json");
 
     let dry_run = sub.get_flag("dry-run");
@@ -50,12 +50,22 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
         return crate::verbs::ingest_plan_stub(sub, mode, no_diff, json);
     }
 
-    // §3.5 trust-boundary guard: refuse if the vault is degraded.
-    // In this P0 stub the report is always clean (no store is open); full async
-    // wiring against the resolved vault path is deferred to issue #9.
-    if let Err(e) = refuse_if_degraded(&ReconciliationReport::default(), vec![]) {
-        eprintln!("cairn forget: VaultDegraded — {e}");
-        return ExitCode::from(75); // EX_TEMPFAIL
+    if let Some(record_id) = sub.get_one::<String>("record_id") {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                let resp =
+                    super::signed::aborted(ResponseVerb::Forget, format!("runtime build: {e}"));
+                emit_response(&resp, json, record_id);
+                return ExitCode::FAILURE;
+            }
+        };
+        let resp = rt.block_on(run_record(record_id.clone(), vault_root, config));
+        emit_response(&resp, json, record_id);
+        return response_exit_code(&resp);
     }
 
     let capability = requested_capability(sub);
@@ -71,4 +81,85 @@ pub fn run(sub: &ArgMatches) -> ExitCode {
         );
     }
     ExitCode::from(EX_UNAVAILABLE)
+}
+
+async fn run_record(record_id_raw: String, vault_root: PathBuf, config: CairnConfig) -> Response {
+    let record_id = match RecordId::parse(record_id_raw.clone()) {
+        Ok(record_id) => record_id,
+        Err(e) => return super::signed::rejected_from_domain(ResponseVerb::Forget, e),
+    };
+    let ctx = match super::signed::open_context(ResponseVerb::Forget, &vault_root, config).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+    match ctx.store.forget_record(&record_id).await {
+        Ok(outcome) => {
+            let data = ForgetData {
+                deleted_count: outcome.deleted_count,
+                plan_ref: None,
+                tombstones: Some(
+                    outcome
+                        .tombstones
+                        .into_iter()
+                        .map(|id| Ulid(id.as_str().to_owned()))
+                        .collect(),
+                ),
+            };
+            super::signed::committed(
+                ResponseVerb::Forget,
+                super::envelope::new_operation_id(),
+                ResponseData::Forget(data),
+                Vec::new(),
+            )
+        }
+        Err(cairn_store_sqlite::StoreError::NotFound { id }) => not_found_response(
+            ResponseVerb::Forget,
+            "record",
+            &format!("record not found: {id}"),
+        ),
+        Err(e) => super::signed::aborted(ResponseVerb::Forget, format!("store forget: {e}")),
+    }
+}
+
+fn emit_response(resp: &Response, json: bool, requested_record_id: &str) {
+    if json {
+        emit_json(resp);
+        return;
+    }
+    match resp.status {
+        ResponseStatus::Committed => {
+            if let Some(ResponseData::Forget(data)) = resp.data.as_ref() {
+                println!(
+                    "cairn forget: committed record {requested_record_id} (deleted {})",
+                    data.deleted_count
+                );
+            } else {
+                println!("cairn forget: committed record {requested_record_id}");
+            }
+        }
+        ResponseStatus::Rejected | ResponseStatus::Aborted => {
+            let code = super::signed::response_error_code(resp).unwrap_or("Internal");
+            let message = resp
+                .error
+                .as_ref()
+                .and_then(|e| e.get("message"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("forget failed");
+            human_error("forget", code, message, &resp.operation_id);
+        }
+        _ => human_error(
+            "forget",
+            "Internal",
+            "unknown response status",
+            &resp.operation_id,
+        ),
+    }
+}
+
+fn response_exit_code(resp: &Response) -> ExitCode {
+    match resp.status {
+        ResponseStatus::Committed => ExitCode::SUCCESS,
+        ResponseStatus::Rejected => ExitCode::from(64),
+        _ => ExitCode::FAILURE,
+    }
 }

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1960,10 +1960,16 @@ fn has_warning_or_error(finding: &Finding) -> bool {
 fn emit_human(data: &LintData, operation_id: &Ulid) {
     println!("cairn lint: committed (operation_id: {})", operation_id.0);
     println!(
-        "summary: total={} contradictions={} ambiguous_edges={} auto_resolved={}",
+        "summary: total={} contradictions={} ambiguous_edges={} purge_pending={} auto_resolved={}",
         data.summary.total,
         summary_count(data, "contradictory_edge"),
         summary_count(data, "ambiguous_edge"),
+        data.findings
+            .iter()
+            .filter(|finding| {
+                finding.kind == Kind::DeferredCheck && finding.message.starts_with("purge_pending:")
+            })
+            .count(),
         data.summary.auto_resolved.unwrap_or(0),
     );
 

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -541,10 +541,23 @@ fn capture_trace_rejects_session_arg_until_scoped_import_supported() {
 }
 
 #[test]
-fn forget_record_returns_capability_unavailable() {
+fn forget_session_returns_capability_unavailable() {
     assert_rejected_capability_unavailable(
-        &["forget", "--record", "01JXXXXXXXXXXXXXXXXXXXXXXX", "--json"],
-        "cairn.mcp.v1.forget.record",
+        &[
+            "forget",
+            "--session",
+            "01JXXXXXXXXXXXXXXXXXXXXXXX",
+            "--json",
+        ],
+        "cairn.mcp.v1.forget.session",
+    );
+}
+
+#[test]
+fn forget_scope_returns_capability_unavailable() {
+    assert_rejected_capability_unavailable(
+        &["forget", "--scope", r#"{"tenant":"default"}"#, "--json"],
+        "cairn.mcp.v1.forget.scope",
     );
 }
 
@@ -639,7 +652,6 @@ fn status_in_bound_vault_advertises_search_and_policy_trace() {
     for stub_cap in [
         "cairn.mcp.v1.retrieve.session",
         "cairn.mcp.v1.retrieve.full",
-        "cairn.mcp.v1.forget.record",
         "cairn.mcp.v1.forget.session",
     ] {
         assert!(

--- a/crates/cairn-cli/tests/forget_record.rs
+++ b/crates/cairn-cli/tests/forget_record.rs
@@ -3,7 +3,9 @@
 use std::path::Path;
 use std::process::{Command, Output};
 
-use cairn_core::generated::envelope::{Response, ResponseData, ResponseStatus, ResponseVerb};
+use cairn_core::generated::envelope::{
+    Response, ResponseData, ResponseStatus, ResponseVerb, RetrieveData,
+};
 use serde_json::Value;
 
 fn cli() -> Command {
@@ -50,6 +52,23 @@ fn hit_count(vault: &Path, query: &str) -> usize {
         .len()
 }
 
+fn retrieve_record(vault: &Path, record_id: &str) -> Response {
+    let out = run_in_vault(vault, &["retrieve", record_id, "--json"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "retrieve should commit\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "retrieve envelope parse failed: {e}\nstdout: {}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    })
+}
+
 fn forget_record_wal_operation_id(vault: &Path) -> String {
     let conn = rusqlite::Connection::open(vault.join(".cairn/cairn.db")).expect("open cairn db");
     conn.query_row(
@@ -75,6 +94,12 @@ fn forget_record_json_commits_in_bound_vault() {
         .expect("ingest record_id")
         .to_owned();
     assert_eq!(hit_count(dir.path(), "issue58forgetunique"), 1);
+    let before = retrieve_record(dir.path(), &record_id);
+    let Some(ResponseData::Retrieve(RetrieveData::Record(before))) = before.data else {
+        panic!("retrieve before forget must return record data");
+    };
+    assert_eq!(before.record_id.0, record_id);
+    assert_eq!(before.body.as_deref(), Some(body));
 
     let out = run_in_vault(dir.path(), &["forget", "--record", &record_id, "--json"]);
     assert_eq!(
@@ -103,7 +128,7 @@ fn forget_record_json_commits_in_bound_vault() {
             .into_iter()
             .map(|id| id.0)
             .collect::<Vec<_>>(),
-        vec![record_id]
+        vec![record_id.clone()]
     );
 
     assert_eq!(
@@ -111,6 +136,94 @@ fn forget_record_json_commits_in_bound_vault() {
         format!("forget_record-{response_operation_id}")
     );
     assert_eq!(hit_count(dir.path(), "issue58forgetunique"), 0);
+
+    let after = retrieve_record(dir.path(), &record_id);
+    let Some(ResponseData::Retrieve(RetrieveData::Record(after))) = after.data else {
+        panic!("retrieve after forget must return typed empty record data");
+    };
+    assert_eq!(after.record_id.0, record_id);
+    assert_eq!(after.kind, "unknown");
+    assert!(
+        after.body.is_none(),
+        "retrieve after record forget must not return forgotten body"
+    );
+}
+
+#[test]
+fn forget_record_human_mode_commits_and_removes_search_hit() {
+    let dir = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(dir.path());
+
+    let body = "issue58humanforget body must disappear";
+    let ingest = run_json_ok(
+        dir.path(),
+        &["ingest", "--kind", "reference", "--body", body, "--json"],
+    );
+    let record_id = ingest["data"]["record_id"]
+        .as_str()
+        .expect("ingest record_id")
+        .to_owned();
+    assert_eq!(hit_count(dir.path(), "issue58humanforget"), 1);
+
+    let out = run_in_vault(dir.path(), &["forget", "--record", &record_id]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "human forget should commit\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf-8 stdout");
+    assert_eq!(
+        stdout.trim(),
+        format!("cairn forget: committed record {record_id} (deleted 1)")
+    );
+    assert_eq!(hit_count(dir.path(), "issue58humanforget"), 0);
+}
+
+#[test]
+fn forget_record_second_cli_call_reports_not_found_without_body_leak() {
+    let dir = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(dir.path());
+
+    let body = "issue58secondforget body must not leak";
+    let ingest = run_json_ok(
+        dir.path(),
+        &["ingest", "--kind", "reference", "--body", body, "--json"],
+    );
+    let record_id = ingest["data"]["record_id"]
+        .as_str()
+        .expect("ingest record_id")
+        .to_owned();
+    let first = run_in_vault(dir.path(), &["forget", "--record", &record_id, "--json"]);
+    assert_eq!(
+        first.status.code(),
+        Some(0),
+        "first forget should commit\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&first.stderr),
+        String::from_utf8_lossy(&first.stdout)
+    );
+
+    let second = run_in_vault(dir.path(), &["forget", "--record", &record_id, "--json"]);
+    assert_eq!(
+        second.status.code(),
+        Some(1),
+        "second forget should surface not found\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&second.stderr),
+        String::from_utf8_lossy(&second.stdout)
+    );
+    let stdout = String::from_utf8(second.stdout).expect("utf-8 stdout");
+    let v: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("not-found JSON parse failed: {e}\nstdout: {stdout:?}"));
+    assert_eq!(v["contract"], "cairn.mcp.v1");
+    assert_eq!(v["status"], "aborted");
+    assert_eq!(v["verb"], "forget");
+    assert_eq!(v["error"]["code"], "NotFound");
+    assert_eq!(v["error"]["data"]["target"], "record");
+    assert!(
+        !stdout.contains(body),
+        "second forget response must not leak forgotten body"
+    );
 }
 
 fn assert_capability_unavailable(vault: Option<&Path>, args: &[&str], capability: &str) {

--- a/crates/cairn-cli/tests/forget_record.rs
+++ b/crates/cairn-cli/tests/forget_record.rs
@@ -1,0 +1,138 @@
+//! CLI coverage for wired `cairn forget --record`.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use cairn_core::generated::envelope::{Response, ResponseData, ResponseStatus, ResponseVerb};
+use serde_json::Value;
+
+fn cli() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cairn"));
+    cmd.env_remove("CAIRN_VAULT");
+    cmd.env_remove("CAIRN_REGISTRY");
+    cmd
+}
+
+fn bootstrap_vault(vault: &Path) {
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: vault.to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+}
+
+fn run_in_vault(vault: &Path, args: &[&str]) -> Output {
+    cli()
+        .current_dir(vault)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run cairn {args:?}: {e}"))
+}
+
+fn run_json_ok(vault: &Path, args: &[&str]) -> Value {
+    let out = run_in_vault(vault, args);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "cairn {args:?} failed\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("cairn {args:?} emitted invalid JSON: {e}"))
+}
+
+fn hit_count(vault: &Path, query: &str) -> usize {
+    let search = run_json_ok(vault, &["search", "--mode", "keyword", query, "--json"]);
+    search["data"]["hits"]
+        .as_array()
+        .unwrap_or_else(|| panic!("search hits must be an array: {search}"))
+        .len()
+}
+
+#[test]
+fn forget_record_json_commits_in_bound_vault() {
+    let dir = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(dir.path());
+
+    let body = "issue58forgetunique body survives until record forget";
+    let ingest = run_json_ok(
+        dir.path(),
+        &["ingest", "--kind", "reference", "--body", body, "--json"],
+    );
+    let record_id = ingest["data"]["record_id"]
+        .as_str()
+        .expect("ingest record_id")
+        .to_owned();
+    assert_eq!(hit_count(dir.path(), "issue58forgetunique"), 1);
+
+    let out = run_in_vault(dir.path(), &["forget", "--record", &record_id, "--json"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "forget should commit\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf-8 stdout");
+    let resp: Response = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("forget envelope parse failed: {e}\nstdout: {stdout:?}"));
+    assert_eq!(resp.contract, "cairn.mcp.v1");
+    assert!(matches!(resp.status, ResponseStatus::Committed));
+    assert!(matches!(resp.verb, ResponseVerb::Forget));
+    let data = resp.data.expect("committed forget must carry data");
+    let ResponseData::Forget(data) = data else {
+        panic!("forget response must carry ForgetData");
+    };
+    assert_eq!(data.deleted_count, 1);
+    assert_eq!(data.plan_ref, None);
+    assert_eq!(
+        data.tombstones
+            .expect("forget should report tombstones")
+            .into_iter()
+            .map(|id| id.0)
+            .collect::<Vec<_>>(),
+        vec![record_id]
+    );
+
+    assert_eq!(hit_count(dir.path(), "issue58forgetunique"), 0);
+}
+
+fn assert_capability_unavailable(args: &[&str], capability: &str) {
+    let out = cli()
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run cairn {args:?}: {e}"));
+    assert_eq!(
+        out.status.code(),
+        Some(69),
+        "cairn {args:?} should exit 69\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf-8 stdout");
+    let v: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("rejection JSON parse failed: {e}\nstdout: {stdout:?}"));
+    assert_eq!(v["contract"], "cairn.mcp.v1");
+    assert_eq!(v["status"], "rejected");
+    assert_eq!(v["verb"], "forget");
+    assert_eq!(v["error"]["code"], "CapabilityUnavailable");
+    assert_eq!(v["error"]["data"]["capability"], capability);
+}
+
+#[test]
+fn forget_session_and_scope_remain_capability_unavailable() {
+    assert_capability_unavailable(
+        &[
+            "forget",
+            "--session",
+            "01JXXXXXXXXXXXXXXXXXXXXXXX",
+            "--json",
+        ],
+        "cairn.mcp.v1.forget.session",
+    );
+    assert_capability_unavailable(
+        &["forget", "--scope", r#"{"tenant":"default"}"#, "--json"],
+        "cairn.mcp.v1.forget.scope",
+    );
+}

--- a/crates/cairn-cli/tests/forget_record.rs
+++ b/crates/cairn-cli/tests/forget_record.rs
@@ -50,6 +50,16 @@ fn hit_count(vault: &Path, query: &str) -> usize {
         .len()
 }
 
+fn forget_record_wal_operation_id(vault: &Path) -> String {
+    let conn = rusqlite::Connection::open(vault.join(".cairn/cairn.db")).expect("open cairn db");
+    conn.query_row(
+        "SELECT operation_id FROM wal_ops WHERE kind = 'forget_record'",
+        [],
+        |row| row.get(0),
+    )
+    .expect("forget_record wal op")
+}
+
 #[test]
 fn forget_record_json_commits_in_bound_vault() {
     let dir = tempfile::tempdir().expect("temp vault");
@@ -80,6 +90,7 @@ fn forget_record_json_commits_in_bound_vault() {
     assert_eq!(resp.contract, "cairn.mcp.v1");
     assert!(matches!(resp.status, ResponseStatus::Committed));
     assert!(matches!(resp.verb, ResponseVerb::Forget));
+    let response_operation_id = resp.operation_id.0.clone();
     let data = resp.data.expect("committed forget must carry data");
     let ResponseData::Forget(data) = data else {
         panic!("forget response must carry ForgetData");
@@ -95,11 +106,19 @@ fn forget_record_json_commits_in_bound_vault() {
         vec![record_id]
     );
 
+    assert_eq!(
+        forget_record_wal_operation_id(dir.path()),
+        format!("forget_record-{response_operation_id}")
+    );
     assert_eq!(hit_count(dir.path(), "issue58forgetunique"), 0);
 }
 
-fn assert_capability_unavailable(args: &[&str], capability: &str) {
-    let out = cli()
+fn assert_capability_unavailable(vault: Option<&Path>, args: &[&str], capability: &str) {
+    let mut cmd = cli();
+    if let Some(vault) = vault {
+        cmd.current_dir(vault);
+    }
+    let out = cmd
         .args(args)
         .output()
         .unwrap_or_else(|e| panic!("failed to run cairn {args:?}: {e}"));
@@ -123,6 +142,7 @@ fn assert_capability_unavailable(args: &[&str], capability: &str) {
 #[test]
 fn forget_session_and_scope_remain_capability_unavailable() {
     assert_capability_unavailable(
+        None,
         &[
             "forget",
             "--session",
@@ -132,6 +152,34 @@ fn forget_session_and_scope_remain_capability_unavailable() {
         "cairn.mcp.v1.forget.session",
     );
     assert_capability_unavailable(
+        None,
+        &["forget", "--scope", r#"{"tenant":"default"}"#, "--json"],
+        "cairn.mcp.v1.forget.scope",
+    );
+}
+
+#[test]
+fn forget_session_and_scope_ignore_malformed_vault_config() {
+    let dir = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(dir.path());
+    std::fs::write(
+        dir.path().join(".cairn/config.yaml"),
+        b": :\nnot: [valid yaml",
+    )
+    .expect("write malformed config");
+
+    assert_capability_unavailable(
+        Some(dir.path()),
+        &[
+            "forget",
+            "--session",
+            "01JXXXXXXXXXXXXXXXXXXXXXXX",
+            "--json",
+        ],
+        "cairn.mcp.v1.forget.session",
+    );
+    assert_capability_unavailable(
+        Some(dir.path()),
         &["forget", "--scope", r#"{"tenant":"default"}"#, "--json"],
         "cairn.mcp.v1.forget.scope",
     );

--- a/crates/cairn-cli/tests/forget_record.rs
+++ b/crates/cairn-cli/tests/forget_record.rs
@@ -184,3 +184,31 @@ fn forget_session_and_scope_ignore_malformed_vault_config() {
         "cairn.mcp.v1.forget.scope",
     );
 }
+
+#[test]
+fn forget_session_and_scope_ignore_invalid_explicit_vault() {
+    assert_capability_unavailable(
+        None,
+        &[
+            "--vault",
+            "definitely-not-a-vault-name",
+            "forget",
+            "--session",
+            "01JXXXXXXXXXXXXXXXXXXXXXXX",
+            "--json",
+        ],
+        "cairn.mcp.v1.forget.session",
+    );
+    assert_capability_unavailable(
+        None,
+        &[
+            "--vault",
+            "definitely-not-a-vault-name",
+            "forget",
+            "--scope",
+            r#"{"tenant":"default"}"#,
+            "--json",
+        ],
+        "cairn.mcp.v1.forget.scope",
+    );
+}

--- a/crates/cairn-cli/tests/issue7_cli_e2e.rs
+++ b/crates/cairn-cli/tests/issue7_cli_e2e.rs
@@ -93,8 +93,8 @@ fn assert_status_capabilities_are_deterministic(vault_path: &str) {
         "retrieve.record must not be advertised until runtime can honor it: {caps_one:?}"
     );
     assert!(
-        !caps_one.contains(&"cairn.mcp.v1.forget.record".to_owned()),
-        "forget.record must not be advertised until runtime can honor it: {caps_one:?}"
+        caps_one.contains(&"cairn.mcp.v1.forget.record".to_owned()),
+        "forget.record must be advertised once runtime can honor it: {caps_one:?}"
     );
 }
 
@@ -145,34 +145,15 @@ fn assert_sensitive_verb_rejection(out: &Output, args: &[&str], verb: &str, capa
 }
 
 fn assert_unadvertised_sensitive_verbs_fail_closed(vault_path: &str) {
-    for (args, verb, capability) in [
-        (
-            vec![
-                "--vault",
-                vault_path,
-                "retrieve",
-                "01JXXXXXXXXXXXXXXXXXXXXXXX",
-                "--json",
-            ],
-            "retrieve",
-            "cairn.mcp.v1.retrieve.record",
-        ),
-        (
-            vec![
-                "--vault",
-                vault_path,
-                "forget",
-                "--record",
-                "01JXXXXXXXXXXXXXXXXXXXXXXX",
-                "--json",
-            ],
-            "forget",
-            "cairn.mcp.v1.forget.record",
-        ),
-    ] {
-        let out = run(&args);
-        assert_sensitive_verb_rejection(&out, &args, verb, capability);
-    }
+    let args = vec![
+        "--vault",
+        vault_path,
+        "retrieve",
+        "01JXXXXXXXXXXXXXXXXXXXXXXX",
+        "--json",
+    ];
+    let out = run(&args);
+    assert_sensitive_verb_rejection(&out, &args, "retrieve", "cairn.mcp.v1.retrieve.record");
 }
 
 fn assert_persisted_handshakes_are_fresh(vault: &Path, vault_path: &str) {

--- a/crates/cairn-cli/tests/snapshots/status_snapshot_insta__default_p0_bound_vault.snap
+++ b/crates/cairn-cli/tests/snapshots/status_snapshot_insta__default_p0_bound_vault.snap
@@ -5,7 +5,8 @@ expression: v
 {
   "capabilities": [
     "cairn.mcp.v1.search.keyword",
-    "cairn.mcp.v1.policy_trace"
+    "cairn.mcp.v1.policy_trace",
+    "cairn.mcp.v1.forget.record"
   ],
   "contract": "cairn.mcp.v1",
   "extensions": [],

--- a/crates/cairn-cli/tests/snapshots/status_snapshot_insta__local_embeddings_off.snap
+++ b/crates/cairn-cli/tests/snapshots/status_snapshot_insta__local_embeddings_off.snap
@@ -5,7 +5,8 @@ expression: v
 {
   "capabilities": [
     "cairn.mcp.v1.search.keyword",
-    "cairn.mcp.v1.policy_trace"
+    "cairn.mcp.v1.policy_trace",
+    "cairn.mcp.v1.forget.record"
   ],
   "contract": "cairn.mcp.v1",
   "extensions": [],

--- a/crates/cairn-cli/tests/vault_registry.rs
+++ b/crates/cairn-cli/tests/vault_registry.rs
@@ -12,6 +12,10 @@ fn make_vault(dir: &tempfile::TempDir) -> PathBuf {
     path
 }
 
+fn non_vault_root_child() -> PathBuf {
+    PathBuf::from(format!("/__cairn_test_no_vault_{}", std::process::id()))
+}
+
 // ── Registry CRUD ────────────────────────────────────────────────────────────
 
 #[test]
@@ -166,7 +170,7 @@ fn walk_up_skips_dir_without_cairn() {
 
     let err = resolve_vault(ResolveOpts {
         explicit: None,
-        cwd: Some(PathBuf::from("/tmp")),
+        cwd: Some(non_vault_root_child()),
         store: &store,
     })
     .unwrap_err();
@@ -196,7 +200,7 @@ fn registry_default_used_as_fallback() {
 
     let resolved = resolve_vault(ResolveOpts {
         explicit: None,
-        cwd: Some(PathBuf::from("/tmp")),
+        cwd: Some(non_vault_root_child()),
         store: &store,
     })
     .unwrap();

--- a/crates/cairn-core/src/status/tests.rs
+++ b/crates/cairn-core/src/status/tests.rs
@@ -100,13 +100,12 @@ fn local_embeddings_off_drops_semantic_and_hybrid() {
 }
 
 #[test]
-fn forget_record_held_back_until_wiring_flips() {
-    // wiring::FORGET_RECORD_WIRED = false today.
+fn forget_record_advertises_when_runtime_is_wired() {
     let g = gates(true, true, None);
     let caps = advertise(&g);
     assert!(
-        !caps.contains(&Capabilities::CairnMcpV1ForgetRecord),
-        "forget.record advertised before runtime wired (brief §15)"
+        caps.contains(&Capabilities::CairnMcpV1ForgetRecord),
+        "forget.record must be advertised once runtime wiring is enabled"
     );
 }
 

--- a/crates/cairn-core/src/status/wiring.rs
+++ b/crates/cairn-core/src/status/wiring.rs
@@ -8,7 +8,7 @@
 //! propagates to every surface.
 
 /// `forget --record` end-to-end dispatch path is wired (issue family #54+).
-pub const FORGET_RECORD_WIRED: bool = false;
+pub const FORGET_RECORD_WIRED: bool = true;
 
 /// `forget --session` (v0.2+ runtime).
 pub const FORGET_SESSION_WIRED: bool = false;

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -310,6 +310,19 @@ impl CairnMcpHandler {
             contract_phase: cairn_core::status::Phase::V0_1,
         };
 
+        // Post-filter capabilities whose shared core wiring flags are true
+        // for another surface but not yet honored by this MCP transport.
+        // CLI `forget --record` is wired for issue #58, but MCP non-search
+        // verbs still fall through `dispatch_stub`; do not advertise record
+        // forget here until MCP dispatch can honor it end-to-end.
+        let mut capabilities = cairn_core::status::advertise(&gates);
+        capabilities.retain(|c| {
+            !matches!(
+                c,
+                cairn_core::generated::common::Capabilities::CairnMcpV1ForgetRecord
+            )
+        });
+
         // Post-filter replay capabilities to keep status advertisement and
         // `handshake` tool exposure in lockstep at the MCP boundary
         // (round-2 review #3). `cairn-core::status::advertise` does not
@@ -320,7 +333,6 @@ impl CairnMcpHandler {
         // `handshake` (the prelude needs the sqlite handle to mint
         // nonces). Brief §15 fail-closed: capability advertisement
         // tracks the runtime that can actually honor it.
-        let mut capabilities = cairn_core::status::advertise(&gates);
         if self.sqlite_store.is_none() {
             capabilities.retain(|c| {
                 !matches!(
@@ -932,5 +944,23 @@ mod tests_plan_a {
                 "replay.{{sequence,challenge}} must not appear in status without a sqlite store; got: {cap:?}"
             );
         }
+    }
+
+    #[test]
+    fn forget_record_capability_filtered_until_mcp_dispatch_is_wired() {
+        let store: Arc<dyn cairn_core::contract::memory_store::MemoryStore> =
+            Arc::new(FixtureStore::default());
+        let scope: Arc<dyn McpSessionScope> = Arc::new(ConfigBackedScope::new(principal()));
+        let mut cfg = CairnConfig::default();
+        cfg.mcp.stdio.single_tenant = true;
+        cfg.mcp.stdio.principal = Some(principal());
+        let handler = CairnMcpHandler::with_store_and_scope(store, scope, cfg, principal());
+        let status = handler.status_response();
+        assert!(
+            !status
+                .capabilities
+                .contains(&cairn_core::generated::common::Capabilities::CairnMcpV1ForgetRecord),
+            "MCP status must not advertise forget.record until MCP dispatch is wired"
+        );
     }
 }

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -253,10 +253,18 @@ impl<T: Transport> Sdk<T> {
     /// Project the SDK's executable state into a wire-format capability list.
     ///
     /// Delegates to [`cairn_core::status::advertise`] — the single source of
-    /// truth for capability advertisement. Both [`Self::status`] and
-    /// [`Self::require_capability`] read from here so they cannot drift.
+    /// truth for capability advertisement — then filters capabilities whose
+    /// shared wiring flag is true for another surface but not yet honored by
+    /// this SDK transport. Both [`Self::status`] and [`Self::require_capability`]
+    /// read from here so they cannot drift.
     fn advertised_capabilities(&self) -> Vec<Capabilities> {
-        cairn_core::status::advertise(&self.gates())
+        let mut capabilities = cairn_core::status::advertise(&self.gates());
+        // CLI `forget --record` is wired for issue #58, so the shared core
+        // flag is true. The SDK `forget` method still returns
+        // `Unimplemented` for all targets; do not advertise record forget
+        // here until SDK dispatch can honor it end-to-end.
+        capabilities.retain(|c| !matches!(c, Capabilities::CairnMcpV1ForgetRecord));
+        capabilities
     }
 
     /// `handshake` — challenge mint (brief §8.0.a point d).

--- a/crates/cairn-sdk/tests/surface.rs
+++ b/crates/cairn-sdk/tests/surface.rs
@@ -1067,7 +1067,18 @@ fn sdk_error_code_helper_returns_typed_code() {
 
 #[test]
 fn forget_rejects_unadvertised_target_with_capability_unavailable() {
-    let err = sdk()
+    let sdk = Sdk::with_store(
+        std::sync::Arc::new(noop_store::NoopStore),
+        cairn_core::config::CairnConfig::default(),
+    );
+    assert!(
+        !sdk.status()
+            .capabilities
+            .contains(&cairn_sdk::generated::common::Capabilities::CairnMcpV1ForgetRecord),
+        "SDK status must not advertise forget.record until SDK dispatch is wired"
+    );
+
+    let err = sdk
         .forget(&ForgetArgs::Record {
             record_id: ulid(),
             dry_run: None,

--- a/crates/cairn-store-sqlite/src/entity_graph/mod.rs
+++ b/crates/cairn-store-sqlite/src/entity_graph/mod.rs
@@ -38,6 +38,24 @@ pub(crate) const ENTITY_EDGE_PRE_IMAGE_JSON: &str = "json_object(\
     'source_record_id', source_record_id, \
     'body_hash_hex', hex(body_hash))";
 
+pub(crate) fn entity_edge_body_hash_components(
+    confidence_db_str: &str,
+    confidence_score: f32,
+    valid_at: i64,
+    invalid_at: Option<i64>,
+    created_at: i64,
+    source_record_id: Option<&str>,
+) -> [u8; 32] {
+    edge::body_hash_components(
+        confidence_db_str,
+        confidence_score,
+        valid_at,
+        invalid_at,
+        created_at,
+        source_record_id,
+    )
+}
+
 /// Translate a worker-side error into a typed [`StoreError`], preserving
 /// any [`StoreError`] previously wrapped via `tokio_rusqlite::Error::Other`.
 /// Without this, the blanket `From<tokio_rusqlite::Error>` collapses every

--- a/crates/cairn-store-sqlite/src/lib.rs
+++ b/crates/cairn-store-sqlite/src/lib.rs
@@ -28,7 +28,7 @@ pub mod wal;
 
 pub use error::StoreError;
 pub use identity::SqliteIdentityRegistry;
-pub use lint::{EdgeLintReport, lint_edges, resolve_edge_contradictions};
+pub use lint::{EdgeLintReport, lint_edges, lint_purge_pending, resolve_edge_contradictions};
 pub use open::{
     open, open_in_memory, open_in_memory_with_embedder, open_in_memory_with_embedder_and_config,
     open_with_embedder, open_with_embedder_and_config, peek_capabilities,

--- a/crates/cairn-store-sqlite/src/lint.rs
+++ b/crates/cairn-store-sqlite/src/lint.rs
@@ -68,11 +68,12 @@ pub fn lint_purge_pending(conn: &Connection) -> Result<Vec<Finding>, StoreError>
     ensure_table(conn, WAL_STEPS_TABLE)?;
 
     let mut stmt = conn.prepare(
-        "SELECT wo.operation_id, wo.target_hash, ws.step_ord, ws.step_kind, ws.state, ws.attempts
+        "SELECT wo.operation_id, wo.target_hash, wo.state, \
+                ws.step_ord, ws.step_kind, ws.state, ws.attempts
          FROM wal_ops wo
          JOIN wal_steps ws ON ws.operation_id = wo.operation_id
          WHERE wo.kind = 'forget_record'
-           AND wo.state = 'PREPARED'
+           AND wo.state IN ('PREPARED', 'ABORTED')
            AND ws.step_ord >= 1
            AND ws.state <> 'DONE'
          ORDER BY wo.issued_seq, ws.step_ord",
@@ -81,28 +82,39 @@ pub fn lint_purge_pending(conn: &Connection) -> Result<Vec<Finding>, StoreError>
         Ok((
             row.get::<_, String>(0)?,
             row.get::<_, String>(1)?,
-            row.get::<_, i64>(2)?,
-            row.get::<_, String>(3)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, i64>(3)?,
             row.get::<_, String>(4)?,
-            row.get::<_, i64>(5)?,
+            row.get::<_, String>(5)?,
+            row.get::<_, i64>(6)?,
         ))
     })?;
 
     let mut findings = Vec::new();
     for row in rows {
-        let (operation_id, target_hash, step_ord, step_kind, state, attempts) = row?;
+        let (operation_id, target_hash, op_state, step_ord, step_kind, step_state, attempts) = row?;
+        let (label, suggested_fix) = if op_state == "ABORTED" {
+            (
+                "purge_failed",
+                "manual intervention required: inspect the WAL step error and verify residual \
+                 payload/pre-image purge before retrying or repairing the operation",
+            )
+        } else {
+            (
+                "purge_pending",
+                "restart Cairn to resume WAL recovery; if it repeats, inspect the WAL step error",
+            )
+        };
         findings.push(Finding {
             kind: Kind::DeferredCheck,
             severity: Severity::Warning,
             message: format!(
-                "purge_pending: forget_record operation {operation_id} target {target_hash} \
-                 stalled at step {step_ord} ({step_kind}) state={state} attempts={attempts}"
+                "{label}: forget_record operation {operation_id} target {target_hash} \
+                 op_state={op_state} stalled at step {step_ord} ({step_kind}) \
+                 state={step_state} attempts={attempts}"
             ),
             entities: None,
-            suggested_fix: Some(
-                "restart Cairn to resume WAL recovery; if it repeats, inspect the WAL step error"
-                    .to_owned(),
-            ),
+            suggested_fix: Some(suggested_fix.to_owned()),
             target: Some(Target {
                 operation_id: ulid_from_operation_id(&operation_id),
                 path: None,

--- a/crates/cairn-store-sqlite/src/lint.rs
+++ b/crates/cairn-store-sqlite/src/lint.rs
@@ -3,6 +3,8 @@
 use std::collections::BTreeMap;
 
 use cairn_core::domain::graph::EdgeConfidence;
+use cairn_core::generated::common::Ulid;
+use cairn_core::generated::verbs::lint::Target;
 use cairn_core::generated::verbs::lint::{Finding, Kind, Severity};
 use rusqlite::{Connection, Transaction, TransactionBehavior};
 
@@ -41,9 +43,11 @@ pub fn lint_edges(conn: &Connection) -> Result<EdgeLintReport, StoreError> {
 
     let mut findings = contradiction_findings(conn)?;
     let ambiguous_findings = ambiguous_findings(conn)?;
+    let purge_findings = lint_purge_pending(conn)?;
     let contradictions = usize_to_u64(findings.len());
     let ambiguous_edges = usize_to_u64(ambiguous_findings.len());
     findings.extend(ambiguous_findings);
+    findings.extend(purge_findings);
 
     Ok(EdgeLintReport {
         findings,
@@ -51,6 +55,63 @@ pub fn lint_edges(conn: &Connection) -> Result<EdgeLintReport, StoreError> {
         ambiguous_edges,
         auto_resolved: 0,
     })
+}
+
+/// Find record-forget operations whose Phase B purge work is still incomplete.
+///
+/// # Errors
+///
+/// Returns [`StoreError`] when WAL tables are missing or `SQLite` rejects the
+/// query.
+pub fn lint_purge_pending(conn: &Connection) -> Result<Vec<Finding>, StoreError> {
+    ensure_table(conn, WAL_OPS_TABLE)?;
+    ensure_table(conn, WAL_STEPS_TABLE)?;
+
+    let mut stmt = conn.prepare(
+        "SELECT wo.operation_id, wo.target_hash, ws.step_ord, ws.step_kind, ws.state, ws.attempts
+         FROM wal_ops wo
+         JOIN wal_steps ws ON ws.operation_id = wo.operation_id
+         WHERE wo.kind = 'forget_record'
+           AND wo.state = 'PREPARED'
+           AND ws.step_ord >= 1
+           AND ws.state <> 'DONE'
+         ORDER BY wo.issued_seq, ws.step_ord",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, i64>(5)?,
+        ))
+    })?;
+
+    let mut findings = Vec::new();
+    for row in rows {
+        let (operation_id, target_hash, step_ord, step_kind, state, attempts) = row?;
+        findings.push(Finding {
+            kind: Kind::DeferredCheck,
+            severity: Severity::Warning,
+            message: format!(
+                "purge_pending: forget_record operation {operation_id} target {target_hash} \
+                 stalled at step {step_ord} ({step_kind}) state={state} attempts={attempts}"
+            ),
+            entities: None,
+            suggested_fix: Some(
+                "restart Cairn to resume WAL recovery; if it repeats, inspect the WAL step error"
+                    .to_owned(),
+            ),
+            target: Some(Target {
+                operation_id: ulid_from_operation_id(&operation_id),
+                path: None,
+                record_id: None,
+            }),
+            tracking_issue: Some(58),
+        });
+    }
+    Ok(findings)
 }
 
 /// Invalidate duplicate live edges and record the repair through the WAL.
@@ -294,6 +355,13 @@ fn parse_confidence(edge_id: &str, value: &str) -> Result<EdgeConfidence, StoreE
         edge_id: edge_id.to_owned(),
         value: value.to_owned(),
     })
+}
+
+fn ulid_from_operation_id(raw: &str) -> Option<Ulid> {
+    raw.rsplit_once('-')
+        .map(|(_, tail)| tail)
+        .filter(|tail| tail.len() == 26)
+        .map(|tail| Ulid((*tail).to_owned()))
 }
 
 fn edge_body_hash(

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -95,6 +95,9 @@ const M0052_LOCK_ACQUISITION_ULID_UNIQUE: &str =
 const M0053_WAL_PAYLOADS: &str = include_str!("sql/0053_wal_payloads.sql");
 // Issue #57 round-2 — internal marker for pre-activation COW rows.
 const M0054_RECORDS_COW_STAGING: &str = include_str!("sql/0054_records_cow_staging.sql");
+// Issue #58 - forget_record payloads and WAL scrub stubs.
+const M0055_FORGET_RECORD_PAYLOAD_SCRUB: &str =
+    include_str!("sql/0055_forget_record_payload_scrub.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -247,6 +250,11 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
     ),
     (53, "0053_wal_payloads", M0053_WAL_PAYLOADS),
     (54, "0054_records_cow_staging", M0054_RECORDS_COW_STAGING),
+    (
+        55,
+        "0055_forget_record_payload_scrub",
+        M0055_FORGET_RECORD_PAYLOAD_SCRUB,
+    ),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -302,5 +310,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0052_LOCK_ACQUISITION_ULID_UNIQUE),
         M::up(M0053_WAL_PAYLOADS),
         M::up(M0054_RECORDS_COW_STAGING),
+        M::up(M0055_FORGET_RECORD_PAYLOAD_SCRUB),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/sql/0055_forget_record_payload_scrub.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0055_forget_record_payload_scrub.sql
@@ -41,8 +41,10 @@ CREATE TRIGGER wal_payloads_scrub_only
   FOR EACH ROW
   WHEN NEW.operation_id IS NOT OLD.operation_id
     OR NEW.created_at IS NOT OLD.created_at
+    OR OLD.kind = 'purged'
     OR NEW.kind <> 'purged'
-    OR json_extract(NEW.payload_json, '$.type') <> 'purged'
+    OR json_type(NEW.payload_json, '$.type') IS NOT 'text'
+    OR json_extract(NEW.payload_json, '$.type') IS NOT 'purged'
 BEGIN
   SELECT RAISE(ABORT, 'wal_payloads updates are limited to purged scrub stubs');
 END;

--- a/crates/cairn-store-sqlite/src/migrations/sql/0055_forget_record_payload_scrub.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0055_forget_record_payload_scrub.sql
@@ -1,0 +1,58 @@
+-- Migration 0055: allow record-forget payloads and body-scrub stubs.
+-- Issue #58: forget_record recovery needs a body-free payload, and Phase B
+-- must scrub body-bearing upsert/expire WAL retention without deleting audit rows.
+
+DROP TRIGGER IF EXISTS wal_payloads_kind_matches_wal;
+DROP TRIGGER IF EXISTS wal_payloads_immutable;
+DROP TRIGGER IF EXISTS wal_payloads_no_delete;
+
+ALTER TABLE wal_payloads RENAME TO wal_payloads_old;
+
+CREATE TABLE wal_payloads (
+  operation_id TEXT NOT NULL PRIMARY KEY
+                    REFERENCES wal_ops(operation_id),
+  kind         TEXT NOT NULL CHECK (kind IN ('upsert', 'expire', 'forget_record', 'purged')),
+  payload_json TEXT NOT NULL,
+  created_at   INTEGER NOT NULL
+);
+
+INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at)
+SELECT operation_id, kind, payload_json, created_at
+  FROM wal_payloads_old;
+
+DROP TABLE wal_payloads_old;
+
+CREATE TRIGGER wal_payloads_kind_matches_wal
+  BEFORE INSERT ON wal_payloads
+  FOR EACH ROW
+  WHEN NEW.kind <> 'purged'
+   AND EXISTS (
+    SELECT 1
+      FROM wal_ops
+     WHERE operation_id = NEW.operation_id
+       AND kind IS NOT NEW.kind
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads.kind must match wal_ops.kind');
+END;
+
+CREATE TRIGGER wal_payloads_scrub_only
+  BEFORE UPDATE ON wal_payloads
+  FOR EACH ROW
+  WHEN NEW.operation_id IS NOT OLD.operation_id
+    OR NEW.created_at IS NOT OLD.created_at
+    OR NEW.kind <> 'purged'
+    OR json_extract(NEW.payload_json, '$.type') <> 'purged'
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads updates are limited to purged scrub stubs');
+END;
+
+CREATE TRIGGER wal_payloads_no_delete
+  BEFORE DELETE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads is append-only');
+END;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (55, '0055_forget_record_payload_scrub', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/record_wal/forget.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/forget.rs
@@ -3,10 +3,16 @@
 use std::sync::Arc;
 
 use cairn_core::domain::{RecordId, ScopeTuple, TargetId};
+use cairn_core::wal::{OpState, OperationId, WalKind, graph_for};
 use rusqlite::{OptionalExtension, params};
 
 use crate::error::StoreError;
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::ops::{finalize, issue_prepared, new_operation_id};
+use crate::record_wal::payload::{ForgetPayload, RecordWalPayload, save_payload};
+use crate::record_wal::steps::RecordStepBody;
 use crate::store::SqliteMemoryStore;
+use crate::wal::runner::{self, StepBody};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForgetTarget {
@@ -15,6 +21,88 @@ pub struct ForgetTarget {
     pub scope: ScopeTuple,
     pub record_ids: Vec<RecordId>,
     pub target_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgetOutcome {
+    pub deleted_count: u64,
+    pub tombstones: Vec<RecordId>,
+    pub operation_id: OperationId,
+}
+
+pub(crate) async fn apply_forget_record(
+    store: &SqliteMemoryStore,
+    record_id: &RecordId,
+) -> Result<ForgetOutcome, StoreError> {
+    let conn = Arc::clone(store.require_conn("forget_record")?);
+    let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
+        what: "forget_record requires daemon incarnation".to_owned(),
+    })?;
+    let target = resolve_forget_target(store, record_id).await?;
+    let op_id = new_operation_id(WalKind::ForgetRecord)?;
+    let locks = acquire_for_record(
+        &conn,
+        &target.scope,
+        &target.target_id,
+        &incarnation,
+        op_id.as_str(),
+        "record_wal_forget_record",
+    )
+    .await
+    .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
+
+    let payload = ForgetPayload {
+        requested_record_id: target.requested_record_id.clone(),
+        target_id: target.target_id.clone(),
+        scope: target.scope.clone(),
+        record_ids: target.record_ids.clone(),
+        target_hash: target.target_hash.clone(),
+        reason_code: "user_command".to_owned(),
+    };
+
+    let payload_for_body = payload.clone();
+    let op_for_issue = op_id.clone();
+    let target_hash = target.target_hash.clone();
+    let scope_wire = target.scope.canonical_wire();
+    conn.call(move |c| {
+        let tx = c.transaction()?;
+        issue_prepared(
+            &tx,
+            &op_for_issue,
+            WalKind::ForgetRecord,
+            &target_hash,
+            &scope_wire,
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        save_payload(
+            &tx,
+            &op_for_issue,
+            &RecordWalPayload::ForgetRecord(Box::new(payload_for_body)),
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        tx.commit()?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .map_err(unpack_worker_err)?;
+
+    let body: Arc<dyn StepBody> = Arc::new(RecordStepBody::new_forget_record(payload, locks));
+    runner::run_from(&conn, graph_for(WalKind::ForgetRecord), &op_id, 0, body).await?;
+
+    let op_for_finalize = op_id.clone();
+    conn.call(move |c| {
+        finalize(c, &op_for_finalize, OpState::Committed, "applied")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .map_err(unpack_worker_err)?;
+
+    Ok(ForgetOutcome {
+        deleted_count: u64::try_from(target.record_ids.len()).unwrap_or(u64::MAX),
+        tombstones: target.record_ids,
+        operation_id: op_id,
+    })
 }
 
 async fn resolve_forget_target(

--- a/crates/cairn-store-sqlite/src/record_wal/forget.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/forget.rs
@@ -42,10 +42,13 @@ async fn resolve_forget_target(
                 },
             )));
         };
-        let target_id = TargetId::parse(target_raw.clone())
-            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(StoreError::InvalidRecord(e))))?;
+        let target_id = TargetId::parse(target_raw.clone()).map_err(|e| {
+            tokio_rusqlite::Error::Other(Box::new(StoreError::Invariant {
+                what: format!("invalid target_id `{target_raw}` in forget target: {e}"),
+            }))
+        })?;
         let scope: ScopeTuple = serde_json::from_str(&scope_json)
-            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(StoreError::Codec(e))))?;
 
         let mut stmt = c.prepare(
             "SELECT record_id \
@@ -53,20 +56,18 @@ async fn resolve_forget_target(
               WHERE target_id = ?1 \
               ORDER BY version ASC, record_id ASC",
         )?;
-        let ids = stmt
+        let raw_ids = stmt
             .query_map(params![target_id.as_str()], |row| row.get::<_, String>(0))?
-            .map(|row| {
-                row.and_then(|raw| {
-                    RecordId::parse(raw).map_err(|e| {
-                        rusqlite::Error::FromSqlConversionFailure(
-                            0,
-                            rusqlite::types::Type::Text,
-                            Box::new(e),
-                        )
-                    })
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        let ids = raw_ids
+            .into_iter()
+            .map(|raw| {
+                RecordId::parse(raw.clone()).map_err(|e| StoreError::Invariant {
+                    what: format!("invalid record_id `{raw}` in forget lineage: {e}"),
                 })
             })
-            .collect::<rusqlite::Result<Vec<_>>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
         let target_hash = hash_target_id(target_id.as_str());
         Ok::<_, tokio_rusqlite::Error>(ForgetTarget {
             requested_record_id: requested,

--- a/crates/cairn-store-sqlite/src/record_wal/forget.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/forget.rs
@@ -59,9 +59,12 @@ pub(crate) async fn apply_forget_record(
     .await
     .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
 
-    let record_ids =
-        load_forget_lineage(&conn, &target_seed.target_id, &target_seed.requested_record_id)
-            .await?;
+    let record_ids = load_forget_lineage(
+        &conn,
+        &target_seed.target_id,
+        &target_seed.requested_record_id,
+    )
+    .await?;
     let target = ForgetTarget {
         requested_record_id: target_seed.requested_record_id,
         target_id: target_seed.target_id,

--- a/crates/cairn-store-sqlite/src/record_wal/forget.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/forget.rs
@@ -24,6 +24,14 @@ pub struct ForgetTarget {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct ForgetTargetSeed {
+    requested_record_id: RecordId,
+    target_id: TargetId,
+    scope: ScopeTuple,
+    target_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForgetOutcome {
     pub deleted_count: u64,
     pub tombstones: Vec<RecordId>,
@@ -38,18 +46,29 @@ pub(crate) async fn apply_forget_record(
     let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
         what: "forget_record requires daemon incarnation".to_owned(),
     })?;
-    let target = resolve_forget_target(store, record_id).await?;
+    let target_seed = resolve_forget_target_seed(store, record_id).await?;
     let op_id = new_operation_id(WalKind::ForgetRecord)?;
     let locks = acquire_for_record(
         &conn,
-        &target.scope,
-        &target.target_id,
+        &target_seed.scope,
+        &target_seed.target_id,
         &incarnation,
         op_id.as_str(),
         "record_wal_forget_record",
     )
     .await
     .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
+
+    let record_ids =
+        load_forget_lineage(&conn, &target_seed.target_id, &target_seed.requested_record_id)
+            .await?;
+    let target = ForgetTarget {
+        requested_record_id: target_seed.requested_record_id,
+        target_id: target_seed.target_id,
+        scope: target_seed.scope,
+        record_ids,
+        target_hash: target_seed.target_hash,
+    };
 
     let payload = ForgetPayload {
         requested_record_id: target.requested_record_id.clone(),
@@ -110,6 +129,22 @@ async fn resolve_forget_target(
     record_id: &RecordId,
 ) -> Result<ForgetTarget, StoreError> {
     let conn = Arc::clone(store.require_conn("forget_record")?);
+    let seed = resolve_forget_target_seed(store, record_id).await?;
+    let record_ids = load_forget_lineage(&conn, &seed.target_id, &seed.requested_record_id).await?;
+    Ok(ForgetTarget {
+        requested_record_id: seed.requested_record_id,
+        target_id: seed.target_id,
+        scope: seed.scope,
+        record_ids,
+        target_hash: seed.target_hash,
+    })
+}
+
+async fn resolve_forget_target_seed(
+    store: &SqliteMemoryStore,
+    record_id: &RecordId,
+) -> Result<ForgetTargetSeed, StoreError> {
+    let conn = Arc::clone(store.require_conn("forget_record")?);
     let requested = record_id.clone();
     conn.call(move |c| {
         let row: Option<(String, String)> = c
@@ -137,7 +172,26 @@ async fn resolve_forget_target(
         })?;
         let scope: ScopeTuple = serde_json::from_str(&scope_json)
             .map_err(|e| tokio_rusqlite::Error::Other(Box::new(StoreError::Codec(e))))?;
+        let target_hash = hash_target_id(target_id.as_str());
+        Ok::<_, tokio_rusqlite::Error>(ForgetTargetSeed {
+            requested_record_id: requested,
+            target_id,
+            scope,
+            target_hash,
+        })
+    })
+    .await
+    .map_err(unpack_worker_err)
+}
 
+async fn load_forget_lineage(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    target_id: &TargetId,
+    requested: &RecordId,
+) -> Result<Vec<RecordId>, StoreError> {
+    let target = target_id.as_str().to_owned();
+    let requested = requested.clone();
+    conn.call(move |c| {
         let mut stmt = c.prepare(
             "SELECT record_id \
                FROM records \
@@ -145,9 +199,16 @@ async fn resolve_forget_target(
               ORDER BY version ASC, record_id ASC",
         )?;
         let raw_ids = stmt
-            .query_map(params![target_id.as_str()], |row| row.get::<_, String>(0))?
+            .query_map(params![target], |row| row.get::<_, String>(0))?
             .collect::<rusqlite::Result<Vec<_>>>()?;
-        let ids = raw_ids
+        if raw_ids.is_empty() {
+            return Err(tokio_rusqlite::Error::Other(Box::new(
+                StoreError::NotFound {
+                    id: requested.as_str().to_owned(),
+                },
+            )));
+        }
+        raw_ids
             .into_iter()
             .map(|raw| {
                 RecordId::parse(raw.clone()).map_err(|e| StoreError::Invariant {
@@ -155,15 +216,7 @@ async fn resolve_forget_target(
                 })
             })
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
-        let target_hash = hash_target_id(target_id.as_str());
-        Ok::<_, tokio_rusqlite::Error>(ForgetTarget {
-            requested_record_id: requested,
-            target_id,
-            scope,
-            record_ids: ids,
-            target_hash,
-        })
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
     })
     .await
     .map_err(unpack_worker_err)

--- a/crates/cairn-store-sqlite/src/record_wal/forget.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/forget.rs
@@ -1,0 +1,106 @@
+//! Public record-level forget apply through record WAL.
+
+use std::sync::Arc;
+
+use cairn_core::domain::{RecordId, ScopeTuple, TargetId};
+use rusqlite::{OptionalExtension, params};
+
+use crate::error::StoreError;
+use crate::store::SqliteMemoryStore;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgetTarget {
+    pub requested_record_id: RecordId,
+    pub target_id: TargetId,
+    pub scope: ScopeTuple,
+    pub record_ids: Vec<RecordId>,
+    pub target_hash: String,
+}
+
+async fn resolve_forget_target(
+    store: &SqliteMemoryStore,
+    record_id: &RecordId,
+) -> Result<ForgetTarget, StoreError> {
+    let conn = Arc::clone(store.require_conn("forget_record")?);
+    let requested = record_id.clone();
+    conn.call(move |c| {
+        let row: Option<(String, String)> = c
+            .query_row(
+                "SELECT target_id, scope \
+                   FROM records \
+                  WHERE record_id = ?1 \
+                  ORDER BY version DESC \
+                  LIMIT 1",
+                params![requested.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let Some((target_raw, scope_json)) = row else {
+            return Err(tokio_rusqlite::Error::Other(Box::new(
+                StoreError::NotFound {
+                    id: requested.as_str().to_owned(),
+                },
+            )));
+        };
+        let target_id = TargetId::parse(target_raw.clone())
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(StoreError::InvalidRecord(e))))?;
+        let scope: ScopeTuple = serde_json::from_str(&scope_json)
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+
+        let mut stmt = c.prepare(
+            "SELECT record_id \
+               FROM records \
+              WHERE target_id = ?1 \
+              ORDER BY version ASC, record_id ASC",
+        )?;
+        let ids = stmt
+            .query_map(params![target_id.as_str()], |row| row.get::<_, String>(0))?
+            .map(|row| {
+                row.and_then(|raw| {
+                    RecordId::parse(raw).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Text,
+                            Box::new(e),
+                        )
+                    })
+                })
+            })
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        let target_hash = hash_target_id(target_id.as_str());
+        Ok::<_, tokio_rusqlite::Error>(ForgetTarget {
+            requested_record_id: requested,
+            target_id,
+            scope,
+            record_ids: ids,
+            target_hash,
+        })
+    })
+    .await
+    .map_err(unpack_worker_err)
+}
+
+fn hash_target_id(target_id: &str) -> String {
+    format!(
+        "hash:{}",
+        cairn_core::domain::projection::body_hash(&format!("forget_record:{target_id}"))
+    )
+}
+
+fn unpack_worker_err(err: tokio_rusqlite::Error) -> StoreError {
+    match err {
+        tokio_rusqlite::Error::Other(boxed) => match boxed.downcast::<StoreError>() {
+            Ok(inner) => *inner,
+            Err(other) => StoreError::Worker(tokio_rusqlite::Error::Other(other)),
+        },
+        other => StoreError::from(other),
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub async fn resolve_forget_target_for_test(
+    store: &SqliteMemoryStore,
+    record_id: &RecordId,
+) -> Result<ForgetTarget, StoreError> {
+    resolve_forget_target(store, record_id).await
+}

--- a/crates/cairn-store-sqlite/src/record_wal/mod.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/mod.rs
@@ -7,6 +7,7 @@
     reason = "Task 3 intentionally lands record WAL scaffolding before later tasks wire callers"
 )]
 
+pub mod forget;
 pub mod payload;
 
 pub(crate) mod expire;

--- a/crates/cairn-store-sqlite/src/record_wal/mod.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/mod.rs
@@ -18,5 +18,6 @@ pub(crate) mod steps;
 pub(crate) mod upsert;
 
 pub(crate) use expire::apply_expire;
+pub(crate) use forget::apply_forget_record;
 pub use recovery::RecordWalRegistry;
 pub(crate) use upsert::apply_upsert;

--- a/crates/cairn-store-sqlite/src/record_wal/payload.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/payload.rs
@@ -13,6 +13,8 @@ use crate::store::current_unix_ms;
 pub enum RecordWalPayload {
     Upsert(Box<UpsertPayload>),
     Expire(Box<ExpirePayload>),
+    ForgetRecord(Box<ForgetPayload>),
+    Purged(Box<PurgedPayload>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -83,6 +85,23 @@ pub struct ExpirePayload {
     pub scope: ScopeTuple,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ForgetPayload {
+    pub requested_record_id: RecordId,
+    pub target_id: TargetId,
+    pub scope: ScopeTuple,
+    pub record_ids: Vec<RecordId>,
+    pub target_hash: String,
+    pub reason_code: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PurgedPayload {
+    pub target_hash: String,
+    pub purged_by: String,
+    pub purged_at: i64,
+}
+
 pub(crate) fn save_payload(
     conn: &Connection,
     op_id: &OperationId,
@@ -91,6 +110,12 @@ pub(crate) fn save_payload(
     let kind = match payload {
         RecordWalPayload::Upsert(_) => WalKind::Upsert.as_str(),
         RecordWalPayload::Expire(_) => WalKind::Expire.as_str(),
+        RecordWalPayload::ForgetRecord(_) => WalKind::ForgetRecord.as_str(),
+        RecordWalPayload::Purged(_) => {
+            return Err(StoreError::Invariant {
+                what: "purged wal payloads are written by scrub updates, not inserted".to_owned(),
+            });
+        }
     };
     let json = serde_json::to_string(payload)?;
     conn.execute(
@@ -166,6 +191,71 @@ pub fn load_upsert_payload_for_test(
         RecordWalPayload::Upsert(payload) => Ok(*payload),
         RecordWalPayload::Expire(_) => Err(StoreError::Invariant {
             what: "expected upsert payload, found expire payload".to_owned(),
+        }),
+        RecordWalPayload::ForgetRecord(_) => Err(StoreError::Invariant {
+            what: "expected upsert payload, found forget_record payload".to_owned(),
+        }),
+        RecordWalPayload::Purged(_) => Err(StoreError::Invariant {
+            what: "expected upsert payload, found purged payload".to_owned(),
+        }),
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl ForgetPayload {
+    #[must_use]
+    pub fn new_for_test(
+        requested_record_id: RecordId,
+        target_id: TargetId,
+        scope: ScopeTuple,
+        record_ids: Vec<RecordId>,
+        target_hash: String,
+    ) -> Self {
+        Self {
+            requested_record_id,
+            target_id,
+            scope,
+            record_ids,
+            target_hash,
+            reason_code: "user_command".to_owned(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn save_forget_payload_for_test(
+    conn: &Connection,
+    op_id: &str,
+    payload: &ForgetPayload,
+) -> Result<(), StoreError> {
+    let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
+        what: format!("invalid test op id: {e}"),
+    })?;
+    save_payload(
+        conn,
+        &op,
+        &RecordWalPayload::ForgetRecord(Box::new(payload.clone())),
+    )
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn load_forget_payload_for_test(
+    conn: &Connection,
+    op_id: &str,
+) -> Result<ForgetPayload, StoreError> {
+    let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
+        what: format!("invalid test op id: {e}"),
+    })?;
+    match load_payload(conn, &op)? {
+        RecordWalPayload::ForgetRecord(payload) => Ok(*payload),
+        RecordWalPayload::Upsert(_) => Err(StoreError::Invariant {
+            what: "expected forget_record payload, found upsert payload".to_owned(),
+        }),
+        RecordWalPayload::Expire(_) => Err(StoreError::Invariant {
+            what: "expected forget_record payload, found expire payload".to_owned(),
+        }),
+        RecordWalPayload::Purged(_) => Err(StoreError::Invariant {
+            what: "expected forget_record payload, found purged payload".to_owned(),
         }),
     }
 }

--- a/crates/cairn-store-sqlite/src/record_wal/payload.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/payload.rs
@@ -259,3 +259,19 @@ pub fn load_forget_payload_for_test(
         }),
     }
 }
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn save_purged_payload_for_test(
+    conn: &Connection,
+    op_id: &str,
+    payload: &PurgedPayload,
+) -> Result<(), StoreError> {
+    let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
+        what: format!("invalid test op id: {e}"),
+    })?;
+    save_payload(
+        conn,
+        &op,
+        &RecordWalPayload::Purged(Box::new(payload.clone())),
+    )
+}

--- a/crates/cairn-store-sqlite/src/record_wal/recovery.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/recovery.rs
@@ -89,7 +89,6 @@ impl StepBodyRegistry for RecordWalRegistry {
                 }
                 RecordWalPayload::Purged(_) => Err(payload_mismatch("purged", "expire")),
             },
-            WalKind::ForgetRecord => Ok(None),
             _ => Ok(None),
         }
     }

--- a/crates/cairn-store-sqlite/src/record_wal/recovery.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/recovery.rs
@@ -36,7 +36,7 @@ impl StepBodyRegistry for RecordWalRegistry {
         op_id: &OperationId,
     ) -> Result<Option<Arc<dyn StepBody>>, RecoveryError> {
         match kind {
-            WalKind::Upsert | WalKind::Expire => {}
+            WalKind::Upsert | WalKind::Expire | WalKind::ForgetRecord => {}
             _ => return Ok(None),
         }
 
@@ -48,47 +48,67 @@ impl StepBodyRegistry for RecordWalRegistry {
             .await
             .map_err(RecoveryError::Storage)?;
 
-        match kind {
-            WalKind::Upsert => match payload {
-                RecordWalPayload::Upsert(payload) => {
-                    let locks = acquire_for_record(
-                        conn,
-                        &payload.record.scope,
-                        &payload.record.target_id,
-                        &self.incarnation,
-                        op_id.as_str(),
-                        "record_wal_recovery_upsert",
-                    )
-                    .await
-                    .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
-                    Ok(Some(Arc::new(RecordStepBody::new_upsert(*payload, locks))))
-                }
-                RecordWalPayload::Expire(_) => Err(payload_mismatch("expire", "upsert")),
-                RecordWalPayload::ForgetRecord(_) => {
-                    Err(payload_mismatch("forget_record", "upsert"))
-                }
-                RecordWalPayload::Purged(_) => Err(payload_mismatch("purged", "upsert")),
-            },
-            WalKind::Expire => match payload {
-                RecordWalPayload::Expire(payload) => {
-                    let locks = acquire_for_record(
-                        conn,
-                        &payload.scope,
-                        &payload.target_id,
-                        &self.incarnation,
-                        op_id.as_str(),
-                        "record_wal_recovery_expire",
-                    )
-                    .await
-                    .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
-                    Ok(Some(Arc::new(RecordStepBody::new_expire(*payload, locks))))
-                }
-                RecordWalPayload::Upsert(_) => Err(payload_mismatch("upsert", "expire")),
-                RecordWalPayload::ForgetRecord(_) => {
-                    Err(payload_mismatch("forget_record", "expire"))
-                }
-                RecordWalPayload::Purged(_) => Err(payload_mismatch("purged", "expire")),
-            },
+        match (kind, payload) {
+            (WalKind::Upsert, RecordWalPayload::Upsert(payload)) => {
+                let locks = acquire_for_record(
+                    conn,
+                    &payload.record.scope,
+                    &payload.record.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_upsert",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_upsert(*payload, locks))))
+            }
+            (WalKind::Expire, RecordWalPayload::Expire(payload)) => {
+                let locks = acquire_for_record(
+                    conn,
+                    &payload.scope,
+                    &payload.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_expire",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_expire(*payload, locks))))
+            }
+            (WalKind::ForgetRecord, RecordWalPayload::ForgetRecord(payload)) => {
+                let locks = acquire_for_record(
+                    conn,
+                    &payload.scope,
+                    &payload.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_forget_record",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_forget_record(
+                    *payload, locks,
+                ))))
+            }
+            (kind, RecordWalPayload::Purged(_)) => Err(purged_payload_recovery(kind)),
+            (WalKind::Upsert, RecordWalPayload::Expire(_)) => {
+                Err(payload_mismatch("expire", "upsert"))
+            }
+            (WalKind::Upsert, RecordWalPayload::ForgetRecord(_)) => {
+                Err(payload_mismatch("forget_record", "upsert"))
+            }
+            (WalKind::Expire, RecordWalPayload::Upsert(_)) => {
+                Err(payload_mismatch("upsert", "expire"))
+            }
+            (WalKind::Expire, RecordWalPayload::ForgetRecord(_)) => {
+                Err(payload_mismatch("forget_record", "expire"))
+            }
+            (WalKind::ForgetRecord, RecordWalPayload::Upsert(_)) => {
+                Err(payload_mismatch("upsert", "forget_record"))
+            }
+            (WalKind::ForgetRecord, RecordWalPayload::Expire(_)) => {
+                Err(payload_mismatch("expire", "forget_record"))
+            }
             _ => Ok(None),
         }
     }
@@ -97,5 +117,13 @@ impl StepBodyRegistry for RecordWalRegistry {
 fn payload_mismatch(payload_variant: &str, wal_kind: &str) -> RecoveryError {
     RecoveryError::Invariant(format!(
         "record wal payload variant {payload_variant} does not match wal kind {wal_kind}"
+    ))
+}
+
+fn purged_payload_recovery(kind: WalKind) -> RecoveryError {
+    RecoveryError::Invariant(format!(
+        "purged record wal payload cannot be recovered as an active operation; \
+         record wal payload variant purged does not match wal kind {}",
+        kind.as_str()
     ))
 }

--- a/crates/cairn-store-sqlite/src/record_wal/recovery.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/recovery.rs
@@ -48,40 +48,55 @@ impl StepBodyRegistry for RecordWalRegistry {
             .await
             .map_err(RecoveryError::Storage)?;
 
-        match (kind, payload) {
-            (WalKind::Upsert, RecordWalPayload::Upsert(payload)) => {
-                let locks = acquire_for_record(
-                    conn,
-                    &payload.record.scope,
-                    &payload.record.target_id,
-                    &self.incarnation,
-                    op_id.as_str(),
-                    "record_wal_recovery_upsert",
-                )
-                .await
-                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
-                Ok(Some(Arc::new(RecordStepBody::new_upsert(*payload, locks))))
-            }
-            (WalKind::Expire, RecordWalPayload::Expire(payload)) => {
-                let locks = acquire_for_record(
-                    conn,
-                    &payload.scope,
-                    &payload.target_id,
-                    &self.incarnation,
-                    op_id.as_str(),
-                    "record_wal_recovery_expire",
-                )
-                .await
-                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
-                Ok(Some(Arc::new(RecordStepBody::new_expire(*payload, locks))))
-            }
-            (WalKind::Upsert, RecordWalPayload::Expire(_)) => Err(RecoveryError::Invariant(
-                "record wal payload variant expire does not match wal kind upsert".to_owned(),
-            )),
-            (WalKind::Expire, RecordWalPayload::Upsert(_)) => Err(RecoveryError::Invariant(
-                "record wal payload variant upsert does not match wal kind expire".to_owned(),
-            )),
+        match kind {
+            WalKind::Upsert => match payload {
+                RecordWalPayload::Upsert(payload) => {
+                    let locks = acquire_for_record(
+                        conn,
+                        &payload.record.scope,
+                        &payload.record.target_id,
+                        &self.incarnation,
+                        op_id.as_str(),
+                        "record_wal_recovery_upsert",
+                    )
+                    .await
+                    .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                    Ok(Some(Arc::new(RecordStepBody::new_upsert(*payload, locks))))
+                }
+                RecordWalPayload::Expire(_) => Err(payload_mismatch("expire", "upsert")),
+                RecordWalPayload::ForgetRecord(_) => {
+                    Err(payload_mismatch("forget_record", "upsert"))
+                }
+                RecordWalPayload::Purged(_) => Err(payload_mismatch("purged", "upsert")),
+            },
+            WalKind::Expire => match payload {
+                RecordWalPayload::Expire(payload) => {
+                    let locks = acquire_for_record(
+                        conn,
+                        &payload.scope,
+                        &payload.target_id,
+                        &self.incarnation,
+                        op_id.as_str(),
+                        "record_wal_recovery_expire",
+                    )
+                    .await
+                    .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                    Ok(Some(Arc::new(RecordStepBody::new_expire(*payload, locks))))
+                }
+                RecordWalPayload::Upsert(_) => Err(payload_mismatch("upsert", "expire")),
+                RecordWalPayload::ForgetRecord(_) => {
+                    Err(payload_mismatch("forget_record", "expire"))
+                }
+                RecordWalPayload::Purged(_) => Err(payload_mismatch("purged", "expire")),
+            },
+            WalKind::ForgetRecord => Ok(None),
             _ => Ok(None),
         }
     }
+}
+
+fn payload_mismatch(payload_variant: &str, wal_kind: &str) -> RecoveryError {
+    RecoveryError::Invariant(format!(
+        "record wal payload variant {payload_variant} does not match wal kind {wal_kind}"
+    ))
 }

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -1,15 +1,22 @@
 //! Record WAL step bodies.
 
+use cairn_core::domain::{
+    ConsentEvent, ConsentKind, ConsentPayload, Identity, MemoryVisibility, Rfc3339Timestamp,
+};
 use cairn_core::wal::{OperationId, StepDef};
 use rusqlite::{Transaction, params};
 
 use crate::record_wal::locks::RecordLocks;
-use crate::record_wal::payload::{ExpirePayload, StoredEmbedOutcome, UpsertPayload};
+use crate::record_wal::payload::{
+    ExpirePayload, ForgetPayload, PurgedPayload, RecordWalPayload, StoredEmbedOutcome,
+    UpsertPayload,
+};
 use crate::wal::runner::{StepBody, StepBodyError};
 
 pub(crate) enum RecordStepPayload {
     Upsert(Box<UpsertPayload>),
     Expire(Box<ExpirePayload>),
+    ForgetRecord(Box<ForgetPayload>),
 }
 
 pub(crate) struct RecordStepBody {
@@ -30,6 +37,14 @@ impl RecordStepBody {
     pub(crate) fn new_expire(payload: ExpirePayload, locks: RecordLocks) -> Self {
         Self {
             payload: RecordStepPayload::Expire(Box::new(payload)),
+            locks,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn new_forget_record(payload: ForgetPayload, locks: RecordLocks) -> Self {
+        Self {
+            payload: RecordStepPayload::ForgetRecord(Box::new(payload)),
             locks,
         }
     }
@@ -85,7 +100,31 @@ impl StepBody for RecordStepBody {
             (RecordStepPayload::Expire(payload), "vector.drain") => drain_vectors(tx, payload),
             (RecordStepPayload::Expire(payload), "fts.drain") => drain_fts(tx, payload),
             (RecordStepPayload::Expire(payload), "edges.drain") => drain_edges(tx, payload),
-            (RecordStepPayload::Upsert(_) | RecordStepPayload::Expire(_), _) => Ok(()),
+            (RecordStepPayload::ForgetRecord(payload), "primary.mark_tombstone") => {
+                mark_forget_tombstone(tx, op_id, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "vector.drain") => {
+                drain_forget_vectors(tx, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "fts.drain") => {
+                drain_forget_fts(tx, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "edges.drain") => {
+                drain_forget_edges(tx, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "primary.purge") => {
+                purge_forget_primary(tx, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "wal.purge_pre_images") => {
+                scrub_forget_wal(tx, op_id, payload)
+            }
+            (RecordStepPayload::ForgetRecord(_), "snapshot.purge")
+            | (
+                RecordStepPayload::Upsert(_)
+                | RecordStepPayload::Expire(_)
+                | RecordStepPayload::ForgetRecord(_),
+                _,
+            ) => Ok(()),
         }
     }
 }
@@ -261,6 +300,165 @@ fn drain_edges(tx: &Transaction<'_>, payload: &ExpirePayload) -> Result<(), Step
         params![payload.target_id.as_str()],
     )
     .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn mark_forget_tombstone(
+    tx: &Transaction<'_>,
+    op_id: &OperationId,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "UPDATE records \
+            SET active = 0, \
+                tombstoned = 1, \
+                tombstone_reason = 'forget', \
+                updated_at = ?1 \
+          WHERE target_id = ?2",
+        params![crate::store::current_unix_ms(), payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    append_forget_consent(tx, op_id, payload)
+}
+
+fn append_forget_consent(
+    tx: &Transaction<'_>,
+    op_id: &OperationId,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    let actor =
+        Identity::parse("hmn:cairn-cli").map_err(|e| StepBodyError::Failed(e.to_string()))?;
+    let decided_at = Rfc3339Timestamp::from_unix_secs(crate::store::current_unix_ms() / 1000)
+        .map_err(|e| StepBodyError::Failed(e.to_string()))?;
+    let event = ConsentEvent {
+        consent_id: ulid::Ulid::new().to_string(),
+        kind: ConsentKind::ForgetIntent,
+        actor,
+        subject: payload.target_hash.clone(),
+        scope: payload.scope.canonical_wire(),
+        op_id: Some(op_id.as_str().to_owned()),
+        sensor_id: None,
+        payload: ConsentPayload::IntentReceipt {
+            target_id_hash: payload.target_hash.clone(),
+            scope_tier: MemoryVisibility::Private,
+            reason_code: payload.reason_code.clone(),
+        },
+        decided_at,
+        expires_at: None,
+    };
+    crate::consent::append(tx, &event).map_err(|e| StepBodyError::Failed(e.to_string()))?;
+    Ok(())
+}
+
+fn drain_forget_vectors(
+    tx: &Transaction<'_>,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM record_vectors \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM pending_embeddings \
+          WHERE record_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn drain_forget_fts(tx: &Transaction<'_>, payload: &ForgetPayload) -> Result<(), StepBodyError> {
+    let rowids = {
+        let mut stmt = tx
+            .prepare("SELECT rowid FROM records WHERE target_id = ?1")
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(params![payload.target_id.as_str()], |row| {
+            row.get::<_, i64>(0)
+        })
+        .map_err(StepBodyError::Storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StepBodyError::Storage)?
+    };
+    for rowid in rowids {
+        tx.execute("DELETE FROM records_fts WHERE rowid = ?1", params![rowid])
+            .map_err(StepBodyError::Storage)?;
+    }
+    Ok(())
+}
+
+fn drain_forget_edges(tx: &Transaction<'_>, payload: &ForgetPayload) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM edges \
+          WHERE src IN (SELECT record_id FROM records WHERE target_id = ?1) \
+             OR dst IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM entity_episodes \
+          WHERE episode_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn purge_forget_primary(
+    tx: &Transaction<'_>,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM records WHERE target_id = ?1",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn scrub_forget_wal(
+    tx: &Transaction<'_>,
+    op_id: &OperationId,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    let stub = serde_json::to_string(&RecordWalPayload::Purged(Box::new(PurgedPayload {
+        target_hash: payload.target_hash.clone(),
+        purged_by: op_id.as_str().to_owned(),
+        purged_at: crate::store::current_unix_ms(),
+    })))
+    .map_err(|e| StepBodyError::Failed(format!("purged payload json: {e}")))?;
+    let stub_bytes = stub.as_bytes();
+    let mut needles = Vec::with_capacity(payload.record_ids.len() + 1);
+    needles.push(payload.target_id.as_str().to_owned());
+    needles.extend(
+        payload
+            .record_ids
+            .iter()
+            .map(|record_id| record_id.as_str().to_owned()),
+    );
+
+    for needle in needles {
+        let like = format!("%{needle}%");
+        tx.execute(
+            "UPDATE wal_steps \
+                SET pre_image = ?1 \
+              WHERE operation_id <> ?2 \
+                AND pre_image IS NOT NULL \
+                AND CAST(pre_image AS TEXT) LIKE ?3",
+            params![stub_bytes, op_id.as_str(), like],
+        )
+        .map_err(StepBodyError::Storage)?;
+        tx.execute(
+            "UPDATE wal_payloads \
+                SET kind = 'purged', payload_json = ?1 \
+              WHERE operation_id <> ?2 \
+                AND kind IN ('upsert', 'expire') \
+                AND payload_json LIKE ?3",
+            params![stub, op_id.as_str(), like],
+        )
+        .map_err(StepBodyError::Storage)?;
+    }
     Ok(())
 }
 

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -389,6 +389,7 @@ fn drain_forget_fts(tx: &Transaction<'_>, payload: &ForgetPayload) -> Result<(),
 }
 
 fn drain_forget_edges(tx: &Transaction<'_>, payload: &ForgetPayload) -> Result<(), StepBodyError> {
+    tombstone_forget_entity_edges(tx, payload)?;
     tx.execute(
         "DELETE FROM edges \
           WHERE src IN (SELECT record_id FROM records WHERE target_id = ?1) \
@@ -402,6 +403,78 @@ fn drain_forget_edges(tx: &Transaction<'_>, payload: &ForgetPayload) -> Result<(
         params![payload.target_id.as_str()],
     )
     .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+struct ForgetEntityEdge {
+    id: String,
+    confidence: String,
+    confidence_score: f32,
+    valid_at: i64,
+    invalid_at: Option<i64>,
+    created_at: i64,
+    expired_at: Option<i64>,
+    tombstone_reason: Option<String>,
+}
+
+fn tombstone_forget_entity_edges(
+    tx: &Transaction<'_>,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    let edges = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT id, confidence, confidence_score, valid_at, invalid_at, \
+                        created_at, expired_at, tombstone_reason \
+                   FROM entity_edges \
+                  WHERE source_record_id IN (\
+                        SELECT record_id FROM records WHERE target_id = ?1\
+                  )",
+            )
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(params![payload.target_id.as_str()], |row| {
+            Ok(ForgetEntityEdge {
+                id: row.get(0)?,
+                confidence: row.get(1)?,
+                confidence_score: row.get(2)?,
+                valid_at: row.get(3)?,
+                invalid_at: row.get(4)?,
+                created_at: row.get(5)?,
+                expired_at: row.get(6)?,
+                tombstone_reason: row.get(7)?,
+            })
+        })
+        .map_err(StepBodyError::Storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StepBodyError::Storage)?
+    };
+
+    let now_ms = crate::store::current_unix_ms();
+    for edge in edges {
+        let hash = crate::entity_graph::entity_edge_body_hash_components(
+            &edge.confidence,
+            edge.confidence_score,
+            edge.valid_at,
+            edge.invalid_at,
+            edge.created_at,
+            None,
+        );
+        tx.execute(
+            "UPDATE entity_edges \
+                SET expired_at = ?1, \
+                    tombstone_reason = ?2, \
+                    source_record_id = NULL, \
+                    body_hash = ?3 \
+              WHERE id = ?4",
+            params![
+                edge.expired_at.unwrap_or(now_ms),
+                edge.tombstone_reason.unwrap_or_else(|| "forget".to_owned()),
+                &hash[..],
+                edge.id,
+            ],
+        )
+        .map_err(StepBodyError::Storage)?;
+    }
     Ok(())
 }
 

--- a/crates/cairn-store-sqlite/src/record_wal/steps.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/steps.rs
@@ -429,33 +429,40 @@ fn scrub_forget_wal(
     })))
     .map_err(|e| StepBodyError::Failed(format!("purged payload json: {e}")))?;
     let stub_bytes = stub.as_bytes();
-    let mut needles = Vec::with_capacity(payload.record_ids.len() + 1);
-    needles.push(payload.target_id.as_str().to_owned());
-    needles.extend(
-        payload
-            .record_ids
-            .iter()
-            .map(|record_id| record_id.as_str().to_owned()),
-    );
+    let candidate_ops = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT p.operation_id \
+                   FROM wal_payloads p \
+                   JOIN wal_ops o ON o.operation_id = p.operation_id \
+                  WHERE p.kind IN ('upsert', 'expire') \
+                    AND p.operation_id <> ?1 \
+                    AND o.target_hash = ?2",
+            )
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(params![op_id.as_str(), payload.target_id.as_str()], |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(StepBodyError::Storage)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StepBodyError::Storage)?
+    };
 
-    for needle in needles {
-        let like = format!("%{needle}%");
+    for candidate_op in candidate_ops {
         tx.execute(
             "UPDATE wal_steps \
                 SET pre_image = ?1 \
-              WHERE operation_id <> ?2 \
-                AND pre_image IS NOT NULL \
-                AND CAST(pre_image AS TEXT) LIKE ?3",
-            params![stub_bytes, op_id.as_str(), like],
+              WHERE operation_id = ?2 \
+                AND pre_image IS NOT NULL",
+            params![stub_bytes, candidate_op.as_str()],
         )
         .map_err(StepBodyError::Storage)?;
         tx.execute(
             "UPDATE wal_payloads \
                 SET kind = 'purged', payload_json = ?1 \
-              WHERE operation_id <> ?2 \
-                AND kind IN ('upsert', 'expire') \
-                AND payload_json LIKE ?3",
-            params![stub, op_id.as_str(), like],
+              WHERE operation_id = ?2 \
+                AND kind IN ('upsert', 'expire')",
+            params![stub.as_str(), candidate_op.as_str()],
         )
         .map_err(StepBodyError::Storage)?;
     }

--- a/crates/cairn-store-sqlite/src/store/forget.rs
+++ b/crates/cairn-store-sqlite/src/store/forget.rs
@@ -1,0 +1,18 @@
+//! Store-facing record forget helper.
+
+use cairn_core::domain::RecordId;
+
+use crate::error::StoreError;
+use crate::record_wal::forget::{ForgetOutcome, apply_forget_record};
+use crate::store::SqliteMemoryStore;
+
+impl SqliteMemoryStore {
+    /// Forget one public record id by deleting the full target lineage.
+    ///
+    /// # Errors
+    /// Returns [`StoreError`] if the record id is not present, WAL setup fails,
+    /// lock fencing fails, or a Phase B step exhausts retries.
+    pub async fn forget_record(&self, record_id: &RecordId) -> Result<ForgetOutcome, StoreError> {
+        apply_forget_record(self, record_id).await
+    }
+}

--- a/crates/cairn-store-sqlite/src/store/mod.rs
+++ b/crates/cairn-store-sqlite/src/store/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod edges;
 pub(crate) mod expire;
+pub mod forget;
 pub(crate) mod graph_search;
 pub(crate) mod hybrid;
 pub(crate) mod projection;

--- a/crates/cairn-store-sqlite/src/verify.rs
+++ b/crates/cairn-store-sqlite/src/verify.rs
@@ -101,7 +101,7 @@ const EXPECTED_OBJECTS: &[(&str, &str)] = &[
     // 0053_wal_payloads
     ("table", "wal_payloads"),
     ("trigger", "wal_payloads_kind_matches_wal"),
-    ("trigger", "wal_payloads_immutable"),
+    ("trigger", "wal_payloads_scrub_only"),
     ("trigger", "wal_payloads_no_delete"),
     // 0005_consent
     ("table", "consent_journal"),

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -127,6 +127,115 @@ async fn assert_forget_purged_surfaces(
     .expect("physical purge assertions");
 }
 
+async fn seed_upsert_pre_image_leak(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    record: &MemoryRecord,
+) -> String {
+    let record_id = record.id.as_str().to_owned();
+    let target_id = record.target_id.as_str().to_owned();
+    let body = record.body.clone();
+    conn.call(move |c| {
+        let upsert_op = c.query_row(
+            "SELECT p.operation_id \
+               FROM wal_payloads p \
+               JOIN wal_ops o ON o.operation_id = p.operation_id \
+              WHERE p.kind = 'upsert' AND o.target_hash = ?1",
+            params![target_id],
+            |row| row.get::<_, String>(0),
+        )?;
+        let leaked_pre_image = serde_json::json!({
+            "type": "test_leak",
+            "record_id": record_id,
+            "body": body,
+        })
+        .to_string()
+        .into_bytes();
+        let changed = c.execute(
+            "UPDATE wal_steps \
+                SET pre_image = ?1 \
+              WHERE operation_id = ?2 \
+                AND step_ord = ( \
+                    SELECT MIN(step_ord) FROM wal_steps WHERE operation_id = ?2 \
+                )",
+            params![leaked_pre_image, upsert_op],
+        )?;
+        assert_eq!(changed, 1, "test should seed one upsert pre_image leak");
+        Ok::<_, tokio_rusqlite::Error>(upsert_op)
+    })
+    .await
+    .expect("seed leaking pre_image")
+}
+
+async fn assert_forget_scrubbed_prior_wal_and_kept_body_free_payload(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    record: &MemoryRecord,
+    upsert_op: String,
+    forget_op: &OperationId,
+) {
+    let record_id = record.id.as_str().to_owned();
+    let body = record.body.clone();
+    let forget_op = forget_op.as_str().to_owned();
+    conn.call(move |c| {
+        let retained_fragments = {
+            let mut stmt = c.prepare(
+                "SELECT 'payload', payload_json \
+                   FROM wal_payloads \
+                  WHERE operation_id = ?1 \
+                 UNION ALL \
+                 SELECT 'pre_image', CAST(pre_image AS TEXT) \
+                   FROM wal_steps \
+                  WHERE operation_id = ?1 AND pre_image IS NOT NULL",
+            )?;
+            stmt.query_map(params![upsert_op], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+        };
+        assert!(
+            !retained_fragments.is_empty(),
+            "prior body-bearing WAL retention should remain as scrub stubs"
+        );
+        for (surface, retained) in &retained_fragments {
+            assert!(
+                !retained.contains(&body),
+                "scrubbed prior {surface} must not retain body text: {retained}"
+            );
+            assert!(
+                !retained.contains(&record_id),
+                "scrubbed prior {surface} must not retain raw record id: {retained}"
+            );
+        }
+
+        let purged_stubs: i64 = c.query_row(
+            "SELECT COUNT(*) \
+               FROM wal_payloads \
+              WHERE operation_id = ?1 \
+                AND kind = 'purged' \
+                AND json_extract(payload_json, '$.type') = 'purged'",
+            params![upsert_op],
+            |row| row.get(0),
+        )?;
+        assert!(purged_stubs > 0, "at least one purged stub should remain");
+
+        let (forget_kind, forget_type, forget_json): (String, String, String) = c.query_row(
+            "SELECT kind, json_extract(payload_json, '$.type'), payload_json \
+               FROM wal_payloads \
+              WHERE operation_id = ?1",
+            params![forget_op],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(forget_kind, "forget_record");
+        assert_eq!(forget_type, "forget_record");
+        assert!(
+            !forget_json.contains(&body),
+            "current forget payload must remain body-free"
+        );
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("scrub assertions");
+}
+
 #[tokio::test]
 async fn forget_payload_round_trips_body_free() {
     let store = open_in_memory().await.expect("open");
@@ -401,6 +510,50 @@ async fn forget_record_purges_primary_indexes_and_vectors() {
 
     let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
     assert_forget_purged_surfaces(&conn, &record, &outcome.operation_id).await;
+}
+
+#[tokio::test]
+async fn forget_record_scrubs_body_bearing_wal_payloads_and_pre_images() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    store.upsert(&record).await.expect("upsert");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let upsert_op = seed_upsert_pre_image_leak(&conn, &record).await;
+
+    let outcome = store
+        .forget_record(&record.id)
+        .await
+        .expect("forget record");
+    assert_eq!(outcome.deleted_count, 1);
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    assert_forget_scrubbed_prior_wal_and_kept_body_free_payload(
+        &conn,
+        &record,
+        upsert_op,
+        &outcome.operation_id,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn forget_record_replay_is_idempotent_after_primary_purge() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    store.upsert(&record).await.expect("upsert");
+
+    let outcome = store
+        .forget_record(&record.id)
+        .await
+        .expect("first forget");
+    assert_eq!(outcome.deleted_count, 1);
+
+    let err = store
+        .forget_record(&record.id)
+        .await
+        .expect_err("second forget should see purged primary row");
+    assert!(matches!(err, StoreError::NotFound { id } if id == record.id.as_str()));
 }
 
 #[tokio::test]

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -563,10 +563,7 @@ async fn forget_record_replay_is_idempotent_after_primary_purge() {
     let record = sample_record();
     store.upsert(&record).await.expect("upsert");
 
-    let outcome = store
-        .forget_record(&record.id)
-        .await
-        .expect("first forget");
+    let outcome = store.forget_record(&record.id).await.expect("first forget");
     assert_eq!(outcome.deleted_count, 1);
 
     let err = store

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -183,9 +183,8 @@ async fn recovery_rejects_purged_payload_for_body_bearing_kinds() {
         ),
     ] {
         let op_id = OperationId::parse(op.to_owned()).expect("op id");
-        let err = match registry.body_for(&conn, kind, &op_id).await {
-            Err(err) => err,
-            Ok(_) => panic!("expected purged payload mismatch for {kind_name}"),
+        let Err(err) = registry.body_for(&conn, kind, &op_id).await else {
+            panic!("expected purged payload mismatch for {kind_name}");
         };
         match err {
             RecoveryError::Invariant(message) => {

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -7,16 +7,124 @@ use std::sync::Arc;
 use cairn_core::contract::memory_store::{ListArgs, MemoryStore};
 use cairn_core::domain::{MemoryRecord, RecordId, ScopeTuple};
 use cairn_core::wal::{OperationId, WalKind};
+use cairn_embeddings_local::{EmbeddingModel, EmbeddingModelKind, MockEmbedder};
 use cairn_store_sqlite::record_wal::RecordWalRegistry;
 use cairn_store_sqlite::record_wal::payload::{
     PurgedPayload, RecordWalPayload, UpsertPayload, save_purged_payload_for_test,
 };
 use cairn_store_sqlite::wal::{RecoveryError, StepBodyRegistry};
-use cairn_store_sqlite::{StoreError, open_in_memory};
+use cairn_store_sqlite::{StoreError, open_in_memory, open_in_memory_with_embedder};
 use rusqlite::params;
 
 fn sample_record() -> MemoryRecord {
     cairn_core::domain::record::tests_export::sample_record()
+}
+
+async fn seed_pending_and_assert_vector_surfaces(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    record_id: &RecordId,
+) {
+    let record_id = record_id.as_str().to_owned();
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO pending_embeddings \
+               (record_id, reason, attempt_count, last_error, enqueued_at) \
+             VALUES (?1, 'opt_in_backfill', 0, NULL, 1)",
+            params![record_id],
+        )?;
+        let vectors: i64 = c.query_row(
+            "SELECT COUNT(*) FROM record_vectors WHERE record_id = ?1",
+            params![record_id],
+            |row| row.get(0),
+        )?;
+        let pending: i64 = c.query_row(
+            "SELECT COUNT(*) FROM pending_embeddings WHERE record_id = ?1",
+            params![record_id],
+            |row| row.get(0),
+        )?;
+        assert!(vectors > 0, "upsert should write a vector before forget");
+        assert!(pending > 0, "test should seed pending row before forget");
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("pre-forget vector assertions");
+}
+
+async fn assert_forget_purged_surfaces(
+    conn: &Arc<tokio_rusqlite::Connection>,
+    record: &MemoryRecord,
+    operation_id: &OperationId,
+) {
+    let record_id = record.id.as_str().to_owned();
+    let target_id = record.target_id.as_str().to_owned();
+    let body = record.body.clone();
+    let operation_id = operation_id.as_str().to_owned();
+    conn.call(move |c| {
+        let records: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records WHERE target_id = ?1",
+            params![target_id],
+            |row| row.get(0),
+        )?;
+        let vectors: i64 = c.query_row(
+            "SELECT COUNT(*) FROM record_vectors WHERE record_id = ?1",
+            params![record_id],
+            |row| row.get(0),
+        )?;
+        let pending: i64 = c.query_row(
+            "SELECT COUNT(*) FROM pending_embeddings WHERE record_id = ?1",
+            params![record_id],
+            |row| row.get(0),
+        )?;
+        let fts_rows: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records_fts WHERE body MATCH ?1",
+            params![body],
+            |row| row.get(0),
+        )?;
+        let op_state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE operation_id = ?1",
+            params![operation_id],
+            |row| row.get(0),
+        )?;
+        let done_steps: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps \
+              WHERE operation_id = ?1 AND state = 'DONE'",
+            params![operation_id],
+            |row| row.get(0),
+        )?;
+        let total_steps: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps WHERE operation_id = ?1",
+            params![operation_id],
+            |row| row.get(0),
+        )?;
+        let consent_payload: String = c.query_row(
+            "SELECT payload_json FROM consent_journal \
+              WHERE op_id = ?1 AND kind = 'forget_intent'",
+            params![operation_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(records, 0);
+        assert_eq!(vectors, 0);
+        assert_eq!(pending, 0);
+        assert_eq!(fts_rows, 0);
+        assert_eq!(op_state, "COMMITTED");
+        assert_eq!(done_steps, 7);
+        assert_eq!(total_steps, 7);
+        assert!(
+            !consent_payload.contains(&record_id),
+            "forget consent event must not retain record id"
+        );
+        assert!(
+            !consent_payload.contains(&target_id),
+            "forget consent event must not retain target id"
+        );
+        assert!(
+            !consent_payload.contains(&body),
+            "forget consent event must not retain body text"
+        );
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("physical purge assertions");
 }
 
 #[tokio::test]
@@ -267,10 +375,16 @@ async fn forget_resolution_reports_codec_for_malformed_scope() {
 
 #[tokio::test]
 async fn forget_record_purges_primary_indexes_and_vectors() {
-    let store = open_in_memory().await.expect("open");
+    let embedder: Arc<dyn EmbeddingModel> =
+        Arc::new(MockEmbedder::new(EmbeddingModelKind::BgeSmallEnV1_5));
+    let store = open_in_memory_with_embedder(Some(Arc::clone(&embedder)))
+        .await
+        .expect("open");
     let record = sample_record();
-    let body = record.body.clone();
     store.upsert(&record).await.expect("upsert");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    seed_pending_and_assert_vector_surfaces(&conn, &record.id).await;
 
     let outcome = store
         .forget_record(&record.id)
@@ -283,75 +397,7 @@ async fn forget_record_purges_primary_indexes_and_vectors() {
     assert!(listed.records.is_empty(), "forgotten record must be invisible");
 
     let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
-    let record_id = record.id.as_str().to_owned();
-    let target_id = record.target_id.as_str().to_owned();
-    let operation_id = outcome.operation_id.as_str().to_owned();
-    conn.call(move |c| {
-        let records: i64 = c.query_row(
-            "SELECT COUNT(*) FROM records WHERE target_id = ?1",
-            params![target_id],
-            |row| row.get(0),
-        )?;
-        let vectors: i64 = c.query_row(
-            "SELECT COUNT(*) FROM record_vectors WHERE record_id = ?1",
-            params![record_id],
-            |row| row.get(0),
-        )?;
-        let pending: i64 = c.query_row(
-            "SELECT COUNT(*) FROM pending_embeddings WHERE record_id = ?1",
-            params![record_id],
-            |row| row.get(0),
-        )?;
-        let fts_rows: i64 = c.query_row(
-            "SELECT COUNT(*) FROM records_fts WHERE body MATCH ?1",
-            params![body],
-            |row| row.get(0),
-        )?;
-        let op_state: String = c.query_row(
-            "SELECT state FROM wal_ops WHERE operation_id = ?1",
-            params![operation_id],
-            |row| row.get(0),
-        )?;
-        let done_steps: i64 = c.query_row(
-            "SELECT COUNT(*) FROM wal_steps \
-              WHERE operation_id = ?1 AND state = 'DONE'",
-            params![operation_id],
-            |row| row.get(0),
-        )?;
-        let total_steps: i64 = c.query_row(
-            "SELECT COUNT(*) FROM wal_steps WHERE operation_id = ?1",
-            params![operation_id],
-            |row| row.get(0),
-        )?;
-        let consent_payload: String = c.query_row(
-            "SELECT payload_json FROM consent_journal \
-              WHERE op_id = ?1 AND kind = 'forget_intent'",
-            params![operation_id],
-            |row| row.get(0),
-        )?;
-        assert_eq!(records, 0);
-        assert_eq!(vectors, 0);
-        assert_eq!(pending, 0);
-        assert_eq!(fts_rows, 0);
-        assert_eq!(op_state, "COMMITTED");
-        assert_eq!(done_steps, 7);
-        assert_eq!(total_steps, 7);
-        assert!(
-            !consent_payload.contains(&record_id),
-            "forget consent event must not retain record id"
-        );
-        assert!(
-            !consent_payload.contains(&target_id),
-            "forget consent event must not retain target id"
-        );
-        assert!(
-            !consent_payload.contains(&body),
-            "forget consent event must not retain body text"
-        );
-        Ok::<_, tokio_rusqlite::Error>(())
-    })
-    .await
-    .expect("physical purge assertions");
+    assert_forget_purged_surfaces(&conn, &record, &outcome.operation_id).await;
 }
 
 #[tokio::test]
@@ -401,22 +447,37 @@ async fn forget_record_does_not_scrub_unrelated_payload_mentions() {
 
     let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
     let unrelated_target = unrelated.target_id.as_str().to_owned();
-    let unrelated_op = conn
+    let forgotten_target = forgotten.target_id.as_str().to_owned();
+    let (unrelated_op, forgotten_op, forgotten_pre_images) = conn
         .call(move |c| {
-            c.query_row(
+            let unrelated_op = c.query_row(
                 "SELECT p.operation_id \
                    FROM wal_payloads p \
                    JOIN wal_ops o ON o.operation_id = p.operation_id \
                   WHERE p.kind = 'upsert' AND o.target_hash = ?1",
                 params![unrelated_target],
                 |row| row.get::<_, String>(0),
-            )
-            .map_err(tokio_rusqlite::Error::Rusqlite)
+            )?;
+            let forgotten_op = c.query_row(
+                "SELECT p.operation_id \
+                   FROM wal_payloads p \
+                   JOIN wal_ops o ON o.operation_id = p.operation_id \
+                  WHERE p.kind = 'upsert' AND o.target_hash = ?1",
+                params![forgotten_target],
+                |row| row.get::<_, String>(0),
+            )?;
+            let forgotten_pre_images = c.query_row(
+                "SELECT COUNT(*) FROM wal_steps \
+                  WHERE operation_id = ?1 AND pre_image IS NOT NULL",
+                params![forgotten_op],
+                |row| row.get::<_, i64>(0),
+            )?;
+            Ok::<_, tokio_rusqlite::Error>((unrelated_op, forgotten_op, forgotten_pre_images))
         })
         .await
-        .expect("unrelated upsert op");
+        .expect("upsert ops");
 
-    store
+    let outcome = store
         .forget_record(&forgotten.id)
         .await
         .expect("forget original");
@@ -429,6 +490,37 @@ async fn forget_record_does_not_scrub_unrelated_payload_mentions() {
             |row| row.get(0),
         )?;
         assert_eq!(kind, "upsert");
+        let (forgotten_kind, forgotten_type, purged_by): (String, String, String) = c.query_row(
+            "SELECT kind, \
+                    json_extract(payload_json, '$.type'), \
+                    json_extract(payload_json, '$.purged_by') \
+               FROM wal_payloads WHERE operation_id = ?1",
+            params![forgotten_op],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(forgotten_kind, "purged");
+        assert_eq!(forgotten_type, "purged");
+        assert_eq!(purged_by, outcome.operation_id.as_str());
+
+        let current_kind: String = c.query_row(
+            "SELECT kind FROM wal_payloads WHERE operation_id = ?1",
+            params![outcome.operation_id.as_str()],
+            |row| row.get(0),
+        )?;
+        assert_eq!(current_kind, "forget_record");
+
+        if forgotten_pre_images > 0 {
+            let purged_pre_images: i64 = c.query_row(
+                "SELECT COUNT(*) FROM wal_steps \
+                  WHERE operation_id = ?1 \
+                    AND pre_image IS NOT NULL \
+                    AND json_extract(CAST(pre_image AS TEXT), '$.type') = 'purged' \
+                    AND json_extract(CAST(pre_image AS TEXT), '$.purged_by') = ?2",
+                params![forgotten_op, outcome.operation_id.as_str()],
+                |row| row.get(0),
+            )?;
+            assert_eq!(purged_pre_images, forgotten_pre_images);
+        }
         Ok::<_, tokio_rusqlite::Error>(())
     })
     .await

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -1,0 +1,66 @@
+//! Issue #58: record-level forget through the record WAL.
+
+#![allow(missing_docs)]
+#![allow(unused_imports)]
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::{ListArgs, MemoryStore};
+use cairn_core::domain::{MemoryRecord, RecordId, ScopeTuple};
+use cairn_core::wal::WalKind;
+use cairn_store_sqlite::{StoreError, open, open_in_memory};
+use rusqlite::params;
+
+fn sample_record() -> MemoryRecord {
+    cairn_core::domain::record::tests_export::sample_record()
+}
+
+#[tokio::test]
+async fn forget_payload_round_trips_body_free() {
+    let store = open_in_memory().await.expect("open");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let record = sample_record();
+    let payload = cairn_store_sqlite::record_wal::payload::ForgetPayload::new_for_test(
+        record.id.clone(),
+        record.target_id.clone(),
+        record.scope.clone(),
+        vec![record.id.clone()],
+        "hash:00000000000000000000000000000000".to_owned(),
+    );
+
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-forget-payload', 1, ?1, 'ISSUED', '{}', 'issuer', ?2, ?3, 0, 'sig', 1, 1)",
+            params![
+                WalKind::ForgetRecord.as_str(),
+                payload.target_hash,
+                payload.scope.canonical_wire(),
+            ],
+        )?;
+        cairn_store_sqlite::record_wal::payload::save_forget_payload_for_test(
+            c,
+            "op-forget-payload",
+            &payload,
+        )
+        .expect("save forget payload");
+        let loaded = cairn_store_sqlite::record_wal::payload::load_forget_payload_for_test(
+            c,
+            "op-forget-payload",
+        )
+        .expect("load forget payload");
+        assert_eq!(loaded.requested_record_id, payload.requested_record_id);
+        assert_eq!(loaded.target_id, payload.target_id);
+        assert_eq!(loaded.record_ids, payload.record_ids);
+        let json = serde_json::to_string(&loaded).expect("payload json");
+        assert!(
+            !json.contains(&record.body),
+            "forget payload must not contain body text"
+        );
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("payload round trip");
+}

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -237,3 +237,30 @@ async fn forget_resolution_reports_not_found_for_missing_record() {
             .expect_err("missing record rejects");
     assert!(matches!(err, StoreError::NotFound { id } if id == missing.as_str()));
 }
+
+#[tokio::test]
+async fn forget_resolution_reports_codec_for_malformed_scope() {
+    let store = open_in_memory().await.expect("open");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let record = sample_record();
+    store.upsert(&record).await.expect("upsert");
+
+    conn.call({
+        let record_id = record.id.clone();
+        move |c| {
+            c.execute(
+                "UPDATE records SET scope = ?1 WHERE record_id = ?2",
+                params!["not-json", record_id.as_str()],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        }
+    })
+    .await
+    .expect("corrupt scope");
+
+    let err =
+        cairn_store_sqlite::record_wal::forget::resolve_forget_target_for_test(&store, &record.id)
+            .await
+            .expect_err("malformed scope rejects");
+    assert!(matches!(err, StoreError::Codec(_)));
+}

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -4,7 +4,8 @@
 
 use std::sync::Arc;
 
-use cairn_core::domain::MemoryRecord;
+use cairn_core::contract::memory_store::MemoryStore;
+use cairn_core::domain::{MemoryRecord, RecordId};
 use cairn_core::wal::{OperationId, WalKind};
 use cairn_store_sqlite::record_wal::RecordWalRegistry;
 use cairn_store_sqlite::record_wal::payload::{
@@ -200,4 +201,39 @@ async fn recovery_rejects_purged_payload_for_body_bearing_kinds() {
             other => panic!("expected invariant, got {other:?}"),
         }
     }
+}
+
+#[tokio::test]
+async fn forget_resolution_loads_full_target_lineage() {
+    let store = open_in_memory().await.expect("open");
+    let first = sample_record();
+    let mut second = first.clone();
+    second.id = RecordId::parse("01J00000000000000000000002").expect("record id");
+    second.body = "replacement body for same target".to_owned();
+    let first_out = store.upsert(&first).await.expect("first upsert");
+    let second_out = store.upsert(&second).await.expect("second upsert");
+
+    let target =
+        cairn_store_sqlite::record_wal::forget::resolve_forget_target_for_test(&store, &first.id)
+            .await
+            .expect("resolve");
+
+    assert_eq!(target.requested_record_id, first.id);
+    assert_eq!(target.target_id, first.target_id);
+    assert_eq!(target.record_ids.len(), 2);
+    assert!(target.record_ids.contains(&first_out.record_id));
+    assert!(target.record_ids.contains(&second_out.record_id));
+    assert_eq!(target.scope, first.scope);
+    assert!(target.target_hash.starts_with("hash:"));
+}
+
+#[tokio::test]
+async fn forget_resolution_reports_not_found_for_missing_record() {
+    let store = open_in_memory().await.expect("open");
+    let missing = RecordId::parse("01J00000000000000000000999").expect("record id");
+    let err =
+        cairn_store_sqlite::record_wal::forget::resolve_forget_target_for_test(&store, &missing)
+            .await
+            .expect_err("missing record rejects");
+    assert!(matches!(err, StoreError::NotFound { id } if id == missing.as_str()));
 }

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -13,7 +13,7 @@ use cairn_store_sqlite::record_wal::payload::{
     PurgedPayload, RecordWalPayload, UpsertPayload, save_purged_payload_for_test,
 };
 use cairn_store_sqlite::wal::{RecoveryError, StepBodyRegistry};
-use cairn_store_sqlite::{StoreError, open_in_memory, open_in_memory_with_embedder};
+use cairn_store_sqlite::{StoreError, open, open_in_memory, open_in_memory_with_embedder};
 use rusqlite::params;
 
 fn sample_record() -> MemoryRecord {
@@ -394,7 +394,10 @@ async fn forget_record_purges_primary_indexes_and_vectors() {
     assert_eq!(outcome.tombstones, vec![record.id.clone()]);
 
     let listed = store.list(&ListArgs::default()).await.expect("list");
-    assert!(listed.records.is_empty(), "forgotten record must be invisible");
+    assert!(
+        listed.records.is_empty(),
+        "forgotten record must be invisible"
+    );
 
     let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
     assert_forget_purged_surfaces(&conn, &record, &outcome.operation_id).await;
@@ -418,10 +421,7 @@ async fn forget_record_keeps_session_siblings_visible() {
 
     store.upsert(&first).await.expect("first upsert");
     store.upsert(&sibling).await.expect("sibling upsert");
-    store
-        .forget_record(&first.id)
-        .await
-        .expect("forget first");
+    store.forget_record(&first.id).await.expect("forget first");
 
     let listed = store.list(&ListArgs::default()).await.expect("list");
     assert_eq!(listed.records.len(), 1);
@@ -525,4 +525,202 @@ async fn forget_record_does_not_scrub_unrelated_payload_mentions() {
     })
     .await
     .expect("unrelated payload remains");
+}
+
+#[tokio::test]
+async fn prepared_forget_recovers_from_persisted_payload() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+    let op_id = "forget_record-01J00000000000000000001000";
+    let record = sample_record();
+    let target_hash = "hash:00000000000000000000000000000000".to_owned();
+
+    {
+        let store = open(&path).await.expect("open #1");
+        store.upsert(&record).await.expect("seed record");
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let payload_json = serde_json::json!({
+            "type": "forget_record",
+            "requested_record_id": record.id.as_str(),
+            "target_id": record.target_id.as_str(),
+            "scope": record.scope.clone(),
+            "record_ids": [record.id.as_str()],
+            "target_hash": target_hash.clone(),
+            "reason_code": "user_command"
+        })
+        .to_string();
+        conn.call(move |c| {
+            c.execute("DELETE FROM lock_holders", [])?;
+            c.execute("DELETE FROM locks", [])?;
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES (?1, 100, 'forget_record', 'ISSUED', '{}', 'issuer', ?2, ?3, 0, 'sig', 1, 1)",
+                params![op_id, target_hash, record.scope.canonical_wire()],
+            )?;
+            c.execute(
+                "UPDATE wal_ops SET state = 'PREPARED', updated_at = 2 \
+                 WHERE operation_id = ?1",
+                params![op_id],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES (?1, 'forget_record', ?2, 1)",
+                params![op_id, payload_json],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed prepared forget");
+    }
+
+    let store = open(&path).await.expect("open #2 triggers recovery");
+    assert!(
+        store
+            .list(&ListArgs::default())
+            .await
+            .expect("list")
+            .records
+            .is_empty()
+    );
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE operation_id = ?1",
+            params![op_id],
+            |row| row.get(0),
+        )?;
+        let done: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps WHERE operation_id = ?1 AND state = 'DONE'",
+            params![op_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state, "COMMITTED");
+        assert_eq!(done, 7);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("recovery assertions");
+}
+
+#[tokio::test]
+async fn prepared_forget_recovers_after_tombstone_linearization() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+    let op_id = "forget_record-01J00000000000000000001002";
+    let record = sample_record();
+    let target_hash = "hash:22222222222222222222222222222222".to_owned();
+
+    {
+        let store = open(&path).await.expect("open #1");
+        store.upsert(&record).await.expect("seed record");
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let payload_json = serde_json::json!({
+            "type": "forget_record",
+            "requested_record_id": record.id.as_str(),
+            "target_id": record.target_id.as_str(),
+            "scope": record.scope.clone(),
+            "record_ids": [record.id.as_str()],
+            "target_hash": target_hash.clone(),
+            "reason_code": "user_command"
+        })
+        .to_string();
+        conn.call(move |c| {
+            c.execute("DELETE FROM lock_holders", [])?;
+            c.execute("DELETE FROM locks", [])?;
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES (?1, 101, 'forget_record', 'PREPARED', '{}', 'issuer', ?2, ?3, 0, 'sig', 1, 2)",
+                params![op_id, target_hash, record.scope.canonical_wire()],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES (?1, 'forget_record', ?2, 1)",
+                params![op_id, payload_json],
+            )?;
+            c.execute(
+                "UPDATE records \
+                    SET active = 0, tombstoned = 1, tombstone_reason = 'forget' \
+                  WHERE target_id = ?1",
+                params![record.target_id.as_str()],
+            )?;
+            c.execute(
+                "INSERT INTO wal_steps \
+                   (operation_id, step_ord, step_kind, state, attempts, started_at, finished_at) \
+                 VALUES (?1, 0, 'primary.mark_tombstone', 'DONE', 1, 1, 2)",
+                params![op_id],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed linearized forget");
+    }
+
+    let store = open(&path).await.expect("open #2 triggers recovery");
+    assert!(
+        store
+            .list(&ListArgs::default())
+            .await
+            .expect("list")
+            .records
+            .is_empty(),
+        "linearized forget must stay invisible during recovery"
+    );
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE operation_id = ?1",
+            params![op_id],
+            |row| row.get(0),
+        )?;
+        let remaining_records: i64 =
+            c.query_row("SELECT COUNT(*) FROM records", [], |row| row.get(0))?;
+        assert_eq!(state, "COMMITTED");
+        assert_eq!(remaining_records, 0);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("linearized recovery assertions");
+}
+
+#[tokio::test]
+async fn purge_pending_lint_reports_exhausted_forget_phase_b_without_raw_ids() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    store.upsert(&record).await.expect("upsert");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let raw_record_id = record.id.as_str().to_owned();
+    let raw_target_id = record.target_id.as_str().to_owned();
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('forget_record-01J00000000000000000001001', 200, 'forget_record', \
+                     'PREPARED', '{}', 'issuer', \
+                     'hash:11111111111111111111111111111111', 'user=hmn:tafeng', 0, 'sig', 1, 1)",
+            [],
+        )?;
+        c.execute(
+            "INSERT INTO wal_steps \
+               (operation_id, step_ord, step_kind, state, attempts, last_error, started_at, finished_at) \
+             VALUES ('forget_record-01J00000000000000000001001', 5, 'wal.purge_pre_images', \
+                     'FAILED', 3, 'boom', 1, 2)",
+            [],
+        )?;
+        let findings =
+            cairn_store_sqlite::lint_purge_pending(c).expect("lint purge pending");
+        assert_eq!(findings.len(), 1);
+        let rendered = serde_json::to_string(&findings).expect("finding json");
+        assert!(rendered.contains("purge_pending"));
+        assert!(rendered.contains("hash:11111111111111111111111111111111"));
+        assert!(!rendered.contains(&raw_record_id));
+        assert!(!rendered.contains(&raw_target_id));
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("lint assertions");
 }

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -1,14 +1,17 @@
 //! Issue #58: record-level forget through the record WAL.
 
 #![allow(missing_docs)]
-#![allow(unused_imports)]
 
 use std::sync::Arc;
 
-use cairn_core::contract::memory_store::{ListArgs, MemoryStore};
-use cairn_core::domain::{MemoryRecord, RecordId, ScopeTuple};
-use cairn_core::wal::WalKind;
-use cairn_store_sqlite::{StoreError, open, open_in_memory};
+use cairn_core::domain::MemoryRecord;
+use cairn_core::wal::{OperationId, WalKind};
+use cairn_store_sqlite::record_wal::RecordWalRegistry;
+use cairn_store_sqlite::record_wal::payload::{
+    PurgedPayload, RecordWalPayload, UpsertPayload, save_purged_payload_for_test,
+};
+use cairn_store_sqlite::wal::{RecoveryError, StepBodyRegistry};
+use cairn_store_sqlite::{StoreError, open_in_memory};
 use rusqlite::params;
 
 fn sample_record() -> MemoryRecord {
@@ -46,6 +49,15 @@ async fn forget_payload_round_trips_body_free() {
             &payload,
         )
         .expect("save forget payload");
+        let raw_json: String = c.query_row(
+            "SELECT payload_json FROM wal_payloads WHERE operation_id = ?1",
+            params!["op-forget-payload"],
+            |row| row.get(0),
+        )?;
+        assert!(
+            !raw_json.contains(&record.body),
+            "persisted forget payload must not contain body text"
+        );
         let loaded = cairn_store_sqlite::record_wal::payload::load_forget_payload_for_test(
             c,
             "op-forget-payload",
@@ -63,4 +75,130 @@ async fn forget_payload_round_trips_body_free() {
     })
     .await
     .expect("payload round trip");
+}
+
+#[tokio::test]
+async fn purged_payload_cannot_be_saved_directly() {
+    let store = open_in_memory().await.expect("open");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    conn.call(|c| {
+        let payload = PurgedPayload {
+            target_hash: "hash:00000000000000000000000000000000".to_owned(),
+            purged_by: "forget-record-test".to_owned(),
+            purged_at: 1,
+        };
+        let err = save_purged_payload_for_test(c, "op-purged-payload", &payload)
+            .expect_err("direct purged payload save must fail");
+        match err {
+            StoreError::Invariant { what } => assert!(
+                what.contains("purged wal payloads are written by scrub updates"),
+                "unexpected invariant: {what}"
+            ),
+            other => panic!("expected invariant, got {other:?}"),
+        }
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("purged payload assertion");
+}
+
+#[tokio::test]
+async fn recovery_rejects_purged_payload_for_body_bearing_kinds() {
+    let store = open_in_memory().await.expect("open");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let record = sample_record();
+    let upsert_payload = UpsertPayload::new_for_test(record.clone());
+    let expire_payload_json = serde_json::json!({
+        "type": "expire",
+        "target_id": record.target_id.as_str(),
+        "reason": "expire",
+        "scope": record.scope,
+    })
+    .to_string();
+    let purged_payload_json =
+        serde_json::to_string(&RecordWalPayload::Purged(Box::new(PurgedPayload {
+            target_hash: "hash:00000000000000000000000000000000".to_owned(),
+            purged_by: "forget-record-test".to_owned(),
+            purged_at: 1,
+        })))
+        .expect("purged payload json");
+
+    conn.call({
+        let purged_payload_json = purged_payload_json.clone();
+        move |c| {
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES ('op-upsert-purged-recovery', 1, 'upsert', 'ISSUED', '{}', 'issuer', ?1, '{}', 0, 'sig', 1, 1)",
+                params![record.target_id.as_str()],
+            )?;
+            cairn_store_sqlite::record_wal::payload::save_upsert_payload_for_test(
+                c,
+                "op-upsert-purged-recovery",
+                &upsert_payload,
+            )
+            .expect("save upsert payload");
+            c.execute(
+                "UPDATE wal_payloads SET kind = 'purged', payload_json = ?1 \
+                 WHERE operation_id = 'op-upsert-purged-recovery'",
+                params![purged_payload_json],
+            )?;
+
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES ('op-expire-purged-recovery', 2, 'expire', 'ISSUED', '{}', 'issuer', ?1, '{}', 0, 'sig', 1, 1)",
+                params![record.target_id.as_str()],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES ('op-expire-purged-recovery', 'expire', ?1, 1)",
+                params![expire_payload_json],
+            )?;
+            c.execute(
+                "UPDATE wal_payloads SET kind = 'purged', payload_json = ?1 \
+                 WHERE operation_id = 'op-expire-purged-recovery'",
+                params![purged_payload_json],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        }
+    })
+    .await
+    .expect("seed purged payloads");
+
+    let registry = RecordWalRegistry::new(Arc::from("forget-record-test"));
+    for (op, kind, kind_name) in [
+        (
+            "op-upsert-purged-recovery",
+            WalKind::Upsert,
+            WalKind::Upsert.as_str(),
+        ),
+        (
+            "op-expire-purged-recovery",
+            WalKind::Expire,
+            WalKind::Expire.as_str(),
+        ),
+    ] {
+        let op_id = OperationId::parse(op.to_owned()).expect("op id");
+        let err = match registry.body_for(&conn, kind, &op_id).await {
+            Err(err) => err,
+            Ok(_) => panic!("expected purged payload mismatch for {kind_name}"),
+        };
+        match err {
+            RecoveryError::Invariant(message) => {
+                assert!(
+                    message.contains("payload variant purged does not match wal kind"),
+                    "unexpected invariant: {message}"
+                );
+                assert!(
+                    message.contains(kind_name),
+                    "invariant should name wal kind: {message}"
+                );
+            }
+            other => panic!("expected invariant, got {other:?}"),
+        }
+    }
 }

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -285,6 +285,7 @@ async fn forget_record_purges_primary_indexes_and_vectors() {
     let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
     let record_id = record.id.as_str().to_owned();
     let target_id = record.target_id.as_str().to_owned();
+    let operation_id = outcome.operation_id.as_str().to_owned();
     conn.call(move |c| {
         let records: i64 = c.query_row(
             "SELECT COUNT(*) FROM records WHERE target_id = ?1",
@@ -306,10 +307,47 @@ async fn forget_record_purges_primary_indexes_and_vectors() {
             params![body],
             |row| row.get(0),
         )?;
+        let op_state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE operation_id = ?1",
+            params![operation_id],
+            |row| row.get(0),
+        )?;
+        let done_steps: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps \
+              WHERE operation_id = ?1 AND state = 'DONE'",
+            params![operation_id],
+            |row| row.get(0),
+        )?;
+        let total_steps: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps WHERE operation_id = ?1",
+            params![operation_id],
+            |row| row.get(0),
+        )?;
+        let consent_payload: String = c.query_row(
+            "SELECT payload_json FROM consent_journal \
+              WHERE op_id = ?1 AND kind = 'forget_intent'",
+            params![operation_id],
+            |row| row.get(0),
+        )?;
         assert_eq!(records, 0);
         assert_eq!(vectors, 0);
         assert_eq!(pending, 0);
         assert_eq!(fts_rows, 0);
+        assert_eq!(op_state, "COMMITTED");
+        assert_eq!(done_steps, 7);
+        assert_eq!(total_steps, 7);
+        assert!(
+            !consent_payload.contains(&record_id),
+            "forget consent event must not retain record id"
+        );
+        assert!(
+            !consent_payload.contains(&target_id),
+            "forget consent event must not retain target id"
+        );
+        assert!(
+            !consent_payload.contains(&body),
+            "forget consent event must not retain body text"
+        );
         Ok::<_, tokio_rusqlite::Error>(())
     })
     .await
@@ -342,4 +380,57 @@ async fn forget_record_keeps_session_siblings_visible() {
     let listed = store.list(&ListArgs::default()).await.expect("list");
     assert_eq!(listed.records.len(), 1);
     assert_eq!(listed.records[0].id, sibling.id);
+}
+
+#[tokio::test]
+async fn forget_record_does_not_scrub_unrelated_payload_mentions() {
+    let store = open_in_memory().await.expect("open");
+    let forgotten = sample_record();
+    let mut unrelated = sample_record();
+    unrelated.id = RecordId::parse("01J00000000000000000000004").expect("record id");
+    unrelated.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000004").expect("target");
+    unrelated.body = format!(
+        "unrelated note mentions {} and {} only as text",
+        forgotten.id.as_str(),
+        forgotten.target_id.as_str()
+    );
+
+    store.upsert(&forgotten).await.expect("forgotten upsert");
+    store.upsert(&unrelated).await.expect("unrelated upsert");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let unrelated_target = unrelated.target_id.as_str().to_owned();
+    let unrelated_op = conn
+        .call(move |c| {
+            c.query_row(
+                "SELECT p.operation_id \
+                   FROM wal_payloads p \
+                   JOIN wal_ops o ON o.operation_id = p.operation_id \
+                  WHERE p.kind = 'upsert' AND o.target_hash = ?1",
+                params![unrelated_target],
+                |row| row.get::<_, String>(0),
+            )
+            .map_err(tokio_rusqlite::Error::Rusqlite)
+        })
+        .await
+        .expect("unrelated upsert op");
+
+    store
+        .forget_record(&forgotten.id)
+        .await
+        .expect("forget original");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let kind: String = c.query_row(
+            "SELECT kind FROM wal_payloads WHERE operation_id = ?1",
+            params![unrelated_op],
+            |row| row.get(0),
+        )?;
+        assert_eq!(kind, "upsert");
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("unrelated payload remains");
 }

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -130,7 +130,7 @@ async fn assert_forget_purged_surfaces(
 async fn seed_upsert_pre_image_leak(
     conn: &Arc<tokio_rusqlite::Connection>,
     record: &MemoryRecord,
-) -> String {
+) -> (String, i64) {
     let record_id = record.id.as_str().to_owned();
     let target_id = record.target_id.as_str().to_owned();
     let body = record.body.clone();
@@ -150,17 +150,20 @@ async fn seed_upsert_pre_image_leak(
         })
         .to_string()
         .into_bytes();
+        let step_ord = c.query_row(
+            "SELECT MIN(step_ord) FROM wal_steps WHERE operation_id = ?1",
+            params![upsert_op],
+            |row| row.get::<_, i64>(0),
+        )?;
         let changed = c.execute(
             "UPDATE wal_steps \
                 SET pre_image = ?1 \
               WHERE operation_id = ?2 \
-                AND step_ord = ( \
-                    SELECT MIN(step_ord) FROM wal_steps WHERE operation_id = ?2 \
-                )",
-            params![leaked_pre_image, upsert_op],
+                AND step_ord = ?3",
+            params![leaked_pre_image, upsert_op, step_ord],
         )?;
         assert_eq!(changed, 1, "test should seed one upsert pre_image leak");
-        Ok::<_, tokio_rusqlite::Error>(upsert_op)
+        Ok::<_, tokio_rusqlite::Error>((upsert_op, step_ord))
     })
     .await
     .expect("seed leaking pre_image")
@@ -170,6 +173,7 @@ async fn assert_forget_scrubbed_prior_wal_and_kept_body_free_payload(
     conn: &Arc<tokio_rusqlite::Connection>,
     record: &MemoryRecord,
     upsert_op: String,
+    seeded_step_ord: i64,
     forget_op: &OperationId,
 ) {
     let record_id = record.id.as_str().to_owned();
@@ -206,16 +210,31 @@ async fn assert_forget_scrubbed_prior_wal_and_kept_body_free_payload(
             );
         }
 
-        let purged_stubs: i64 = c.query_row(
-            "SELECT COUNT(*) \
+        let (payload_type, payload_purged_by): (String, String) = c.query_row(
+            "SELECT json_extract(payload_json, '$.type'), \
+                    json_extract(payload_json, '$.purged_by') \
                FROM wal_payloads \
               WHERE operation_id = ?1 \
                 AND kind = 'purged' \
                 AND json_extract(payload_json, '$.type') = 'purged'",
             params![upsert_op],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )?;
-        assert!(purged_stubs > 0, "at least one purged stub should remain");
+        assert_eq!(payload_type, "purged");
+        assert_eq!(payload_purged_by, forget_op);
+
+        let (pre_image_type, pre_image_purged_by): (String, String) = c.query_row(
+            "SELECT json_extract(CAST(pre_image AS TEXT), '$.type'), \
+                    json_extract(CAST(pre_image AS TEXT), '$.purged_by') \
+               FROM wal_steps \
+              WHERE operation_id = ?1 \
+                AND step_ord = ?2 \
+                AND pre_image IS NOT NULL",
+            params![upsert_op, seeded_step_ord],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(pre_image_type, "purged");
+        assert_eq!(pre_image_purged_by, forget_op);
 
         let (forget_kind, forget_type, forget_json): (String, String, String) = c.query_row(
             "SELECT kind, json_extract(payload_json, '$.type'), payload_json \
@@ -519,7 +538,7 @@ async fn forget_record_scrubs_body_bearing_wal_payloads_and_pre_images() {
     store.upsert(&record).await.expect("upsert");
 
     let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
-    let upsert_op = seed_upsert_pre_image_leak(&conn, &record).await;
+    let (upsert_op, seeded_step_ord) = seed_upsert_pre_image_leak(&conn, &record).await;
 
     let outcome = store
         .forget_record(&record.id)
@@ -532,6 +551,7 @@ async fn forget_record_scrubs_body_bearing_wal_payloads_and_pre_images() {
         &conn,
         &record,
         upsert_op,
+        seeded_step_ord,
         &outcome.operation_id,
     )
     .await;

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -4,8 +4,8 @@
 
 use std::sync::Arc;
 
-use cairn_core::contract::memory_store::MemoryStore;
-use cairn_core::domain::{MemoryRecord, RecordId};
+use cairn_core::contract::memory_store::{ListArgs, MemoryStore};
+use cairn_core::domain::{MemoryRecord, RecordId, ScopeTuple};
 use cairn_core::wal::{OperationId, WalKind};
 use cairn_store_sqlite::record_wal::RecordWalRegistry;
 use cairn_store_sqlite::record_wal::payload::{
@@ -263,4 +263,83 @@ async fn forget_resolution_reports_codec_for_malformed_scope() {
             .await
             .expect_err("malformed scope rejects");
     assert!(matches!(err, StoreError::Codec(_)));
+}
+
+#[tokio::test]
+async fn forget_record_purges_primary_indexes_and_vectors() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    let body = record.body.clone();
+    store.upsert(&record).await.expect("upsert");
+
+    let outcome = store
+        .forget_record(&record.id)
+        .await
+        .expect("forget record");
+    assert_eq!(outcome.deleted_count, 1);
+    assert_eq!(outcome.tombstones, vec![record.id.clone()]);
+
+    let listed = store.list(&ListArgs::default()).await.expect("list");
+    assert!(listed.records.is_empty(), "forgotten record must be invisible");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let record_id = record.id.as_str().to_owned();
+    let target_id = record.target_id.as_str().to_owned();
+    conn.call(move |c| {
+        let records: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records WHERE target_id = ?1",
+            params![target_id],
+            |row| row.get(0),
+        )?;
+        let vectors: i64 = c.query_row(
+            "SELECT COUNT(*) FROM record_vectors WHERE record_id = ?1",
+            params![record_id],
+            |row| row.get(0),
+        )?;
+        let pending: i64 = c.query_row(
+            "SELECT COUNT(*) FROM pending_embeddings WHERE record_id = ?1",
+            params![record_id],
+            |row| row.get(0),
+        )?;
+        let fts_rows: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records_fts WHERE body MATCH ?1",
+            params![body],
+            |row| row.get(0),
+        )?;
+        assert_eq!(records, 0);
+        assert_eq!(vectors, 0);
+        assert_eq!(pending, 0);
+        assert_eq!(fts_rows, 0);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("physical purge assertions");
+}
+
+#[tokio::test]
+async fn forget_record_keeps_session_siblings_visible() {
+    let store = open_in_memory().await.expect("open");
+    let first = sample_record();
+    let mut sibling = sample_record();
+    sibling.id = RecordId::parse("01J00000000000000000000003").expect("record id");
+    sibling.target_id =
+        cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000003").expect("target");
+    sibling.body = "sibling body remains".to_owned();
+    sibling.scope = ScopeTuple {
+        session_id: first.scope.session_id.clone(),
+        user: first.scope.user.clone(),
+        agent: first.scope.agent.clone(),
+        ..ScopeTuple::default()
+    };
+
+    store.upsert(&first).await.expect("first upsert");
+    store.upsert(&sibling).await.expect("sibling upsert");
+    store
+        .forget_record(&first.id)
+        .await
+        .expect("forget first");
+
+    let listed = store.list(&ListArgs::default()).await.expect("list");
+    assert_eq!(listed.records.len(), 1);
+    assert_eq!(listed.records[0].id, sibling.id);
 }

--- a/crates/cairn-store-sqlite/tests/forget_record.rs
+++ b/crates/cairn-store-sqlite/tests/forget_record.rs
@@ -532,6 +532,86 @@ async fn forget_record_purges_primary_indexes_and_vectors() {
 }
 
 #[tokio::test]
+async fn forget_record_expires_entity_edges_and_clears_source_record_id() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    store.upsert(&record).await.expect("upsert");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let raw_record_id = record.id.as_str().to_owned();
+    conn.call(move |c| {
+        c.execute_batch(
+            "INSERT OR IGNORE INTO entity_nodes (id, name, name_norm, created_at) VALUES
+               ('forget-source', 'Forget Source', 'forget source', 1),
+               ('forget-target', 'Forget Target', 'forget target', 1);",
+        )?;
+        c.execute(
+            "INSERT INTO entity_edges \
+               (id, source_id, target_id, relation, confidence, confidence_score, \
+                valid_at, invalid_at, created_at, expired_at, tombstone_reason, \
+                source_record_id, body_hash) \
+             VALUES ('forget-edge', 'forget-source', 'forget-target', 'mentions', \
+                     'EXTRACTED', 0.9, 100, NULL, 100, NULL, NULL, ?1, ?2)",
+            params![raw_record_id, vec![7_u8; 32]],
+        )?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("seed entity edge");
+
+    let outcome = store
+        .forget_record(&record.id)
+        .await
+        .expect("forget record");
+    assert_eq!(outcome.deleted_count, 1);
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let raw_record_id = record.id.as_str().to_owned();
+    conn.call(move |c| {
+        let live_edges: i64 = c.query_row(
+            "SELECT COUNT(*) FROM entity_edges \
+              WHERE id = 'forget-edge' AND expired_at IS NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        let retained_sources: i64 = c.query_row(
+            "SELECT COUNT(*) FROM entity_edges WHERE source_record_id = ?1",
+            params![raw_record_id],
+            |row| row.get(0),
+        )?;
+        let (expired_at, tombstone_reason): (Option<i64>, Option<String>) = c.query_row(
+            "SELECT expired_at, tombstone_reason \
+               FROM entity_edges WHERE id = 'forget-edge'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(live_edges, 0);
+        assert_eq!(retained_sources, 0);
+        assert!(expired_at.is_some());
+        assert_eq!(tombstone_reason.as_deref(), Some("forget"));
+
+        c.execute(
+            "INSERT INTO entity_edges \
+               (id, source_id, target_id, relation, confidence, confidence_score, \
+                valid_at, invalid_at, created_at, source_record_id, body_hash) \
+             VALUES ('forget-edge-successor', 'forget-source', 'forget-target', 'mentions', \
+                     'EXTRACTED', 0.8, 200, NULL, 200, NULL, ?1)",
+            params![vec![8_u8; 32]],
+        )?;
+        let successor_live: i64 = c.query_row(
+            "SELECT COUNT(*) FROM entity_edges \
+              WHERE id = 'forget-edge-successor' AND expired_at IS NULL",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(successor_live, 1);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("entity edge forget assertions");
+}
+
+#[tokio::test]
 async fn forget_record_scrubs_body_bearing_wal_payloads_and_pre_images() {
     let store = open_in_memory().await.expect("open");
     let record = sample_record();
@@ -893,4 +973,44 @@ async fn purge_pending_lint_reports_exhausted_forget_phase_b_without_raw_ids() {
     })
     .await
     .expect("lint assertions");
+}
+
+#[tokio::test]
+async fn purge_pending_lint_reports_aborted_forget_phase_b_without_restart_remediation() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    store.upsert(&record).await.expect("upsert");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let raw_record_id = record.id.as_str().to_owned();
+    let raw_target_id = record.target_id.as_str().to_owned();
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('forget_record-01J00000000000000000001003', 201, 'forget_record', \
+                     'ABORTED', '{}', 'issuer', \
+                     'hash:22222222222222222222222222222222', 'user=hmn:tafeng', 0, 'sig', 1, 1)",
+            [],
+        )?;
+        c.execute(
+            "INSERT INTO wal_steps \
+               (operation_id, step_ord, step_kind, state, attempts, last_error, started_at, finished_at) \
+             VALUES ('forget_record-01J00000000000000000001003', 5, 'wal.purge_pre_images', \
+                     'FAILED', 4, 'boom', 1, 2)",
+            [],
+        )?;
+        let findings =
+            cairn_store_sqlite::lint_purge_pending(c).expect("lint purge pending");
+        assert_eq!(findings.len(), 1);
+        let rendered = serde_json::to_string(&findings).expect("finding json");
+        assert!(rendered.contains("purge_failed"));
+        assert!(rendered.contains("ABORTED"));
+        assert!(!rendered.contains("restart Cairn to resume WAL recovery"));
+        assert!(!rendered.contains(&raw_record_id));
+        assert!(!rendered.contains(&raw_target_id));
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("aborted lint assertions");
 }

--- a/crates/cairn-store-sqlite/tests/migrations.rs
+++ b/crates/cairn-store-sqlite/tests/migrations.rs
@@ -15,7 +15,7 @@ fn fresh_in_memory_opens_to_head() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 54);
+    assert_eq!(head, 55);
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn fresh_vault_opens_and_reopens_idempotent() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 54);
+    assert_eq!(head, 55);
 }
 
 #[test]

--- a/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
+++ b/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
@@ -9,7 +9,7 @@ use cairn_store_sqlite::open_in_memory;
 use rusqlite::params;
 
 #[tokio::test]
-async fn wal_payloads_table_is_present_and_immutable() {
+async fn wal_payloads_table_is_present_and_rejects_non_scrub_updates() {
     let store = open_in_memory().await.expect("open in-memory store");
     let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
 
@@ -134,6 +134,17 @@ async fn wal_payloads_accepts_forget_record_and_only_scrub_updates() {
             "non-scrub payload updates must still be blocked"
         );
 
+        let missing_type_scrub = c.execute(
+            "UPDATE wal_payloads \
+                SET kind = 'purged', payload_json = '{}' \
+              WHERE operation_id = 'forget-record-payload'",
+            [],
+        );
+        assert!(
+            missing_type_scrub.is_err(),
+            "scrub updates must require a purged payload type"
+        );
+
         c.execute(
             "UPDATE wal_payloads \
                 SET kind = 'purged', \
@@ -147,6 +158,18 @@ async fn wal_payloads_accepts_forget_record_and_only_scrub_updates() {
             |row| row.get(0),
         )?;
         assert_eq!(kind, "purged");
+
+        let second_scrub = c.execute(
+            "UPDATE wal_payloads \
+                SET kind = 'purged', \
+                    payload_json = '{\"type\":\"purged\",\"target_hash\":\"hash:00000000000000000000000000000000\",\"purged_by\":\"forget-record-payload\",\"purged_at\":2}' \
+              WHERE operation_id = 'forget-record-payload'",
+            [],
+        );
+        assert!(
+            second_scrub.is_err(),
+            "purged payload rows must not be scrubbed again"
+        );
 
         let delete = c.execute(
             "DELETE FROM wal_payloads WHERE operation_id = 'forget-record-payload'",

--- a/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
+++ b/crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
@@ -101,3 +101,61 @@ async fn wal_payloads_kind_must_match_parent_operation() {
     .await
     .expect("kind-match assertion");
 }
+
+#[tokio::test]
+async fn wal_payloads_accepts_forget_record_and_only_scrub_updates() {
+    let store = open_in_memory().await.expect("open in-memory store");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    conn.call(|c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('forget-record-payload', 1, 'forget_record', 'ISSUED', '{}', \
+                     'issuer', 'hash:00000000000000000000000000000000', 'user=hmn:tafeng', \
+                     0, 'sig', 1, 1)",
+            [],
+        )?;
+        c.execute(
+            "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+             VALUES ('forget-record-payload', 'forget_record', \
+                     '{\"type\":\"forget_record\",\"target_hash\":\"hash:00000000000000000000000000000000\"}', 1)",
+            [],
+        )?;
+
+        let normal_update = c.execute(
+            "UPDATE wal_payloads SET payload_json = '{}' \
+             WHERE operation_id = 'forget-record-payload'",
+            [],
+        );
+        assert!(
+            normal_update.is_err(),
+            "non-scrub payload updates must still be blocked"
+        );
+
+        c.execute(
+            "UPDATE wal_payloads \
+                SET kind = 'purged', \
+                    payload_json = '{\"type\":\"purged\",\"target_hash\":\"hash:00000000000000000000000000000000\",\"purged_by\":\"forget-record-payload\",\"purged_at\":1}' \
+              WHERE operation_id = 'forget-record-payload'",
+            [],
+        )?;
+        let kind: String = c.query_row(
+            "SELECT kind FROM wal_payloads WHERE operation_id = 'forget-record-payload'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(kind, "purged");
+
+        let delete = c.execute(
+            "DELETE FROM wal_payloads WHERE operation_id = 'forget-record-payload'",
+            [],
+        );
+        assert!(delete.is_err(), "payload rows remain append-only");
+
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("schema assertions");
+}

--- a/docs/superpowers/plans/2026-05-10-issue-58-record-forget-wal.md
+++ b/docs/superpowers/plans/2026-05-10-issue-58-record-forget-wal.md
@@ -1,0 +1,2069 @@
+# Issue 58 Record Forget WAL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `cairn forget --record <record_id>` as a WAL-backed, crash-safe two-phase delete that tombstones a target lineage, purges primary vault surfaces, scrubs body-bearing WAL retention, recovers after crash, and advertises only the record forget capability.
+
+**Architecture:** Extend the existing `record_wal` subsystem with a third payload/body pair for `WalKind::ForgetRecord`; no new `MemoryStore` trait method is added. The public store helper resolves public `record_id` to internal `target_id`, persists a body-free `ForgetPayload`, acquires the existing record locks, runs `FORGET_RECORD_STEPS`, and finalizes `COMMITTED` only after Phase B completes. Boot recovery loads the durable forget payload through `RecordWalRegistry`, reacquires the same locks, resumes incomplete steps, and `cairn lint` surfaces exhausted Phase B work as a body-free `purge_pending` deferred check.
+
+**Tech Stack:** Rust 2024, `tokio_rusqlite`, `rusqlite`, SQLite migrations, `cairn_core::wal` step graphs, existing record WAL runner/locks, existing consent journal helpers, generated CLI envelopes, integration tests under `crates/cairn-store-sqlite/tests` and `crates/cairn-cli/tests`.
+
+---
+
+## File Structure
+
+- Create: `crates/cairn-store-sqlite/src/migrations/sql/0055_forget_record_payload_scrub.sql`
+  - Widens `wal_payloads.kind` to include `forget_record` and `purged`.
+  - Replaces the all-update ban with a trigger that permits only scrub-to-`purged` updates.
+- Modify: `crates/cairn-store-sqlite/src/migrations/mod.rs`
+  - Registers migration 55 after existing migration 54.
+- Modify: `crates/cairn-store-sqlite/src/verify.rs`
+  - Replaces the expected `wal_payloads_immutable` trigger name with `wal_payloads_scrub_only`.
+- Modify: `crates/cairn-store-sqlite/tests/wal_payloads_migration.rs`
+  - Keeps normal immutability assertions and adds `forget_record` plus scrub-stub coverage.
+- Modify: `crates/cairn-store-sqlite/src/record_wal/payload.rs`
+  - Adds `ForgetPayload`, `PurgedPayload`, `RecordWalPayload::ForgetRecord`, and test helpers.
+- Create: `crates/cairn-store-sqlite/src/record_wal/forget.rs`
+  - Owns record-id resolution, body-free audit hash construction, WAL orchestration, and `ForgetOutcome`.
+- Modify: `crates/cairn-store-sqlite/src/record_wal/steps.rs`
+  - Adds `RecordStepPayload::ForgetRecord` and all seven `FORGET_RECORD_STEPS` bodies.
+- Modify: `crates/cairn-store-sqlite/src/record_wal/recovery.rs`
+  - Maps `WalKind::ForgetRecord` to `RecordStepBody::new_forget_record`.
+- Modify: `crates/cairn-store-sqlite/src/record_wal/mod.rs`
+  - Exports `forget` inside the crate and re-exports `apply_forget_record`.
+- Create: `crates/cairn-store-sqlite/src/store/forget.rs`
+  - Adds `SqliteMemoryStore::forget_record(&RecordId)` as the concrete public adapter API.
+- Modify: `crates/cairn-store-sqlite/src/store/mod.rs`
+  - Registers the `forget` module.
+- Modify: `crates/cairn-store-sqlite/src/lint.rs`
+  - Adds purge-pending detection for exhausted or open forget Phase B operations.
+- Modify: `crates/cairn-store-sqlite/src/lib.rs`
+  - Re-exports `lint_purge_pending` for integration tests and CLI-facing diagnostics.
+- Create: `crates/cairn-store-sqlite/tests/forget_record.rs`
+  - Store integration tests for tombstone, purge, WAL scrub, recovery, idempotency, sibling preservation, and leakage sentinels.
+- Modify: `crates/cairn-cli/src/main.rs`
+  - Routes `forget` through `resolve_vault_and_config`, matching wired verbs.
+- Modify: `crates/cairn-cli/src/verbs/forget.rs`
+  - Replaces the stub autonomous record branch with the real store call while preserving dry-run/human-review and session/scope rejection.
+- Create: `crates/cairn-cli/tests/forget_record.rs`
+  - CLI tests for JSON commit, search/retrieve invisibility, session/scope rejection, and status advertisement.
+- Modify: `crates/cairn-cli/tests/envelope_tests.rs`
+  - Replaces the old record-mode capability-unavailable assertion with session/scope-only rejection.
+- Modify: `crates/cairn-cli/tests/issue7_cli_e2e.rs`
+  - Updates status capability expectations to include `cairn.mcp.v1.forget.record`.
+- Modify: `crates/cairn-core/src/status/wiring.rs`
+  - Flips `FORGET_RECORD_WIRED` to `true`.
+- Modify: `crates/cairn-core/src/status/tests.rs`
+  - Updates the record forget gate test and keeps session/scope pinned off.
+
+---
+
+### Task 1: Widen WAL Payload Storage For Forget And Scrub Stubs
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/migrations/sql/0055_forget_record_payload_scrub.sql`
+- Modify: `crates/cairn-store-sqlite/src/migrations/mod.rs`
+- Modify: `crates/cairn-store-sqlite/src/verify.rs`
+- Modify: `crates/cairn-store-sqlite/tests/wal_payloads_migration.rs`
+
+- [ ] **Step 1: Write the failing migration test**
+
+Append this test to `crates/cairn-store-sqlite/tests/wal_payloads_migration.rs`:
+
+```rust
+#[tokio::test]
+async fn wal_payloads_accepts_forget_record_and_only_scrub_updates() {
+    let store = open_in_memory().await.expect("open in-memory store");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+
+    conn.call(|c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('forget-record-payload', 1, 'forget_record', 'ISSUED', '{}', \
+                     'issuer', 'hash:00000000000000000000000000000000', 'user=hmn:tafeng', \
+                     0, 'sig', 1, 1)",
+            [],
+        )?;
+        c.execute(
+            "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+             VALUES ('forget-record-payload', 'forget_record', \
+                     '{\"type\":\"forget_record\",\"target_hash\":\"hash:00000000000000000000000000000000\"}', 1)",
+            [],
+        )?;
+
+        let normal_update = c.execute(
+            "UPDATE wal_payloads SET payload_json = '{}' \
+             WHERE operation_id = 'forget-record-payload'",
+            [],
+        );
+        assert!(
+            normal_update.is_err(),
+            "non-scrub payload updates must still be blocked"
+        );
+
+        c.execute(
+            "UPDATE wal_payloads \
+                SET kind = 'purged', \
+                    payload_json = '{\"type\":\"purged\",\"target_hash\":\"hash:00000000000000000000000000000000\",\"purged_by\":\"forget-record-payload\",\"purged_at\":1}' \
+              WHERE operation_id = 'forget-record-payload'",
+            [],
+        )?;
+        let kind: String = c.query_row(
+            "SELECT kind FROM wal_payloads WHERE operation_id = 'forget-record-payload'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(kind, "purged");
+
+        let delete = c.execute(
+            "DELETE FROM wal_payloads WHERE operation_id = 'forget-record-payload'",
+            [],
+        );
+        assert!(delete.is_err(), "payload rows remain append-only");
+
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("schema assertions");
+}
+```
+
+- [ ] **Step 2: Run the migration test to verify it fails**
+
+Run: `cargo test -p cairn-store-sqlite --test wal_payloads_migration wal_payloads_accepts_forget_record_and_only_scrub_updates -- --nocapture`
+
+Expected: FAIL with a SQLite `CHECK constraint failed` or `wal_payloads rows are immutable` message because the existing schema accepts only `upsert` and `expire` and blocks every update.
+
+- [ ] **Step 3: Add migration 0055**
+
+Create `crates/cairn-store-sqlite/src/migrations/sql/0055_forget_record_payload_scrub.sql`:
+
+```sql
+-- Migration 0055: allow record-forget payloads and body-scrub stubs.
+-- Issue #58: forget_record recovery needs a body-free payload, and Phase B
+-- must scrub body-bearing upsert/expire WAL retention without deleting audit rows.
+
+DROP TRIGGER IF EXISTS wal_payloads_kind_matches_wal;
+DROP TRIGGER IF EXISTS wal_payloads_immutable;
+DROP TRIGGER IF EXISTS wal_payloads_no_delete;
+
+ALTER TABLE wal_payloads RENAME TO wal_payloads_old;
+
+CREATE TABLE wal_payloads (
+  operation_id TEXT NOT NULL PRIMARY KEY
+                    REFERENCES wal_ops(operation_id),
+  kind         TEXT NOT NULL CHECK (kind IN ('upsert', 'expire', 'forget_record', 'purged')),
+  payload_json TEXT NOT NULL,
+  created_at   INTEGER NOT NULL
+);
+
+INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at)
+SELECT operation_id, kind, payload_json, created_at
+  FROM wal_payloads_old;
+
+DROP TABLE wal_payloads_old;
+
+CREATE TRIGGER wal_payloads_kind_matches_wal
+  BEFORE INSERT ON wal_payloads
+  FOR EACH ROW
+  WHEN NEW.kind <> 'purged'
+   AND EXISTS (
+    SELECT 1
+      FROM wal_ops
+     WHERE operation_id = NEW.operation_id
+       AND kind IS NOT NEW.kind
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads.kind must match wal_ops.kind');
+END;
+
+CREATE TRIGGER wal_payloads_scrub_only
+  BEFORE UPDATE ON wal_payloads
+  FOR EACH ROW
+  WHEN NEW.operation_id IS NOT OLD.operation_id
+    OR NEW.created_at IS NOT OLD.created_at
+    OR NEW.kind <> 'purged'
+    OR json_extract(NEW.payload_json, '$.type') <> 'purged'
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads updates are limited to purged scrub stubs');
+END;
+
+CREATE TRIGGER wal_payloads_no_delete
+  BEFORE DELETE ON wal_payloads
+  FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'wal_payloads is append-only');
+END;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (55, '0055_forget_record_payload_scrub', '', strftime('%s','now') * 1000);
+```
+
+- [ ] **Step 4: Register migration 55**
+
+In `crates/cairn-store-sqlite/src/migrations/mod.rs`, add this const after `M0054_RECORDS_COW_STAGING`:
+
+```rust
+// Issue #58 - forget_record payloads and WAL scrub stubs.
+const M0055_FORGET_RECORD_PAYLOAD_SCRUB: &str =
+    include_str!("sql/0055_forget_record_payload_scrub.sql");
+```
+
+Add this tuple after migration 54 in `MIGRATION_SOURCES`:
+
+```rust
+    (
+        55,
+        "0055_forget_record_payload_scrub",
+        M0055_FORGET_RECORD_PAYLOAD_SCRUB,
+    ),
+```
+
+Add this migration after `M::up(M0054_RECORDS_COW_STAGING),`:
+
+```rust
+        M::up(M0055_FORGET_RECORD_PAYLOAD_SCRUB),
+```
+
+- [ ] **Step 5: Update schema verification trigger expectations**
+
+In `crates/cairn-store-sqlite/src/verify.rs`, replace this expected object:
+
+```rust
+("trigger", "wal_payloads_immutable"),
+```
+
+with:
+
+```rust
+("trigger", "wal_payloads_scrub_only"),
+```
+
+- [ ] **Step 6: Run migration tests**
+
+Run: `cargo test -p cairn-store-sqlite --test wal_payloads_migration -- --nocapture`
+
+Expected: PASS. The existing immutability test still proves ordinary updates fail, and the new test proves the single scrub path is accepted.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/migrations/sql/0055_forget_record_payload_scrub.sql \
+        crates/cairn-store-sqlite/src/migrations/mod.rs \
+        crates/cairn-store-sqlite/src/verify.rs \
+        crates/cairn-store-sqlite/tests/wal_payloads_migration.rs
+git commit -m "feat: allow forget record wal scrub payloads (#58)"
+```
+
+---
+
+### Task 2: Add Body-Free Forget Payloads
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/record_wal/payload.rs`
+- Create: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+- [ ] **Step 1: Write the failing payload round-trip test**
+
+Create `crates/cairn-store-sqlite/tests/forget_record.rs`:
+
+```rust
+//! Issue #58: record-level forget through the record WAL.
+
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::{ListArgs, MemoryStore};
+use cairn_core::domain::{MemoryRecord, RecordId, ScopeTuple};
+use cairn_core::wal::WalKind;
+use cairn_store_sqlite::{StoreError, open, open_in_memory};
+use rusqlite::params;
+
+fn sample_record() -> MemoryRecord {
+    cairn_core::domain::record::tests_export::sample_record()
+}
+
+#[tokio::test]
+async fn forget_payload_round_trips_body_free() {
+    let store = open_in_memory().await.expect("open");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let record = sample_record();
+    let payload = cairn_store_sqlite::record_wal::payload::ForgetPayload::new_for_test(
+        record.id.clone(),
+        record.target_id.clone(),
+        record.scope.clone(),
+        vec![record.id.clone()],
+        "hash:00000000000000000000000000000000".to_owned(),
+    );
+
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('op-forget-payload', 1, ?1, 'ISSUED', '{}', 'issuer', ?2, ?3, 0, 'sig', 1, 1)",
+            params![
+                WalKind::ForgetRecord.as_str(),
+                payload.target_hash,
+                payload.scope.canonical_wire(),
+            ],
+        )?;
+        cairn_store_sqlite::record_wal::payload::save_forget_payload_for_test(
+            c,
+            "op-forget-payload",
+            &payload,
+        )
+        .expect("save forget payload");
+        let loaded = cairn_store_sqlite::record_wal::payload::load_forget_payload_for_test(
+            c,
+            "op-forget-payload",
+        )
+        .expect("load forget payload");
+        assert_eq!(loaded.requested_record_id, payload.requested_record_id);
+        assert_eq!(loaded.target_id, payload.target_id);
+        assert_eq!(loaded.record_ids, payload.record_ids);
+        let json = serde_json::to_string(&loaded).expect("payload json");
+        assert!(!json.contains(&record.body), "forget payload must not contain body text");
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("payload round trip");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record forget_payload_round_trips_body_free -- --nocapture`
+
+Expected: FAIL to compile with `could not find ForgetPayload in payload`.
+
+- [ ] **Step 3: Add payload structs and enum variant**
+
+In `crates/cairn-store-sqlite/src/record_wal/payload.rs`, add `ForgetPayload` and `PurgedPayload` after `ExpirePayload`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ForgetPayload {
+    pub requested_record_id: RecordId,
+    pub target_id: TargetId,
+    pub scope: ScopeTuple,
+    pub record_ids: Vec<RecordId>,
+    pub target_hash: String,
+    pub reason_code: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PurgedPayload {
+    pub target_hash: String,
+    pub purged_by: String,
+    pub purged_at: i64,
+}
+```
+
+Add the enum variant:
+
+```rust
+pub enum RecordWalPayload {
+    Upsert(Box<UpsertPayload>),
+    Expire(Box<ExpirePayload>),
+    ForgetRecord(Box<ForgetPayload>),
+    Purged(Box<PurgedPayload>),
+}
+```
+
+Update `save_payload` so only production payloads are inserted through it:
+
+```rust
+    let kind = match payload {
+        RecordWalPayload::Upsert(_) => WalKind::Upsert.as_str(),
+        RecordWalPayload::Expire(_) => WalKind::Expire.as_str(),
+        RecordWalPayload::ForgetRecord(_) => WalKind::ForgetRecord.as_str(),
+        RecordWalPayload::Purged(_) => {
+            return Err(StoreError::Invariant {
+                what: "purged wal payloads are written by scrub updates, not inserted".to_owned(),
+            });
+        }
+    };
+```
+
+Update `load_upsert_payload_for_test` to reject the new variants:
+
+```rust
+        RecordWalPayload::Expire(_) => Err(StoreError::Invariant {
+            what: "expected upsert payload, found expire payload".to_owned(),
+        }),
+        RecordWalPayload::ForgetRecord(_) => Err(StoreError::Invariant {
+            what: "expected upsert payload, found forget_record payload".to_owned(),
+        }),
+        RecordWalPayload::Purged(_) => Err(StoreError::Invariant {
+            what: "expected upsert payload, found purged payload".to_owned(),
+        }),
+```
+
+- [ ] **Step 4: Add forget payload test helpers**
+
+Append this helper block to `crates/cairn-store-sqlite/src/record_wal/payload.rs`:
+
+```rust
+#[cfg(any(test, feature = "test-helpers"))]
+impl ForgetPayload {
+    #[must_use]
+    pub fn new_for_test(
+        requested_record_id: RecordId,
+        target_id: TargetId,
+        scope: ScopeTuple,
+        record_ids: Vec<RecordId>,
+        target_hash: String,
+    ) -> Self {
+        Self {
+            requested_record_id,
+            target_id,
+            scope,
+            record_ids,
+            target_hash,
+            reason_code: "user_command".to_owned(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn save_forget_payload_for_test(
+    conn: &Connection,
+    op_id: &str,
+    payload: &ForgetPayload,
+) -> Result<(), StoreError> {
+    let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
+        what: format!("invalid test op id: {e}"),
+    })?;
+    save_payload(
+        conn,
+        &op,
+        &RecordWalPayload::ForgetRecord(Box::new(payload.clone())),
+    )
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub fn load_forget_payload_for_test(
+    conn: &Connection,
+    op_id: &str,
+) -> Result<ForgetPayload, StoreError> {
+    let op = OperationId::parse(op_id.to_owned()).map_err(|e| StoreError::Invariant {
+        what: format!("invalid test op id: {e}"),
+    })?;
+    match load_payload(conn, &op)? {
+        RecordWalPayload::ForgetRecord(payload) => Ok(*payload),
+        RecordWalPayload::Upsert(_) => Err(StoreError::Invariant {
+            what: "expected forget_record payload, found upsert payload".to_owned(),
+        }),
+        RecordWalPayload::Expire(_) => Err(StoreError::Invariant {
+            what: "expected forget_record payload, found expire payload".to_owned(),
+        }),
+        RecordWalPayload::Purged(_) => Err(StoreError::Invariant {
+            what: "expected forget_record payload, found purged payload".to_owned(),
+        }),
+    }
+}
+```
+
+- [ ] **Step 5: Run the payload test**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record forget_payload_round_trips_body_free -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/payload.rs \
+        crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "feat: add forget record wal payload (#58)"
+```
+
+---
+
+### Task 3: Resolve Public Record ID To Target Lineage
+
+**Files:**
+- Create: `crates/cairn-store-sqlite/src/record_wal/forget.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/mod.rs`
+- Modify: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+- [ ] **Step 1: Write the failing resolution tests**
+
+Append these tests to `crates/cairn-store-sqlite/tests/forget_record.rs`:
+
+```rust
+#[tokio::test]
+async fn forget_resolution_loads_full_target_lineage() {
+    let store = open_in_memory().await.expect("open");
+    let first = sample_record();
+    let mut second = first.clone();
+    second.id = RecordId::parse("01J00000000000000000000002").expect("record id");
+    second.body = "replacement body for same target".to_owned();
+    second.body_hash = cairn_core::domain::BodyHash::compute(&second.body);
+
+    store.upsert(&first).await.expect("first upsert");
+    store.upsert(&second).await.expect("second upsert");
+
+    let target = cairn_store_sqlite::record_wal::forget::resolve_forget_target_for_test(
+        &store,
+        &first.id,
+    )
+    .await
+    .expect("resolve");
+
+    assert_eq!(target.requested_record_id, first.id);
+    assert_eq!(target.target_id, first.target_id);
+    assert_eq!(target.record_ids.len(), 2);
+    assert!(target.record_ids.contains(&first.id));
+    assert!(target.record_ids.contains(&second.id));
+    assert_eq!(target.scope, first.scope);
+    assert!(target.target_hash.starts_with("hash:"));
+}
+
+#[tokio::test]
+async fn forget_resolution_reports_not_found_for_missing_record() {
+    let store = open_in_memory().await.expect("open");
+    let missing = RecordId::parse("01J00000000000000000000999").expect("record id");
+    let err = cairn_store_sqlite::record_wal::forget::resolve_forget_target_for_test(
+        &store,
+        &missing,
+    )
+    .await
+    .expect_err("missing record rejects");
+    assert!(matches!(err, StoreError::NotFound { id } if id == missing.as_str()));
+}
+```
+
+- [ ] **Step 2: Run the resolution tests to verify they fail**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record forget_resolution_ -- --nocapture`
+
+Expected: FAIL to compile with `could not find forget in record_wal`.
+
+- [ ] **Step 3: Create `record_wal::forget` with target resolution**
+
+Create `crates/cairn-store-sqlite/src/record_wal/forget.rs`:
+
+```rust
+//! Public record-level forget apply through record WAL.
+
+use std::sync::Arc;
+
+use cairn_core::domain::{RecordId, ScopeTuple, TargetId};
+use rusqlite::{OptionalExtension, params};
+
+use crate::error::StoreError;
+use crate::store::SqliteMemoryStore;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgetTarget {
+    pub requested_record_id: RecordId,
+    pub target_id: TargetId,
+    pub scope: ScopeTuple,
+    pub record_ids: Vec<RecordId>,
+    pub target_hash: String,
+}
+
+async fn resolve_forget_target(
+    store: &SqliteMemoryStore,
+    record_id: &RecordId,
+) -> Result<ForgetTarget, StoreError> {
+    let conn = Arc::clone(store.require_conn("forget_record")?);
+    let requested = record_id.clone();
+    conn.call(move |c| {
+        let row: Option<(String, String)> = c
+            .query_row(
+                "SELECT target_id, scope \
+                   FROM records \
+                  WHERE record_id = ?1 \
+                  ORDER BY version DESC \
+                  LIMIT 1",
+                params![requested.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let Some((target_raw, scope_json)) = row else {
+            return Err(tokio_rusqlite::Error::Other(Box::new(StoreError::NotFound {
+                id: requested.as_str().to_owned(),
+            })));
+        };
+        let target_id = TargetId::parse(target_raw.clone())
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(StoreError::InvalidRecord(e))))?;
+        let scope: ScopeTuple = serde_json::from_str(&scope_json)
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+
+        let mut stmt = c.prepare(
+            "SELECT record_id \
+               FROM records \
+              WHERE target_id = ?1 \
+              ORDER BY version ASC, record_id ASC",
+        )?;
+        let ids = stmt
+            .query_map(params![target_id.as_str()], |row| row.get::<_, String>(0))?
+            .map(|row| {
+                row.and_then(|raw| {
+                    RecordId::parse(raw).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            0,
+                            rusqlite::types::Type::Text,
+                            Box::new(e),
+                        )
+                    })
+                })
+            })
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        let target_hash = hash_target_id(target_id.as_str());
+        Ok::<_, tokio_rusqlite::Error>(ForgetTarget {
+            requested_record_id: requested,
+            target_id,
+            scope,
+            record_ids: ids,
+            target_hash,
+        })
+    })
+    .await
+    .map_err(unpack_worker_err)
+}
+
+fn hash_target_id(target_id: &str) -> String {
+    format!(
+        "hash:{}",
+        cairn_core::domain::projection::body_hash(&format!("forget_record:{target_id}"))
+    )
+}
+
+fn unpack_worker_err(err: tokio_rusqlite::Error) -> StoreError {
+    match err {
+        tokio_rusqlite::Error::Other(boxed) => match boxed.downcast::<StoreError>() {
+            Ok(inner) => *inner,
+            Err(other) => StoreError::Worker(tokio_rusqlite::Error::Other(other)),
+        },
+        other => StoreError::from(other),
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+pub async fn resolve_forget_target_for_test(
+    store: &SqliteMemoryStore,
+    record_id: &RecordId,
+) -> Result<ForgetTarget, StoreError> {
+    resolve_forget_target(store, record_id).await
+}
+```
+
+- [ ] **Step 4: Export the module**
+
+In `crates/cairn-store-sqlite/src/record_wal/mod.rs`, add:
+
+```rust
+pub mod forget;
+```
+
+- [ ] **Step 5: Run the resolution tests**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record forget_resolution_ -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/forget.rs \
+        crates/cairn-store-sqlite/src/record_wal/mod.rs \
+        crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "feat: resolve forget record target lineage (#58)"
+```
+
+---
+
+### Task 4: Run Forget Phase A And Phase B Through The Record WAL
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/record_wal/forget.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/steps.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/mod.rs`
+- Create: `crates/cairn-store-sqlite/src/store/forget.rs`
+- Modify: `crates/cairn-store-sqlite/src/store/mod.rs`
+- Modify: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+- [ ] **Step 1: Write failing end-to-end store tests**
+
+Append these tests to `crates/cairn-store-sqlite/tests/forget_record.rs`:
+
+```rust
+#[tokio::test]
+async fn forget_record_purges_primary_indexes_and_vectors() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    let body = record.body.clone();
+    store.upsert(&record).await.expect("upsert");
+
+    let outcome = store
+        .forget_record(&record.id)
+        .await
+        .expect("forget record");
+    assert_eq!(outcome.deleted_count, 1);
+    assert_eq!(outcome.tombstones, vec![record.id.clone()]);
+
+    let listed = store.list(&ListArgs::default()).await.expect("list");
+    assert!(listed.records.is_empty(), "forgotten record must be invisible");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let record_id = record.id.as_str().to_owned();
+    let target_id = record.target_id.as_str().to_owned();
+    conn.call(move |c| {
+        let records: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records WHERE target_id = ?1",
+            params![target_id],
+            |row| row.get(0),
+        )?;
+        let vectors: i64 = c.query_row(
+            "SELECT COUNT(*) FROM record_vectors WHERE record_id = ?1",
+            params![record_id],
+            |row| row.get(0),
+        )?;
+        let pending: i64 = c.query_row(
+            "SELECT COUNT(*) FROM pending_embeddings WHERE record_id = ?1",
+            params![record_id],
+            |row| row.get(0),
+        )?;
+        let fts_rows: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records_fts WHERE body MATCH ?1",
+            params![body],
+            |row| row.get(0),
+        )?;
+        assert_eq!(records, 0);
+        assert_eq!(vectors, 0);
+        assert_eq!(pending, 0);
+        assert_eq!(fts_rows, 0);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("physical purge assertions");
+}
+
+#[tokio::test]
+async fn forget_record_keeps_session_siblings_visible() {
+    let store = open_in_memory().await.expect("open");
+    let first = sample_record();
+    let mut sibling = sample_record();
+    sibling.id = RecordId::parse("01J00000000000000000000003").expect("record id");
+    sibling.target_id = cairn_core::domain::TargetId::parse("sibling-target").expect("target");
+    sibling.body = "sibling body remains".to_owned();
+    sibling.body_hash = cairn_core::domain::BodyHash::compute(&sibling.body);
+    sibling.scope = ScopeTuple {
+        session_id: first.scope.session_id.clone(),
+        user: first.scope.user.clone(),
+        agent: first.scope.agent.clone(),
+        ..ScopeTuple::default()
+    };
+
+    store.upsert(&first).await.expect("first upsert");
+    store.upsert(&sibling).await.expect("sibling upsert");
+    store.forget_record(&first.id).await.expect("forget first");
+
+    let listed = store.list(&ListArgs::default()).await.expect("list");
+    assert_eq!(listed.records.len(), 1);
+    assert_eq!(listed.records[0].id, sibling.id);
+}
+```
+
+- [ ] **Step 2: Run the store tests to verify they fail**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record forget_record_ -- --nocapture`
+
+Expected: FAIL to compile with `no method named forget_record found for struct SqliteMemoryStore`.
+
+- [ ] **Step 3: Add store-facing API**
+
+Create `crates/cairn-store-sqlite/src/store/forget.rs`:
+
+```rust
+//! Store-facing record forget helper.
+
+use cairn_core::domain::RecordId;
+
+use crate::error::StoreError;
+use crate::record_wal::forget::{ForgetOutcome, apply_forget_record};
+use crate::store::SqliteMemoryStore;
+
+impl SqliteMemoryStore {
+    /// Forget one public record id by deleting the full target lineage.
+    ///
+    /// # Errors
+    /// Returns [`StoreError`] if the record id is not present, WAL setup fails,
+    /// lock fencing fails, or a Phase B step exhausts retries.
+    pub async fn forget_record(&self, record_id: &RecordId) -> Result<ForgetOutcome, StoreError> {
+        apply_forget_record(self, record_id).await
+    }
+}
+```
+
+In `crates/cairn-store-sqlite/src/store/mod.rs`, add:
+
+```rust
+pub mod forget;
+```
+
+- [ ] **Step 4: Complete WAL orchestration in `record_wal::forget`**
+
+Extend `crates/cairn-store-sqlite/src/record_wal/forget.rs` with:
+
+```rust
+use cairn_core::wal::{OpState, WalKind, graph_for};
+
+use crate::record_wal::locks::acquire_for_record;
+use crate::record_wal::ops::{finalize, issue_prepared, new_operation_id};
+use crate::record_wal::payload::{ForgetPayload, RecordWalPayload, save_payload};
+use crate::record_wal::steps::RecordStepBody;
+use crate::wal::runner::{self, StepBody};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgetOutcome {
+    pub deleted_count: u64,
+    pub tombstones: Vec<RecordId>,
+    pub operation_id: cairn_core::wal::OperationId,
+}
+
+pub(crate) async fn apply_forget_record(
+    store: &SqliteMemoryStore,
+    record_id: &RecordId,
+) -> Result<ForgetOutcome, StoreError> {
+    let conn = Arc::clone(store.require_conn("forget_record")?);
+    let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
+        what: "forget_record requires daemon incarnation".to_owned(),
+    })?;
+    let target = resolve_forget_target(store, record_id).await?;
+    let op_id = new_operation_id(WalKind::ForgetRecord)?;
+    let locks = acquire_for_record(
+        &conn,
+        &target.scope,
+        &target.target_id,
+        &incarnation,
+        op_id.as_str(),
+        "record_wal_forget_record",
+    )
+    .await
+    .map_err(|e| StoreError::RecordWalLock(Box::new(e)))?;
+
+    let payload = ForgetPayload {
+        requested_record_id: target.requested_record_id.clone(),
+        target_id: target.target_id.clone(),
+        scope: target.scope.clone(),
+        record_ids: target.record_ids.clone(),
+        target_hash: target.target_hash.clone(),
+        reason_code: "user_command".to_owned(),
+    };
+
+    let payload_for_body = payload.clone();
+    let op_for_issue = op_id.clone();
+    let target_hash = target.target_hash.clone();
+    let scope_wire = target.scope.canonical_wire();
+    conn.call(move |c| {
+        let tx = c.transaction()?;
+        issue_prepared(&tx, &op_for_issue, WalKind::ForgetRecord, &target_hash, &scope_wire)
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        save_payload(
+            &tx,
+            &op_for_issue,
+            &RecordWalPayload::ForgetRecord(Box::new(payload_for_body)),
+        )
+        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        tx.commit()?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .map_err(unpack_worker_err)?;
+
+    let body: Arc<dyn StepBody> = Arc::new(RecordStepBody::new_forget_record(payload, locks));
+    runner::run_from(&conn, graph_for(WalKind::ForgetRecord), &op_id, 0, body).await?;
+
+    let op_for_finalize = op_id.clone();
+    conn.call(move |c| {
+        finalize(c, &op_for_finalize, OpState::Committed, "applied")
+            .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .map_err(unpack_worker_err)?;
+
+    Ok(ForgetOutcome {
+        deleted_count: u64::try_from(target.record_ids.len()).unwrap_or(u64::MAX),
+        tombstones: target.record_ids,
+        operation_id: op_id,
+    })
+}
+```
+
+In `crates/cairn-store-sqlite/src/record_wal/mod.rs`, add:
+
+```rust
+pub(crate) use forget::apply_forget_record;
+```
+
+- [ ] **Step 5: Add forget step payload dispatch**
+
+In `crates/cairn-store-sqlite/src/record_wal/steps.rs`, update imports:
+
+```rust
+use cairn_core::domain::{
+    ConsentEvent, ConsentKind, ConsentPayload, Identity, MemoryVisibility, Rfc3339Timestamp,
+};
+use crate::record_wal::payload::{ExpirePayload, ForgetPayload, PurgedPayload, StoredEmbedOutcome, UpsertPayload};
+```
+
+Add the enum variant and constructor:
+
+```rust
+pub(crate) enum RecordStepPayload {
+    Upsert(Box<UpsertPayload>),
+    Expire(Box<ExpirePayload>),
+    ForgetRecord(Box<ForgetPayload>),
+}
+```
+
+```rust
+    #[must_use]
+    pub(crate) fn new_forget_record(payload: ForgetPayload, locks: RecordLocks) -> Self {
+        Self {
+            payload: RecordStepPayload::ForgetRecord(Box::new(payload)),
+            locks,
+        }
+    }
+```
+
+Add these match arms before the catch-all arm:
+
+```rust
+            (RecordStepPayload::ForgetRecord(payload), "primary.mark_tombstone") => {
+                mark_forget_tombstone(tx, op_id, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "vector.drain") => {
+                drain_forget_vectors(tx, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "fts.drain") => {
+                drain_forget_fts(tx, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "edges.drain") => {
+                drain_forget_edges(tx, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "primary.purge") => {
+                purge_forget_primary(tx, payload)
+            }
+            (RecordStepPayload::ForgetRecord(payload), "wal.purge_pre_images") => {
+                scrub_forget_wal(tx, op_id, payload)
+            }
+            (RecordStepPayload::ForgetRecord(_), "snapshot.purge") => Ok(()),
+```
+
+Update the catch-all to include `RecordStepPayload::ForgetRecord(_)`.
+
+- [ ] **Step 6: Add step helper functions**
+
+Append these helpers to `crates/cairn-store-sqlite/src/record_wal/steps.rs` before `now_secs()`:
+
+```rust
+fn mark_forget_tombstone(
+    tx: &Transaction<'_>,
+    op_id: &OperationId,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "UPDATE records \
+            SET active = 0, \
+                tombstoned = 1, \
+                tombstone_reason = 'forget', \
+                updated_at = ?1 \
+          WHERE target_id = ?2",
+        params![crate::store::current_unix_ms(), payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+
+    let decided_at = Rfc3339Timestamp::from_unix_secs(now_secs())
+        .map_err(|e| StepBodyError::Failed(format!("forget consent timestamp: {e}")))?;
+    let event = ConsentEvent {
+        consent_id: ulid::Ulid::new().to_string(),
+        kind: ConsentKind::ForgetIntent,
+        actor: Identity::parse("hmn:cairn-cli")
+            .map_err(|e| StepBodyError::Failed(format!("forget consent actor: {e}")))?,
+        subject: payload.target_hash.clone(),
+        scope: payload.scope.canonical_wire(),
+        op_id: Some(op_id.as_str().to_owned()),
+        sensor_id: None,
+        payload: ConsentPayload::IntentReceipt {
+            target_id_hash: payload.target_hash.clone(),
+            scope_tier: MemoryVisibility::Private,
+            reason_code: payload.reason_code.clone(),
+        },
+        decided_at,
+        expires_at: None,
+    };
+    crate::consent::append(tx, &event).map_err(|e| StepBodyError::Failed(e.to_string()))?;
+    Ok(())
+}
+
+fn drain_forget_vectors(
+    tx: &Transaction<'_>,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM record_vectors WHERE record_id IN \
+         (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM pending_embeddings WHERE record_id IN \
+         (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn drain_forget_fts(
+    tx: &Transaction<'_>,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    let rowids = {
+        let mut stmt = tx
+            .prepare("SELECT rowid FROM records WHERE target_id = ?1")
+            .map_err(StepBodyError::Storage)?;
+        stmt.query_map(params![payload.target_id.as_str()], |row| row.get::<_, i64>(0))
+            .map_err(StepBodyError::Storage)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(StepBodyError::Storage)?
+    };
+    for rowid in rowids {
+        tx.execute("DELETE FROM records_fts WHERE rowid = ?1", params![rowid])
+            .map_err(StepBodyError::Storage)?;
+    }
+    Ok(())
+}
+
+fn drain_forget_edges(
+    tx: &Transaction<'_>,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM edges \
+          WHERE src IN (SELECT record_id FROM records WHERE target_id = ?1) \
+             OR dst IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    tx.execute(
+        "DELETE FROM entity_episodes \
+          WHERE episode_id IN (SELECT record_id FROM records WHERE target_id = ?1)",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn purge_forget_primary(
+    tx: &Transaction<'_>,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    tx.execute(
+        "DELETE FROM records WHERE target_id = ?1",
+        params![payload.target_id.as_str()],
+    )
+    .map_err(StepBodyError::Storage)?;
+    Ok(())
+}
+
+fn scrub_forget_wal(
+    tx: &Transaction<'_>,
+    op_id: &OperationId,
+    payload: &ForgetPayload,
+) -> Result<(), StepBodyError> {
+    let stub = serde_json::to_string(&crate::record_wal::payload::RecordWalPayload::Purged(
+        Box::new(PurgedPayload {
+            target_hash: payload.target_hash.clone(),
+            purged_by: op_id.as_str().to_owned(),
+            purged_at: crate::store::current_unix_ms(),
+        }),
+    ))
+    .map_err(|e| StepBodyError::Failed(format!("purged payload json: {e}")))?;
+    let stub_bytes = stub.as_bytes();
+    let mut needles = Vec::with_capacity(payload.record_ids.len() + 1);
+    needles.push(payload.target_id.as_str().to_owned());
+    needles.extend(payload.record_ids.iter().map(|id| id.as_str().to_owned()));
+
+    for needle in needles {
+        let like = format!("%{needle}%");
+        tx.execute(
+            "UPDATE wal_steps \
+                SET pre_image = ?1 \
+              WHERE operation_id <> ?2 \
+                AND pre_image IS NOT NULL \
+                AND CAST(pre_image AS TEXT) LIKE ?3",
+            params![stub_bytes, op_id.as_str(), like],
+        )
+        .map_err(StepBodyError::Storage)?;
+        tx.execute(
+            "UPDATE wal_payloads \
+                SET kind = 'purged', payload_json = ?1 \
+              WHERE operation_id <> ?2 \
+                AND kind IN ('upsert', 'expire') \
+                AND payload_json LIKE ?3",
+            params![stub, op_id.as_str(), like],
+        )
+        .map_err(StepBodyError::Storage)?;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 7: Run the end-to-end store tests**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record forget_record_ -- --nocapture`
+
+Expected: PASS for the payload, resolution, purge, and sibling tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/forget.rs \
+        crates/cairn-store-sqlite/src/record_wal/steps.rs \
+        crates/cairn-store-sqlite/src/record_wal/mod.rs \
+        crates/cairn-store-sqlite/src/store/forget.rs \
+        crates/cairn-store-sqlite/src/store/mod.rs \
+        crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "feat: apply record forget through wal (#58)"
+```
+
+---
+
+### Task 5: Wire Recovery And Purge-Pending Lint
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/record_wal/recovery.rs`
+- Modify: `crates/cairn-store-sqlite/src/lint.rs`
+- Modify: `crates/cairn-store-sqlite/src/lib.rs`
+- Modify: `crates/cairn-cli/src/verbs/lint.rs`
+- Modify: `crates/cairn-store-sqlite/tests/forget_record.rs`
+
+- [ ] **Step 1: Write failing recovery and lint tests**
+
+Append these tests to `crates/cairn-store-sqlite/tests/forget_record.rs`:
+
+```rust
+#[tokio::test]
+async fn prepared_forget_recovers_from_persisted_payload() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+    let op_id = "forget_record-01J00000000000000000001000";
+    let record = sample_record();
+    let target_hash = "hash:00000000000000000000000000000000".to_owned();
+
+    {
+        let store = open(&path).await.expect("open #1");
+        store.upsert(&record).await.expect("seed record");
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let payload_json = serde_json::json!({
+            "type": "forget_record",
+            "requested_record_id": record.id.as_str(),
+            "target_id": record.target_id.as_str(),
+            "scope": record.scope.clone(),
+            "record_ids": [record.id.as_str()],
+            "target_hash": target_hash.clone(),
+            "reason_code": "user_command"
+        })
+        .to_string();
+        conn.call(move |c| {
+            c.execute("DELETE FROM lock_holders", [])?;
+            c.execute("DELETE FROM locks", [])?;
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES (?1, 100, 'forget_record', 'ISSUED', '{}', 'issuer', ?2, ?3, 0, 'sig', 1, 1)",
+                params![op_id, target_hash, record.scope.canonical_wire()],
+            )?;
+            c.execute(
+                "UPDATE wal_ops SET state = 'PREPARED', updated_at = 2 \
+                 WHERE operation_id = ?1",
+                params![op_id],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES (?1, 'forget_record', ?2, 1)",
+                params![op_id, payload_json],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed prepared forget");
+    }
+
+    let store = open(&path).await.expect("open #2 triggers recovery");
+    assert!(store.list(&ListArgs::default()).await.expect("list").records.is_empty());
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE operation_id = ?1",
+            params![op_id],
+            |row| row.get(0),
+        )?;
+        let done: i64 = c.query_row(
+            "SELECT COUNT(*) FROM wal_steps WHERE operation_id = ?1 AND state = 'DONE'",
+            params![op_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state, "COMMITTED");
+        assert_eq!(done, 7);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("recovery assertions");
+}
+
+#[tokio::test]
+async fn prepared_forget_recovers_after_tombstone_linearization() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("cairn.sqlite");
+    let op_id = "forget_record-01J00000000000000000001002";
+    let record = sample_record();
+    let target_hash = "hash:22222222222222222222222222222222".to_owned();
+
+    {
+        let store = open(&path).await.expect("open #1");
+        store.upsert(&record).await.expect("seed record");
+        let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+        let payload_json = serde_json::json!({
+            "type": "forget_record",
+            "requested_record_id": record.id.as_str(),
+            "target_id": record.target_id.as_str(),
+            "scope": record.scope.clone(),
+            "record_ids": [record.id.as_str()],
+            "target_hash": target_hash.clone(),
+            "reason_code": "user_command"
+        })
+        .to_string();
+        conn.call(move |c| {
+            c.execute("DELETE FROM lock_holders", [])?;
+            c.execute("DELETE FROM locks", [])?;
+            c.execute(
+                "INSERT INTO wal_ops \
+                   (operation_id, issued_seq, kind, state, envelope, issuer, \
+                    target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+                 VALUES (?1, 101, 'forget_record', 'PREPARED', '{}', 'issuer', ?2, ?3, 0, 'sig', 1, 2)",
+                params![op_id, target_hash, record.scope.canonical_wire()],
+            )?;
+            c.execute(
+                "INSERT INTO wal_payloads(operation_id, kind, payload_json, created_at) \
+                 VALUES (?1, 'forget_record', ?2, 1)",
+                params![op_id, payload_json],
+            )?;
+            c.execute(
+                "UPDATE records \
+                    SET active = 0, tombstoned = 1, tombstone_reason = 'forget' \
+                  WHERE target_id = ?1",
+                params![record.target_id.as_str()],
+            )?;
+            c.execute(
+                "INSERT INTO wal_steps \
+                   (operation_id, step_ord, step_kind, state, attempts, started_at, finished_at) \
+                 VALUES (?1, 0, 'primary.mark_tombstone', 'DONE', 1, 1, 2)",
+                params![op_id],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await
+        .expect("seed linearized forget");
+    }
+
+    let store = open(&path).await.expect("open #2 triggers recovery");
+    assert!(
+        store
+            .list(&ListArgs::default())
+            .await
+            .expect("list")
+            .records
+            .is_empty(),
+        "linearized forget must stay invisible during recovery"
+    );
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let state: String = c.query_row(
+            "SELECT state FROM wal_ops WHERE operation_id = ?1",
+            params![op_id],
+            |row| row.get(0),
+        )?;
+        let remaining_records: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(state, "COMMITTED");
+        assert_eq!(remaining_records, 0);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("linearized recovery assertions");
+}
+
+#[tokio::test]
+async fn purge_pending_lint_reports_exhausted_forget_phase_b_without_raw_ids() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    store.upsert(&record).await.expect("upsert");
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let raw_record_id = record.id.as_str().to_owned();
+    let raw_target_id = record.target_id.as_str().to_owned();
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO wal_ops \
+               (operation_id, issued_seq, kind, state, envelope, issuer, \
+                target_hash, scope_json, expires_at, signature, issued_at, updated_at) \
+             VALUES ('forget_record-01J00000000000000000001001', 200, 'forget_record', \
+                     'PREPARED', '{}', 'issuer', \
+                     'hash:11111111111111111111111111111111', 'user=hmn:tafeng', 0, 'sig', 1, 1)",
+            [],
+        )?;
+        c.execute(
+            "INSERT INTO wal_steps \
+               (operation_id, step_ord, step_kind, state, attempts, last_error, started_at, finished_at) \
+             VALUES ('forget_record-01J00000000000000000001001', 5, 'wal.purge_pre_images', \
+                     'FAILED', 3, 'boom', 1, 2)",
+            [],
+        )?;
+        let findings = cairn_store_sqlite::lint_purge_pending(c)
+            .expect("lint purge pending");
+        assert_eq!(findings.len(), 1);
+        let rendered = serde_json::to_string(&findings).expect("finding json");
+        assert!(rendered.contains("purge_pending"));
+        assert!(rendered.contains("hash:11111111111111111111111111111111"));
+        assert!(!rendered.contains(&raw_record_id));
+        assert!(!rendered.contains(&raw_target_id));
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("lint assertions");
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record prepared_forget_recovers_from_persisted_payload prepared_forget_recovers_after_tombstone_linearization purge_pending_lint_reports_exhausted_forget_phase_b_without_raw_ids -- --nocapture`
+
+Expected: FAIL because `RecordWalRegistry` returns no body for `forget_record` and `lint_purge_pending` does not exist.
+
+- [ ] **Step 3: Wire forget recovery body**
+
+In `crates/cairn-store-sqlite/src/record_wal/recovery.rs`, change the upfront match to:
+
+```rust
+        match kind {
+            WalKind::Upsert | WalKind::Expire | WalKind::ForgetRecord => {}
+        }
+```
+
+Add this match arm:
+
+```rust
+            (WalKind::ForgetRecord, RecordWalPayload::ForgetRecord(payload)) => {
+                let locks = acquire_for_record(
+                    conn,
+                    &payload.scope,
+                    &payload.target_id,
+                    &self.incarnation,
+                    op_id.as_str(),
+                    "record_wal_recovery_forget_record",
+                )
+                .await
+                .map_err(|e| RecoveryError::Invariant(format!("recovery lock failed: {e}")))?;
+                Ok(Some(Arc::new(RecordStepBody::new_forget_record(*payload, locks))))
+            }
+```
+
+Add mismatch arms:
+
+```rust
+            (WalKind::ForgetRecord, RecordWalPayload::Upsert(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant upsert does not match wal kind forget_record".to_owned(),
+            )),
+            (WalKind::ForgetRecord, RecordWalPayload::Expire(_)) => Err(RecoveryError::Invariant(
+                "record wal payload variant expire does not match wal kind forget_record".to_owned(),
+            )),
+            (_, RecordWalPayload::Purged(_)) => Err(RecoveryError::Invariant(
+                "purged record wal payload cannot be recovered as an active operation".to_owned(),
+            )),
+```
+
+- [ ] **Step 4: Add purge-pending lint helper**
+
+In `crates/cairn-store-sqlite/src/lint.rs`, add this public function near `lint_edges`:
+
+```rust
+/// Find record-forget operations whose Phase B purge work is still incomplete.
+///
+/// # Errors
+/// Returns [`StoreError`] when WAL tables are missing or SQLite rejects the query.
+pub fn lint_purge_pending(conn: &Connection) -> Result<Vec<Finding>, StoreError> {
+    ensure_table(conn, WAL_OPS_TABLE)?;
+    ensure_table(conn, WAL_STEPS_TABLE)?;
+
+    let mut stmt = conn.prepare(
+        "SELECT wo.operation_id, wo.target_hash, ws.step_ord, ws.step_kind, ws.state, ws.attempts \
+           FROM wal_ops wo \
+           JOIN wal_steps ws ON ws.operation_id = wo.operation_id \
+          WHERE wo.kind = 'forget_record' \
+            AND wo.state = 'PREPARED' \
+            AND ws.step_ord >= 1 \
+            AND ws.state <> 'DONE' \
+          ORDER BY wo.issued_seq, ws.step_ord",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+            row.get::<_, i64>(5)?,
+        ))
+    })?;
+
+    let mut findings = Vec::new();
+    for row in rows {
+        let (operation_id, target_hash, step_ord, step_kind, state, attempts) = row?;
+        findings.push(Finding {
+            kind: Kind::DeferredCheck,
+            severity: Severity::Warning,
+            message: format!(
+                "purge_pending: forget_record operation {operation_id} target {target_hash} stalled at step {step_ord} ({step_kind}) state={state} attempts={attempts}"
+            ),
+            entities: None,
+            suggested_fix: Some("restart Cairn to resume WAL recovery; if it repeats, inspect the WAL step error".to_owned()),
+            target: Some(cairn_core::generated::verbs::lint::Target {
+                operation_id: ulid_from_operation_id(&operation_id),
+                path: None,
+                record_id: None,
+            }),
+            tracking_issue: Some(58),
+        });
+    }
+    Ok(findings)
+}
+
+fn ulid_from_operation_id(raw: &str) -> Option<cairn_core::generated::common::Ulid> {
+    raw.rsplit_once('-')
+        .map(|(_, tail)| tail)
+        .filter(|tail| tail.len() == 26)
+        .map(|tail| cairn_core::generated::common::Ulid(tail.to_owned()))
+}
+```
+
+Update `lint_edges` so purge-pending findings are included with existing edge findings:
+
+```rust
+    let mut findings = contradiction_findings(conn)?;
+    let ambiguous_findings = ambiguous_findings(conn)?;
+    let purge_findings = lint_purge_pending(conn)?;
+    let contradictions = usize_to_u64(findings.len());
+    let ambiguous_edges = usize_to_u64(ambiguous_findings.len());
+    findings.extend(ambiguous_findings);
+    findings.extend(purge_findings);
+```
+
+In `crates/cairn-store-sqlite/src/lib.rs`, update the re-export:
+
+```rust
+pub use lint::{EdgeLintReport, lint_edges, lint_purge_pending, resolve_edge_contradictions};
+```
+
+- [ ] **Step 5: Update CLI human summary to show purge-pending counts**
+
+In `crates/cairn-cli/src/verbs/lint.rs`, update the human summary format string and arguments:
+
+```rust
+    println!(
+        "summary: total={} contradictions={} ambiguous_edges={} purge_pending={} auto_resolved={}",
+        data.summary.total,
+        summary_count(data, "contradictory_edge"),
+        summary_count(data, "ambiguous_edge"),
+        data.findings
+            .iter()
+            .filter(|finding| {
+                finding.kind == Kind::DeferredCheck
+                    && finding.message.starts_with("purge_pending:")
+            })
+            .count(),
+        data.summary.auto_resolved.unwrap_or(0),
+    );
+```
+
+- [ ] **Step 6: Run recovery and lint tests**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record prepared_forget_recovers_from_persisted_payload prepared_forget_recovers_after_tombstone_linearization purge_pending_lint_reports_exhausted_forget_phase_b_without_raw_ids -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 7: Run lint-focused CLI/unit tests**
+
+Run: `cargo test -p cairn-cli --test lint_crash_recovery -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/recovery.rs \
+        crates/cairn-store-sqlite/src/lint.rs \
+        crates/cairn-store-sqlite/src/lib.rs \
+        crates/cairn-cli/src/verbs/lint.rs \
+        crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "feat: recover and lint pending record forgets (#58)"
+```
+
+---
+
+### Task 6: Add WAL Scrub And Leakage Regression Coverage
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/tests/forget_record.rs`
+- Modify: `crates/cairn-store-sqlite/src/record_wal/steps.rs`
+
+- [ ] **Step 1: Write failing WAL scrub tests**
+
+Append these tests to `crates/cairn-store-sqlite/tests/forget_record.rs`:
+
+```rust
+#[tokio::test]
+async fn forget_record_scrubs_body_bearing_wal_payloads_and_pre_images() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    let leaked_body = record.body.clone();
+    let leaked_record_id = record.id.as_str().to_owned();
+    store.upsert(&record).await.expect("upsert");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    let body_for_seed = leaked_body.clone();
+    let record_for_seed = leaked_record_id.clone();
+    conn.call(move |c| {
+        c.execute(
+            "UPDATE wal_steps \
+                SET pre_image = ?1 \
+              WHERE operation_id IN (SELECT operation_id FROM wal_ops WHERE kind = 'upsert') \
+                AND step_ord = 0",
+            params![format!("{{\"record_id\":\"{record_for_seed}\",\"body\":\"{body_for_seed}\"}}").as_bytes()],
+        )?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("seed pre_image leak");
+
+    store.forget_record(&record.id).await.expect("forget");
+
+    let conn = Arc::clone(store.raw_conn_for_admin().expect("connected"));
+    conn.call(move |c| {
+        let payload_text: String = c.query_row(
+            "SELECT group_concat(payload_json, '\n') FROM wal_payloads",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )?.unwrap_or_default();
+        let pre_image_text: String = c.query_row(
+            "SELECT group_concat(CAST(pre_image AS TEXT), '\n') FROM wal_steps",
+            [],
+            |row| row.get::<_, Option<String>>(0),
+        )?.unwrap_or_default();
+        let combined = format!("{payload_text}\n{pre_image_text}");
+        assert!(!combined.contains(&leaked_body), "body text must be scrubbed");
+        assert!(!combined.contains(&leaked_record_id), "raw record id must be scrubbed");
+        assert!(combined.contains("\"type\":\"purged\""), "audit scrub stub remains");
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("scrub assertions");
+}
+
+#[tokio::test]
+async fn forget_record_replay_is_idempotent_after_primary_purge() {
+    let store = open_in_memory().await.expect("open");
+    let record = sample_record();
+    store.upsert(&record).await.expect("upsert");
+    let first = store.forget_record(&record.id).await.expect("forget");
+    assert_eq!(first.deleted_count, 1);
+    let second = store.forget_record(&record.id).await.expect_err("record no longer resolvable");
+    assert!(matches!(second, StoreError::NotFound { .. }));
+}
+```
+
+- [ ] **Step 2: Run scrub tests to verify they fail if scrub is incomplete**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record forget_record_scrubs_body_bearing_wal_payloads_and_pre_images forget_record_replay_is_idempotent_after_primary_purge -- --nocapture`
+
+Expected: PASS if Task 4 scrub code already covers both surfaces. If it fails, the failure identifies the remaining surface containing body text or raw ids.
+
+- [ ] **Step 3: Tighten scrub code if the test fails**
+
+If the failure shows body text or raw ids still present, update `scrub_forget_wal` in `crates/cairn-store-sqlite/src/record_wal/steps.rs` so it searches every payload needle from:
+
+```rust
+let mut needles = Vec::with_capacity(payload.record_ids.len() + 1);
+needles.push(payload.target_id.as_str().to_owned());
+needles.extend(payload.record_ids.iter().map(|id| id.as_str().to_owned()));
+```
+
+and updates both retention tables:
+
+```rust
+tx.execute(
+    "UPDATE wal_steps \
+        SET pre_image = ?1 \
+      WHERE operation_id <> ?2 \
+        AND pre_image IS NOT NULL \
+        AND CAST(pre_image AS TEXT) LIKE ?3",
+    params![stub_bytes, op_id.as_str(), like],
+)
+.map_err(StepBodyError::Storage)?;
+tx.execute(
+    "UPDATE wal_payloads \
+        SET kind = 'purged', payload_json = ?1 \
+      WHERE operation_id <> ?2 \
+        AND kind IN ('upsert', 'expire') \
+        AND payload_json LIKE ?3",
+    params![stub, op_id.as_str(), like],
+)
+.map_err(StepBodyError::Storage)?;
+```
+
+- [ ] **Step 4: Run scrub tests again**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record forget_record_scrubs_body_bearing_wal_payloads_and_pre_images forget_record_replay_is_idempotent_after_primary_purge -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-store-sqlite/src/record_wal/steps.rs \
+        crates/cairn-store-sqlite/tests/forget_record.rs
+git commit -m "test: cover record forget wal scrubbing (#58)"
+```
+
+---
+
+### Task 7: Wire CLI Record Forget And Status Advertisement
+
+**Files:**
+- Modify: `crates/cairn-cli/src/main.rs`
+- Modify: `crates/cairn-cli/src/verbs/forget.rs`
+- Create: `crates/cairn-cli/tests/forget_record.rs`
+- Modify: `crates/cairn-cli/tests/envelope_tests.rs`
+- Modify: `crates/cairn-cli/tests/issue7_cli_e2e.rs`
+- Modify: `crates/cairn-core/src/status/wiring.rs`
+- Modify: `crates/cairn-core/src/status/tests.rs`
+
+- [ ] **Step 1: Write failing CLI record forget tests**
+
+Create `crates/cairn-cli/tests/forget_record.rs`:
+
+```rust
+//! Issue #58: CLI record forget wiring.
+
+#![allow(missing_docs)]
+
+use serde_json::Value;
+use std::{path::Path, process::Command};
+
+fn cli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_cairn"))
+}
+
+fn bootstrap_vault(vault: &Path) {
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: vault.to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+}
+
+fn json_stdout(out: &std::process::Output) -> Value {
+    let stdout = String::from_utf8(out.stdout.clone()).expect("utf-8 stdout");
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!("stdout was not valid JSON: {e}\nstdout: {stdout:?}");
+    })
+}
+
+#[test]
+fn forget_record_json_commits_in_bound_vault() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let vault = tmp.path();
+    bootstrap_vault(vault);
+
+    let ingest = cli()
+        .current_dir(vault)
+        .args([
+            "ingest",
+            "--kind",
+            "reference",
+            "--body",
+            "forget me through cli",
+            "--json",
+        ])
+        .output()
+        .expect("ingest");
+    assert!(ingest.status.success(), "stderr: {}", String::from_utf8_lossy(&ingest.stderr));
+    let ingest_json = json_stdout(&ingest);
+    let record_id = ingest_json["data"]["record_id"]
+        .as_str()
+        .expect("record id")
+        .to_owned();
+
+    let forget = cli()
+        .current_dir(vault)
+        .args([
+            "forget",
+            "--record",
+            &record_id,
+            "--json",
+        ])
+        .output()
+        .expect("forget");
+    assert!(forget.status.success(), "stderr: {}", String::from_utf8_lossy(&forget.stderr));
+    let forget_json = json_stdout(&forget);
+    assert_eq!(forget_json["verb"], "forget");
+    assert_eq!(forget_json["status"], "committed");
+    assert_eq!(forget_json["data"]["deleted_count"], 1);
+    assert_eq!(forget_json["data"]["tombstones"][0], record_id);
+
+    let search = cli()
+        .current_dir(vault)
+        .args([
+            "search",
+            "forget me through cli",
+            "--mode",
+            "keyword",
+            "--json",
+        ])
+        .output()
+        .expect("search after forget");
+    assert!(search.status.success(), "stderr: {}", String::from_utf8_lossy(&search.stderr));
+    let search_json = json_stdout(&search);
+    assert_eq!(
+        search_json["data"]["hits"].as_array().expect("hits").len(),
+        0
+    );
+}
+
+#[test]
+fn forget_session_and_scope_remain_capability_unavailable() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    bootstrap_vault(tmp.path());
+    for args in [
+        vec!["forget", "--session", "session-1", "--json"],
+        vec!["forget", "--scope", r#"{"user":"hmn:tafeng"}"#, "--json"],
+    ] {
+        let out = cli()
+            .current_dir(tmp.path())
+            .args(args)
+            .output()
+            .expect("forget rejection");
+        assert_eq!(out.status.code(), Some(69));
+        let json: Value = serde_json::from_slice(&out.stdout).expect("json");
+        assert_eq!(json["error"]["code"], "CapabilityUnavailable");
+    }
+}
+```
+
+- [ ] **Step 2: Run CLI tests to verify they fail**
+
+Run: `cargo test -p cairn-cli --test forget_record -- --nocapture`
+
+Expected: FAIL because record mode still returns `CapabilityUnavailable`.
+
+- [ ] **Step 3: Route `forget` through vault/config resolution**
+
+In `crates/cairn-cli/src/main.rs`, replace:
+
+```rust
+        Some(("forget", sub)) => verbs::forget::run(sub),
+```
+
+with:
+
+```rust
+        Some(("forget", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
+            Ok((vault_root, _source, config)) => verbs::forget::run(sub, vault_root, config),
+            Err(code) => code,
+        },
+```
+
+- [ ] **Step 4: Implement CLI record branch**
+
+Change `crates/cairn-cli/src/verbs/forget.rs` imports to include:
+
+```rust
+use std::path::PathBuf;
+
+use cairn_core::config::CairnConfig;
+use cairn_core::domain::RecordId;
+use cairn_core::generated::common::Ulid;
+use cairn_core::generated::envelope::{Response, ResponseData, ResponseStatus};
+use cairn_core::generated::verbs::forget::ForgetData;
+use cairn_store_sqlite::StoreError;
+```
+
+Change the signature:
+
+```rust
+pub fn run(sub: &ArgMatches, vault_root: PathBuf, config: CairnConfig) -> ExitCode {
+```
+
+After the dry-run/human-review block and before capability fallback, add:
+
+```rust
+    if let Some(record_id_raw) = sub.get_one::<String>("record_id") {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                let resp = super::signed::aborted(ResponseVerb::Forget, format!("runtime build: {e}"));
+                emit_forget_response(json, &resp);
+                return response_exit_code(&resp);
+            }
+        };
+        let resp = rt.block_on(run_record_forget(
+            record_id_raw.clone(),
+            vault_root,
+            config,
+        ));
+        emit_forget_response(json, &resp);
+        return response_exit_code(&resp);
+    }
+```
+
+Append helper functions:
+
+```rust
+async fn run_record_forget(record_id_raw: String, vault_root: PathBuf, config: CairnConfig) -> Response {
+    let ctx = match super::signed::open_context(ResponseVerb::Forget, &vault_root, config).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+    let record_id = match RecordId::parse(record_id_raw.clone()) {
+        Ok(record_id) => record_id,
+        Err(e) => return super::signed::rejected_from_domain(ResponseVerb::Forget, e),
+    };
+    match ctx.store.forget_record(&record_id).await {
+        Ok(outcome) => super::signed::committed(
+            ResponseVerb::Forget,
+            super::envelope::new_operation_id(),
+            ResponseData::Forget(ForgetData {
+                deleted_count: outcome.deleted_count,
+                plan_ref: None,
+                tombstones: Some(
+                    outcome
+                        .tombstones
+                        .into_iter()
+                        .map(|id| Ulid(id.as_str().to_owned()))
+                        .collect(),
+                ),
+            }),
+            Vec::new(),
+        ),
+        Err(StoreError::NotFound { id }) => super::envelope::not_found_response(
+            ResponseVerb::Forget,
+            "record",
+            &format!("record {id} was not found"),
+        ),
+        Err(e) => super::signed::aborted(ResponseVerb::Forget, e.to_string()),
+    }
+}
+
+fn emit_forget_response(json: bool, resp: &Response) {
+    if json {
+        emit_json(resp);
+    } else if resp.status == ResponseStatus::Committed {
+        println!("cairn forget: committed (operation_id: {})", resp.operation_id.0);
+    } else {
+        let code = resp
+            .error
+            .as_ref()
+            .and_then(|e| e.get("code"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("Internal");
+        let message = resp
+            .error
+            .as_ref()
+            .and_then(|e| e.get("message"))
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("forget failed");
+        human_error("forget", code, message, &resp.operation_id);
+    }
+}
+
+fn response_exit_code(resp: &Response) -> ExitCode {
+    match resp.status {
+        ResponseStatus::Committed => ExitCode::SUCCESS,
+        ResponseStatus::Rejected => {
+            if super::signed::response_error_code(resp) == Some("CapabilityUnavailable") {
+                ExitCode::from(EX_UNAVAILABLE)
+            } else {
+                ExitCode::from(64)
+            }
+        }
+        ResponseStatus::Aborted => ExitCode::from(78),
+        _ => ExitCode::FAILURE,
+    }
+}
+```
+
+- [ ] **Step 5: Flip status wiring and update status tests**
+
+In `crates/cairn-core/src/status/wiring.rs`, change:
+
+```rust
+pub const FORGET_RECORD_WIRED: bool = false;
+```
+
+to:
+
+```rust
+pub const FORGET_RECORD_WIRED: bool = true;
+```
+
+In `crates/cairn-core/src/status/tests.rs`, replace `forget_record_held_back_until_wiring_flips` with:
+
+```rust
+#[test]
+fn forget_record_advertises_when_runtime_is_wired() {
+    let g = gates(true, true, None);
+    let caps = advertise(&g);
+    assert!(
+        caps.contains(&Capabilities::CairnMcpV1ForgetRecord),
+        "forget.record must advertise once runtime dispatch is wired"
+    );
+}
+```
+
+Update `crates/cairn-cli/tests/issue7_cli_e2e.rs` by replacing the assertion that `caps_one` does not contain `cairn.mcp.v1.forget.record` with:
+
+```rust
+    assert!(
+        caps_one.contains(&"cairn.mcp.v1.forget.record".to_owned()),
+        "forget.record is wired by issue #58 and must be advertised: {caps_one:?}"
+    );
+```
+
+In `crates/cairn-cli/tests/envelope_tests.rs`, remove `forget_record_returns_capability_unavailable` and keep coverage for session/scope `CapabilityUnavailable`.
+
+- [ ] **Step 6: Run CLI and status tests**
+
+Run: `cargo test -p cairn-core status::tests::forget_record_advertises_when_runtime_is_wired -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-cli --test forget_record -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-cli --test envelope_tests forget_ -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cairn-cli/src/main.rs \
+        crates/cairn-cli/src/verbs/forget.rs \
+        crates/cairn-cli/tests/forget_record.rs \
+        crates/cairn-cli/tests/envelope_tests.rs \
+        crates/cairn-cli/tests/issue7_cli_e2e.rs \
+        crates/cairn-core/src/status/wiring.rs \
+        crates/cairn-core/src/status/tests.rs
+git commit -m "feat: wire cli record forget capability (#58)"
+```
+
+---
+
+### Task 8: Final Verification
+
+**Files:**
+- No new files.
+- Verify all files changed in Tasks 1 through 7.
+
+- [ ] **Step 1: Run focused store tests**
+
+Run: `cargo test -p cairn-store-sqlite --test forget_record -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run migration and WAL regression tests**
+
+Run: `cargo test -p cairn-store-sqlite --test wal_payloads_migration -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-store-sqlite --test cow_upsert_expire -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-store-sqlite --test wal_recovery -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run CLI tests affected by record forget**
+
+Run: `cargo test -p cairn-cli --test forget_record -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-cli --test envelope_tests -- --nocapture`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-cli --test issue7_cli_e2e -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run core status tests**
+
+Run: `cargo test -p cairn-core status::tests -- --nocapture`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run formatting and lint checks**
+
+Run: `cargo fmt --all -- --check`
+
+Expected: PASS.
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full workspace tests**
+
+Run: `cargo test --workspace --all-targets`
+
+Expected: PASS.
+
+- [ ] **Step 7: Inspect final diff**
+
+Run: `git status --short`
+
+Expected: only intentional uncommitted changes, or no output if every task commit was made.
+
+Run: `git log --oneline origin/main..HEAD`
+
+Expected: includes the design commit, the plan commit if committed, and the Task 1 through Task 7 commits.
+
+- [ ] **Step 8: Commit verification-only fixes if needed**
+
+If formatting or verification required mechanical fixes, commit them:
+
+```bash
+git add crates/cairn-store-sqlite crates/cairn-cli crates/cairn-core
+git commit -m "chore: verify record forget wal flow (#58)"
+```

--- a/docs/superpowers/specs/2026-05-10-issue-58-record-forget-design.md
+++ b/docs/superpowers/specs/2026-05-10-issue-58-record-forget-design.md
@@ -1,0 +1,307 @@
+# Issue #58 record-level forget — design
+
+- **Issue:** [#58](https://github.com/windoliver/cairn/issues/58)
+- **Parent epic:** [#8](https://github.com/windoliver/cairn/issues/8) WAL, locks, replay, and record-level forget
+- **Phase:** v0.1 P0
+- **Brief sections:** §5.6 forget_record · §14 Privacy and Consent · §18.c US8
+- **Status:** approved design, awaiting implementation plan
+- **Date:** 2026-05-10
+
+## 1. Goal
+
+Implement `forget` mode `record` as a WAL-backed, crash-safe two-phase delete
+for one target lineage. Phase A tombstones every version of the target and
+makes it immediately reader-invisible. Phase B physically purges the target
+from the primary vault surfaces that exist in v0.1: `records`, FTS, vectors,
+pending embedding queues, record edges, entity episode links, body-bearing WAL
+payloads or pre-images, and markdown/profile/cache surfaces that are present in
+the local vault.
+
+The CLI, status advertisement, and recovery path must all agree: once this
+lands, `cairn forget --record <record_id>` is an advertised v0.1 capability,
+while session and scope forget remain unavailable.
+
+## 2. Non-goals
+
+- Session-wide forget fan-out. `forget --session` remains
+  `CapabilityUnavailable` until the v0.2 task.
+- Scope/folder forget. `forget --scope` remains `CapabilityUnavailable` until
+  the v0.3 task.
+- Backup registry tombstone replay and source-side `redact_on_forget` fan-out.
+  The issue comment explicitly defers those to #160.
+- A new storage contract method. The implementation should fit the existing
+  SQLite record WAL path and avoid a parallel direct-delete API.
+- P1 Nexus durable messaging. P0 remains a single SQLite authority.
+
+## 3. Source-of-truth alignment
+
+| Source | Requirement | Design choice |
+|---|---|---|
+| §5.6 `forget_record` | Phase A marks every version of a target tombstoned | Resolve the public `record_id` to `target_id`, then update all rows in that lineage |
+| §5.6 Phase B | Purge vectors, FTS, edges, primary rows, WAL pre-images, and snapshots | Add `ForgetPayload` and `RecordStepBody` arms for all seven `FORGET_RECORD_STEPS` |
+| §5.6 recovery | Recovery resumes from durable `wal_steps` markers | Extend `RecordWalRegistry` to return a body for `WalKind::ForgetRecord` |
+| §14 Privacy and Consent | Forget is body-free but auditable | Append a `forget_intent` `consent_journal` event whose subject is a salted target hash, not body text |
+| §18.c US8 | Record-level delete ships in v0.1; session delete is v0.2 | Flip only `FORGET_RECORD_WIRED`; keep session/scope rejected |
+| #58 issue comment | Primary vault only; backups/sources deferred | `snapshot.purge` only handles present local primary surfaces and records a no-op for absent v0.1 backup/source machinery |
+
+## 4. Current baseline
+
+`origin/main` already includes the prerequisite substrate:
+
+- `cairn_core::wal::FORGET_RECORD_STEPS` with seven stable step names.
+- `crates/cairn-store-sqlite/src/record_wal/` for upsert and expire payloads,
+  locks, operation issue/finalize helpers, `RecordStepBody`, and
+  `RecordWalRegistry`.
+- `wal_payloads` for recovery payloads.
+- `recover_pending` wired from `open.rs` with `RecordWalRegistry`.
+- SQLite record, FTS, vector, pending embedding, edge, entity graph, and
+  consent-journal tables.
+- `cairn forget` exists but currently returns `CapabilityUnavailable` outside
+  the dry-run/human-review placeholder plan path.
+- `FORGET_RECORD_WIRED` is still `false`, so status correctly does not
+  advertise the capability.
+
+The implementation should extend this shape instead of introducing a second
+mutation runner.
+
+## 5. Architecture
+
+Add `forget_record` as the third production body in the existing record WAL
+module:
+
+```text
+cairn forget --record <record_id>
+  -> open bound vault/store
+  -> resolve record_id -> target_id + scope + active body hash
+  -> issue prepared wal_ops row kind=forget_record
+  -> save RecordWalPayload::ForgetRecord
+  -> acquire entity lock through record_wal::locks
+  -> run FORGET_RECORD_STEPS through StepRunner
+  -> finalize wal_ops state=COMMITTED
+  -> return ForgetData { deleted_count, tombstones }
+
+Store::open(...)
+  -> init_incarnation(conn)
+  -> recover_pending(conn, RecoveryConfig { bodies: RecordWalRegistry })
+     -> WalKind::ForgetRecord reloads ForgetPayload and resumes steps
+```
+
+Files expected to change:
+
+- `crates/cairn-store-sqlite/src/record_wal/payload.rs` adds
+  `RecordWalPayload::ForgetRecord(Box<ForgetPayload>)`.
+- `crates/cairn-store-sqlite/src/record_wal/steps.rs` adds
+  `RecordStepPayload::ForgetRecord` step arms.
+- `crates/cairn-store-sqlite/src/record_wal/recovery.rs` maps
+  `WalKind::ForgetRecord` to the new body.
+- `crates/cairn-store-sqlite/src/record_wal/forget.rs` owns public apply
+  orchestration and payload construction.
+- `crates/cairn-store-sqlite/src/record_wal/mod.rs` exports the new apply
+  helper inside the crate.
+- `crates/cairn-cli/src/verbs/forget.rs` becomes an async real dispatch path
+  for record mode.
+- `crates/cairn-core/src/status/wiring.rs` flips only
+  `FORGET_RECORD_WIRED`.
+- `crates/cairn-core/src/verbs/lint/` and the SQLite lint bridge gain a
+  `purge_pending` report for exhausted or incomplete Phase B forget work.
+
+## 6. Target resolution
+
+The public input is `record_id` because that is the ID users and search results
+carry. The storage operation targets a `target_id` lineage because §5.6 requires
+forget to tombstone and purge every version of that target.
+
+Resolution happens before issuing the WAL op:
+
+1. Look up `record_id` in `records`, including inactive and tombstoned rows.
+2. If no row exists, return a not-found envelope for normal calls.
+3. If the row exists, capture `target_id`, `scope`, all version `record_id`s,
+   and body hashes needed for target/audit hashing.
+4. Build `ForgetPayload` with the `target_id`, original requested `record_id`,
+   scope, target-hash/audit salt material, and expected version IDs.
+
+Repeated recovery does not need the original row to still exist; it reloads the
+saved payload from `wal_payloads`.
+
+## 7. WAL steps
+
+### 7.1 `primary.mark_tombstone`
+
+Inside the StepRunner transaction:
+
+```sql
+UPDATE records
+   SET active = 0,
+       tombstoned = 1,
+       tombstone_reason = 'forget',
+       updated_at = :now
+ WHERE target_id = :target_id;
+```
+
+The same transaction appends a body-free `forget_intent` event to
+`consent_journal`. The event subject is a salted hash of the target, not the
+body or raw target string. This step is the reader-visible linearization point:
+after it commits, `get`, `list`, FTS, semantic search, graph search, and
+retrieve paths must not surface the target because they all join/filter on
+`tombstoned = 0` or active rows.
+
+### 7.2 `vector.drain`
+
+Delete `record_vectors` and `pending_embeddings` rows for every record id in
+the target lineage. This is idempotent: no matching rows means the step is
+already complete.
+
+### 7.3 `fts.drain`
+
+Delete `records_fts` rows by source `records.rowid` for the target lineage.
+Even though records triggers may remove rows during `primary.purge`, this step
+is explicit so Phase B can prove the search index is clean before primary rows
+disappear.
+
+### 7.4 `edges.drain`
+
+Delete record-level edges whose `src` or `dst` belongs to the target lineage.
+Also delete entity graph episode links that reference those record IDs. Entity
+nodes and non-episode entity edges remain unless their own lifecycle rules say
+otherwise; the forget contract is about references back to the forgotten record
+content.
+
+### 7.5 `primary.purge`
+
+Physically delete every `records` row for the target. SQLite triggers and
+foreign keys handle any remaining derived cleanup, but tests assert explicit
+absence from all primary surfaces. The step records the deleted count for the
+CLI response before deletion. During recovery, if the payload target has no
+remaining rows and prior steps are `DONE`, this step is treated as complete.
+
+### 7.6 `wal.purge_pre_images`
+
+Scrub body-bearing WAL retention surfaces for this target:
+
+- `wal_steps.pre_image` rows whose JSON references any forgotten `record_id` or
+  target id are replaced with a salted audit stub containing only the
+  forgetting operation id, scrub timestamp, and salted target hash.
+- `wal_payloads` rows for prior upsert/expire operations that contain the
+  forgotten target/body are similarly replaced or removed.
+- The current forget payload must remain body-free and recoverable until the
+  forget op is terminal.
+
+No raw body text, original target id, or original record id may remain in these
+body-bearing WAL surfaces after this step.
+
+### 7.7 `snapshot.purge`
+
+For v0.1 primary vault scope, this step performs idempotent local cleanup only
+for snapshot/projection/cache surfaces that exist in the checkout. Backup
+registry rewrite and source-file redaction are explicitly skipped because #160
+owns them. The step still records `DONE` so the static seven-step graph stays
+stable and future backup/source machinery can extend the body without changing
+step ordinals.
+
+## 8. CLI and capability behavior
+
+Record mode becomes real:
+
+```text
+cairn forget --record <record_id> --json
+```
+
+The command returns a normal `forget` response envelope with
+`ForgetData.deleted_count`, `tombstones`, and no `plan_ref` unless the caller
+asked for `--human-review`.
+
+Dry-run and human-review keep the FlushPlan behavior from #54. They should
+produce `PlannedMutation::ForgetRecord { target }` after resolving the input
+record to its target. Applying a human-review plan can remain a plan-lifecycle
+operation until the existing flush apply path is upgraded; the direct
+autonomous `forget --record` path must perform the real WAL mutation.
+
+Session and scope modes continue to return `CapabilityUnavailable`, and status
+advertises only `cairn.mcp.v1.forget.record`.
+
+## 9. Error handling
+
+- Missing record for a new autonomous request maps to the wire `NotFound`
+  error.
+- A duplicate/replayed WAL operation returns the original result when the
+  existing replay ledger can identify it; otherwise the operation remains
+  idempotent at the SQLite step level.
+- Lock acquisition errors use the existing lock error types, including owner,
+  operation, timeout, and retry hint.
+- Stale fencing fails before step side effects run.
+- Schema drift, malformed WAL payloads, or impossible step state combinations
+  return `StoreError::Invariant` or `SchemaDrift` and leave the op recoverable
+  or aborted according to the StepRunner policy.
+- Session/scope requests remain fail-closed with `CapabilityUnavailable`.
+
+## 10. Recovery
+
+`RecordWalRegistry::body_for` should accept `WalKind::ForgetRecord`, load the
+`ForgetPayload`, acquire the entity lock for the payload target/scope, and
+return `RecordStepBody::new_forget_record`.
+
+Recovery properties:
+
+- A crash before `primary.mark_tombstone` leaves no reader-visible change.
+- A crash after `primary.mark_tombstone` keeps the target reader-invisible and
+  resumes Phase B from the next incomplete step.
+- Already `DONE` drain/purge steps are skipped by the StepRunner.
+- Exhausted Phase B retries leave the target reader-invisible and surface a
+  `purge_pending` lint finding keyed by `operation_id`, `target_hash`, and the
+  failed `step_ord`; the finding must not include raw body, record id, or target
+  id.
+- Terminal commit occurs only after every `FORGET_RECORD_STEPS` row is `DONE`.
+
+## 11. Tests
+
+Use TDD and write failing tests before implementation.
+
+Store integration tests in
+`crates/cairn-store-sqlite/tests/forget_record.rs`:
+
+- `forget_record_tombstones_all_versions`: supersede a target twice, run the
+  Phase A body, assert every version is tombstoned and default reads/searches
+  miss it.
+- `forget_record_purges_primary_and_indexes`: run the full apply path and
+  assert no rows remain in `records`, `records_fts`, `record_vectors`,
+  `pending_embeddings`, `edges`, or entity episode tables for the target.
+- `forget_record_scrubs_wal_payloads`: seed a body-bearing upsert payload and
+  `wal_steps.pre_image`, run forget, and assert the unique sentinel body token
+  is absent from WAL surfaces.
+- `forget_record_recovery_resumes_after_each_done_step`: seed prepared ops with
+  different completed prefixes and assert boot recovery finishes the purge.
+- `forget_record_replay_is_idempotent`: run the same operation twice and assert
+  no duplicate consent events with body-bearing payload and no SQL errors.
+- `forget_record_keeps_session_siblings_visible`: insert two targets in the
+  same session, forget one, and assert the other still appears in reads/search.
+
+CLI tests in `crates/cairn-cli/tests/forget_record.rs`:
+
+- `forget_record_json_commits`: create a temp vault, insert one record, run
+  `cairn forget --record <id> --json`, and assert `deleted_count = 1`.
+- `forget_record_removes_from_search_and_retrieve`: after CLI forget, search
+  and retrieve cannot surface the record.
+- `forget_session_still_unavailable`: assert `forget --session` still returns
+  `CapabilityUnavailable`.
+- `status_advertises_record_only`: assert status includes record forget and
+  does not include session/scope forget.
+
+Leakage regression:
+
+- Insert a body containing a unique sentinel token.
+- Run full record forget.
+- Directly query every primary-vault table that can hold body/index/edge/WAL
+  content and assert the sentinel is absent. Hash-only audit metadata is
+  allowed; raw body text, raw target id, and raw record id are not.
+
+## 12. Self-review notes
+
+- The design scopes the issue to primary vault surfaces, matching the #58
+  comment and leaving backups/source rewrite to #160.
+- It uses the existing record WAL modules from #57 rather than adding a direct
+  store delete method.
+- It keeps `forget_record` lineages target-based even though the public input
+  is record-based.
+- It preserves fail-closed capability advertisement for session/scope forget.
+- It contains no placeholder requirements; every deferred item is tied to a
+  concrete out-of-scope issue, while purge-pending lint is in scope here.


### PR DESCRIPTION
Closes #58.

## Summary
- Add WAL-backed `forget_record` payloads, migration coverage, recovery handling, and lint reporting for pending or failed purge phases.
- Implement record forget tombstone and purge flow across primary records, consent/search surfaces, vectors, FTS, legacy edges, entity episodes, entity edges, and WAL payload/pre-image scrubbing.
- Wire `cairn forget --record` and status capability reporting while keeping session/scope forget unavailable for v0.1.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`