### PR TITLE
[codex] Add deterministic local sensor adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,8 @@ dependencies = [
  "async-trait",
  "cairn-core",
  "cairn-test-fixtures",
+ "regex",
+ "sha2",
  "tracing",
 ]
 

--- a/crates/cairn-cli/tests/plugins_verify.rs
+++ b/crates/cairn-cli/tests/plugins_verify.rs
@@ -34,6 +34,34 @@ fn plugins_verify_json_default_succeeds() {
 }
 
 #[test]
+fn plugins_verify_json_exercises_local_sensor_registration_e2e() {
+    let output = Command::new(cairn_binary())
+        .args(["plugins", "verify", "--json"])
+        .output()
+        .expect("spawn cairn binary");
+
+    assert!(
+        output.status.success(),
+        "cairn plugins verify --json must exit 0 in default mode; got {:?}",
+        output.status
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    let plugins = v["plugins"].as_array().expect("plugins array");
+    let sensors = plugins
+        .iter()
+        .find(|plugin| plugin["name"] == "cairn-sensors-local")
+        .expect("cairn-sensors-local plugin reported");
+
+    assert_eq!(sensors["contract"], "SensorIngress");
+    assert_case_status(sensors, "manifest_matches_host", "ok");
+    assert_case_status(sensors, "capability_self_consistency_floor", "ok");
+    assert_case_status(sensors, "manifest_features_match_capabilities", "ok");
+    assert_case_status(sensors, "emits_envelope_when_poked", "pending");
+}
+
+#[test]
 fn plugins_verify_strict_exits_69_with_pendings() {
     let output = Command::new(cairn_binary())
         .args(["plugins", "verify", "--strict"])
@@ -80,4 +108,14 @@ fn plugins_list_emits_alphabetical_rows() {
     assert!(mcp_idx < sensors_idx);
     assert!(sensors_idx < store_idx);
     assert!(store_idx < workflows_idx);
+}
+
+fn assert_case_status(plugin: &serde_json::Value, case_id: &str, expected: &str) {
+    let cases = plugin["cases"].as_array().expect("cases array");
+    let case = cases
+        .iter()
+        .find(|case| case["id"] == case_id)
+        .unwrap_or_else(|| panic!("missing conformance case {case_id}: {plugin}"));
+
+    assert_eq!(case["status"], expected, "case {case_id}: {case}");
 }

--- a/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
+++ b/crates/cairn-cli/tests/snapshots/plugins_list_snapshot__plugins_list_json.snap
@@ -22,8 +22,8 @@ expression: json
     },
     {
       "capabilities": {
-        "batches": false,
-        "consent_aware": false,
+        "batches": true,
+        "consent_aware": true,
         "streaming": false
       },
       "contract": "SensorIngress",

--- a/crates/cairn-sensors-local/Cargo.toml
+++ b/crates/cairn-sensors-local/Cargo.toml
@@ -13,6 +13,8 @@ description = "Local sensors (IDE hook, terminal, clipboard, voice, screen) for 
 [dependencies]
 cairn-core = { workspace = true }
 async-trait = { workspace = true }
+regex = { workspace = true }
+sha2 = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cairn-sensors-local/plugin.toml
+++ b/crates/cairn-sensors-local/plugin.toml
@@ -12,6 +12,6 @@ minor = 2
 patch = 0
 
 [features]
-batches = false
+batches = true
 streaming = false
-consent_aware = false
+consent_aware = true

--- a/crates/cairn-sensors-local/src/clipboard.rs
+++ b/crates/cairn-sensors-local/src/clipboard.rs
@@ -45,7 +45,7 @@ pub fn emit(config: &LocalSensorConfig, observation: ClipboardObservation) -> Em
         };
     }
 
-    let (sanitized_bytes, payload_byte_len) = if observation.mime_type == TEXT_PLAIN {
+    let (sanitized_bytes, payload_byte_len) = if is_text_plain_mime(&observation.mime_type) {
         let Ok(text) = std::str::from_utf8(&observation.bytes) else {
             return EmitOutcome::Dropped {
                 sensor: SensorKind::Clipboard,
@@ -101,4 +101,11 @@ pub fn emit(config: &LocalSensorConfig, observation: ClipboardObservation) -> Em
             reason: DropReason::MalformedObservation(err.to_string()),
         },
     }
+}
+
+fn is_text_plain_mime(mime_type: &str) -> bool {
+    mime_type
+        .split(';')
+        .next()
+        .is_some_and(|mime| mime.trim().eq_ignore_ascii_case(TEXT_PLAIN))
 }

--- a/crates/cairn-sensors-local/src/clipboard.rs
+++ b/crates/cairn-sensors-local/src/clipboard.rs
@@ -1,0 +1,100 @@
+//! Clipboard sensor emission.
+
+use cairn_core::domain::{
+    CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily,
+};
+
+use crate::event::build_auto_event;
+use crate::policy::{PolicyAction, sanitize_text_payload};
+use crate::{DropReason, EmitOutcome, LocalSensorConfig, SensorKind};
+
+const SENSOR_LABEL: &str = "local:clipboard:default:v1";
+const TEXT_PLAIN: &str = "text/plain";
+
+/// Raw clipboard observation ready for policy sanitization and capture event construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClipboardObservation {
+    /// Capture event id assigned by the caller.
+    pub event_id: CaptureEventId,
+    /// Observation capture timestamp.
+    pub captured_at: Rfc3339Timestamp,
+    /// Clipboard MIME type.
+    pub mime_type: String,
+    /// Raw clipboard payload bytes.
+    pub bytes: Vec<u8>,
+    /// Whether non-text clipboard payloads should emit metadata only.
+    pub metadata_only: bool,
+    /// Optional session, turn, and tool references.
+    pub refs: Option<CaptureRefs>,
+}
+
+/// Emit one clipboard observation as a validated capture event.
+#[must_use]
+pub fn emit(config: &LocalSensorConfig, observation: ClipboardObservation) -> EmitOutcome {
+    if !config.clipboard.enabled {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::Disabled,
+        };
+    }
+
+    if !config.clipboard.budget.allows(1, observation.bytes.len()) {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::BudgetExceeded,
+        };
+    }
+
+    let sanitized_bytes = if observation.mime_type == TEXT_PLAIN {
+        let Ok(text) = std::str::from_utf8(&observation.bytes) else {
+            return EmitOutcome::Dropped {
+                sensor: SensorKind::Clipboard,
+                reason: DropReason::PolicyRejected("clipboard text is not UTF-8".to_owned()),
+            };
+        };
+        match sanitize_text_payload(text) {
+            PolicyAction::Sanitized(text) => text.into_bytes(),
+            PolicyAction::Rejected(reason) => {
+                return EmitOutcome::Dropped {
+                    sensor: SensorKind::Clipboard,
+                    reason: DropReason::PolicyRejected(reason),
+                };
+            }
+        }
+    } else if observation.metadata_only {
+        Vec::new()
+    } else {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::PolicyRejected("unsupported clipboard MIME type".to_owned()),
+        };
+    };
+
+    let Ok(byte_len) = u64::try_from(sanitized_bytes.len()) else {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::MalformedObservation(
+                "clipboard payload length exceeds u64".to_owned(),
+            ),
+        };
+    };
+
+    match build_auto_event(
+        observation.event_id,
+        observation.captured_at,
+        SENSOR_LABEL,
+        CapturePayload::Clipboard {
+            mime_type: observation.mime_type,
+            byte_len,
+        },
+        SourceFamily::Clipboard,
+        observation.refs,
+        &sanitized_bytes,
+    ) {
+        Ok(event) => EmitOutcome::Emitted(event),
+        Err(err) => EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::MalformedObservation(err.to_string()),
+        },
+    }
+}

--- a/crates/cairn-sensors-local/src/clipboard.rs
+++ b/crates/cairn-sensors-local/src/clipboard.rs
@@ -45,7 +45,7 @@ pub fn emit(config: &LocalSensorConfig, observation: ClipboardObservation) -> Em
         };
     }
 
-    let sanitized_bytes = if observation.mime_type == TEXT_PLAIN {
+    let (sanitized_bytes, payload_byte_len) = if observation.mime_type == TEXT_PLAIN {
         let Ok(text) = std::str::from_utf8(&observation.bytes) else {
             return EmitOutcome::Dropped {
                 sensor: SensorKind::Clipboard,
@@ -53,7 +53,11 @@ pub fn emit(config: &LocalSensorConfig, observation: ClipboardObservation) -> Em
             };
         };
         match sanitize_text_payload(text) {
-            PolicyAction::Sanitized(text) => text.into_bytes(),
+            PolicyAction::Sanitized(text) => {
+                let sanitized_bytes = text.into_bytes();
+                let byte_len = sanitized_bytes.len();
+                (sanitized_bytes, byte_len)
+            }
             PolicyAction::Rejected(reason) => {
                 return EmitOutcome::Dropped {
                     sensor: SensorKind::Clipboard,
@@ -62,7 +66,7 @@ pub fn emit(config: &LocalSensorConfig, observation: ClipboardObservation) -> Em
             }
         }
     } else if observation.metadata_only {
-        Vec::new()
+        (Vec::new(), observation.bytes.len())
     } else {
         return EmitOutcome::Dropped {
             sensor: SensorKind::Clipboard,
@@ -70,7 +74,7 @@ pub fn emit(config: &LocalSensorConfig, observation: ClipboardObservation) -> Em
         };
     };
 
-    let Ok(byte_len) = u64::try_from(sanitized_bytes.len()) else {
+    let Ok(byte_len) = u64::try_from(payload_byte_len) else {
         return EmitOutcome::Dropped {
             sensor: SensorKind::Clipboard,
             reason: DropReason::MalformedObservation(

--- a/crates/cairn-sensors-local/src/config.rs
+++ b/crates/cairn-sensors-local/src/config.rs
@@ -1,0 +1,91 @@
+//! Local sensor adapter configuration.
+
+/// Per-sensor event budget enforced before payload hashing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CaptureBudget {
+    /// Maximum number of observations accepted by a single adapter call.
+    pub max_items: Option<usize>,
+    /// Maximum raw byte count accepted by a single adapter call.
+    pub max_bytes: Option<usize>,
+}
+
+impl CaptureBudget {
+    /// Return whether this budget accepts `items` and `bytes`.
+    #[must_use]
+    pub fn allows(self, items: usize, bytes: usize) -> bool {
+        self.max_items.is_none_or(|limit| items <= limit)
+            && self.max_bytes.is_none_or(|limit| bytes <= limit)
+    }
+}
+
+/// Shared settings for one local sensor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SensorSettings {
+    /// Whether this sensor emits events.
+    pub enabled: bool,
+    /// Source-side budget for one observation.
+    pub budget: CaptureBudget,
+}
+
+impl SensorSettings {
+    /// Enabled settings with no item or byte limit.
+    #[must_use]
+    pub const fn enabled() -> Self {
+        Self {
+            enabled: true,
+            budget: CaptureBudget {
+                max_items: None,
+                max_bytes: None,
+            },
+        }
+    }
+
+    /// Disabled settings with no item or byte limit.
+    #[must_use]
+    pub const fn disabled() -> Self {
+        Self {
+            enabled: false,
+            budget: CaptureBudget {
+                max_items: None,
+                max_bytes: None,
+            },
+        }
+    }
+}
+
+/// Configuration for deterministic local sensor adapters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalSensorConfig {
+    /// Hook sensor settings.
+    pub hooks: SensorSettings,
+    /// IDE sensor settings.
+    pub ide: SensorSettings,
+    /// Terminal sensor settings.
+    pub terminal: SensorSettings,
+    /// Clipboard sensor settings.
+    pub clipboard: SensorSettings,
+}
+
+impl LocalSensorConfig {
+    /// Disable every local sensor.
+    #[must_use]
+    pub const fn all_disabled() -> Self {
+        Self {
+            hooks: SensorSettings::disabled(),
+            ide: SensorSettings::disabled(),
+            terminal: SensorSettings::disabled(),
+            clipboard: SensorSettings::disabled(),
+        }
+    }
+}
+
+impl Default for LocalSensorConfig {
+    fn default() -> Self {
+        Self {
+            hooks: SensorSettings::enabled(),
+            ide: SensorSettings::enabled(),
+            terminal: SensorSettings::disabled(),
+            clipboard: SensorSettings::disabled(),
+        }
+    }
+}

--- a/crates/cairn-sensors-local/src/event.rs
+++ b/crates/cairn-sensors-local/src/event.rs
@@ -1,0 +1,113 @@
+//! Shared local sensor event construction.
+
+#![allow(dead_code)]
+
+use cairn_core::domain::{
+    ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs,
+    ChainRole, DomainError, Identity, PayloadHash, Rfc3339Timestamp, SourceFamily,
+};
+use sha2::{Digest as _, Sha256};
+
+/// Compute the canonical SHA-256 payload hash.
+pub(crate) fn payload_hash(bytes: &[u8]) -> Result<PayloadHash, DomainError> {
+    PayloadHash::parse(format!("sha256:{:x}", Sha256::digest(bytes)))
+}
+
+/// Build the vault-relative source payload ref for an event.
+pub(crate) fn payload_ref(family: SourceFamily, event_id: &CaptureEventId) -> String {
+    format!("sources/{family}/{event_id}.json")
+}
+
+/// Build a validated Mode A event authored by the emitting sensor.
+pub(crate) fn build_auto_event(
+    event_id: CaptureEventId,
+    captured_at: Rfc3339Timestamp,
+    sensor_label: &'static str,
+    payload: CapturePayload,
+    source_family: SourceFamily,
+    refs: Option<CaptureRefs>,
+    sanitized_payload_bytes: &[u8],
+) -> Result<CaptureEvent, DomainError> {
+    let sensor_id = Identity::parse(format!("snr:{sensor_label}"))?;
+    let actor_chain = vec![ActorChainEntry {
+        role: ChainRole::Author,
+        identity: sensor_id.clone(),
+        at: captured_at.clone(),
+    }];
+    let payload_hash = payload_hash(sanitized_payload_bytes)?;
+    let payload_ref = payload_ref(source_family, &event_id);
+
+    CaptureEvent::try_new(
+        event_id,
+        sensor_id,
+        CaptureMode::Auto,
+        actor_chain,
+        refs,
+        payload_hash,
+        payload_ref,
+        captured_at,
+        payload,
+        source_family,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use cairn_core::domain::{
+        CaptureEventId, CaptureMode, CapturePayload, Rfc3339Timestamp, SourceFamily,
+    };
+
+    use super::{build_auto_event, payload_hash, payload_ref};
+
+    fn event_id() -> CaptureEventId {
+        CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid test ULID")
+    }
+
+    fn ts() -> Rfc3339Timestamp {
+        Rfc3339Timestamp::parse("2026-05-11T12:00:00Z").expect("valid test timestamp")
+    }
+
+    #[test]
+    fn payload_hash_uses_sha256_prefix() {
+        let hash = payload_hash(b"hello").expect("hash parses");
+
+        assert_eq!(
+            hash.as_str(),
+            "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn payload_ref_is_sources_family_event_json() {
+        assert_eq!(
+            payload_ref(SourceFamily::Hook, &event_id()),
+            "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json"
+        );
+    }
+
+    #[test]
+    fn build_auto_event_binds_sensor_author_to_sensor_id() {
+        let event = build_auto_event(
+            event_id(),
+            ts(),
+            "local:hook:cc-session:v1",
+            CapturePayload::Hook {
+                hook_name: "UserPromptSubmit".to_owned(),
+                tool_name: None,
+            },
+            SourceFamily::Hook,
+            None,
+            b"{\"prompt\":\"hi\"}",
+        )
+        .expect("event validates");
+
+        assert_eq!(event.capture_mode, CaptureMode::Auto);
+        assert_eq!(event.sensor_id.as_str(), "snr:local:hook:cc-session:v1");
+        assert_eq!(event.actor_chain.len(), 1);
+        assert_eq!(
+            event.actor_chain[0].identity.as_str(),
+            "snr:local:hook:cc-session:v1"
+        );
+        event.validate_for_capture().expect("fresh event is valid");
+    }
+}

--- a/crates/cairn-sensors-local/src/event.rs
+++ b/crates/cairn-sensors-local/src/event.rs
@@ -1,7 +1,5 @@
 //! Shared local sensor event construction.
 
-#![allow(dead_code)]
-
 use cairn_core::domain::{
     ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs,
     ChainRole, DomainError, Identity, PayloadHash, Rfc3339Timestamp, SourceFamily,

--- a/crates/cairn-sensors-local/src/hook.rs
+++ b/crates/cairn-sensors-local/src/hook.rs
@@ -1,0 +1,95 @@
+//! Harness hook sensor emission.
+
+use cairn_core::domain::{
+    CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily,
+};
+
+use crate::event::build_auto_event;
+use crate::{DropReason, EmitOutcome, LocalSensorConfig, SensorKind};
+
+/// Supported local hook harnesses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HookHarness {
+    /// Claude Code hook harness.
+    ClaudeCode,
+    /// Codex hook harness.
+    Codex,
+    /// Gemini hook harness.
+    Gemini,
+}
+
+impl HookHarness {
+    const fn sensor_label(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "local:hook:cc-session:v1",
+            Self::Codex => "local:hook:codex-session:v1",
+            Self::Gemini => "local:hook:gemini-session:v1",
+        }
+    }
+}
+
+/// Sanitized hook observation ready for capture event construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookObservation {
+    /// Capture event id assigned by the caller.
+    pub event_id: CaptureEventId,
+    /// Observation capture timestamp.
+    pub captured_at: Rfc3339Timestamp,
+    /// Hook harness that produced the observation.
+    pub harness: HookHarness,
+    /// Harness hook name.
+    pub hook_name: String,
+    /// Optional tool name for tool hook observations.
+    pub tool_name: Option<String>,
+    /// Optional session, turn, and tool references.
+    pub refs: Option<CaptureRefs>,
+    /// Sanitized raw payload bytes stored behind the capture payload ref.
+    pub raw_payload: Vec<u8>,
+}
+
+/// Emit one hook observation as a validated capture event.
+#[must_use]
+pub fn emit(config: &LocalSensorConfig, observation: HookObservation) -> EmitOutcome {
+    if !config.hooks.enabled {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Hook,
+            reason: DropReason::Disabled,
+        };
+    }
+
+    if !config.hooks.budget.allows(1, observation.raw_payload.len()) {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Hook,
+            reason: DropReason::BudgetExceeded,
+        };
+    }
+
+    let HookObservation {
+        event_id,
+        captured_at,
+        harness,
+        hook_name,
+        tool_name,
+        refs,
+        raw_payload,
+    } = observation;
+
+    match build_auto_event(
+        event_id,
+        captured_at,
+        harness.sensor_label(),
+        CapturePayload::Hook {
+            hook_name,
+            tool_name,
+        },
+        SourceFamily::Hook,
+        refs,
+        &raw_payload,
+    ) {
+        Ok(event) => EmitOutcome::Emitted(event),
+        Err(err) => EmitOutcome::Dropped {
+            sensor: SensorKind::Hook,
+            reason: DropReason::MalformedObservation(err.to_string()),
+        },
+    }
+}

--- a/crates/cairn-sensors-local/src/ide.rs
+++ b/crates/cairn-sensors-local/src/ide.rs
@@ -1,0 +1,73 @@
+//! IDE sensor emission.
+
+use cairn_core::domain::{
+    CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily,
+};
+
+use crate::event::build_auto_event;
+use crate::{DropReason, EmitOutcome, LocalSensorConfig, SensorKind};
+
+const SENSOR_LABEL: &str = "local:ide:default:v1";
+
+/// Sanitized IDE observation ready for capture event construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdeObservation {
+    /// Capture event id assigned by the caller.
+    pub event_id: CaptureEventId,
+    /// Observation capture timestamp.
+    pub captured_at: Rfc3339Timestamp,
+    /// Workspace-relative affected file path.
+    pub file_path: String,
+    /// IDE event subtype.
+    pub event_kind: String,
+    /// Optional session, turn, and tool references.
+    pub refs: Option<CaptureRefs>,
+    /// Sanitized raw payload bytes stored behind the capture payload ref.
+    pub raw_payload: Vec<u8>,
+}
+
+/// Emit one IDE observation as a validated capture event.
+#[must_use]
+pub fn emit(config: &LocalSensorConfig, observation: IdeObservation) -> EmitOutcome {
+    if !config.ide.enabled {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Ide,
+            reason: DropReason::Disabled,
+        };
+    }
+
+    if !config.ide.budget.allows(1, observation.raw_payload.len()) {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Ide,
+            reason: DropReason::BudgetExceeded,
+        };
+    }
+
+    let IdeObservation {
+        event_id,
+        captured_at,
+        file_path,
+        event_kind,
+        refs,
+        raw_payload,
+    } = observation;
+
+    match build_auto_event(
+        event_id,
+        captured_at,
+        SENSOR_LABEL,
+        CapturePayload::Ide {
+            file_path,
+            event_kind,
+        },
+        SourceFamily::Ide,
+        refs,
+        &raw_payload,
+    ) {
+        Ok(event) => EmitOutcome::Emitted(event),
+        Err(err) => EmitOutcome::Dropped {
+            sensor: SensorKind::Ide,
+            reason: DropReason::MalformedObservation(err.to_string()),
+        },
+    }
+}

--- a/crates/cairn-sensors-local/src/lib.rs
+++ b/crates/cairn-sensors-local/src/lib.rs
@@ -11,6 +11,12 @@ use cairn_core::contract::sensor_ingress::{
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::register_plugin;
 
+pub mod config;
+pub mod outcome;
+
+pub use config::{CaptureBudget, LocalSensorConfig, SensorSettings};
+pub use outcome::{DropReason, EmitOutcome, SensorKind};
+
 /// Stable plugin name. Matches `name = ...` in `plugin.toml`.
 pub const PLUGIN_NAME: &str = "cairn-sensors-local";
 
@@ -22,7 +28,7 @@ pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
 pub const ACCEPTED_RANGE: VersionRange =
     VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
 
-/// P0 stub `SensorIngress`. All capability flags are `false`.
+/// Deterministic local sensor ingress.
 #[derive(Default)]
 pub struct LocalSensorIngress;
 
@@ -34,9 +40,9 @@ impl SensorIngress for LocalSensorIngress {
 
     fn capabilities(&self) -> &SensorIngressCapabilities {
         static CAPS: SensorIngressCapabilities = SensorIngressCapabilities {
-            batches: false,
+            batches: true,
             streaming: false,
-            consent_aware: false,
+            consent_aware: true,
         };
         &CAPS
     }

--- a/crates/cairn-sensors-local/src/lib.rs
+++ b/crates/cairn-sensors-local/src/lib.rs
@@ -16,6 +16,7 @@ mod event;
 pub mod hook;
 pub mod ide;
 pub mod outcome;
+pub mod policy;
 
 pub use config::{CaptureBudget, LocalSensorConfig, SensorSettings};
 pub use outcome::{DropReason, EmitOutcome, SensorKind};

--- a/crates/cairn-sensors-local/src/lib.rs
+++ b/crates/cairn-sensors-local/src/lib.rs
@@ -13,6 +13,8 @@ use cairn_core::register_plugin;
 
 pub mod config;
 mod event;
+pub mod hook;
+pub mod ide;
 pub mod outcome;
 
 pub use config::{CaptureBudget, LocalSensorConfig, SensorSettings};

--- a/crates/cairn-sensors-local/src/lib.rs
+++ b/crates/cairn-sensors-local/src/lib.rs
@@ -1,7 +1,7 @@
 //! Local sensors for Cairn — IDE hook, terminal, clipboard, voice, screen.
 //!
-//! P0 scaffold: stub `SensorIngress` impl with all capability flags
-//! `false`. Real capture lands per-sensor in #84 and follow-ups.
+//! Deterministic local sensor ingress advertises batch emission and
+//! consent-aware capture. Real capture lands per-sensor in #84 follow-ups.
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 

--- a/crates/cairn-sensors-local/src/lib.rs
+++ b/crates/cairn-sensors-local/src/lib.rs
@@ -12,6 +12,7 @@ use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::register_plugin;
 
 pub mod config;
+mod event;
 pub mod outcome;
 
 pub use config::{CaptureBudget, LocalSensorConfig, SensorSettings};

--- a/crates/cairn-sensors-local/src/lib.rs
+++ b/crates/cairn-sensors-local/src/lib.rs
@@ -11,12 +11,14 @@ use cairn_core::contract::sensor_ingress::{
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::register_plugin;
 
+pub mod clipboard;
 pub mod config;
 mod event;
 pub mod hook;
 pub mod ide;
 pub mod outcome;
 pub mod policy;
+pub mod terminal;
 
 pub use config::{CaptureBudget, LocalSensorConfig, SensorSettings};
 pub use outcome::{DropReason, EmitOutcome, SensorKind};

--- a/crates/cairn-sensors-local/src/outcome.rs
+++ b/crates/cairn-sensors-local/src/outcome.rs
@@ -43,6 +43,9 @@ pub enum DropReason {
 }
 
 /// Result of trying to emit one local sensor event.
+// Keep the emitted event by value: this short-lived adapter return type is
+// matched directly by integration tests and callers using the public API.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum EmitOutcome {
     /// Observation became a validated capture event.

--- a/crates/cairn-sensors-local/src/outcome.rs
+++ b/crates/cairn-sensors-local/src/outcome.rs
@@ -1,0 +1,86 @@
+//! Local sensor emission outcomes.
+
+use cairn_core::domain::{CaptureEvent, SourceFamily};
+
+/// Local sensor family handled by this adapter crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SensorKind {
+    /// Harness hook sensor.
+    Hook,
+    /// IDE event sensor.
+    Ide,
+    /// Terminal command/output sensor.
+    Terminal,
+    /// Clipboard snapshot sensor.
+    Clipboard,
+}
+
+impl SensorKind {
+    /// Convert a core source family emitted by this crate into its sensor kind.
+    #[must_use]
+    pub const fn from_source_family(family: SourceFamily) -> Option<Self> {
+        match family {
+            SourceFamily::Hook => Some(Self::Hook),
+            SourceFamily::Ide => Some(Self::Ide),
+            SourceFamily::Terminal => Some(Self::Terminal),
+            SourceFamily::Clipboard => Some(Self::Clipboard),
+            _ => None,
+        }
+    }
+}
+
+/// Reason an observation produced no event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DropReason {
+    /// Sensor was disabled at source.
+    Disabled,
+    /// Raw observation exceeded its configured source-side budget.
+    BudgetExceeded,
+    /// Local privacy policy rejected the observation.
+    PolicyRejected(String),
+    /// Observation was malformed or failed core capture validation.
+    MalformedObservation(String),
+}
+
+/// Result of trying to emit one local sensor event.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EmitOutcome {
+    /// Observation became a validated capture event.
+    Emitted(CaptureEvent),
+    /// Observation was dropped before event emission.
+    Dropped {
+        /// Sensor that dropped the observation.
+        sensor: SensorKind,
+        /// Concrete drop reason.
+        reason: DropReason,
+    },
+}
+
+impl EmitOutcome {
+    /// Borrow the emitted event when present.
+    #[must_use]
+    pub const fn event(&self) -> Option<&CaptureEvent> {
+        match self {
+            Self::Emitted(event) => Some(event),
+            Self::Dropped { .. } => None,
+        }
+    }
+
+    /// Sensor kind associated with this outcome.
+    #[must_use]
+    pub const fn sensor(&self) -> Option<SensorKind> {
+        match self {
+            Self::Emitted(event) => SensorKind::from_source_family(event.source_family),
+            Self::Dropped { sensor, .. } => Some(*sensor),
+        }
+    }
+
+    /// Borrow the drop reason when present.
+    #[must_use]
+    pub const fn drop_reason(&self) -> Option<&DropReason> {
+        match self {
+            Self::Emitted(_) => None,
+            Self::Dropped { reason, .. } => Some(reason),
+        }
+    }
+}

--- a/crates/cairn-sensors-local/src/policy.rs
+++ b/crates/cairn-sensors-local/src/policy.rs
@@ -1,0 +1,46 @@
+//! Local redaction and source-side drop policy.
+
+use regex::Regex;
+
+/// Policy result for text-bearing sensor payloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyAction {
+    /// Text was accepted after redaction.
+    Sanitized(String),
+    /// Text was rejected and must not be emitted.
+    Rejected(String),
+}
+
+/// Sanitize text payloads before hashing or event construction.
+#[must_use]
+pub fn sanitize_text_payload(input: &str) -> PolicyAction {
+    if contains_private_key_block(input) {
+        return PolicyAction::Rejected("private key block".to_owned());
+    }
+
+    let mut text = input.to_owned();
+    text = redact_regex(
+        &text,
+        r"(?i)\b([A-Z0-9_]*(TOKEN|API_KEY|SECRET|PASSWORD)[A-Z0-9_]*)=([^\s]+)",
+        "$1=[REDACTED]",
+    );
+    text = redact_regex(
+        &text,
+        r"(?i)Authorization:\s*Bearer\s+[A-Za-z0-9._~+/=-]+",
+        "Authorization: Bearer [REDACTED]",
+    );
+
+    PolicyAction::Sanitized(text)
+}
+
+fn redact_regex(input: &str, pattern: &str, replacement: &str) -> String {
+    match Regex::new(pattern) {
+        Ok(regex) => regex.replace_all(input, replacement).into_owned(),
+        Err(_) => input.to_owned(),
+    }
+}
+
+fn contains_private_key_block(input: &str) -> bool {
+    let upper = input.to_ascii_uppercase();
+    upper.contains("-----BEGIN ") && upper.contains("PRIVATE KEY-----")
+}

--- a/crates/cairn-sensors-local/src/terminal.rs
+++ b/crates/cairn-sensors-local/src/terminal.rs
@@ -1,0 +1,96 @@
+//! Terminal sensor emission.
+
+use cairn_core::domain::{
+    CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily, TerminalContext,
+};
+
+use crate::event::build_auto_event;
+use crate::policy::{PolicyAction, sanitize_text_payload};
+use crate::{DropReason, EmitOutcome, LocalSensorConfig, SensorKind};
+
+const SENSOR_LABEL: &str = "local:terminal:default:v1";
+
+/// Raw terminal observation ready for policy sanitization and capture event construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalObservation {
+    /// Capture event id assigned by the caller.
+    pub event_id: CaptureEventId,
+    /// Observation capture timestamp.
+    pub captured_at: Rfc3339Timestamp,
+    /// Argv-style command line.
+    pub command: String,
+    /// Process exit code, if the command had completed at capture time.
+    pub exit_code: Option<i32>,
+    /// Sensor-classified execution context for fresh terminal writes.
+    pub context: Option<TerminalContext>,
+    /// Terminal output bytes decoded as text by the local sensor.
+    pub output: String,
+    /// Optional session, turn, and tool references.
+    pub refs: Option<CaptureRefs>,
+}
+
+/// Emit one terminal observation as a validated capture event.
+#[must_use]
+pub fn emit(config: &LocalSensorConfig, observation: TerminalObservation) -> EmitOutcome {
+    if !config.terminal.enabled {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::Disabled,
+        };
+    }
+
+    let raw_len = observation.command.len() + observation.output.len();
+    if !config.terminal.budget.allows(1, raw_len) {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::BudgetExceeded,
+        };
+    }
+
+    let Some(context) = observation.context else {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::MalformedObservation("terminal context is required".to_owned()),
+        };
+    };
+
+    let command = match sanitize_text_payload(&observation.command) {
+        PolicyAction::Sanitized(command) => command,
+        PolicyAction::Rejected(reason) => {
+            return EmitOutcome::Dropped {
+                sensor: SensorKind::Terminal,
+                reason: DropReason::PolicyRejected(reason),
+            };
+        }
+    };
+    let output = match sanitize_text_payload(&observation.output) {
+        PolicyAction::Sanitized(output) => output,
+        PolicyAction::Rejected(reason) => {
+            return EmitOutcome::Dropped {
+                sensor: SensorKind::Terminal,
+                reason: DropReason::PolicyRejected(reason),
+            };
+        }
+    };
+    let sanitized_payload = format!("{command}\n{output}");
+
+    match build_auto_event(
+        observation.event_id,
+        observation.captured_at,
+        SENSOR_LABEL,
+        CapturePayload::Terminal {
+            command,
+            exit_code: observation.exit_code,
+            context: Some(context),
+        },
+        SourceFamily::Terminal,
+        observation.refs,
+        sanitized_payload.as_bytes(),
+    ) {
+        Ok(event) => EmitOutcome::Emitted(event),
+        Err(err) => EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::MalformedObservation(err.to_string()),
+        },
+    }
+}

--- a/crates/cairn-sensors-local/tests/local_sensor_capabilities.rs
+++ b/crates/cairn-sensors-local/tests/local_sensor_capabilities.rs
@@ -1,0 +1,47 @@
+#![allow(missing_docs)]
+
+use cairn_core::contract::sensor_ingress::SensorIngress;
+use cairn_sensors_local::{
+    CaptureBudget, DropReason, EmitOutcome, LocalSensorConfig, LocalSensorIngress, SensorKind,
+    SensorSettings,
+};
+
+#[test]
+fn local_sensor_ingress_advertises_batch_consent_capabilities() {
+    let ingress = LocalSensorIngress;
+    let caps = ingress.capabilities();
+
+    assert!(caps.batches);
+    assert!(!caps.streaming);
+    assert!(caps.consent_aware);
+}
+
+#[test]
+fn local_sensor_config_can_disable_every_source() {
+    let config = LocalSensorConfig::all_disabled();
+
+    assert!(!config.hooks.enabled);
+    assert!(!config.ide.enabled);
+    assert!(!config.terminal.enabled);
+    assert!(!config.clipboard.enabled);
+}
+
+#[test]
+fn emit_outcome_exposes_drop_reason_without_event() {
+    let outcome = EmitOutcome::Dropped {
+        sensor: SensorKind::Clipboard,
+        reason: DropReason::Disabled,
+    };
+
+    assert!(outcome.event().is_none());
+    assert_eq!(outcome.sensor(), Some(SensorKind::Clipboard));
+    assert_eq!(outcome.drop_reason(), Some(&DropReason::Disabled));
+}
+
+#[test]
+fn sensor_settings_default_budget_is_unbounded() {
+    let settings = SensorSettings::enabled();
+
+    assert!(settings.budget.allows(1, 1024));
+    assert_eq!(settings.budget, CaptureBudget::default());
+}

--- a/crates/cairn-sensors-local/tests/local_sensor_capabilities.rs
+++ b/crates/cairn-sensors-local/tests/local_sensor_capabilities.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 
 use cairn_core::contract::sensor_ingress::SensorIngress;
+use cairn_core::domain::SourceFamily;
 use cairn_sensors_local::{
     CaptureBudget, DropReason, EmitOutcome, LocalSensorConfig, LocalSensorIngress, SensorKind,
     SensorSettings,
@@ -44,4 +45,25 @@ fn sensor_settings_default_budget_is_unbounded() {
 
     assert!(settings.budget.allows(1, 1024));
     assert_eq!(settings.budget, CaptureBudget::default());
+}
+
+#[test]
+fn sensor_kind_maps_local_source_families_only() {
+    assert_eq!(
+        SensorKind::from_source_family(SourceFamily::Hook),
+        Some(SensorKind::Hook)
+    );
+    assert_eq!(
+        SensorKind::from_source_family(SourceFamily::Ide),
+        Some(SensorKind::Ide)
+    );
+    assert_eq!(
+        SensorKind::from_source_family(SourceFamily::Terminal),
+        Some(SensorKind::Terminal)
+    );
+    assert_eq!(
+        SensorKind::from_source_family(SourceFamily::Clipboard),
+        Some(SensorKind::Clipboard)
+    );
+    assert_eq!(SensorKind::from_source_family(SourceFamily::Cli), None);
 }

--- a/crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs
+++ b/crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs
@@ -6,7 +6,8 @@ use cairn_core::domain::{
 use cairn_sensors_local::hook::{HookHarness, HookObservation};
 use cairn_sensors_local::ide::IdeObservation;
 use cairn_sensors_local::{
-    DropReason, EmitOutcome, LocalSensorConfig, SensorKind, SensorSettings, hook, ide,
+    CaptureBudget, DropReason, EmitOutcome, LocalSensorConfig, SensorKind, SensorSettings, hook,
+    ide,
 };
 
 fn id(raw: &str) -> CaptureEventId {
@@ -60,6 +61,39 @@ fn enabled_hook_sensor_emits_valid_capture_event() {
 }
 
 #[test]
+fn hook_harnesses_emit_distinct_sensor_labels() {
+    let cases = [
+        (
+            HookHarness::Codex,
+            "01ARZ3NDEKTSV4RRFFQ69G5FB5",
+            "snr:local:hook:codex-session:v1",
+        ),
+        (
+            HookHarness::Gemini,
+            "01ARZ3NDEKTSV4RRFFQ69G5FB6",
+            "snr:local:hook:gemini-session:v1",
+        ),
+    ];
+
+    for (harness, event_id, sensor_id) in cases {
+        let observation = HookObservation {
+            event_id: id(event_id),
+            captured_at: ts(),
+            harness,
+            hook_name: "PostToolUse".to_owned(),
+            tool_name: Some("shell".to_owned()),
+            refs: None,
+            raw_payload: br#"{"tool_name":"shell","status":"ok"}"#.to_vec(),
+        };
+
+        let event = emitted(hook::emit(&LocalSensorConfig::default(), observation));
+
+        assert_eq!(event.sensor_id.as_str(), sensor_id);
+        event.validate_for_capture().expect("valid event");
+    }
+}
+
+#[test]
 fn disabled_hook_sensor_drops_without_event() {
     let config = LocalSensorConfig {
         hooks: SensorSettings::disabled(),
@@ -82,6 +116,39 @@ fn disabled_hook_sensor_drops_without_event() {
         EmitOutcome::Dropped {
             sensor: SensorKind::Hook,
             reason: DropReason::Disabled
+        }
+    );
+}
+
+#[test]
+fn hook_budget_drops_before_event_creation() {
+    let config = LocalSensorConfig {
+        hooks: SensorSettings {
+            enabled: true,
+            budget: CaptureBudget {
+                max_items: Some(1),
+                max_bytes: Some(4),
+            },
+        },
+        ..Default::default()
+    };
+    let observation = HookObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB7"),
+        captured_at: ts(),
+        harness: HookHarness::ClaudeCode,
+        hook_name: String::new(),
+        tool_name: None,
+        refs: None,
+        raw_payload: b"12345".to_vec(),
+    };
+
+    let outcome = hook::emit(&config, observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Hook,
+            reason: DropReason::BudgetExceeded
         }
     );
 }
@@ -112,4 +179,62 @@ fn enabled_ide_sensor_emits_valid_capture_event() {
         other => panic!("unexpected payload: {other:?}"),
     }
     event.validate_for_capture().expect("valid event");
+}
+
+#[test]
+fn disabled_ide_sensor_drops_without_event() {
+    let config = LocalSensorConfig {
+        ide: SensorSettings::disabled(),
+        ..Default::default()
+    };
+    let observation = IdeObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB8"),
+        captured_at: ts(),
+        file_path: "crates/cairn-core/src/domain/capture.rs".to_owned(),
+        event_kind: "diagnostic".to_owned(),
+        refs: None,
+        raw_payload: br#"{"diagnostics":1}"#.to_vec(),
+    };
+
+    let outcome = ide::emit(&config, observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Ide,
+            reason: DropReason::Disabled
+        }
+    );
+}
+
+#[test]
+fn ide_budget_drops_before_event_creation() {
+    let config = LocalSensorConfig {
+        ide: SensorSettings {
+            enabled: true,
+            budget: CaptureBudget {
+                max_items: Some(1),
+                max_bytes: Some(4),
+            },
+        },
+        ..Default::default()
+    };
+    let observation = IdeObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB9"),
+        captured_at: ts(),
+        file_path: String::new(),
+        event_kind: "diagnostic".to_owned(),
+        refs: None,
+        raw_payload: b"12345".to_vec(),
+    };
+
+    let outcome = ide::emit(&config, observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Ide,
+            reason: DropReason::BudgetExceeded
+        }
+    );
 }

--- a/crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs
+++ b/crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs
@@ -61,8 +61,10 @@ fn enabled_hook_sensor_emits_valid_capture_event() {
 
 #[test]
 fn disabled_hook_sensor_drops_without_event() {
-    let mut config = LocalSensorConfig::default();
-    config.hooks = SensorSettings::disabled();
+    let config = LocalSensorConfig {
+        hooks: SensorSettings::disabled(),
+        ..Default::default()
+    };
     let observation = HookObservation {
         event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAW"),
         captured_at: ts(),

--- a/crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs
+++ b/crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs
@@ -1,0 +1,113 @@
+#![allow(missing_docs)]
+
+use cairn_core::domain::{
+    CaptureEvent, CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily,
+};
+use cairn_sensors_local::hook::{HookHarness, HookObservation};
+use cairn_sensors_local::ide::IdeObservation;
+use cairn_sensors_local::{
+    DropReason, EmitOutcome, LocalSensorConfig, SensorKind, SensorSettings, hook, ide,
+};
+
+fn id(raw: &str) -> CaptureEventId {
+    CaptureEventId::parse(raw).expect("valid test ULID")
+}
+
+fn ts() -> Rfc3339Timestamp {
+    Rfc3339Timestamp::parse("2026-05-11T12:00:00Z").expect("valid test timestamp")
+}
+
+fn emitted(outcome: EmitOutcome) -> CaptureEvent {
+    match outcome {
+        EmitOutcome::Emitted(event) => event,
+        EmitOutcome::Dropped { sensor, reason } => {
+            panic!("expected emitted event, got drop from {sensor:?}: {reason:?}")
+        }
+    }
+}
+
+#[test]
+fn enabled_hook_sensor_emits_valid_capture_event() {
+    let observation = HookObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        captured_at: ts(),
+        harness: HookHarness::ClaudeCode,
+        hook_name: "UserPromptSubmit".to_owned(),
+        tool_name: None,
+        refs: Some(CaptureRefs {
+            session_id: Some("session-1".to_owned()),
+            turn_id: Some("turn-1".to_owned()),
+            tool_id: None,
+        }),
+        raw_payload: br#"{"prompt":"remember this"}"#.to_vec(),
+    };
+
+    let event = emitted(hook::emit(&LocalSensorConfig::default(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:hook:cc-session:v1");
+    assert_eq!(event.source_family, SourceFamily::Hook);
+    match &event.payload {
+        CapturePayload::Hook {
+            hook_name,
+            tool_name,
+        } => {
+            assert_eq!(hook_name, "UserPromptSubmit");
+            assert_eq!(tool_name, &None);
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}
+
+#[test]
+fn disabled_hook_sensor_drops_without_event() {
+    let mut config = LocalSensorConfig::default();
+    config.hooks = SensorSettings::disabled();
+    let observation = HookObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAW"),
+        captured_at: ts(),
+        harness: HookHarness::Codex,
+        hook_name: "SessionStart".to_owned(),
+        tool_name: None,
+        refs: None,
+        raw_payload: br#"{"session_id":"session-1"}"#.to_vec(),
+    };
+
+    let outcome = hook::emit(&config, observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Hook,
+            reason: DropReason::Disabled
+        }
+    );
+}
+
+#[test]
+fn enabled_ide_sensor_emits_valid_capture_event() {
+    let observation = IdeObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAX"),
+        captured_at: ts(),
+        file_path: "crates/cairn-core/src/domain/capture.rs".to_owned(),
+        event_kind: "diagnostic".to_owned(),
+        refs: None,
+        raw_payload: br#"{"diagnostics":1}"#.to_vec(),
+    };
+
+    let event = emitted(ide::emit(&LocalSensorConfig::default(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:ide:default:v1");
+    assert_eq!(event.source_family, SourceFamily::Ide);
+    match &event.payload {
+        CapturePayload::Ide {
+            file_path,
+            event_kind,
+        } => {
+            assert_eq!(file_path, "crates/cairn-core/src/domain/capture.rs");
+            assert_eq!(event_kind, "diagnostic");
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}

--- a/crates/cairn-sensors-local/tests/local_sensor_policy.rs
+++ b/crates/cairn-sensors-local/tests/local_sensor_policy.rs
@@ -1,0 +1,34 @@
+#![allow(missing_docs)]
+
+use cairn_sensors_local::policy::{PolicyAction, sanitize_text_payload};
+
+#[test]
+fn redacts_common_secret_assignments() {
+    let action = sanitize_text_payload("run API_KEY=sk-test TOKEN=abc ok");
+
+    assert_eq!(
+        action,
+        PolicyAction::Sanitized("run API_KEY=[REDACTED] TOKEN=[REDACTED] ok".to_owned())
+    );
+}
+
+#[test]
+fn redacts_authorization_bearer_header() {
+    let action = sanitize_text_payload("Authorization: Bearer abc.def-123");
+
+    assert_eq!(
+        action,
+        PolicyAction::Sanitized("Authorization: Bearer [REDACTED]".to_owned())
+    );
+}
+
+#[test]
+fn rejects_private_key_blocks() {
+    let action =
+        sanitize_text_payload("-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----");
+
+    assert_eq!(
+        action,
+        PolicyAction::Rejected("private key block".to_owned())
+    );
+}

--- a/crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs
+++ b/crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs
@@ -1,0 +1,201 @@
+#![allow(missing_docs)]
+
+use cairn_core::domain::{
+    CaptureEvent, CaptureEventId, CapturePayload, Rfc3339Timestamp, SourceFamily, TerminalContext,
+};
+use cairn_sensors_local::clipboard::ClipboardObservation;
+use cairn_sensors_local::terminal::TerminalObservation;
+use cairn_sensors_local::{
+    CaptureBudget, DropReason, EmitOutcome, LocalSensorConfig, SensorKind, SensorSettings,
+    clipboard, terminal,
+};
+use sha2::{Digest as _, Sha256};
+
+fn id(raw: &str) -> CaptureEventId {
+    CaptureEventId::parse(raw).expect("valid test ULID")
+}
+
+fn ts() -> Rfc3339Timestamp {
+    Rfc3339Timestamp::parse("2026-05-11T12:00:00Z").expect("valid test timestamp")
+}
+
+fn enabled_config() -> LocalSensorConfig {
+    LocalSensorConfig {
+        terminal: SensorSettings::enabled(),
+        clipboard: SensorSettings::enabled(),
+        ..LocalSensorConfig::default()
+    }
+}
+
+fn emitted(outcome: EmitOutcome) -> CaptureEvent {
+    match outcome {
+        EmitOutcome::Emitted(event) => event,
+        EmitOutcome::Dropped { sensor, reason } => {
+            panic!("expected emitted event, got drop from {sensor:?}: {reason:?}")
+        }
+    }
+}
+
+fn hash(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+#[test]
+fn terminal_sensor_redacts_before_hashing_and_emits_valid_event() {
+    let observation = TerminalObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAY"),
+        captured_at: ts(),
+        command: "run TOKEN=secret".to_owned(),
+        exit_code: Some(0),
+        context: Some(TerminalContext::InteractiveTty),
+        output: "PASSWORD=hunter2".to_owned(),
+        refs: None,
+    };
+
+    let event = emitted(terminal::emit(&enabled_config(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:terminal:default:v1");
+    assert_eq!(event.source_family, SourceFamily::Terminal);
+    assert_eq!(
+        event.payload_hash.as_str(),
+        hash(b"run TOKEN=[REDACTED]\nPASSWORD=[REDACTED]")
+    );
+    match &event.payload {
+        CapturePayload::Terminal {
+            command,
+            exit_code,
+            context,
+        } => {
+            assert_eq!(command, "run TOKEN=[REDACTED]");
+            assert_eq!(*exit_code, Some(0));
+            assert_eq!(*context, Some(TerminalContext::InteractiveTty));
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}
+
+#[test]
+fn terminal_sensor_drops_missing_context() {
+    let observation = TerminalObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+        captured_at: ts(),
+        command: "cargo test".to_owned(),
+        exit_code: None,
+        context: None,
+        output: String::new(),
+        refs: None,
+    };
+
+    let outcome = terminal::emit(&enabled_config(), observation);
+
+    assert!(matches!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::MalformedObservation(_)
+        }
+    ));
+}
+
+#[test]
+fn terminal_sensor_drops_private_key_output() {
+    let observation = TerminalObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB0"),
+        captured_at: ts(),
+        command: "cat key.pem".to_owned(),
+        exit_code: Some(0),
+        context: Some(TerminalContext::InteractiveTty),
+        output: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----".to_owned(),
+        refs: None,
+    };
+
+    let outcome = terminal::emit(&enabled_config(), observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::PolicyRejected("private key block".to_owned())
+        }
+    );
+}
+
+#[test]
+fn terminal_budget_drops_before_event_creation() {
+    let mut config = enabled_config();
+    config.terminal.budget = CaptureBudget {
+        max_items: Some(1),
+        max_bytes: Some(4),
+    };
+    let observation = TerminalObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB1"),
+        captured_at: ts(),
+        command: "12345".to_owned(),
+        exit_code: None,
+        context: Some(TerminalContext::NonInteractiveOrStructured),
+        output: String::new(),
+        refs: None,
+    };
+
+    let outcome = terminal::emit(&config, observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::BudgetExceeded
+        }
+    );
+}
+
+#[test]
+fn clipboard_text_redacts_before_hashing_and_emits_valid_event() {
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB2"),
+        captured_at: ts(),
+        mime_type: "text/plain".to_owned(),
+        bytes: b"API_KEY=secret".to_vec(),
+        metadata_only: false,
+        refs: None,
+    };
+
+    let event = emitted(clipboard::emit(&enabled_config(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:clipboard:default:v1");
+    assert_eq!(event.source_family, SourceFamily::Clipboard);
+    assert_eq!(event.payload_hash.as_str(), hash(b"API_KEY=[REDACTED]"));
+    match &event.payload {
+        CapturePayload::Clipboard {
+            mime_type,
+            byte_len,
+        } => {
+            assert_eq!(mime_type, "text/plain");
+            assert_eq!(*byte_len, 18);
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}
+
+#[test]
+fn clipboard_drops_unsupported_mime_without_metadata_only() {
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB3"),
+        captured_at: ts(),
+        mime_type: "application/octet-stream".to_owned(),
+        bytes: vec![1, 2, 3],
+        metadata_only: false,
+        refs: None,
+    };
+
+    let outcome = clipboard::emit(&enabled_config(), observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::PolicyRejected("unsupported clipboard MIME type".to_owned())
+        }
+    );
+}

--- a/crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs
+++ b/crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs
@@ -76,6 +76,29 @@ fn terminal_sensor_redacts_before_hashing_and_emits_valid_event() {
 }
 
 #[test]
+fn disabled_terminal_sensor_drops_without_event() {
+    let observation = TerminalObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB5"),
+        captured_at: ts(),
+        command: "cargo test".to_owned(),
+        exit_code: Some(0),
+        context: Some(TerminalContext::InteractiveTty),
+        output: String::new(),
+        refs: None,
+    };
+
+    let outcome = terminal::emit(&LocalSensorConfig::default(), observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::Disabled
+        }
+    );
+}
+
+#[test]
 fn terminal_sensor_drops_missing_context() {
     let observation = TerminalObservation {
         event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
@@ -179,6 +202,35 @@ fn clipboard_text_redacts_before_hashing_and_emits_valid_event() {
 }
 
 #[test]
+fn clipboard_text_with_charset_redacts_before_hashing_and_emits_valid_event() {
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB8"),
+        captured_at: ts(),
+        mime_type: "text/plain; charset=utf-8".to_owned(),
+        bytes: b"TOKEN=secret".to_vec(),
+        metadata_only: false,
+        refs: None,
+    };
+
+    let event = emitted(clipboard::emit(&enabled_config(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:clipboard:default:v1");
+    assert_eq!(event.source_family, SourceFamily::Clipboard);
+    assert_eq!(event.payload_hash.as_str(), hash(b"TOKEN=[REDACTED]"));
+    match &event.payload {
+        CapturePayload::Clipboard {
+            mime_type,
+            byte_len,
+        } => {
+            assert_eq!(mime_type, "text/plain; charset=utf-8");
+            assert_eq!(*byte_len, 16);
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}
+
+#[test]
 fn clipboard_metadata_only_non_text_reports_original_byte_len_and_hashes_empty_payload() {
     let observation = ClipboardObservation {
         event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB3"),
@@ -225,6 +277,99 @@ fn clipboard_drops_unsupported_mime_without_metadata_only() {
         EmitOutcome::Dropped {
             sensor: SensorKind::Clipboard,
             reason: DropReason::PolicyRejected("unsupported clipboard MIME type".to_owned())
+        }
+    );
+}
+
+#[test]
+fn disabled_clipboard_sensor_drops_without_event() {
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB9"),
+        captured_at: ts(),
+        mime_type: "text/plain".to_owned(),
+        bytes: b"hello".to_vec(),
+        metadata_only: false,
+        refs: None,
+    };
+
+    let outcome = clipboard::emit(&LocalSensorConfig::default(), observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::Disabled
+        }
+    );
+}
+
+#[test]
+fn clipboard_budget_drops_before_policy_or_event_creation() {
+    let mut config = enabled_config();
+    config.clipboard.budget = CaptureBudget {
+        max_items: Some(1),
+        max_bytes: Some(4),
+    };
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FBA"),
+        captured_at: ts(),
+        mime_type: "text/plain".to_owned(),
+        bytes: b"-----BEGIN PRIVATE KEY-----".to_vec(),
+        metadata_only: false,
+        refs: None,
+    };
+
+    let outcome = clipboard::emit(&config, observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::BudgetExceeded
+        }
+    );
+}
+
+#[test]
+fn clipboard_text_rejects_non_utf8_payload() {
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FBB"),
+        captured_at: ts(),
+        mime_type: "text/plain".to_owned(),
+        bytes: vec![0xff],
+        metadata_only: false,
+        refs: None,
+    };
+
+    let outcome = clipboard::emit(&enabled_config(), observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::PolicyRejected("clipboard text is not UTF-8".to_owned())
+        }
+    );
+}
+
+#[test]
+fn clipboard_text_rejects_private_key_payload() {
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FBC"),
+        captured_at: ts(),
+        mime_type: "text/plain".to_owned(),
+        bytes: b"-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----".to_vec(),
+        metadata_only: false,
+        refs: None,
+    };
+
+    let outcome = clipboard::emit(&enabled_config(), observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::PolicyRejected("private key block".to_owned())
         }
     );
 }

--- a/crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs
+++ b/crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs
@@ -179,9 +179,38 @@ fn clipboard_text_redacts_before_hashing_and_emits_valid_event() {
 }
 
 #[test]
-fn clipboard_drops_unsupported_mime_without_metadata_only() {
+fn clipboard_metadata_only_non_text_reports_original_byte_len_and_hashes_empty_payload() {
     let observation = ClipboardObservation {
         event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB3"),
+        captured_at: ts(),
+        mime_type: "image/png".to_owned(),
+        bytes: vec![1, 2, 3, 4, 5],
+        metadata_only: true,
+        refs: None,
+    };
+
+    let event = emitted(clipboard::emit(&enabled_config(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:clipboard:default:v1");
+    assert_eq!(event.source_family, SourceFamily::Clipboard);
+    assert_eq!(event.payload_hash.as_str(), hash(b""));
+    match &event.payload {
+        CapturePayload::Clipboard {
+            mime_type,
+            byte_len,
+        } => {
+            assert_eq!(mime_type, "image/png");
+            assert_eq!(*byte_len, 5);
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}
+
+#[test]
+fn clipboard_drops_unsupported_mime_without_metadata_only() {
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB4"),
         captured_at: ts(),
         mime_type: "application/octet-stream".to_owned(),
         bytes: vec![1, 2, 3],

--- a/docs/site/src/reference/generated/plugins.md
+++ b/docs/site/src/reference/generated/plugins.md
@@ -7,6 +7,6 @@ Generated from the bundled plugin registry.
 | Name | Contract | Version Range | Source | Capabilities |
 |---|---|---|---|---|
 | `cairn-mcp` | `MCPServer` | `[0.1.0, 0.2.0)` | `bundled:cairn-mcp` | `{"extensions":false,"http_streamable":false,"sse":false,"stdio":true}` |
-| `cairn-sensors-local` | `SensorIngress` | `[0.1.0, 0.2.0)` | `bundled:cairn-sensors-local` | `{"batches":false,"consent_aware":false,"streaming":false}` |
+| `cairn-sensors-local` | `SensorIngress` | `[0.1.0, 0.2.0)` | `bundled:cairn-sensors-local` | `{"batches":true,"consent_aware":true,"streaming":false}` |
 | `cairn-store-sqlite` | `MemoryStore` | `[0.5.0, 0.6.0)` | `bundled:cairn-store-sqlite` | `{"fts":true,"graph_edges":true,"per_record_consent_model":true,"transactions":true,"vector":false}` |
 | `cairn-workflows` | `WorkflowOrchestrator` | `[0.1.0, 0.2.0)` | `bundled:cairn-workflows` | `{"crash_safe":false,"cron_schedules":false,"durable":false}` |

--- a/docs/superpowers/plans/2026-05-11-issue-84-local-sensors.md
+++ b/docs/superpowers/plans/2026-05-11-issue-84-local-sensors.md
@@ -1,0 +1,1625 @@
+# Issue 84 Local Sensors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build deterministic hook, IDE, terminal, and clipboard adapters in `cairn-sensors-local` that emit validated `CaptureEvent`s or explicit drop reasons.
+
+**Architecture:** Keep the core `SensorIngress` trait unchanged. Add focused adapter modules in `crates/cairn-sensors-local/src/` that gate observations by config and budget, sanitize terminal/clipboard text, build sensor-authored Mode A `CaptureEvent`s through `CaptureEvent::try_new`, and leave persistence to `capture_trace`.
+
+**Tech Stack:** Rust 2024, `cairn-core` domain types, `sha2` for payload hashes, `regex` for local redaction, cargo integration tests.
+
+---
+
+## File Structure
+
+- Modify `crates/cairn-sensors-local/Cargo.toml`: add `sha2` and `regex` workspace deps used by the adapter crate.
+- Modify `crates/cairn-sensors-local/src/lib.rs`: expose modules and update `LocalSensorIngress` capabilities.
+- Create `crates/cairn-sensors-local/src/config.rs`: local per-sensor settings and budgets.
+- Create `crates/cairn-sensors-local/src/outcome.rs`: `EmitOutcome`, `DropReason`, and `SensorKind`.
+- Create `crates/cairn-sensors-local/src/event.rs`: shared payload hash, sensor identity, actor-chain, and `CaptureEvent::try_new` helpers.
+- Create `crates/cairn-sensors-local/src/policy.rs`: terminal/clipboard redaction and policy rejection helpers.
+- Create `crates/cairn-sensors-local/src/hook.rs`: hook observation adapter.
+- Create `crates/cairn-sensors-local/src/ide.rs`: IDE observation adapter.
+- Create `crates/cairn-sensors-local/src/terminal.rs`: terminal observation adapter.
+- Create `crates/cairn-sensors-local/src/clipboard.rs`: clipboard observation adapter.
+- Create tests:
+  - `crates/cairn-sensors-local/tests/local_sensor_capabilities.rs`
+  - `crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs`
+  - `crates/cairn-sensors-local/tests/local_sensor_policy.rs`
+  - `crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs`
+
+## Task 1: Config, Outcome, And Capability Surface
+
+**Files:**
+- Modify: `crates/cairn-sensors-local/src/lib.rs`
+- Create: `crates/cairn-sensors-local/src/config.rs`
+- Create: `crates/cairn-sensors-local/src/outcome.rs`
+- Test: `crates/cairn-sensors-local/tests/local_sensor_capabilities.rs`
+
+- [ ] **Step 1: Write the failing capability/config test**
+
+Create `crates/cairn-sensors-local/tests/local_sensor_capabilities.rs`:
+
+```rust
+#![allow(missing_docs)]
+
+use cairn_core::contract::sensor_ingress::SensorIngress;
+use cairn_sensors_local::{
+    CaptureBudget, DropReason, EmitOutcome, LocalSensorConfig, LocalSensorIngress, SensorKind,
+    SensorSettings,
+};
+
+#[test]
+fn local_sensor_ingress_advertises_batch_consent_capabilities() {
+    let ingress = LocalSensorIngress;
+    let caps = ingress.capabilities();
+
+    assert!(caps.batches);
+    assert!(!caps.streaming);
+    assert!(caps.consent_aware);
+}
+
+#[test]
+fn local_sensor_config_can_disable_every_source() {
+    let config = LocalSensorConfig::all_disabled();
+
+    assert!(!config.hooks.enabled);
+    assert!(!config.ide.enabled);
+    assert!(!config.terminal.enabled);
+    assert!(!config.clipboard.enabled);
+}
+
+#[test]
+fn emit_outcome_exposes_drop_reason_without_event() {
+    let outcome = EmitOutcome::Dropped {
+        sensor: SensorKind::Clipboard,
+        reason: DropReason::Disabled,
+    };
+
+    assert!(outcome.event().is_none());
+    assert_eq!(outcome.sensor(), Some(SensorKind::Clipboard));
+    assert_eq!(outcome.drop_reason(), Some(&DropReason::Disabled));
+}
+
+#[test]
+fn sensor_settings_default_budget_is_unbounded() {
+    let settings = SensorSettings::enabled();
+
+    assert!(settings.budget.allows(1, 1024));
+    assert_eq!(settings.budget, CaptureBudget::default());
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local --test local_sensor_capabilities
+```
+
+Expected: compile failure with unresolved imports such as `CaptureBudget`, `EmitOutcome`, `LocalSensorConfig`, and `SensorKind`.
+
+- [ ] **Step 3: Implement config and outcome types**
+
+Create `crates/cairn-sensors-local/src/config.rs`:
+
+```rust
+//! Local sensor adapter configuration.
+
+/// Per-sensor event budget enforced before payload hashing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CaptureBudget {
+    /// Maximum number of observations accepted by a single adapter call.
+    pub max_items: Option<usize>,
+    /// Maximum raw byte count accepted by a single adapter call.
+    pub max_bytes: Option<usize>,
+}
+
+impl CaptureBudget {
+    /// Return whether this budget accepts `items` and `bytes`.
+    #[must_use]
+    pub fn allows(self, items: usize, bytes: usize) -> bool {
+        self.max_items.is_none_or(|limit| items <= limit)
+            && self.max_bytes.is_none_or(|limit| bytes <= limit)
+    }
+}
+
+/// Shared settings for one local sensor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SensorSettings {
+    /// Whether this sensor emits events.
+    pub enabled: bool,
+    /// Source-side budget for one observation.
+    pub budget: CaptureBudget,
+}
+
+impl SensorSettings {
+    /// Enabled settings with no item or byte limit.
+    #[must_use]
+    pub const fn enabled() -> Self {
+        Self {
+            enabled: true,
+            budget: CaptureBudget {
+                max_items: None,
+                max_bytes: None,
+            },
+        }
+    }
+
+    /// Disabled settings with no item or byte limit.
+    #[must_use]
+    pub const fn disabled() -> Self {
+        Self {
+            enabled: false,
+            budget: CaptureBudget {
+                max_items: None,
+                max_bytes: None,
+            },
+        }
+    }
+}
+
+/// Configuration for deterministic local sensor adapters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalSensorConfig {
+    /// Hook sensor settings.
+    pub hooks: SensorSettings,
+    /// IDE sensor settings.
+    pub ide: SensorSettings,
+    /// Terminal sensor settings.
+    pub terminal: SensorSettings,
+    /// Clipboard sensor settings.
+    pub clipboard: SensorSettings,
+}
+
+impl LocalSensorConfig {
+    /// Disable every local sensor.
+    #[must_use]
+    pub const fn all_disabled() -> Self {
+        Self {
+            hooks: SensorSettings::disabled(),
+            ide: SensorSettings::disabled(),
+            terminal: SensorSettings::disabled(),
+            clipboard: SensorSettings::disabled(),
+        }
+    }
+}
+
+impl Default for LocalSensorConfig {
+    fn default() -> Self {
+        Self {
+            hooks: SensorSettings::enabled(),
+            ide: SensorSettings::enabled(),
+            terminal: SensorSettings::disabled(),
+            clipboard: SensorSettings::disabled(),
+        }
+    }
+}
+```
+
+Create `crates/cairn-sensors-local/src/outcome.rs`:
+
+```rust
+//! Local sensor emission outcomes.
+
+use cairn_core::domain::CaptureEvent;
+
+/// Local sensor family handled by this adapter crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SensorKind {
+    /// Harness hook sensor.
+    Hook,
+    /// IDE event sensor.
+    Ide,
+    /// Terminal command/output sensor.
+    Terminal,
+    /// Clipboard snapshot sensor.
+    Clipboard,
+}
+
+impl SensorKind {
+    /// Convert a core source family emitted by this crate into its sensor kind.
+    #[must_use]
+    pub const fn from_source_family(family: cairn_core::domain::SourceFamily) -> Option<Self> {
+        match family {
+            cairn_core::domain::SourceFamily::Hook => Some(Self::Hook),
+            cairn_core::domain::SourceFamily::Ide => Some(Self::Ide),
+            cairn_core::domain::SourceFamily::Terminal => Some(Self::Terminal),
+            cairn_core::domain::SourceFamily::Clipboard => Some(Self::Clipboard),
+            _ => None,
+        }
+    }
+}
+
+/// Reason an observation produced no event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DropReason {
+    /// Sensor was disabled at source.
+    Disabled,
+    /// Raw observation exceeded its configured source-side budget.
+    BudgetExceeded,
+    /// Local privacy policy rejected the observation.
+    PolicyRejected(String),
+    /// Observation was malformed or failed core capture validation.
+    MalformedObservation(String),
+}
+
+/// Result of trying to emit one local sensor event.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EmitOutcome {
+    /// Observation became a validated capture event.
+    Emitted(CaptureEvent),
+    /// Observation was dropped before event emission.
+    Dropped {
+        /// Sensor that dropped the observation.
+        sensor: SensorKind,
+        /// Concrete drop reason.
+        reason: DropReason,
+    },
+}
+
+impl EmitOutcome {
+    /// Borrow the emitted event when present.
+    #[must_use]
+    pub const fn event(&self) -> Option<&CaptureEvent> {
+        match self {
+            Self::Emitted(event) => Some(event),
+            Self::Dropped { .. } => None,
+        }
+    }
+
+    /// Sensor kind associated with this outcome.
+    #[must_use]
+    pub const fn sensor(&self) -> Option<SensorKind> {
+        match self {
+            Self::Emitted(event) => SensorKind::from_source_family(event.source_family),
+            Self::Dropped { sensor, .. } => Some(*sensor),
+        }
+    }
+
+    /// Borrow the drop reason when present.
+    #[must_use]
+    pub const fn drop_reason(&self) -> Option<&DropReason> {
+        match self {
+            Self::Emitted(_) => None,
+            Self::Dropped { reason, .. } => Some(reason),
+        }
+    }
+}
+```
+
+Modify `crates/cairn-sensors-local/src/lib.rs`:
+
+```rust
+//! Local sensors for Cairn — hook, IDE, terminal, clipboard, voice, screen.
+//!
+//! Deterministic P0 adapters for hook, IDE, terminal, and clipboard
+//! observations live here. Runtime loops that collect OS or editor events
+//! call these adapters and pass the resulting `CaptureEvent`s to the
+//! ingestion pipeline.
+
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
+pub mod config;
+pub mod outcome;
+
+use cairn_core::contract::sensor_ingress::{
+    CONTRACT_VERSION, SensorIngress, SensorIngressCapabilities,
+};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::register_plugin;
+
+pub use config::{CaptureBudget, LocalSensorConfig, SensorSettings};
+pub use outcome::{DropReason, EmitOutcome, SensorKind};
+
+/// Stable plugin name. Matches `name = ...` in `plugin.toml`.
+pub const PLUGIN_NAME: &str = "cairn-sensors-local";
+
+/// Plugin capability manifest TOML (parsed at registration time).
+pub const MANIFEST_TOML: &str = include_str!("../plugin.toml");
+
+/// Accepted host contract version range. Single source of truth for both the
+/// trait impl's `supported_contract_versions()` and the const-eval guard.
+pub const ACCEPTED_RANGE: VersionRange =
+    VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
+
+/// Local sensor `SensorIngress` plugin registration type.
+#[derive(Default)]
+pub struct LocalSensorIngress;
+
+#[async_trait::async_trait]
+impl SensorIngress for LocalSensorIngress {
+    fn name(&self) -> &str {
+        PLUGIN_NAME
+    }
+
+    fn capabilities(&self) -> &SensorIngressCapabilities {
+        static CAPS: SensorIngressCapabilities = SensorIngressCapabilities {
+            batches: true,
+            streaming: false,
+            consent_aware: true,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        ACCEPTED_RANGE
+    }
+}
+
+const _: () = assert!(
+    ACCEPTED_RANGE.accepts(CONTRACT_VERSION),
+    "host CONTRACT_VERSION outside this crate's declared range"
+);
+
+register_plugin!(
+    SensorIngress,
+    LocalSensorIngress,
+    "cairn-sensors-local",
+    MANIFEST_TOML
+);
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local --test local_sensor_capabilities
+```
+
+Expected: all four tests in `local_sensor_capabilities` pass.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add crates/cairn-sensors-local/src/lib.rs \
+  crates/cairn-sensors-local/src/config.rs \
+  crates/cairn-sensors-local/src/outcome.rs \
+  crates/cairn-sensors-local/tests/local_sensor_capabilities.rs
+git commit -m "feat(sensors): add local sensor config outcomes"
+```
+
+## Task 2: Shared CaptureEvent Construction
+
+**Files:**
+- Modify: `crates/cairn-sensors-local/Cargo.toml`
+- Modify: `crates/cairn-sensors-local/src/lib.rs`
+- Create: `crates/cairn-sensors-local/src/event.rs`
+- Test: unit tests in `crates/cairn-sensors-local/src/event.rs`
+
+- [ ] **Step 1: Add failing shared event tests**
+
+Create `crates/cairn-sensors-local/src/event.rs` with tests first:
+
+```rust
+//! Shared local sensor event construction.
+
+#[cfg(test)]
+mod tests {
+    use cairn_core::domain::{
+        CaptureEventId, CaptureMode, CapturePayload, Rfc3339Timestamp, SourceFamily,
+    };
+
+    use super::{build_auto_event, payload_hash, payload_ref};
+
+    fn event_id() -> CaptureEventId {
+        CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid test ULID")
+    }
+
+    fn ts() -> Rfc3339Timestamp {
+        Rfc3339Timestamp::parse("2026-05-11T12:00:00Z").expect("valid test timestamp")
+    }
+
+    #[test]
+    fn payload_hash_uses_sha256_prefix() {
+        let hash = payload_hash(b"hello").expect("hash parses");
+
+        assert_eq!(
+            hash.as_str(),
+            "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn payload_ref_is_sources_family_event_json() {
+        assert_eq!(
+            payload_ref(SourceFamily::Hook, &event_id()),
+            "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json"
+        );
+    }
+
+    #[test]
+    fn build_auto_event_binds_sensor_author_to_sensor_id() {
+        let event = build_auto_event(
+            event_id(),
+            ts(),
+            "local:hook:cc-session:v1",
+            CapturePayload::Hook {
+                hook_name: "UserPromptSubmit".to_owned(),
+                tool_name: None,
+            },
+            SourceFamily::Hook,
+            None,
+            b"{\"prompt\":\"hi\"}",
+        )
+        .expect("event validates");
+
+        assert_eq!(event.capture_mode, CaptureMode::Auto);
+        assert_eq!(event.sensor_id.as_str(), "snr:local:hook:cc-session:v1");
+        assert_eq!(event.actor_chain.len(), 1);
+        assert_eq!(
+            event.actor_chain[0].identity.as_str(),
+            "snr:local:hook:cc-session:v1"
+        );
+        event.validate_for_capture().expect("fresh event is valid");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local event::
+```
+
+Expected: compile failure for missing `build_auto_event`, `payload_hash`, and `payload_ref`.
+
+- [ ] **Step 3: Implement shared event helpers**
+
+Modify `crates/cairn-sensors-local/Cargo.toml`:
+
+```toml
+[dependencies]
+cairn-core = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+sha2 = { workspace = true }
+regex = { workspace = true }
+```
+
+Modify `crates/cairn-sensors-local/src/lib.rs` by adding the module:
+
+```rust
+mod event;
+```
+
+Replace `crates/cairn-sensors-local/src/event.rs` with:
+
+```rust
+//! Shared local sensor event construction.
+
+use cairn_core::domain::{
+    ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs,
+    ChainRole, DomainError, Identity, PayloadHash, Rfc3339Timestamp, SourceFamily,
+};
+use sha2::{Digest as _, Sha256};
+
+/// Compute the canonical SHA-256 payload hash.
+pub(crate) fn payload_hash(bytes: &[u8]) -> Result<PayloadHash, DomainError> {
+    PayloadHash::parse(format!("sha256:{:x}", Sha256::digest(bytes)))
+}
+
+/// Build the vault-relative source payload ref for an event.
+pub(crate) fn payload_ref(family: SourceFamily, event_id: &CaptureEventId) -> String {
+    format!("sources/{family}/{event_id}.json")
+}
+
+/// Build a validated Mode A event authored by the emitting sensor.
+pub(crate) fn build_auto_event(
+    event_id: CaptureEventId,
+    captured_at: Rfc3339Timestamp,
+    sensor_label: &'static str,
+    payload: CapturePayload,
+    source_family: SourceFamily,
+    refs: Option<CaptureRefs>,
+    sanitized_payload_bytes: &[u8],
+) -> Result<CaptureEvent, DomainError> {
+    let sensor_id = Identity::parse(format!("snr:{sensor_label}"))?;
+    let actor_chain = vec![ActorChainEntry {
+        role: ChainRole::Author,
+        identity: sensor_id.clone(),
+        at: captured_at.clone(),
+    }];
+    let payload_hash = payload_hash(sanitized_payload_bytes)?;
+    let payload_ref = payload_ref(source_family, &event_id);
+
+    CaptureEvent::try_new(
+        event_id,
+        sensor_id,
+        CaptureMode::Auto,
+        actor_chain,
+        refs,
+        payload_hash,
+        payload_ref,
+        captured_at,
+        payload,
+        source_family,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use cairn_core::domain::{
+        CaptureEventId, CaptureMode, CapturePayload, Rfc3339Timestamp, SourceFamily,
+    };
+
+    use super::{build_auto_event, payload_hash, payload_ref};
+
+    fn event_id() -> CaptureEventId {
+        CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid test ULID")
+    }
+
+    fn ts() -> Rfc3339Timestamp {
+        Rfc3339Timestamp::parse("2026-05-11T12:00:00Z").expect("valid test timestamp")
+    }
+
+    #[test]
+    fn payload_hash_uses_sha256_prefix() {
+        let hash = payload_hash(b"hello").expect("hash parses");
+
+        assert_eq!(
+            hash.as_str(),
+            "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn payload_ref_is_sources_family_event_json() {
+        assert_eq!(
+            payload_ref(SourceFamily::Hook, &event_id()),
+            "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAV.json"
+        );
+    }
+
+    #[test]
+    fn build_auto_event_binds_sensor_author_to_sensor_id() {
+        let event = build_auto_event(
+            event_id(),
+            ts(),
+            "local:hook:cc-session:v1",
+            CapturePayload::Hook {
+                hook_name: "UserPromptSubmit".to_owned(),
+                tool_name: None,
+            },
+            SourceFamily::Hook,
+            None,
+            b"{\"prompt\":\"hi\"}",
+        )
+        .expect("event validates");
+
+        assert_eq!(event.capture_mode, CaptureMode::Auto);
+        assert_eq!(event.sensor_id.as_str(), "snr:local:hook:cc-session:v1");
+        assert_eq!(event.actor_chain.len(), 1);
+        assert_eq!(
+            event.actor_chain[0].identity.as_str(),
+            "snr:local:hook:cc-session:v1"
+        );
+        event.validate_for_capture().expect("fresh event is valid");
+    }
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local event::
+```
+
+Expected: the three `event` module tests pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add crates/cairn-sensors-local/Cargo.toml \
+  crates/cairn-sensors-local/src/lib.rs \
+  crates/cairn-sensors-local/src/event.rs
+git commit -m "feat(sensors): build shared capture events"
+```
+
+## Task 3: Hook And IDE Adapters
+
+**Files:**
+- Modify: `crates/cairn-sensors-local/src/lib.rs`
+- Create: `crates/cairn-sensors-local/src/hook.rs`
+- Create: `crates/cairn-sensors-local/src/ide.rs`
+- Test: `crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs`
+
+- [ ] **Step 1: Write failing hook and IDE adapter tests**
+
+Create `crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs`:
+
+```rust
+#![allow(missing_docs)]
+
+use cairn_core::domain::{
+    CaptureEvent, CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily,
+};
+use cairn_sensors_local::hook::{HookHarness, HookObservation};
+use cairn_sensors_local::ide::IdeObservation;
+use cairn_sensors_local::{
+    DropReason, EmitOutcome, LocalSensorConfig, SensorKind, SensorSettings, hook, ide,
+};
+
+fn id(raw: &str) -> CaptureEventId {
+    CaptureEventId::parse(raw).expect("valid test ULID")
+}
+
+fn ts() -> Rfc3339Timestamp {
+    Rfc3339Timestamp::parse("2026-05-11T12:00:00Z").expect("valid test timestamp")
+}
+
+fn emitted(outcome: EmitOutcome) -> CaptureEvent {
+    match outcome {
+        EmitOutcome::Emitted(event) => event,
+        EmitOutcome::Dropped { sensor, reason } => {
+            panic!("expected emitted event, got drop from {sensor:?}: {reason:?}")
+        }
+    }
+}
+
+#[test]
+fn enabled_hook_sensor_emits_valid_capture_event() {
+    let observation = HookObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+        captured_at: ts(),
+        harness: HookHarness::ClaudeCode,
+        hook_name: "UserPromptSubmit".to_owned(),
+        tool_name: None,
+        refs: Some(CaptureRefs {
+            session_id: Some("session-1".to_owned()),
+            turn_id: Some("turn-1".to_owned()),
+            tool_id: None,
+        }),
+        raw_payload: br#"{"prompt":"remember this"}"#.to_vec(),
+    };
+
+    let event = emitted(hook::emit(&LocalSensorConfig::default(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:hook:cc-session:v1");
+    assert_eq!(event.source_family, SourceFamily::Hook);
+    match event.payload {
+        CapturePayload::Hook {
+            hook_name,
+            tool_name,
+        } => {
+            assert_eq!(hook_name, "UserPromptSubmit");
+            assert_eq!(tool_name, None);
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}
+
+#[test]
+fn disabled_hook_sensor_drops_without_event() {
+    let mut config = LocalSensorConfig::default();
+    config.hooks = SensorSettings::disabled();
+    let observation = HookObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAW"),
+        captured_at: ts(),
+        harness: HookHarness::Codex,
+        hook_name: "SessionStart".to_owned(),
+        tool_name: None,
+        refs: None,
+        raw_payload: br#"{"session_id":"session-1"}"#.to_vec(),
+    };
+
+    let outcome = hook::emit(&config, observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Hook,
+            reason: DropReason::Disabled
+        }
+    );
+}
+
+#[test]
+fn enabled_ide_sensor_emits_valid_capture_event() {
+    let observation = IdeObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAX"),
+        captured_at: ts(),
+        file_path: "crates/cairn-core/src/domain/capture.rs".to_owned(),
+        event_kind: "diagnostic".to_owned(),
+        refs: None,
+        raw_payload: br#"{"diagnostics":1}"#.to_vec(),
+    };
+
+    let event = emitted(ide::emit(&LocalSensorConfig::default(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:ide:default:v1");
+    assert_eq!(event.source_family, SourceFamily::Ide);
+    match event.payload {
+        CapturePayload::Ide {
+            file_path,
+            event_kind,
+        } => {
+            assert_eq!(file_path, "crates/cairn-core/src/domain/capture.rs");
+            assert_eq!(event_kind, "diagnostic");
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local --test local_sensor_hook_ide
+```
+
+Expected: compile failure for missing `hook`, `ide`, `HookObservation`, `HookHarness`, and `IdeObservation`.
+
+- [ ] **Step 3: Implement hook and IDE adapters**
+
+Modify `crates/cairn-sensors-local/src/lib.rs`:
+
+```rust
+mod event;
+pub mod hook;
+pub mod ide;
+```
+
+Create `crates/cairn-sensors-local/src/hook.rs`:
+
+```rust
+//! Hook local sensor adapter.
+
+use cairn_core::domain::{
+    CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily,
+};
+
+use crate::config::LocalSensorConfig;
+use crate::event::build_auto_event;
+use crate::outcome::{DropReason, EmitOutcome, SensorKind};
+
+/// Supported local hook harness labels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookHarness {
+    /// Claude Code reference hook surface.
+    ClaudeCode,
+    /// Codex hook surface.
+    Codex,
+    /// Gemini hook surface.
+    Gemini,
+}
+
+impl HookHarness {
+    const fn sensor_label(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "local:hook:cc-session:v1",
+            Self::Codex => "local:hook:codex-session:v1",
+            Self::Gemini => "local:hook:gemini-session:v1",
+        }
+    }
+}
+
+/// Already-observed harness hook payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookObservation {
+    /// Capture event id.
+    pub event_id: CaptureEventId,
+    /// Capture timestamp.
+    pub captured_at: Rfc3339Timestamp,
+    /// Harness that emitted this hook.
+    pub harness: HookHarness,
+    /// Harness hook name.
+    pub hook_name: String,
+    /// Optional tool name for tool hooks.
+    pub tool_name: Option<String>,
+    /// Optional session/turn/tool refs.
+    pub refs: Option<CaptureRefs>,
+    /// Raw hook payload bytes after harness parsing.
+    pub raw_payload: Vec<u8>,
+}
+
+/// Emit a hook capture event or explicit drop reason.
+#[must_use]
+pub fn emit(config: &LocalSensorConfig, observation: HookObservation) -> EmitOutcome {
+    if !config.hooks.enabled {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Hook,
+            reason: DropReason::Disabled,
+        };
+    }
+    if !config.hooks.budget.allows(1, observation.raw_payload.len()) {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Hook,
+            reason: DropReason::BudgetExceeded,
+        };
+    }
+
+    let event = build_auto_event(
+        observation.event_id,
+        observation.captured_at,
+        observation.harness.sensor_label(),
+        CapturePayload::Hook {
+            hook_name: observation.hook_name,
+            tool_name: observation.tool_name,
+        },
+        SourceFamily::Hook,
+        observation.refs,
+        &observation.raw_payload,
+    );
+
+    event.map_or_else(
+        |err| EmitOutcome::Dropped {
+            sensor: SensorKind::Hook,
+            reason: DropReason::MalformedObservation(err.to_string()),
+        },
+        EmitOutcome::Emitted,
+    )
+}
+```
+
+Create `crates/cairn-sensors-local/src/ide.rs`:
+
+```rust
+//! IDE local sensor adapter.
+
+use cairn_core::domain::{
+    CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily,
+};
+
+use crate::config::LocalSensorConfig;
+use crate::event::build_auto_event;
+use crate::outcome::{DropReason, EmitOutcome, SensorKind};
+
+const IDE_SENSOR_LABEL: &str = "local:ide:default:v1";
+
+/// Already-observed IDE event payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdeObservation {
+    /// Capture event id.
+    pub event_id: CaptureEventId,
+    /// Capture timestamp.
+    pub captured_at: Rfc3339Timestamp,
+    /// Workspace-relative path.
+    pub file_path: String,
+    /// IDE event subtype.
+    pub event_kind: String,
+    /// Optional session/turn/tool refs.
+    pub refs: Option<CaptureRefs>,
+    /// Raw IDE payload bytes after editor parsing.
+    pub raw_payload: Vec<u8>,
+}
+
+/// Emit an IDE capture event or explicit drop reason.
+#[must_use]
+pub fn emit(config: &LocalSensorConfig, observation: IdeObservation) -> EmitOutcome {
+    if !config.ide.enabled {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Ide,
+            reason: DropReason::Disabled,
+        };
+    }
+    if !config.ide.budget.allows(1, observation.raw_payload.len()) {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Ide,
+            reason: DropReason::BudgetExceeded,
+        };
+    }
+
+    let event = build_auto_event(
+        observation.event_id,
+        observation.captured_at,
+        IDE_SENSOR_LABEL,
+        CapturePayload::Ide {
+            file_path: observation.file_path,
+            event_kind: observation.event_kind,
+        },
+        SourceFamily::Ide,
+        observation.refs,
+        &observation.raw_payload,
+    );
+
+    event.map_or_else(
+        |err| EmitOutcome::Dropped {
+            sensor: SensorKind::Ide,
+            reason: DropReason::MalformedObservation(err.to_string()),
+        },
+        EmitOutcome::Emitted,
+    )
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local --test local_sensor_hook_ide
+```
+
+Expected: all three tests in `local_sensor_hook_ide` pass.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add crates/cairn-sensors-local/src/lib.rs \
+  crates/cairn-sensors-local/src/hook.rs \
+  crates/cairn-sensors-local/src/ide.rs \
+  crates/cairn-sensors-local/tests/local_sensor_hook_ide.rs
+git commit -m "feat(sensors): emit hook and ide capture events"
+```
+
+## Task 4: Redaction And Policy Helpers
+
+**Files:**
+- Modify: `crates/cairn-sensors-local/src/lib.rs`
+- Create: `crates/cairn-sensors-local/src/policy.rs`
+- Test: `crates/cairn-sensors-local/tests/local_sensor_policy.rs`
+
+- [ ] **Step 1: Write failing policy tests**
+
+Create `crates/cairn-sensors-local/tests/local_sensor_policy.rs`:
+
+```rust
+#![allow(missing_docs)]
+
+use cairn_sensors_local::policy::{PolicyAction, sanitize_text_payload};
+
+#[test]
+fn redacts_common_secret_assignments() {
+    let action = sanitize_text_payload("run API_KEY=sk-test TOKEN=abc ok");
+
+    assert_eq!(
+        action,
+        PolicyAction::Sanitized("run API_KEY=[REDACTED] TOKEN=[REDACTED] ok".to_owned())
+    );
+}
+
+#[test]
+fn redacts_authorization_bearer_header() {
+    let action = sanitize_text_payload("Authorization: Bearer abc.def-123");
+
+    assert_eq!(
+        action,
+        PolicyAction::Sanitized("Authorization: Bearer [REDACTED]".to_owned())
+    );
+}
+
+#[test]
+fn rejects_private_key_blocks() {
+    let action = sanitize_text_payload("-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----");
+
+    assert_eq!(
+        action,
+        PolicyAction::Rejected("private key block".to_owned())
+    );
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local --test local_sensor_policy
+```
+
+Expected: compile failure for missing `policy`, `PolicyAction`, and `sanitize_text_payload`.
+
+- [ ] **Step 3: Implement policy helpers**
+
+Modify `crates/cairn-sensors-local/src/lib.rs`:
+
+```rust
+pub mod policy;
+```
+
+Create `crates/cairn-sensors-local/src/policy.rs`:
+
+```rust
+//! Local redaction and source-side drop policy.
+
+use regex::Regex;
+
+/// Policy result for text-bearing sensor payloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyAction {
+    /// Text was accepted after redaction.
+    Sanitized(String),
+    /// Text was rejected and must not be emitted.
+    Rejected(String),
+}
+
+/// Sanitize text payloads before hashing or event construction.
+#[must_use]
+pub fn sanitize_text_payload(input: &str) -> PolicyAction {
+    if contains_private_key_block(input) {
+        return PolicyAction::Rejected("private key block".to_owned());
+    }
+
+    let mut text = input.to_owned();
+    text = redact_regex(
+        &text,
+        r"(?i)\b([A-Z0-9_]*(TOKEN|API_KEY|SECRET|PASSWORD)[A-Z0-9_]*)=([^\s]+)",
+        "$1=[REDACTED]",
+    );
+    text = redact_regex(
+        &text,
+        r"(?i)Authorization:\s*Bearer\s+[A-Za-z0-9._~+/=-]+",
+        "Authorization: Bearer [REDACTED]",
+    );
+
+    PolicyAction::Sanitized(text)
+}
+
+fn redact_regex(input: &str, pattern: &str, replacement: &str) -> String {
+    match Regex::new(pattern) {
+        Ok(regex) => regex.replace_all(input, replacement).into_owned(),
+        Err(_) => input.to_owned(),
+    }
+}
+
+fn contains_private_key_block(input: &str) -> bool {
+    let upper = input.to_ascii_uppercase();
+    upper.contains("-----BEGIN ") && upper.contains("PRIVATE KEY-----")
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local --test local_sensor_policy
+```
+
+Expected: all three policy tests pass.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add crates/cairn-sensors-local/src/lib.rs \
+  crates/cairn-sensors-local/src/policy.rs \
+  crates/cairn-sensors-local/tests/local_sensor_policy.rs
+git commit -m "feat(sensors): redact local text payloads"
+```
+
+## Task 5: Terminal And Clipboard Adapters
+
+**Files:**
+- Modify: `crates/cairn-sensors-local/src/lib.rs`
+- Create: `crates/cairn-sensors-local/src/terminal.rs`
+- Create: `crates/cairn-sensors-local/src/clipboard.rs`
+- Test: `crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs`
+
+- [ ] **Step 1: Write failing terminal and clipboard tests**
+
+Create `crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs`:
+
+```rust
+#![allow(missing_docs)]
+
+use cairn_core::domain::{
+    CaptureEvent, CaptureEventId, CapturePayload, Rfc3339Timestamp, SourceFamily, TerminalContext,
+};
+use cairn_sensors_local::clipboard::ClipboardObservation;
+use cairn_sensors_local::terminal::TerminalObservation;
+use cairn_sensors_local::{
+    CaptureBudget, DropReason, EmitOutcome, LocalSensorConfig, SensorKind, SensorSettings,
+    clipboard, terminal,
+};
+use sha2::{Digest as _, Sha256};
+
+fn id(raw: &str) -> CaptureEventId {
+    CaptureEventId::parse(raw).expect("valid test ULID")
+}
+
+fn ts() -> Rfc3339Timestamp {
+    Rfc3339Timestamp::parse("2026-05-11T12:00:00Z").expect("valid test timestamp")
+}
+
+fn enabled_config() -> LocalSensorConfig {
+    LocalSensorConfig {
+        terminal: SensorSettings::enabled(),
+        clipboard: SensorSettings::enabled(),
+        ..LocalSensorConfig::default()
+    }
+}
+
+fn emitted(outcome: EmitOutcome) -> CaptureEvent {
+    match outcome {
+        EmitOutcome::Emitted(event) => event,
+        EmitOutcome::Dropped { sensor, reason } => {
+            panic!("expected emitted event, got drop from {sensor:?}: {reason:?}")
+        }
+    }
+}
+
+fn hash(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+#[test]
+fn terminal_sensor_redacts_before_hashing_and_emits_valid_event() {
+    let observation = TerminalObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAY"),
+        captured_at: ts(),
+        command: "run TOKEN=secret".to_owned(),
+        exit_code: Some(0),
+        context: Some(TerminalContext::InteractiveTty),
+        output: "PASSWORD=hunter2".to_owned(),
+        refs: None,
+    };
+
+    let event = emitted(terminal::emit(&enabled_config(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:terminal:default:v1");
+    assert_eq!(event.source_family, SourceFamily::Terminal);
+    assert_eq!(
+        event.payload_hash.as_str(),
+        hash(b"run TOKEN=[REDACTED]\nPASSWORD=[REDACTED]")
+    );
+    match event.payload {
+        CapturePayload::Terminal {
+            command,
+            exit_code,
+            context,
+        } => {
+            assert_eq!(command, "run TOKEN=[REDACTED]");
+            assert_eq!(exit_code, Some(0));
+            assert_eq!(context, Some(TerminalContext::InteractiveTty));
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}
+
+#[test]
+fn terminal_sensor_drops_missing_context() {
+    let observation = TerminalObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+        captured_at: ts(),
+        command: "cargo test".to_owned(),
+        exit_code: None,
+        context: None,
+        output: String::new(),
+        refs: None,
+    };
+
+    let outcome = terminal::emit(&enabled_config(), observation);
+
+    assert!(matches!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::MalformedObservation(_)
+        }
+    ));
+}
+
+#[test]
+fn terminal_sensor_drops_private_key_output() {
+    let observation = TerminalObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB0"),
+        captured_at: ts(),
+        command: "cat key.pem".to_owned(),
+        exit_code: Some(0),
+        context: Some(TerminalContext::InteractiveTty),
+        output: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----".to_owned(),
+        refs: None,
+    };
+
+    let outcome = terminal::emit(&enabled_config(), observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::PolicyRejected("private key block".to_owned())
+        }
+    );
+}
+
+#[test]
+fn terminal_budget_drops_before_event_creation() {
+    let mut config = enabled_config();
+    config.terminal.budget = CaptureBudget {
+        max_items: Some(1),
+        max_bytes: Some(4),
+    };
+    let observation = TerminalObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB1"),
+        captured_at: ts(),
+        command: "12345".to_owned(),
+        exit_code: None,
+        context: Some(TerminalContext::NonInteractiveOrStructured),
+        output: String::new(),
+        refs: None,
+    };
+
+    let outcome = terminal::emit(&config, observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::BudgetExceeded
+        }
+    );
+}
+
+#[test]
+fn clipboard_text_redacts_before_hashing_and_emits_valid_event() {
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB2"),
+        captured_at: ts(),
+        mime_type: "text/plain".to_owned(),
+        bytes: b"API_KEY=secret".to_vec(),
+        metadata_only: false,
+        refs: None,
+    };
+
+    let event = emitted(clipboard::emit(&enabled_config(), observation));
+
+    assert_eq!(event.sensor_id.as_str(), "snr:local:clipboard:default:v1");
+    assert_eq!(event.source_family, SourceFamily::Clipboard);
+    assert_eq!(event.payload_hash.as_str(), hash(b"API_KEY=[REDACTED]"));
+    match event.payload {
+        CapturePayload::Clipboard {
+            mime_type,
+            byte_len,
+        } => {
+            assert_eq!(mime_type, "text/plain");
+            assert_eq!(byte_len, 18);
+        }
+        other => panic!("unexpected payload: {other:?}"),
+    }
+    event.validate_for_capture().expect("valid event");
+}
+
+#[test]
+fn clipboard_drops_unsupported_mime_without_metadata_only() {
+    let observation = ClipboardObservation {
+        event_id: id("01ARZ3NDEKTSV4RRFFQ69G5FB3"),
+        captured_at: ts(),
+        mime_type: "application/octet-stream".to_owned(),
+        bytes: vec![1, 2, 3],
+        metadata_only: false,
+        refs: None,
+    };
+
+    let outcome = clipboard::emit(&enabled_config(), observation);
+
+    assert_eq!(
+        outcome,
+        EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::PolicyRejected("unsupported clipboard MIME type".to_owned())
+        }
+    );
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local --test local_sensor_terminal_clipboard
+```
+
+Expected: compile failure for missing `terminal`, `clipboard`, `TerminalObservation`, and `ClipboardObservation`.
+
+- [ ] **Step 3: Implement terminal and clipboard adapters**
+
+Modify `crates/cairn-sensors-local/src/lib.rs`:
+
+```rust
+pub mod clipboard;
+pub mod terminal;
+```
+
+Create `crates/cairn-sensors-local/src/terminal.rs`:
+
+```rust
+//! Terminal local sensor adapter.
+
+use cairn_core::domain::{
+    CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily, TerminalContext,
+};
+
+use crate::config::LocalSensorConfig;
+use crate::event::build_auto_event;
+use crate::outcome::{DropReason, EmitOutcome, SensorKind};
+use crate::policy::{PolicyAction, sanitize_text_payload};
+
+const TERMINAL_SENSOR_LABEL: &str = "local:terminal:default:v1";
+
+/// Already-observed terminal command/output payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalObservation {
+    /// Capture event id.
+    pub event_id: CaptureEventId,
+    /// Capture timestamp.
+    pub captured_at: Rfc3339Timestamp,
+    /// Command text.
+    pub command: String,
+    /// Exit code if known.
+    pub exit_code: Option<i32>,
+    /// Terminal routing context for fresh writes.
+    pub context: Option<TerminalContext>,
+    /// Captured output text.
+    pub output: String,
+    /// Optional session/turn/tool refs.
+    pub refs: Option<CaptureRefs>,
+}
+
+/// Emit a terminal capture event or explicit drop reason.
+#[must_use]
+pub fn emit(config: &LocalSensorConfig, observation: TerminalObservation) -> EmitOutcome {
+    if !config.terminal.enabled {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::Disabled,
+        };
+    }
+    let raw_len = observation.command.len() + observation.output.len();
+    if !config.terminal.budget.allows(1, raw_len) {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::BudgetExceeded,
+        };
+    }
+    let Some(context) = observation.context else {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::MalformedObservation("terminal context is required".to_owned()),
+        };
+    };
+
+    let command = match sanitize_text_payload(&observation.command) {
+        PolicyAction::Sanitized(text) => text,
+        PolicyAction::Rejected(reason) => {
+            return EmitOutcome::Dropped {
+                sensor: SensorKind::Terminal,
+                reason: DropReason::PolicyRejected(reason),
+            };
+        }
+    };
+    let output = match sanitize_text_payload(&observation.output) {
+        PolicyAction::Sanitized(text) => text,
+        PolicyAction::Rejected(reason) => {
+            return EmitOutcome::Dropped {
+                sensor: SensorKind::Terminal,
+                reason: DropReason::PolicyRejected(reason),
+            };
+        }
+    };
+    let sanitized = format!("{command}\n{output}");
+
+    let event = build_auto_event(
+        observation.event_id,
+        observation.captured_at,
+        TERMINAL_SENSOR_LABEL,
+        CapturePayload::Terminal {
+            command,
+            exit_code: observation.exit_code,
+            context: Some(context),
+        },
+        SourceFamily::Terminal,
+        observation.refs,
+        sanitized.as_bytes(),
+    );
+
+    event.map_or_else(
+        |err| EmitOutcome::Dropped {
+            sensor: SensorKind::Terminal,
+            reason: DropReason::MalformedObservation(err.to_string()),
+        },
+        EmitOutcome::Emitted,
+    )
+}
+```
+
+Create `crates/cairn-sensors-local/src/clipboard.rs`:
+
+```rust
+//! Clipboard local sensor adapter.
+
+use cairn_core::domain::{
+    CaptureEventId, CapturePayload, CaptureRefs, Rfc3339Timestamp, SourceFamily,
+};
+
+use crate::config::LocalSensorConfig;
+use crate::event::build_auto_event;
+use crate::outcome::{DropReason, EmitOutcome, SensorKind};
+use crate::policy::{PolicyAction, sanitize_text_payload};
+
+const CLIPBOARD_SENSOR_LABEL: &str = "local:clipboard:default:v1";
+
+/// Already-observed clipboard payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClipboardObservation {
+    /// Capture event id.
+    pub event_id: CaptureEventId,
+    /// Capture timestamp.
+    pub captured_at: Rfc3339Timestamp,
+    /// Clipboard MIME type.
+    pub mime_type: String,
+    /// Clipboard bytes.
+    pub bytes: Vec<u8>,
+    /// Whether non-text payloads may emit metadata only.
+    pub metadata_only: bool,
+    /// Optional session/turn/tool refs.
+    pub refs: Option<CaptureRefs>,
+}
+
+/// Emit a clipboard capture event or explicit drop reason.
+#[must_use]
+pub fn emit(config: &LocalSensorConfig, observation: ClipboardObservation) -> EmitOutcome {
+    if !config.clipboard.enabled {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::Disabled,
+        };
+    }
+    if !config.clipboard.budget.allows(1, observation.bytes.len()) {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::BudgetExceeded,
+        };
+    }
+
+    let sanitized_bytes = if observation.mime_type == "text/plain" {
+        let text = match String::from_utf8(observation.bytes) {
+            Ok(text) => text,
+            Err(_) => {
+                return EmitOutcome::Dropped {
+                    sensor: SensorKind::Clipboard,
+                    reason: DropReason::PolicyRejected("clipboard text is not UTF-8".to_owned()),
+                };
+            }
+        };
+        match sanitize_text_payload(&text) {
+            PolicyAction::Sanitized(text) => text.into_bytes(),
+            PolicyAction::Rejected(reason) => {
+                return EmitOutcome::Dropped {
+                    sensor: SensorKind::Clipboard,
+                    reason: DropReason::PolicyRejected(reason),
+                };
+            }
+        }
+    } else if observation.metadata_only {
+        Vec::new()
+    } else {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::PolicyRejected("unsupported clipboard MIME type".to_owned()),
+        };
+    };
+
+    let byte_len = match u64::try_from(sanitized_bytes.len()) {
+        Ok(len) => len,
+        Err(_) => {
+            return EmitOutcome::Dropped {
+                sensor: SensorKind::Clipboard,
+                reason: DropReason::MalformedObservation(
+                    "clipboard payload length exceeds u64".to_owned(),
+                ),
+            };
+        }
+    };
+
+    let event = build_auto_event(
+        observation.event_id,
+        observation.captured_at,
+        CLIPBOARD_SENSOR_LABEL,
+        CapturePayload::Clipboard {
+            mime_type: observation.mime_type,
+            byte_len,
+        },
+        SourceFamily::Clipboard,
+        observation.refs,
+        &sanitized_bytes,
+    );
+
+    event.map_or_else(
+        |err| EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::MalformedObservation(err.to_string()),
+        },
+        EmitOutcome::Emitted,
+    )
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local --test local_sensor_terminal_clipboard
+```
+
+Expected: all six tests in `local_sensor_terminal_clipboard` pass.
+
+- [ ] **Step 5: Commit Task 5**
+
+```bash
+git add crates/cairn-sensors-local/src/lib.rs \
+  crates/cairn-sensors-local/src/terminal.rs \
+  crates/cairn-sensors-local/src/clipboard.rs \
+  crates/cairn-sensors-local/tests/local_sensor_terminal_clipboard.rs
+git commit -m "feat(sensors): emit terminal and clipboard events"
+```
+
+## Task 6: Full Verification And Cleanup
+
+**Files:**
+- Modify only files touched by previous tasks if formatting or clippy requires it.
+
+- [ ] **Step 1: Run rustfmt**
+
+Run:
+
+```bash
+cargo fmt --all
+```
+
+Expected: command exits `0`.
+
+- [ ] **Step 2: Run focused crate tests**
+
+Run:
+
+```bash
+cargo test -p cairn-sensors-local
+```
+
+Expected: all `cairn-sensors-local` unit, integration, and doc tests pass.
+
+- [ ] **Step 3: Run core capture boundary tests**
+
+Run:
+
+```bash
+cargo test -p cairn-core capture
+```
+
+Expected: all selected `cairn-core` capture tests pass. This confirms the adapters still satisfy the core `CaptureEvent` validation boundary without editing core.
+
+- [ ] **Step 4: Run clippy for touched crates**
+
+Run:
+
+```bash
+cargo clippy -p cairn-sensors-local -p cairn-core --all-targets -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main..HEAD
+```
+
+Expected: only the issue #84 design/plan docs and `cairn-sensors-local` adapter files changed.
+
+- [ ] **Step 6: Commit verification cleanup if needed**
+
+If `cargo fmt` or clippy required edits after Task 5, commit those edits:
+
+```bash
+git add crates/cairn-sensors-local Cargo.toml
+git commit -m "chore(sensors): format local sensor adapters"
+```
+
+If no files changed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-05-11-issue-84-local-sensors-design.md
+++ b/docs/superpowers/specs/2026-05-11-issue-84-local-sensors-design.md
@@ -1,0 +1,111 @@
+# Issue 84 Local Sensors Design
+
+## Context
+
+Issue #84 implements the local hook, IDE, terminal, and clipboard sensor adapter slice from the design brief §9 Sensors and §19 v0.1 local substrate. The prerequisites are now on `origin/main`: `CaptureEvent` and sensor-label validation live in `cairn-core`, and the five hook CLI handlers live in `cairn-cli`. The remaining gap is that `crates/cairn-sensors-local` still registers a `SensorIngress` plugin with all capability flags disabled and no event-emission surface.
+
+This design keeps the work scoped to the adapter crate. It does not revise the `SensorIngress` contract, add a daemon, poll the OS clipboard, or wire a full LSP/shell runtime. It provides deterministic adapter APIs that receive already-observed local inputs and emit validated `CaptureEvent`s, which is the safe unit needed before runtime capture loops can call into the crate.
+
+## Goals
+
+- Emit valid `CaptureEvent`s for hook, IDE, terminal, and clipboard observations.
+- Enforce per-sensor enablement at the source: disabled sensors return no event and do not hash or retain payload bytes.
+- Attach declared local sensor labels that match `cairn-core`'s P0 manifest families.
+- Represent sensor authorship by binding `sensor_id` and the `actor_chain` author to the same `snr:` identity for Mode A auto captures, then validating with `CaptureEvent::try_new`.
+- Apply budget checks before event creation so over-budget observations are dropped at source.
+- Redact or drop sensitive terminal and clipboard data before payload hashing and event construction.
+
+## Non-Goals
+
+- No change to the `SensorIngress` trait surface in `cairn-core`.
+- No background daemon, file watcher, shell hook installer, clipboard polling loop, or LSP client runtime.
+- No direct persistence to SQLite or the markdown vault. The adapter emits `CaptureEvent`s; `capture_trace` and downstream pipeline code persist them.
+- No new cryptographic key-management layer. Keychain-backed signing is already owned by the identity and signed-envelope work. This slice uses the existing P0 event attribution contract: `sensor_id`, sensor label, and sensor-authored `actor_chain`, all validated by core.
+
+## Architecture
+
+Add focused modules under `crates/cairn-sensors-local/src/`:
+
+- `config.rs`: local adapter configuration, with `SensorToggle`s for `hooks`, `ide`, `terminal`, and `clipboard`, plus byte/item budgets.
+- `event.rs`: shared event-construction helpers for event IDs, timestamps, payload hashes, payload refs, and sensor-authored actor chains.
+- `budget.rs`: reusable budget gate that returns `EmitDecision::Emit` or `EmitDecision::Drop(DropReason)`.
+- `policy.rs`: terminal and clipboard redaction/drop policy.
+- `hook.rs`, `ide.rs`, `terminal.rs`, `clipboard.rs`: per-sensor observation structs and builders.
+
+`LocalSensorIngress` remains the plugin registration type. Its capabilities become `batches: true`, `streaming: false`, `consent_aware: true`, because this slice provides deterministic batch-style event construction with source-side gating, not a long-running stream.
+
+## Data Flow
+
+Each adapter follows the same flow:
+
+1. Caller passes a typed observation and `LocalSensorConfig`.
+2. The adapter checks the per-sensor `enabled` flag.
+3. The adapter checks item and byte budgets.
+4. Terminal and clipboard adapters run redaction/drop policy on sensitive fields.
+5. The adapter computes `payload_hash` from the sanitized payload bytes and constructs a `sources/<family>/<event_id>.json` payload ref.
+6. The adapter constructs a `sensor_id` with the canonical local label for that family:
+   - `snr:local:hook:cc-session:v1` by default for hook observations.
+   - `snr:local:ide:default:v1`.
+   - `snr:local:terminal:default:v1`.
+   - `snr:local:clipboard:default:v1`.
+7. The adapter creates an `actor_chain` containing one `Author` entry with that same sensor identity.
+8. The adapter calls `CaptureEvent::try_new`, which validates payload family, mode/family compatibility, sensor-label shape, actor-chain attribution, payload refs, and terminal `context`.
+
+The output is `EmitOutcome`, which either contains one validated `CaptureEvent` or an explicit drop reason. Disabled or dropped observations produce no event.
+
+## Sensor Shapes
+
+Hook observations carry a hook name, optional tool name, and optional session/turn/tool refs. The default hook sensor label is the existing Claude Code canonical label because §19 names Claude Code as the v0.1 reference consumer; the API allows selecting `cc-session`, `codex-session`, or `gemini-session` so later harness wiring does not need a new type.
+
+IDE observations carry a workspace-relative file path and event kind such as `edit`, `diagnostic`, `test`, or `lsp`. They use `CapturePayload::Ide`.
+
+Terminal observations carry command, optional exit code, terminal context, optional stdout/stderr metadata, and sanitized payload bytes. They use `CapturePayload::Terminal`; fresh events must include `TerminalContext` so `CaptureEvent::try_new` passes the write-boundary validation added for #218.
+
+Clipboard observations carry MIME type, byte length, and sanitized bytes. Text snippets are allowed only after redaction. Non-text payloads are emitted as metadata-only captures when the MIME type is allowed; otherwise they are dropped.
+
+## Redaction And Drop Policy
+
+Terminal policy:
+
+- Redact common secret assignments in command/output text, including `TOKEN=...`, `API_KEY=...`, `SECRET=...`, `PASSWORD=...`, and `Authorization: Bearer ...`.
+- Drop observations that contain private-key block markers.
+- Preserve exit code and terminal context even when command text is partially redacted.
+
+Clipboard policy:
+
+- Redact the same secret patterns for `text/plain`.
+- Drop private-key blocks and obvious high-risk credential blobs.
+- Drop unsupported MIME types unless the caller explicitly marks the observation metadata-only.
+
+The redacted bytes are what get hashed. This prevents raw sensitive bytes from becoming the durable identity of an event.
+
+## Error Handling
+
+Adapters return a small typed result:
+
+- `EmitOutcome::Emitted(CaptureEvent)`.
+- `EmitOutcome::Dropped { sensor, reason }`.
+
+Drop reasons include `Disabled`, `BudgetExceeded`, `PolicyRejected`, and `MalformedObservation`. Core validation errors are surfaced as `MalformedObservation` with the original `DomainError` as source where possible. This keeps source-side decisions explicit without inventing downstream persistence behavior.
+
+## Testing
+
+Tests are added before implementation:
+
+- Enabled hook, IDE, terminal, and clipboard adapters emit `CaptureEvent`s that pass `validate_for_capture`.
+- Disabled sensors emit `EmitOutcome::Dropped { reason: Disabled }` and no event.
+- Sensor identities use the canonical manifest labels and match the emitted source family.
+- Terminal observations with missing `TerminalContext` fail before emission.
+- Terminal and clipboard secret patterns are redacted before hashing.
+- Private-key clipboard and terminal payloads are dropped.
+- Budget limits drop observations before hashing/event creation.
+- `LocalSensorIngress::capabilities()` advertises batch and consent-aware support.
+
+The focused verification command is `cargo test -p cairn-sensors-local`. Boundary confidence is covered by `cargo test -p cairn-core capture` when core validation behavior is touched; this design avoids touching core.
+
+## Follow-Up Work
+
+- Runtime loops for shell integration, clipboard polling, and IDE/LSP watching.
+- CLI or daemon commands to enable sensors and persist per-sensor config.
+- Cryptographic signing integration if the runtime wants to wrap emitted events in signed envelopes before persistence.
+- Voice, screen, neuroskill, and recording-batch adapters.


### PR DESCRIPTION
## Summary
- Add deterministic hook, IDE, terminal, and clipboard adapter APIs in `cairn-sensors-local`.
- Add config/budget gates, explicit `EmitOutcome` drop reasons, shared `CaptureEvent` construction, and terminal/clipboard redaction policy.
- Add CLI e2e coverage for bundled local sensor registration plus broader adapter tests for disabled, budget, MIME, and policy edge cases.

## Impact
This gives runtime capture loops a deterministic adapter surface that emits validated sensor-authored `CaptureEvent`s or explicit drop reasons, without changing the core `SensorIngress` trait or adding background polling/runtime loops.

## Validation
- `cargo fmt --all`
- `cargo test -p cairn-sensors-local`
- `cargo test -p cairn-cli --test plugins_verify`
- `cargo test -p cairn-cli --test hook_cli`
- `cargo test -p cairn-core capture`
- `cargo clippy -p cairn-sensors-local -p cairn-cli -p cairn-core --all-targets -- -D warnings`

Closes #84