### PR TITLE
Map MCP calls to typed core verb envelopes

### DIFF
--- a/crates/cairn-cli/tests/mcp_handshake_e2e.rs
+++ b/crates/cairn-cli/tests/mcp_handshake_e2e.rs
@@ -1,15 +1,21 @@
-//! End-to-end CLI test for the `handshake` MCP prelude tool (issue #65).
+//! End-to-end CLI tests for the `cairn mcp` stdio transport.
 //!
 //! Spawns a real `cairn mcp` subprocess against a synthesized vault
-//! (no `cairn bootstrap`, so no embedding-model download — round-1 review
-//! #3) and drives `initialize` + `tools/list` over the child's stdin/stdout
-//! to assert the production posture for `handshake`:
+//! (no `cairn bootstrap`, so no embedding-model download - round-1 review
+//! #3) and drives JSON-RPC over the child's stdin/stdout.
+//!
+//! For the `handshake` MCP prelude tool (issue #65), this asserts the
+//! production posture:
 //!
 //!  - When [`cairn_core::status::wiring::REPLAY_CHALLENGE_WIRED`] is
 //!    `false` (current state), `handshake` is absent from `tools/list`
 //!    even though the sqlite store is wired (brief §15 fail-closed,
 //!    round-1 review #1).
 //!  - When the flag is `true` (future state), `handshake` is present.
+//!
+//! For typed core verb envelopes (issue #66), this asserts that actual
+//! CLI-served `tools/call` responses carry generated `Response` JSON for
+//! malformed known verbs and known-but-unwired valid verbs.
 //!
 //! Reliability properties (round-3 review #3):
 //!  - The protocol helper returns `Result` instead of panicking, so the
@@ -22,11 +28,12 @@
 #![allow(missing_docs)]
 
 use std::io::{BufRead, BufReader, Write};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use cairn_core::generated::envelope::{Response, ResponseStatus, ResponseVerb};
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -108,7 +115,16 @@ impl Drop for ChildGuard {
 
 #[test]
 fn cairn_mcp_subprocess_advertises_handshake_per_wiring_flag() {
-    let vault = synth_vault("e2e-cli");
+    run_mcp_subprocess("e2e-cli", run_tools_list_protocol);
+}
+
+#[test]
+fn cairn_mcp_subprocess_returns_typed_envelopes_for_core_verb_calls() {
+    run_mcp_subprocess("e2e-cli-typed", run_typed_envelope_protocol);
+}
+
+fn run_mcp_subprocess(tenant: &str, protocol: fn(&mut Child) -> Result<(), String>) {
+    let vault = synth_vault(tenant);
     let child = Command::new(cli_bin())
         .args(["--vault"])
         .arg(vault.path())
@@ -123,7 +139,7 @@ fn cairn_mcp_subprocess_advertises_handshake_per_wiring_flag() {
 
     // Drive the protocol. Any failure path returns Err here; the
     // ChildGuard's Drop kills the subprocess on panic too.
-    if let Err(reason) = run_protocol(guard.as_mut()) {
+    if let Err(reason) = protocol(guard.as_mut()) {
         // Force-kill before we panic so the assertion message contains
         // the captured stderr without the live subprocess holding
         // resources.
@@ -173,71 +189,31 @@ fn cairn_mcp_subprocess_advertises_handshake_per_wiring_flag() {
     }
 }
 
-/// Drive the wire protocol. Returns `Err(reason)` on any failure so the
-/// caller's `ChildGuard` can clean up before propagating.
-fn run_protocol(child: &mut Child) -> Result<(), String> {
-    let mut stdin = child.stdin.take().ok_or("child stdin already taken")?;
-    let stdout = child.stdout.take().ok_or("child stdout already taken")?;
-    let stderr = child.stderr.take().ok_or("child stderr already taken")?;
+/// Drive `initialize` + `tools/list`. Returns `Err(reason)` on any failure so
+/// the caller's `ChildGuard` can clean up before propagating.
+fn run_tools_list_protocol(child: &mut Child) -> Result<(), String> {
+    let mut client = ProtocolClient::new(child)?;
 
-    let (tx_out, rx_out) = mpsc::channel::<Value>();
-    let _stdout_thread = std::thread::spawn(move || {
-        let mut reader = BufReader::new(stdout);
-        let mut line = String::new();
-        while reader.read_line(&mut line).unwrap_or(0) > 0 {
-            if let Ok(v) = serde_json::from_str::<Value>(line.trim())
-                && tx_out.send(v).is_err()
-            {
-                break;
-            }
-            line.clear();
-        }
-    });
-
-    let stderr_collected = Arc::new(Mutex::new(String::new()));
-    let stderr_clone = stderr_collected.clone();
-    let _stderr_thread = std::thread::spawn(move || {
-        let mut reader = BufReader::new(stderr);
-        let mut buf = String::new();
-        while reader.read_line(&mut buf).unwrap_or(0) > 0 {
-            stderr_clone.lock().expect("lock").push_str(&buf);
-            buf.clear();
-        }
-    });
-    let stderr_so_far = || stderr_collected.lock().expect("lock").clone();
-
-    send_frame(
-        &mut stdin,
-        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"cli-e2e","version":"0.0.0"}}}"#,
-    )?;
-    let init_resp = recv_frame(&rx_out, &stderr_so_far)?;
+    let init_resp = client.initialize("cli-e2e")?;
     let contract = init_resp
         .pointer("/result/capabilities/experimental/cairn.status/contract")
         .and_then(Value::as_str);
     if contract != Some("cairn.mcp.v1") {
         return Err(format!(
             "initialize did not carry cairn.mcp.v1 contract; got {contract:?}\nstderr: {}",
-            stderr_so_far()
+            client.stderr_so_far()
         ));
     }
 
-    send_frame(
-        &mut stdin,
-        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
-    )?;
-
-    send_frame(
-        &mut stdin,
-        r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
-    )?;
-    let list_resp = recv_frame(&rx_out, &stderr_so_far)?;
+    client.send(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#)?;
+    let list_resp = client.recv()?;
     let names: Vec<&str> = list_resp
         .pointer("/result/tools")
         .and_then(Value::as_array)
         .ok_or_else(|| {
             format!(
                 "tools/list response missing tools array: {list_resp}\nstderr: {}",
-                stderr_so_far()
+                client.stderr_so_far()
             )
         })?
         .iter()
@@ -257,8 +233,170 @@ fn run_protocol(child: &mut Child) -> Result<(), String> {
     }
 
     // Drop stdin so the server starts shutting down.
-    drop(stdin);
+    client.close_stdin();
     Ok(())
+}
+
+fn run_typed_envelope_protocol(child: &mut Child) -> Result<(), String> {
+    let mut client = ProtocolClient::new(child)?;
+    client.initialize("cli-e2e-typed")?;
+
+    client.send(
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search","arguments":{"query":"hello"}}}"#,
+    )?;
+    let invalid_search = client.recv()?;
+    let invalid_search = typed_error_envelope(
+        &invalid_search,
+        "invalid search args",
+        ResponseVerb::Search,
+        ResponseStatus::Rejected,
+        "InvalidArgs",
+    )?;
+    let err = invalid_search
+        .error
+        .as_ref()
+        .expect("invalid search args must carry error");
+    if err["data"]["field"] != "args" {
+        return Err(format!(
+            "invalid search args must identify args field; got {err}"
+        ));
+    }
+
+    client.send(
+        r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"retrieve","arguments":{"target":"record"}}}"#,
+    )?;
+    let invalid_retrieve = client.recv()?;
+    let invalid_retrieve = typed_error_envelope(
+        &invalid_retrieve,
+        "invalid retrieve args",
+        ResponseVerb::Retrieve,
+        ResponseStatus::Rejected,
+        "InvalidArgs",
+    )?;
+    let err = invalid_retrieve
+        .error
+        .as_ref()
+        .expect("invalid retrieve args must carry error");
+    let reason = err["data"]["reason"].as_str().unwrap_or_default();
+    if err["data"]["field"] != "args" || !reason.contains("missing field") {
+        return Err(format!(
+            "invalid retrieve args must identify missing args field; got {err}"
+        ));
+    }
+
+    client.send(
+        r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"retrieve","arguments":{"target":"record","id":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}}}"#,
+    )?;
+    let unwired_retrieve = client.recv()?;
+    let unwired_retrieve = typed_error_envelope(
+        &unwired_retrieve,
+        "valid unwired retrieve",
+        ResponseVerb::Retrieve,
+        ResponseStatus::Aborted,
+        "Internal",
+    )?;
+    let err = unwired_retrieve
+        .error
+        .as_ref()
+        .expect("unwired retrieve must carry error");
+    if !err["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("not yet implemented")
+    {
+        return Err(format!(
+            "unwired retrieve must explain missing MCP implementation; got {err}"
+        ));
+    }
+
+    // Drop stdin so the server starts shutting down.
+    client.close_stdin();
+    Ok(())
+}
+
+struct ProtocolClient {
+    stdin: Option<ChildStdin>,
+    rx_out: mpsc::Receiver<Value>,
+    stderr_collected: Arc<Mutex<String>>,
+}
+
+impl ProtocolClient {
+    fn new(child: &mut Child) -> Result<Self, String> {
+        let stdin = child.stdin.take().ok_or("child stdin already taken")?;
+        let stdout = child.stdout.take().ok_or("child stdout already taken")?;
+        let stderr = child.stderr.take().ok_or("child stderr already taken")?;
+
+        let (tx_out, rx_out) = mpsc::channel::<Value>();
+        let _stdout_thread = std::thread::spawn(move || {
+            let mut reader = BufReader::new(stdout);
+            let mut line = String::new();
+            while reader.read_line(&mut line).unwrap_or(0) > 0 {
+                if let Ok(v) = serde_json::from_str::<Value>(line.trim())
+                    && tx_out.send(v).is_err()
+                {
+                    break;
+                }
+                line.clear();
+            }
+        });
+
+        let stderr_collected = Arc::new(Mutex::new(String::new()));
+        let stderr_clone = stderr_collected.clone();
+        let _stderr_thread = std::thread::spawn(move || {
+            let mut reader = BufReader::new(stderr);
+            let mut buf = String::new();
+            while reader.read_line(&mut buf).unwrap_or(0) > 0 {
+                stderr_clone.lock().expect("lock").push_str(&buf);
+                buf.clear();
+            }
+        });
+
+        Ok(Self {
+            stdin: Some(stdin),
+            rx_out,
+            stderr_collected,
+        })
+    }
+
+    fn send(&mut self, json: &str) -> Result<(), String> {
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or_else(|| "child stdin already closed".to_owned())?;
+        send_frame(stdin, json)
+    }
+
+    fn recv(&self) -> Result<Value, String> {
+        recv_frame(&self.rx_out, &|| self.stderr_so_far())
+    }
+
+    fn initialize(&mut self, client_name: &str) -> Result<Value, String> {
+        let init = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": client_name,
+                    "version": "0.0.0",
+                },
+            },
+        });
+        self.send(&init.to_string())?;
+        let resp = self.recv()?;
+        self.send(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)?;
+        Ok(resp)
+    }
+
+    fn close_stdin(&mut self) {
+        self.stdin.take();
+    }
+
+    fn stderr_so_far(&self) -> String {
+        self.stderr_collected.lock().expect("lock").clone()
+    }
 }
 
 fn send_frame(stdin: &mut impl Write, json: &str) -> Result<(), String> {
@@ -282,4 +420,75 @@ fn recv_frame(
             stderr_so_far()
         )
     })
+}
+
+fn typed_error_envelope(
+    call_resp: &Value,
+    label: &str,
+    expected_verb: ResponseVerb,
+    expected_status: ResponseStatus,
+    expected_code: &str,
+) -> Result<Response, String> {
+    if call_resp.get("result").is_none() {
+        return Err(format!(
+            "{label} must yield a result frame; got {call_resp}"
+        ));
+    }
+    let is_error = call_resp
+        .pointer("/result/isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !is_error {
+        return Err(format!("{label} must set isError=true; got {call_resp}"));
+    }
+    let text = first_text_content(call_resp)
+        .ok_or_else(|| format!("{label} response must include text content; got {call_resp}"))?;
+    let envelope: Response = serde_json::from_str(text)
+        .map_err(|e| format!("{label} text must parse as Response JSON: {e}; text={text}"))?;
+    if envelope.contract != "cairn.mcp.v1" {
+        return Err(format!(
+            "{label} must carry cairn.mcp.v1 contract; got {}",
+            envelope.contract
+        ));
+    }
+    if envelope.status != expected_status {
+        return Err(format!(
+            "{label} status mismatch; expected {:?}, got {:?}",
+            expected_status, envelope.status
+        ));
+    }
+    if envelope.verb != expected_verb {
+        return Err(format!(
+            "{label} verb mismatch; expected {:?}, got {:?}",
+            expected_verb, envelope.verb
+        ));
+    }
+    if envelope.operation_id.0.len() != 26 {
+        return Err(format!(
+            "{label} operation_id must be a ULID; got {}",
+            envelope.operation_id.0
+        ));
+    }
+    if envelope.data.is_some() {
+        return Err(format!("{label} error envelope must not carry data"));
+    }
+    let err = envelope
+        .error
+        .as_ref()
+        .ok_or_else(|| format!("{label} must carry error object"))?;
+    if err["code"] != expected_code {
+        return Err(format!(
+            "{label} code mismatch; expected {expected_code}, got {err}"
+        ));
+    }
+    Ok(envelope)
+}
+
+fn first_text_content(call_resp: &Value) -> Option<&str> {
+    call_resp
+        .pointer("/result/content")
+        .and_then(Value::as_array)?
+        .first()?
+        .get("text")
+        .and_then(Value::as_str)
 }

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -607,9 +607,9 @@ async fn handle_search(
                 "args",
                 "expected search arguments",
             );
-            return crate::verb_envelope::call_result_from_response(response);
+            return crate::verb_envelope::call_result_from_response(&response);
         }
-        Err(response) => return crate::verb_envelope::call_result_from_response(response),
+        Err(response) => return crate::verb_envelope::call_result_from_response(&response),
     };
 
     // Map IDL mode to core dispatcher mode.
@@ -624,7 +624,7 @@ async fn handle_search(
                 "mode",
                 "unknown search mode",
             );
-            return crate::verb_envelope::call_result_from_response(response);
+            return crate::verb_envelope::call_result_from_response(&response);
         }
     };
 
@@ -668,24 +668,24 @@ async fn handle_search(
                 ResponseVerb::Search,
                 capability,
             );
-            return crate::verb_envelope::call_result_from_response(response);
+            return crate::verb_envelope::call_result_from_response(&response);
         }
         Err(cairn_core::verbs::search::SearchError::InvalidArgs { reason }) => {
             let response =
                 crate::verb_envelope::invalid_args_response(ResponseVerb::Search, "args", &reason);
-            return crate::verb_envelope::call_result_from_response(response);
+            return crate::verb_envelope::call_result_from_response(&response);
         }
         Err(cairn_core::verbs::search::SearchError::InvalidFilter { reason }) => {
             let response =
                 crate::verb_envelope::invalid_filter_response(ResponseVerb::Search, &reason);
-            return crate::verb_envelope::call_result_from_response(response);
+            return crate::verb_envelope::call_result_from_response(&response);
         }
         Err(cairn_core::verbs::search::SearchError::Store(e)) => {
             let response = crate::verb_envelope::aborted_internal(
                 ResponseVerb::Search,
                 &format!("store error: {e}"),
             );
-            return crate::verb_envelope::call_result_from_response(response);
+            return crate::verb_envelope::call_result_from_response(&response);
         }
         // Forward-compat: surface unknown error variants as internal errors.
         Err(e) => {
@@ -693,7 +693,7 @@ async fn handle_search(
                 ResponseVerb::Search,
                 &format!("internal error: {e}"),
             );
-            return crate::verb_envelope::call_result_from_response(response);
+            return crate::verb_envelope::call_result_from_response(&response);
         }
     };
 
@@ -764,7 +764,7 @@ fn search_outcome_to_result(
         ResponseData::Search(data),
         to_wire(&outcome.policy_trace),
     );
-    crate::verb_envelope::call_result_from_response(response)
+    crate::verb_envelope::call_result_from_response(&response)
 }
 
 /// Stub dispatcher returned while real verb wiring is pending.
@@ -781,7 +781,7 @@ pub fn dispatch_stub(verb: &str) -> CallToolResult {
 
     if let Some(request_verb) = crate::verb_envelope::core_verb_for_tool(verb) {
         return crate::verb_envelope::call_result_from_response(
-            crate::verb_envelope::aborted_internal(
+            &crate::verb_envelope::aborted_internal(
                 crate::verb_envelope::response_verb(request_verb),
                 &message,
             ),

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -581,10 +581,10 @@ impl ServerHandler for CairnMcpHandler {
 
 /// Dispatch the `search` tool against a wired store.
 ///
-/// Parses the MCP tool arguments into [`cairn_core::generated::verbs::search::SearchArgs`],
+/// Parses the MCP tool arguments into the generated search request args,
 /// derives the capability set from config, calls
 /// [`cairn_core::verbs::search::run`], and serializes the result into a
-/// [`CallToolResult`].
+/// generated response envelope inside a [`CallToolResult`].
 #[allow(
     clippy::too_many_lines,
     reason = "linear arg→request→outcome→envelope flow; splitting reduces clarity"
@@ -594,17 +594,22 @@ async fn handle_search(
     config: CairnConfig,
     arguments: Option<serde_json::Map<String, serde_json::Value>>,
 ) -> CallToolResult {
-    use cairn_core::generated::verbs::search::{SearchArgs, SearchArgsMode};
+    use cairn_core::generated::envelope::{RequestArgs, RequestVerb, ResponseVerb};
+    use cairn_core::generated::verbs::search::SearchArgsMode;
 
-    // Parse args from the MCP tool argument map.
-    let args_json = serde_json::Value::Object(arguments.unwrap_or_default());
-    let args: SearchArgs = match serde_json::from_value(args_json) {
-        Ok(a) => a,
-        Err(e) => {
-            return CallToolResult::error(vec![Content::text(format!(
-                "cairn search: invalid args: {e}"
-            ))]);
+    // Parse args from the MCP tool argument map through the generated
+    // envelope adapter so parse failures use the canonical Response shape.
+    let args = match crate::verb_envelope::parse_args(RequestVerb::Search, arguments) {
+        Ok(RequestArgs::Search(args)) => args,
+        Ok(_) => {
+            let response = crate::verb_envelope::invalid_args_response(
+                ResponseVerb::Search,
+                "args",
+                "expected search arguments",
+            );
+            return crate::verb_envelope::call_result_from_response(response);
         }
+        Err(response) => return crate::verb_envelope::call_result_from_response(response),
     };
 
     // Map IDL mode to core dispatcher mode.
@@ -614,7 +619,12 @@ async fn handle_search(
         SearchArgsMode::Hybrid => cairn_core::verbs::search::SearchMode::Hybrid,
         // Forward-compat: reject unknown future variants fail-closed.
         _ => {
-            return CallToolResult::error(vec![Content::text("cairn search: unknown mode")]);
+            let response = crate::verb_envelope::invalid_args_response(
+                ResponseVerb::Search,
+                "mode",
+                "unknown search mode",
+            );
+            return crate::verb_envelope::call_result_from_response(response);
         }
     };
 
@@ -649,41 +659,43 @@ async fn handle_search(
         explain: args.explain.unwrap_or(false),
     };
 
-    let outcome =
-        match cairn_core::verbs::search::run(store.as_ref(), &config, &caps, request).await {
-            Ok(o) => o,
-            Err(cairn_core::verbs::search::SearchError::CapabilityUnavailable { capability }) => {
-                let remediation = cairn_core::status::remediation_for(capability);
-                let msg = match remediation {
-                    Some(hint) => format!(
-                        "cairn search: capability unavailable: {capability}\n  hint: {hint}"
-                    ),
-                    None => format!("cairn search: capability unavailable: {capability}"),
-                };
-                return CallToolResult::error(vec![Content::text(msg)]);
-            }
-            Err(cairn_core::verbs::search::SearchError::InvalidArgs { reason }) => {
-                return CallToolResult::error(vec![Content::text(format!(
-                    "cairn search: invalid args: {reason}"
-                ))]);
-            }
-            Err(cairn_core::verbs::search::SearchError::InvalidFilter { reason }) => {
-                return CallToolResult::error(vec![Content::text(format!(
-                    "cairn search: invalid filter: {reason}"
-                ))]);
-            }
-            Err(cairn_core::verbs::search::SearchError::Store(e)) => {
-                return CallToolResult::error(vec![Content::text(format!(
-                    "cairn search: store error: {e}"
-                ))]);
-            }
-            // Forward-compat: surface unknown error variants as internal errors.
-            Err(e) => {
-                return CallToolResult::error(vec![Content::text(format!(
-                    "cairn search: internal error: {e}"
-                ))]);
-            }
-        };
+    let outcome = match cairn_core::verbs::search::run(store.as_ref(), &config, &caps, request)
+        .await
+    {
+        Ok(o) => o,
+        Err(cairn_core::verbs::search::SearchError::CapabilityUnavailable { capability }) => {
+            let response = crate::verb_envelope::capability_unavailable_response(
+                ResponseVerb::Search,
+                capability,
+            );
+            return crate::verb_envelope::call_result_from_response(response);
+        }
+        Err(cairn_core::verbs::search::SearchError::InvalidArgs { reason }) => {
+            let response =
+                crate::verb_envelope::invalid_args_response(ResponseVerb::Search, "args", &reason);
+            return crate::verb_envelope::call_result_from_response(response);
+        }
+        Err(cairn_core::verbs::search::SearchError::InvalidFilter { reason }) => {
+            let response =
+                crate::verb_envelope::invalid_filter_response(ResponseVerb::Search, &reason);
+            return crate::verb_envelope::call_result_from_response(response);
+        }
+        Err(cairn_core::verbs::search::SearchError::Store(e)) => {
+            let response = crate::verb_envelope::aborted_internal(
+                ResponseVerb::Search,
+                &format!("store error: {e}"),
+            );
+            return crate::verb_envelope::call_result_from_response(response);
+        }
+        // Forward-compat: surface unknown error variants as internal errors.
+        Err(e) => {
+            let response = crate::verb_envelope::aborted_internal(
+                ResponseVerb::Search,
+                &format!("internal error: {e}"),
+            );
+            return crate::verb_envelope::call_result_from_response(response);
+        }
+    };
 
     search_outcome_to_result(outcome, mode)
 }
@@ -695,8 +707,9 @@ fn search_outcome_to_result(
     mode: cairn_core::verbs::search::SearchMode,
 ) -> CallToolResult {
     use cairn_core::generated::common::Ulid;
+    use cairn_core::generated::envelope::{ResponseData, ResponseVerb};
     use cairn_core::generated::verbs::search::{Hit, HitTrust, ScoreExplain, SearchData};
-    use cairn_core::policy_trace::to_wire_exclusions;
+    use cairn_core::policy_trace::{to_wire, to_wire_exclusions};
 
     let hits: Vec<Hit> = outcome
         .candidates
@@ -719,9 +732,9 @@ fn search_outcome_to_result(
                 semantic_rank: e
                     .semantic_rank
                     .map(|r| i64::try_from(r).unwrap_or(i64::MAX)),
-                rrf_score: e.rrf_score,
-                cosine: e.cosine,
-                final_score: e.final_score,
+                rrf_score: finite_or_zero(e.rrf_score),
+                cosine: finite_option(e.cosine),
+                final_score: finite_or_zero(e.final_score),
             })
             .collect()
     });
@@ -746,12 +759,12 @@ fn search_outcome_to_result(
         degraded_legs,
     };
 
-    match serde_json::to_string(&data) {
-        Ok(s) => CallToolResult::success(vec![Content::text(s)]),
-        Err(e) => CallToolResult::error(vec![Content::text(format!(
-            "cairn search: serialize error: {e}"
-        ))]),
-    }
+    let response = crate::verb_envelope::committed(
+        ResponseVerb::Search,
+        ResponseData::Search(data),
+        to_wire(&outcome.policy_trace),
+    );
+    crate::verb_envelope::call_result_from_response(response)
 }
 
 /// Stub dispatcher returned while real verb wiring is pending.
@@ -797,7 +810,21 @@ fn hit_score(
         // Keyword + future variants (SearchMode is #[non_exhaustive]).
         _ => c.bm25,
     };
-    if raw.is_finite() { raw } else { 0.0 }
+    finite_or_zero(raw)
+}
+
+/// Replace non-finite floats with zero before writing generated JSON
+/// envelopes. JSON Schema numbers cannot represent NaN or infinity.
+#[inline]
+#[must_use]
+fn finite_or_zero(value: f64) -> f64 {
+    if value.is_finite() { value } else { 0.0 }
+}
+
+#[inline]
+#[must_use]
+fn finite_option(value: Option<f64>) -> Option<f64> {
+    value.map(finite_or_zero)
 }
 
 /// Convert a domain [`cairn_core::search::DegradedLeg`] into the IDL

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -557,7 +557,7 @@ impl ServerHandler for CairnMcpHandler {
                 return Ok(crate::graph_tools::dispatch(&queries, &name, arguments).await);
             }
 
-            let known = TOOLS.iter().any(|d| d.name == name.as_ref());
+            let known = crate::verb_envelope::core_verb_for_tool(name.as_ref()).is_some();
             let store = self.store.clone();
             let config = self.config.clone();
 
@@ -769,15 +769,26 @@ fn search_outcome_to_result(
 
 /// Stub dispatcher returned while real verb wiring is pending.
 ///
-/// Returns a [`CallToolResult`] with `is_error = true` and a message
-/// explaining that the verb is not yet wired. This function is `pub` so the
-/// parity test in Task 8 can call it directly.
+/// Returns a [`CallToolResult`] with `is_error = true` and a message explaining
+/// that the verb is not yet wired. Known generated core verbs are wrapped in
+/// their typed generated aborted response envelopes; unknown direct calls keep
+/// the plain placeholder text.
 #[must_use]
 pub fn dispatch_stub(verb: &str) -> CallToolResult {
-    CallToolResult::error(vec![Content::text(format!(
-        "cairn {verb}: not yet implemented in this P0 scaffold. \
-         Verb dispatch lands in a follow-up PR; no memory operation was performed."
-    ))])
+    let message = format!(
+        "cairn {verb}: not yet implemented in MCP adapter; no memory operation was performed."
+    );
+
+    if let Some(request_verb) = crate::verb_envelope::core_verb_for_tool(verb) {
+        return crate::verb_envelope::call_result_from_response(
+            crate::verb_envelope::aborted_internal(
+                crate::verb_envelope::response_verb(request_verb),
+                &message,
+            ),
+        );
+    }
+
+    CallToolResult::error(vec![Content::text(message)])
 }
 
 /// Mode-appropriate score for an MCP search hit.

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -557,21 +557,36 @@ impl ServerHandler for CairnMcpHandler {
                 return Ok(crate::graph_tools::dispatch(&queries, &name, arguments).await);
             }
 
-            let known = crate::verb_envelope::core_verb_for_tool(name.as_ref()).is_some();
+            let request_verb = crate::verb_envelope::core_verb_for_tool(name.as_ref());
             let store = self.store.clone();
             let config = self.config.clone();
 
-            if !known {
+            let Some(request_verb) = request_verb else {
                 return Ok(CallToolResult::error(vec![Content::text(format!(
                     "cairn: unknown verb '{name}'. Available verbs: {}",
                     TOOLS.iter().map(|d| d.name).collect::<Vec<_>>().join(", ")
                 ))]));
-            }
+            };
+
+            let typed_args = match crate::verb_envelope::parse_args(request_verb, arguments) {
+                Ok(args) => args,
+                Err(response) => {
+                    return Ok(crate::verb_envelope::call_result_from_response(&response));
+                }
+            };
 
             if name.as_ref() == "search"
                 && let Some(store) = store
             {
-                return Ok(handle_search(store, config, arguments).await);
+                let cairn_core::generated::envelope::RequestArgs::Search(args) = typed_args else {
+                    let response = crate::verb_envelope::invalid_args_response(
+                        crate::verb_envelope::response_verb(request_verb),
+                        "args",
+                        "expected search arguments",
+                    );
+                    return Ok(crate::verb_envelope::call_result_from_response(&response));
+                };
+                return Ok(handle_search(store, config, args).await);
             }
 
             Ok(dispatch_stub(&name))
@@ -592,25 +607,10 @@ impl ServerHandler for CairnMcpHandler {
 async fn handle_search(
     store: Arc<dyn MemoryStore>,
     config: CairnConfig,
-    arguments: Option<serde_json::Map<String, serde_json::Value>>,
+    args: cairn_core::generated::verbs::search::SearchArgs,
 ) -> CallToolResult {
-    use cairn_core::generated::envelope::{RequestArgs, RequestVerb, ResponseVerb};
+    use cairn_core::generated::envelope::ResponseVerb;
     use cairn_core::generated::verbs::search::SearchArgsMode;
-
-    // Parse args from the MCP tool argument map through the generated
-    // envelope adapter so parse failures use the canonical Response shape.
-    let args = match crate::verb_envelope::parse_args(RequestVerb::Search, arguments) {
-        Ok(RequestArgs::Search(args)) => args,
-        Ok(_) => {
-            let response = crate::verb_envelope::invalid_args_response(
-                ResponseVerb::Search,
-                "args",
-                "expected search arguments",
-            );
-            return crate::verb_envelope::call_result_from_response(&response);
-        }
-        Err(response) => return crate::verb_envelope::call_result_from_response(&response),
-    };
 
     // Map IDL mode to core dispatcher mode.
     let mode = match args.mode {

--- a/crates/cairn-mcp/src/lib.rs
+++ b/crates/cairn-mcp/src/lib.rs
@@ -16,6 +16,7 @@ pub mod graph_tools;
 pub mod handler;
 pub mod prelude_tools;
 pub mod relay;
+pub mod verb_envelope;
 
 pub use error::TransportError;
 pub use handler::CairnMcpHandler;

--- a/crates/cairn-mcp/src/verb_envelope.rs
+++ b/crates/cairn-mcp/src/verb_envelope.rs
@@ -1,0 +1,599 @@
+//! Typed envelope helpers for core MCP verb calls.
+
+use cairn_core::generated::common::Capabilities;
+use cairn_core::generated::envelope::{
+    RequestArgs, RequestVerb, Response, ResponseData, ResponsePolicyTrace, ResponseStatus,
+    ResponseTarget, ResponseVerb, RetrieveData,
+};
+use rmcp::model::{CallToolResult, Content};
+use serde::de::DeserializeOwned;
+
+const CONTRACT: &str = "cairn.mcp.v1";
+
+/// Return the generated core request verb for an MCP tool name.
+#[must_use]
+pub fn core_verb_for_tool(name: &str) -> Option<RequestVerb> {
+    match name {
+        "ingest" => Some(RequestVerb::Ingest),
+        "search" => Some(RequestVerb::Search),
+        "retrieve" => Some(RequestVerb::Retrieve),
+        "summarize" => Some(RequestVerb::Summarize),
+        "assemble_hot" => Some(RequestVerb::AssembleHot),
+        "capture_trace" => Some(RequestVerb::CaptureTrace),
+        "lint" => Some(RequestVerb::Lint),
+        "forget" => Some(RequestVerb::Forget),
+        _ => None,
+    }
+}
+
+/// Map a generated request verb to its generated response envelope verb.
+#[must_use]
+pub fn response_verb(verb: RequestVerb) -> ResponseVerb {
+    match verb {
+        RequestVerb::Ingest => ResponseVerb::Ingest,
+        RequestVerb::Search => ResponseVerb::Search,
+        RequestVerb::Retrieve => ResponseVerb::Retrieve,
+        RequestVerb::Summarize => ResponseVerb::Summarize,
+        RequestVerb::AssembleHot => ResponseVerb::AssembleHot,
+        RequestVerb::CaptureTrace => ResponseVerb::CaptureTrace,
+        RequestVerb::Lint => ResponseVerb::Lint,
+        RequestVerb::Forget => ResponseVerb::Forget,
+        _ => ResponseVerb::Unknown,
+    }
+}
+
+/// Parse MCP per-tool args into the generated per-verb request arg enum.
+///
+/// MCP passes only an args object, not the whole signed request envelope. This
+/// adapter dispatches on the already-known tool verb and lets the generated
+/// deserializers enforce each verb's shape.
+pub fn parse_args(
+    verb: RequestVerb,
+    arguments: Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<RequestArgs, Response> {
+    let args = match arguments {
+        Some(args) => serde_json::Value::Object(args),
+        None => serde_json::Value::Object(serde_json::Map::new()),
+    };
+
+    match verb {
+        RequestVerb::Ingest => parse_arg_payload(verb, args).map(RequestArgs::Ingest),
+        RequestVerb::Search => parse_arg_payload(verb, args).map(RequestArgs::Search),
+        RequestVerb::Retrieve => parse_arg_payload(verb, args).map(RequestArgs::Retrieve),
+        RequestVerb::Summarize => parse_arg_payload(verb, args).map(RequestArgs::Summarize),
+        RequestVerb::AssembleHot => parse_arg_payload(verb, args).map(RequestArgs::AssembleHot),
+        RequestVerb::CaptureTrace => parse_arg_payload(verb, args).map(RequestArgs::CaptureTrace),
+        RequestVerb::Lint => parse_arg_payload(verb, args).map(RequestArgs::Lint),
+        RequestVerb::Forget => parse_arg_payload(verb, args).map(RequestArgs::Forget),
+        _ => Err(unknown_verb_response(format!("{verb:?}"))),
+    }
+}
+
+/// Build a committed generated response envelope.
+#[must_use]
+pub fn committed(
+    verb: ResponseVerb,
+    data: ResponseData,
+    policy_trace: Vec<ResponsePolicyTrace>,
+) -> Response {
+    if !response_data_matches_verb(verb, &data) {
+        if matches!(verb, ResponseVerb::Unknown) {
+            return unknown_verb_response("unknown");
+        }
+
+        let message = if matches!(
+            (verb, &data),
+            (ResponseVerb::Retrieve, ResponseData::Retrieve(_))
+        ) {
+            "committed retrieve responses require committed_retrieve so target is set"
+        } else {
+            "response verb does not match response data"
+        };
+        return aborted_internal(verb, message);
+    }
+
+    Response {
+        contract: CONTRACT.to_owned(),
+        data: Some(data),
+        error: None,
+        operation_id: cairn_core::time::new_operation_id(),
+        policy_trace,
+        status: ResponseStatus::Committed,
+        target: None,
+        verb,
+    }
+}
+
+/// Build a committed generated retrieve response envelope.
+#[must_use]
+pub fn committed_retrieve(data: RetrieveData, policy_trace: Vec<ResponsePolicyTrace>) -> Response {
+    let Some(target) = retrieve_target(&data) else {
+        return aborted_internal(ResponseVerb::Retrieve, "unsupported retrieve data variant");
+    };
+
+    Response {
+        contract: CONTRACT.to_owned(),
+        data: Some(ResponseData::Retrieve(data)),
+        error: None,
+        operation_id: cairn_core::time::new_operation_id(),
+        policy_trace,
+        status: ResponseStatus::Committed,
+        target: Some(target),
+        verb: ResponseVerb::Retrieve,
+    }
+}
+
+/// Build a valid `UnknownVerb` rejected response envelope.
+#[must_use]
+pub fn unknown_verb_response(attempted: impl Into<String>) -> Response {
+    let attempted = non_empty_or(attempted.into(), "unknown");
+    Response {
+        contract: CONTRACT.to_owned(),
+        data: None,
+        error: Some(serde_json::json!({
+            "code": "UnknownVerb",
+            "message": format!("unknown verb: {attempted}"),
+            "data": { "verb": attempted },
+        })),
+        operation_id: cairn_core::time::new_operation_id(),
+        policy_trace: Vec::new(),
+        status: ResponseStatus::Rejected,
+        target: None,
+        verb: ResponseVerb::Unknown,
+    }
+}
+
+/// Build an `InvalidArgs` rejected response envelope.
+#[must_use]
+pub fn invalid_args_response(verb: ResponseVerb, field: &str, reason: &str) -> Response {
+    if matches!(verb, ResponseVerb::Unknown) {
+        return unknown_verb_response("unknown");
+    }
+
+    let field = non_empty_or(field.to_owned(), "unknown");
+    let reason = non_empty_or(reason.to_owned(), "unknown");
+    Response {
+        contract: CONTRACT.to_owned(),
+        data: None,
+        error: Some(serde_json::json!({
+            "code": "InvalidArgs",
+            "message": format!("invalid args: {field}: {reason}"),
+            "data": { "field": field, "reason": reason },
+        })),
+        operation_id: cairn_core::time::new_operation_id(),
+        policy_trace: Vec::new(),
+        status: ResponseStatus::Rejected,
+        target: None,
+        verb,
+    }
+}
+
+/// Build an `InvalidFilter` rejected response envelope for `filters`.
+#[must_use]
+pub fn invalid_filter_response(verb: ResponseVerb, reason: &str) -> Response {
+    if matches!(verb, ResponseVerb::Unknown) {
+        return unknown_verb_response("unknown");
+    }
+
+    let reason = non_empty_or(reason.to_owned(), "unknown");
+    Response {
+        contract: CONTRACT.to_owned(),
+        data: None,
+        error: Some(serde_json::json!({
+            "code": "InvalidFilter",
+            "message": format!("invalid filter: {reason}"),
+            "data": { "path": "filters", "reason": reason },
+        })),
+        operation_id: cairn_core::time::new_operation_id(),
+        policy_trace: Vec::new(),
+        status: ResponseStatus::Rejected,
+        target: None,
+        verb,
+    }
+}
+
+/// Build a `CapabilityUnavailable` rejected response envelope.
+#[must_use]
+pub fn capability_unavailable_response(verb: ResponseVerb, capability: &str) -> Response {
+    if matches!(verb, ResponseVerb::Unknown) {
+        return unknown_verb_response("unknown");
+    }
+
+    let capability = non_empty_or(capability.to_owned(), "unknown");
+    if !is_known_capability(&capability) {
+        return aborted_internal(verb, &format!("unknown capability: {capability}"));
+    }
+
+    let mut data = serde_json::json!({ "capability": capability });
+    if let Some(remediation) = cairn_core::status::remediation_for(&capability)
+        && let Some(data) = data.as_object_mut()
+    {
+        data.insert(
+            "remediation".to_owned(),
+            serde_json::Value::String(remediation.to_owned()),
+        );
+    }
+
+    Response {
+        contract: CONTRACT.to_owned(),
+        data: None,
+        error: Some(serde_json::json!({
+            "code": "CapabilityUnavailable",
+            "message": format!(
+                "this server does not advertise {capability}; the requested feature requires it"
+            ),
+            "data": data,
+        })),
+        operation_id: cairn_core::time::new_operation_id(),
+        policy_trace: Vec::new(),
+        status: ResponseStatus::Rejected,
+        target: None,
+        verb,
+    }
+}
+
+/// Build an `Internal` aborted response envelope.
+#[must_use]
+pub fn aborted_internal(verb: ResponseVerb, message: &str) -> Response {
+    if matches!(verb, ResponseVerb::Unknown) {
+        return unknown_verb_response("unknown");
+    }
+
+    let message = non_empty_or(message.to_owned(), "internal error");
+    Response {
+        contract: CONTRACT.to_owned(),
+        data: None,
+        error: Some(serde_json::json!({
+            "code": "Internal",
+            "message": message,
+        })),
+        operation_id: cairn_core::time::new_operation_id(),
+        policy_trace: Vec::new(),
+        status: ResponseStatus::Aborted,
+        target: None,
+        verb,
+    }
+}
+
+/// Serialize a generated response envelope into an MCP tool result.
+#[must_use]
+pub fn call_result_from_response(response: Response) -> CallToolResult {
+    let (text, is_serialization_fallback) = response_json_text(&response);
+    let is_committed =
+        matches!(response.status, ResponseStatus::Committed) && !is_serialization_fallback;
+    let content = vec![Content::text(text)];
+
+    if is_committed {
+        CallToolResult::success(content)
+    } else {
+        CallToolResult::error(content)
+    }
+}
+
+fn parse_arg_payload<T: DeserializeOwned>(
+    verb: RequestVerb,
+    args: serde_json::Value,
+) -> Result<T, Response> {
+    serde_json::from_value(args)
+        .map_err(|err| invalid_args_response(response_verb(verb), "args", &err.to_string()))
+}
+
+fn response_data_matches_verb(verb: ResponseVerb, data: &ResponseData) -> bool {
+    matches!(
+        (verb, data),
+        (ResponseVerb::Ingest, ResponseData::Ingest(_))
+            | (ResponseVerb::Search, ResponseData::Search(_))
+            | (ResponseVerb::Summarize, ResponseData::Summarize(_))
+            | (ResponseVerb::AssembleHot, ResponseData::AssembleHot(_))
+            | (ResponseVerb::CaptureTrace, ResponseData::CaptureTrace(_))
+            | (ResponseVerb::Lint, ResponseData::Lint(_))
+            | (ResponseVerb::Forget, ResponseData::Forget(_))
+    )
+}
+
+fn retrieve_target(data: &RetrieveData) -> Option<ResponseTarget> {
+    match data {
+        RetrieveData::Record(_) => Some(ResponseTarget::Record),
+        RetrieveData::Profile(_) => Some(ResponseTarget::Profile),
+        RetrieveData::Session(_) => Some(ResponseTarget::Session),
+        RetrieveData::Turn(_) => Some(ResponseTarget::Turn),
+        RetrieveData::Folder(_) => Some(ResponseTarget::Folder),
+        RetrieveData::Scope(_) => Some(ResponseTarget::Scope),
+        _ => None,
+    }
+}
+
+fn is_known_capability(capability: &str) -> bool {
+    serde_json::from_value::<Capabilities>(serde_json::Value::String(capability.to_owned())).is_ok()
+}
+
+fn non_empty_or(value: String, fallback: &str) -> String {
+    if value.is_empty() {
+        fallback.to_owned()
+    } else {
+        value
+    }
+}
+
+fn response_json_text(response: &Response) -> (String, bool) {
+    match serde_json::to_string(response) {
+        Ok(text) => (text, false),
+        Err(err) => {
+            let fallback = aborted_internal(
+                response.verb,
+                &format!("response serialization failed: {err}"),
+            );
+            match serde_json::to_string(&fallback) {
+                Ok(text) => (text, true),
+                Err(second_err) => (
+                    fallback_json_text(response.verb, &second_err.to_string()),
+                    true,
+                ),
+            }
+        }
+    }
+}
+
+fn fallback_json_text(verb: ResponseVerb, reason: &str) -> String {
+    if matches!(verb, ResponseVerb::Unknown) {
+        return serde_json::json!({
+            "contract": CONTRACT,
+            "error": {
+                "code": "UnknownVerb",
+                "message": "unknown verb: unknown",
+                "data": { "verb": "unknown" },
+            },
+            "operation_id": cairn_core::time::new_operation_id(),
+            "policy_trace": [],
+            "status": "rejected",
+            "verb": "unknown",
+        })
+        .to_string();
+    }
+
+    let verb = match serde_json::to_value(verb) {
+        Ok(verb) => verb,
+        Err(_) => serde_json::Value::String("unknown".to_owned()),
+    };
+    serde_json::json!({
+        "contract": CONTRACT,
+        "error": {
+            "code": "Internal",
+            "message": format!("response serialization failed: {reason}"),
+        },
+        "operation_id": cairn_core::time::new_operation_id(),
+        "policy_trace": [],
+        "status": "aborted",
+        "verb": verb,
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cairn_core::generated::common::Ulid;
+    use cairn_core::generated::envelope::{
+        RequestArgs, RequestVerb, Response, ResponseData, ResponseStatus, ResponseTarget,
+        ResponseVerb, RetrieveData,
+    };
+    use cairn_core::generated::verbs::retrieve::DataRecord;
+    use cairn_core::generated::verbs::search::SearchData;
+    use rmcp::model::RawContent;
+    use serde_json::json;
+
+    fn ulid() -> Ulid {
+        Ulid("01HQZX9F5N0000000000000000".to_owned())
+    }
+
+    fn search_data() -> ResponseData {
+        ResponseData::Search(SearchData {
+            degraded_legs: None,
+            excluded: None,
+            hits: Vec::new(),
+            next_cursor: None,
+            score_explain: None,
+        })
+    }
+
+    fn retrieve_record_data() -> RetrieveData {
+        RetrieveData::Record(DataRecord {
+            body: None,
+            frontmatter: None,
+            kind: "note".to_owned(),
+            record_id: ulid(),
+        })
+    }
+
+    fn response_text(result: &rmcp::model::CallToolResult) -> &str {
+        result
+            .content
+            .iter()
+            .find_map(|c| {
+                if let RawContent::Text(t) = &**c {
+                    Some(t.text.as_str())
+                } else {
+                    None
+                }
+            })
+            .expect("expected text content")
+    }
+
+    #[test]
+    fn maps_all_core_tool_names_to_request_verbs() {
+        let cases = [
+            ("ingest", RequestVerb::Ingest),
+            ("search", RequestVerb::Search),
+            ("retrieve", RequestVerb::Retrieve),
+            ("summarize", RequestVerb::Summarize),
+            ("assemble_hot", RequestVerb::AssembleHot),
+            ("capture_trace", RequestVerb::CaptureTrace),
+            ("lint", RequestVerb::Lint),
+            ("forget", RequestVerb::Forget),
+        ];
+        for (name, expected) in cases {
+            assert_eq!(core_verb_for_tool(name), Some(expected), "{name}");
+        }
+        assert_eq!(core_verb_for_tool("handshake"), None);
+        assert_eq!(core_verb_for_tool("graph.neighbours"), None);
+    }
+
+    #[test]
+    fn parses_search_args_into_typed_request_args() {
+        let args = serde_json::Map::from_iter([
+            ("query".to_owned(), json!("hello")),
+            ("mode".to_owned(), json!("keyword")),
+            ("limit".to_owned(), json!(3)),
+        ]);
+        let parsed = parse_args(RequestVerb::Search, Some(args)).expect("valid search args");
+        let RequestArgs::Search(search) = parsed else {
+            panic!("expected RequestArgs::Search");
+        };
+        assert_eq!(search.query, "hello");
+        assert_eq!(search.limit, Some(3));
+    }
+
+    #[test]
+    fn malformed_args_return_invalid_args_envelope() {
+        let response = parse_args(RequestVerb::Search, Some(serde_json::Map::new()))
+            .expect_err("missing query/mode must reject");
+        assert!(matches!(response.status, ResponseStatus::Rejected));
+        assert!(matches!(response.verb, ResponseVerb::Search));
+        let err = response.error.expect("rejected response must carry error");
+        assert_eq!(err["code"], "InvalidArgs");
+        assert_eq!(err["data"]["field"], "args");
+    }
+
+    #[test]
+    fn response_call_result_round_trips_through_generated_deserializer() {
+        let response =
+            aborted_internal(ResponseVerb::Retrieve, "not yet implemented in MCP adapter");
+        let result = call_result_from_response(response);
+        assert_eq!(result.is_error, Some(true));
+        let decoded: Response =
+            serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
+        assert!(matches!(decoded.status, ResponseStatus::Aborted));
+        assert!(matches!(decoded.verb, ResponseVerb::Retrieve));
+        assert_eq!(decoded.operation_id.0.len(), 26);
+    }
+
+    #[test]
+    fn committed_search_response_round_trips_through_generated_deserializer() {
+        let response = committed(ResponseVerb::Search, search_data(), Vec::new());
+        let result = call_result_from_response(response);
+        assert_eq!(result.is_error, Some(false));
+        let decoded: Response =
+            serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
+        assert!(matches!(decoded.status, ResponseStatus::Committed));
+        assert!(matches!(decoded.verb, ResponseVerb::Search));
+        assert!(decoded.target.is_none());
+    }
+
+    #[test]
+    fn committed_retrieve_sets_target_and_round_trips() {
+        let response = committed_retrieve(retrieve_record_data(), Vec::new());
+        let result = call_result_from_response(response);
+        assert_eq!(result.is_error, Some(false));
+        let decoded: Response =
+            serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
+        assert!(matches!(decoded.status, ResponseStatus::Committed));
+        assert!(matches!(decoded.verb, ResponseVerb::Retrieve));
+        assert!(matches!(decoded.target, Some(ResponseTarget::Record)));
+    }
+
+    #[test]
+    fn committed_retrieve_through_generic_helper_returns_valid_error_envelope() {
+        let response = committed(
+            ResponseVerb::Retrieve,
+            ResponseData::Retrieve(retrieve_record_data()),
+            Vec::new(),
+        );
+        let result = call_result_from_response(response);
+        assert_eq!(result.is_error, Some(true));
+        let decoded: Response =
+            serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
+        assert!(matches!(decoded.status, ResponseStatus::Aborted));
+        assert!(matches!(decoded.verb, ResponseVerb::Retrieve));
+        assert!(decoded.target.is_none());
+    }
+
+    #[test]
+    fn committed_verb_data_mismatch_returns_valid_error_envelope() {
+        let response = committed(
+            ResponseVerb::Search,
+            ResponseData::Retrieve(retrieve_record_data()),
+            Vec::new(),
+        );
+        let result = call_result_from_response(response);
+        assert_eq!(result.is_error, Some(true));
+        let decoded: Response =
+            serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
+        assert!(matches!(decoded.status, ResponseStatus::Aborted));
+        assert!(matches!(decoded.verb, ResponseVerb::Search));
+        let err = decoded.error.expect("mismatch must carry error");
+        assert_eq!(err["code"], "Internal");
+    }
+
+    #[test]
+    fn unknown_capability_falls_back_to_valid_internal_error() {
+        let response =
+            capability_unavailable_response(ResponseVerb::Search, "not.a.real.capability");
+        let result = call_result_from_response(response);
+        assert_eq!(result.is_error, Some(true));
+        let decoded: Response =
+            serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
+        assert!(matches!(decoded.status, ResponseStatus::Aborted));
+        assert!(matches!(decoded.verb, ResponseVerb::Search));
+        let err = decoded.error.expect("invalid capability must carry error");
+        assert_eq!(err["code"], "Internal");
+    }
+
+    #[test]
+    fn unknown_verb_response_round_trips_as_unknown_verb_rejection() {
+        let response = unknown_verb_response("graph.neighbours");
+        let result = call_result_from_response(response);
+        assert_eq!(result.is_error, Some(true));
+        let decoded: Response =
+            serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
+        assert!(matches!(decoded.status, ResponseStatus::Rejected));
+        assert!(matches!(decoded.verb, ResponseVerb::Unknown));
+        let err = decoded.error.expect("unknown verb must carry error");
+        assert_eq!(err["code"], "UnknownVerb");
+        assert_eq!(err["data"]["verb"], "graph.neighbours");
+    }
+
+    #[test]
+    fn unknown_invalid_args_and_internal_helpers_still_round_trip() {
+        for response in [
+            invalid_args_response(ResponseVerb::Unknown, "args", "bad"),
+            invalid_filter_response(ResponseVerb::Unknown, "bad"),
+            capability_unavailable_response(ResponseVerb::Unknown, "not.a.real.capability"),
+            aborted_internal(ResponseVerb::Unknown, "bad"),
+        ] {
+            let result = call_result_from_response(response);
+            assert_eq!(result.is_error, Some(true));
+            let decoded: Response = serde_json::from_str(response_text(&result))
+                .expect("content must be Response JSON");
+            assert!(matches!(decoded.status, ResponseStatus::Rejected));
+            assert!(matches!(decoded.verb, ResponseVerb::Unknown));
+            let err = decoded.error.expect("unknown verb must carry error");
+            assert_eq!(err["code"], "UnknownVerb");
+        }
+    }
+
+    #[test]
+    fn empty_public_error_helper_fields_are_sanitized() {
+        for response in [
+            invalid_args_response(ResponseVerb::Search, "", ""),
+            invalid_filter_response(ResponseVerb::Search, ""),
+            aborted_internal(ResponseVerb::Search, ""),
+        ] {
+            let result = call_result_from_response(response);
+            assert_eq!(result.is_error, Some(true));
+            let decoded: Response = serde_json::from_str(response_text(&result))
+                .expect("content must be Response JSON");
+            assert!(matches!(decoded.verb, ResponseVerb::Search));
+            assert!(decoded.error.is_some());
+        }
+    }
+}

--- a/crates/cairn-mcp/src/verb_envelope.rs
+++ b/crates/cairn-mcp/src/verb_envelope.rs
@@ -47,6 +47,10 @@ pub fn response_verb(verb: RequestVerb) -> ResponseVerb {
 /// MCP passes only an args object, not the whole signed request envelope. This
 /// adapter dispatches on the already-known tool verb and lets the generated
 /// deserializers enforce each verb's shape.
+#[allow(
+    clippy::result_large_err,
+    reason = "the MCP adapter intentionally returns generated response envelopes as typed error payloads at the transport boundary"
+)]
 pub fn parse_args(
     verb: RequestVerb,
     arguments: Option<serde_json::Map<String, serde_json::Value>>,
@@ -257,10 +261,10 @@ pub fn aborted_internal(verb: ResponseVerb, message: &str) -> Response {
 
 /// Serialize a generated response envelope into an MCP tool result.
 #[must_use]
-pub fn call_result_from_response(response: Response) -> CallToolResult {
-    let (text, is_serialization_fallback) = response_json_text(&response);
+pub fn call_result_from_response(response: &Response) -> CallToolResult {
+    let (text, is_serialization_fallback) = response_json_text(response);
     let is_committed =
-        matches!(response.status, ResponseStatus::Committed) && !is_serialization_fallback;
+        matches!(&response.status, ResponseStatus::Committed) && !is_serialization_fallback;
     let content = vec![Content::text(text)];
 
     if is_committed {
@@ -270,6 +274,10 @@ pub fn call_result_from_response(response: Response) -> CallToolResult {
     }
 }
 
+#[allow(
+    clippy::result_large_err,
+    reason = "the MCP adapter intentionally returns generated response envelopes as typed error payloads at the transport boundary"
+)]
 fn parse_arg_payload<T: DeserializeOwned>(
     verb: RequestVerb,
     args: serde_json::Value,
@@ -468,7 +476,7 @@ mod tests {
     fn response_call_result_round_trips_through_generated_deserializer() {
         let response =
             aborted_internal(ResponseVerb::Retrieve, "not yet implemented in MCP adapter");
-        let result = call_result_from_response(response);
+        let result = call_result_from_response(&response);
         assert_eq!(result.is_error, Some(true));
         let decoded: Response =
             serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
@@ -480,7 +488,7 @@ mod tests {
     #[test]
     fn committed_search_response_round_trips_through_generated_deserializer() {
         let response = committed(ResponseVerb::Search, search_data(), Vec::new());
-        let result = call_result_from_response(response);
+        let result = call_result_from_response(&response);
         assert_eq!(result.is_error, Some(false));
         let decoded: Response =
             serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
@@ -492,7 +500,7 @@ mod tests {
     #[test]
     fn committed_retrieve_sets_target_and_round_trips() {
         let response = committed_retrieve(retrieve_record_data(), Vec::new());
-        let result = call_result_from_response(response);
+        let result = call_result_from_response(&response);
         assert_eq!(result.is_error, Some(false));
         let decoded: Response =
             serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
@@ -508,7 +516,7 @@ mod tests {
             ResponseData::Retrieve(retrieve_record_data()),
             Vec::new(),
         );
-        let result = call_result_from_response(response);
+        let result = call_result_from_response(&response);
         assert_eq!(result.is_error, Some(true));
         let decoded: Response =
             serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
@@ -524,7 +532,7 @@ mod tests {
             ResponseData::Retrieve(retrieve_record_data()),
             Vec::new(),
         );
-        let result = call_result_from_response(response);
+        let result = call_result_from_response(&response);
         assert_eq!(result.is_error, Some(true));
         let decoded: Response =
             serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
@@ -538,7 +546,7 @@ mod tests {
     fn unknown_capability_falls_back_to_valid_internal_error() {
         let response =
             capability_unavailable_response(ResponseVerb::Search, "not.a.real.capability");
-        let result = call_result_from_response(response);
+        let result = call_result_from_response(&response);
         assert_eq!(result.is_error, Some(true));
         let decoded: Response =
             serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
@@ -551,7 +559,7 @@ mod tests {
     #[test]
     fn unknown_verb_response_round_trips_as_unknown_verb_rejection() {
         let response = unknown_verb_response("graph.neighbours");
-        let result = call_result_from_response(response);
+        let result = call_result_from_response(&response);
         assert_eq!(result.is_error, Some(true));
         let decoded: Response =
             serde_json::from_str(response_text(&result)).expect("content must be Response JSON");
@@ -570,7 +578,7 @@ mod tests {
             capability_unavailable_response(ResponseVerb::Unknown, "not.a.real.capability"),
             aborted_internal(ResponseVerb::Unknown, "bad"),
         ] {
-            let result = call_result_from_response(response);
+            let result = call_result_from_response(&response);
             assert_eq!(result.is_error, Some(true));
             let decoded: Response = serde_json::from_str(response_text(&result))
                 .expect("content must be Response JSON");
@@ -588,7 +596,7 @@ mod tests {
             invalid_filter_response(ResponseVerb::Search, ""),
             aborted_internal(ResponseVerb::Search, ""),
         ] {
-            let result = call_result_from_response(response);
+            let result = call_result_from_response(&response);
             assert_eq!(result.is_error, Some(true));
             let decoded: Response = serde_json::from_str(response_text(&result))
                 .expect("content must be Response JSON");

--- a/crates/cairn-mcp/tests/handler_rejection.rs
+++ b/crates/cairn-mcp/tests/handler_rejection.rs
@@ -17,6 +17,7 @@ use cairn_core::contract::memory_store::{
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::domain::record::MemoryRecord;
 use cairn_core::domain::{RecordId, TargetId};
+use cairn_core::generated::envelope::{Response, ResponseStatus, ResponseVerb};
 use cairn_mcp::CairnMcpHandler;
 use rmcp::ServiceExt as _;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -200,12 +201,24 @@ async fn mcp_search_semantic_rejection_carries_remediation() {
         .and_then(serde_json::Value::as_str)
         .expect("first content item must have a text field");
 
-    assert!(
-        text.contains("cairn.mcp.v1.search.semantic"),
-        "rejection text must include the capability id; got: {text:?}"
+    let envelope: Response = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("semantic rejection must be a Response: {e}; text={text}"));
+    assert!(matches!(envelope.status, ResponseStatus::Rejected));
+    assert!(matches!(envelope.verb, ResponseVerb::Search));
+    assert_eq!(envelope.operation_id.0.len(), 26);
+    assert!(envelope.data.is_none());
+
+    let err = envelope.error.expect("rejected envelope must carry error");
+    assert_eq!(err["code"], "CapabilityUnavailable");
+    assert_eq!(
+        err["data"]["capability"], "cairn.mcp.v1.search.semantic",
+        "rejection must preserve capability id"
     );
     assert!(
-        text.contains("local_embeddings"),
-        "rejection text must include the remediation hint 'local_embeddings'; got: {text:?}"
+        err["data"]["remediation"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("local_embeddings"),
+        "rejection must preserve remediation hint: {err}"
     );
 }

--- a/crates/cairn-mcp/tests/search_tool.rs
+++ b/crates/cairn-mcp/tests/search_tool.rs
@@ -19,7 +19,7 @@ use cairn_core::contract::memory_store::{
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::domain::record::MemoryRecord;
 use cairn_core::domain::{RecordId, TargetId};
-use cairn_core::generated::verbs::search::SearchData;
+use cairn_core::generated::envelope::{Response, ResponseData, ResponseStatus, ResponseVerb};
 use cairn_mcp::handler::CairnMcpHandler;
 use rmcp::ServiceExt as _;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -140,6 +140,18 @@ async fn recv_frame(
     serde_json::from_str(line.trim()).expect("parse frame as JSON")
 }
 
+fn first_text_content(call_resp: &serde_json::Value) -> &str {
+    let content = call_resp
+        .pointer("/result/content")
+        .and_then(serde_json::Value::as_array)
+        .expect("result.content must be an array");
+    assert!(!content.is_empty(), "content must not be empty");
+    content[0]
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .expect("first content item must have text field")
+}
+
 async fn do_initialize(
     writer: &mut (impl AsyncWriteExt + Unpin),
     reader: &mut BufReader<impl tokio::io::AsyncRead + Unpin>,
@@ -204,24 +216,46 @@ async fn search_tool_with_store_returns_success_envelope() {
         "search with wired store must not be an error; got: {call_resp}"
     );
 
-    // Extract the text content and parse as SearchData.
-    let content = call_resp
-        .pointer("/result/content")
-        .and_then(|v| v.as_array())
-        .expect("result.content must be an array");
-    assert!(!content.is_empty(), "content must not be empty");
+    let text = first_text_content(&call_resp);
+    let envelope: Response = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("text must be valid Response JSON: {e}; text={text}"));
 
-    let text = content[0]
-        .get("text")
-        .and_then(serde_json::Value::as_str)
-        .expect("first content item must have text field");
+    assert_eq!(envelope.contract, "cairn.mcp.v1");
+    assert!(matches!(envelope.status, ResponseStatus::Committed));
+    assert!(matches!(envelope.verb, ResponseVerb::Search));
+    assert_eq!(
+        envelope.operation_id.0.len(),
+        26,
+        "operation_id must be a ULID"
+    );
+    assert!(
+        envelope.policy_trace.is_empty(),
+        "empty fixture store should not add policy trace entries"
+    );
+    assert!(envelope.error.is_none());
+    assert!(envelope.target.is_none());
 
-    let data: SearchData = serde_json::from_str(text).expect("text must be valid SearchData JSON");
-
+    let Some(ResponseData::Search(data)) = envelope.data else {
+        panic!("committed search envelope must carry SearchData: {envelope:?}");
+    };
     assert!(
         data.hits.is_empty(),
         "empty store: no hits expected, got {:?}",
         data.hits
+    );
+    assert!(
+        data.excluded
+            .as_ref()
+            .map_or(true, |excluded| excluded.is_empty()),
+        "empty store: no exclusions expected, got {:?}",
+        data.excluded
+    );
+    assert!(
+        data.degraded_legs
+            .as_ref()
+            .map_or(true, |degraded_legs| degraded_legs.is_empty()),
+        "empty store: no degraded legs expected, got {:?}",
+        data.degraded_legs
     );
     assert!(data.next_cursor.is_none());
     assert!(data.score_explain.is_none());
@@ -272,7 +306,7 @@ async fn search_tool_without_store_returns_stub_error() {
     );
 }
 
-/// Calling `search` with an invalid mode returns `isError = true`.
+/// Calling `search` with malformed/missing required args returns `isError = true`.
 #[tokio::test]
 async fn search_tool_invalid_args_returns_error() {
     let (server_half, client_half) = tokio::io::duplex(65_536);
@@ -314,6 +348,82 @@ async fn search_tool_invalid_args_returns_error() {
     assert!(
         is_error,
         "search with invalid args must return isError=true; got: {call_resp}"
+    );
+
+    let text = first_text_content(&call_resp);
+    let envelope: Response = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("invalid-args response must be a Response: {e}; text={text}"));
+
+    assert!(matches!(envelope.status, ResponseStatus::Rejected));
+    assert!(matches!(envelope.verb, ResponseVerb::Search));
+    assert!(envelope.data.is_none());
+    let err = envelope.error.expect("rejected envelope must carry error");
+    assert_eq!(err["code"], "InvalidArgs");
+    assert_eq!(err["data"]["field"], "args");
+    assert!(
+        err["data"]["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("missing field"),
+        "reason should include serde's missing-field detail: {err}"
+    );
+    assert_eq!(envelope.operation_id.0.len(), 26);
+}
+
+#[tokio::test]
+async fn known_unwired_core_verb_returns_typed_aborted_envelope() {
+    let (server_half, client_half) = tokio::io::duplex(65_536);
+    let _server_task = tokio::spawn(async move {
+        CairnMcpHandler::with_store(Arc::new(EmptyStore), CairnConfig::default())
+            .serve(server_half)
+            .await
+            .expect("server init")
+            .waiting()
+            .await
+            .ok();
+    });
+
+    let (client_read, mut client_write) = tokio::io::split(client_half);
+    let mut client_reader = BufReader::new(client_read);
+
+    do_initialize(&mut client_write, &mut client_reader).await;
+
+    send_frame(
+        &mut client_write,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"retrieve","arguments":{"target":"record","id":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}}}"#,
+    )
+    .await;
+
+    let call_resp = recv_frame(&mut client_reader).await;
+    assert!(
+        call_resp.get("result").is_some(),
+        "known unwired verb must yield result frame; got: {call_resp}"
+    );
+    let is_error = call_resp
+        .pointer("/result/isError")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    assert!(
+        is_error,
+        "known unwired verb must return isError=true; got: {call_resp}"
+    );
+
+    let text = first_text_content(&call_resp);
+    let envelope: Response = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("unwired verb response must be a Response: {e}; text={text}"));
+
+    assert!(matches!(envelope.status, ResponseStatus::Aborted));
+    assert!(matches!(envelope.verb, ResponseVerb::Retrieve));
+    assert_eq!(envelope.operation_id.0.len(), 26);
+    assert!(envelope.data.is_none());
+    let err = envelope.error.expect("aborted envelope must carry error");
+    assert_eq!(err["code"], "Internal");
+    assert!(
+        err["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("not yet implemented"),
+        "message should explain the MCP verb is not wired: {err}"
     );
 }
 

--- a/crates/cairn-mcp/tests/search_tool.rs
+++ b/crates/cairn-mcp/tests/search_tool.rs
@@ -262,16 +262,12 @@ async fn search_tool_with_store_returns_success_envelope() {
         data.hits
     );
     assert!(
-        data.excluded
-            .as_ref()
-            .map_or(true, |excluded| excluded.is_empty()),
+        data.excluded.as_ref().is_none_or(Vec::is_empty),
         "empty store: no exclusions expected, got {:?}",
         data.excluded
     );
     assert!(
-        data.degraded_legs
-            .as_ref()
-            .map_or(true, |degraded_legs| degraded_legs.is_empty()),
+        data.degraded_legs.as_ref().is_none_or(Vec::is_empty),
         "empty store: no degraded legs expected, got {:?}",
         data.degraded_legs
     );

--- a/crates/cairn-mcp/tests/search_tool.rs
+++ b/crates/cairn-mcp/tests/search_tool.rs
@@ -320,6 +320,63 @@ async fn search_tool_without_store_returns_stub_error() {
     );
 }
 
+#[tokio::test]
+async fn search_tool_without_store_invalid_args_returns_invalid_args_envelope() {
+    let (server_half, client_half) = tokio::io::duplex(65_536);
+    let _server_task = tokio::spawn(async move {
+        CairnMcpHandler::new()
+            .serve(server_half)
+            .await
+            .expect("server init")
+            .waiting()
+            .await
+            .ok();
+    });
+
+    let (client_read, mut client_write) = tokio::io::split(client_half);
+    let mut client_reader = BufReader::new(client_read);
+
+    do_initialize(&mut client_write, &mut client_reader).await;
+
+    send_frame(
+        &mut client_write,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search","arguments":{"query":"hello"}}}"#,
+    )
+    .await;
+
+    let call_resp = recv_frame(&mut client_reader).await;
+    assert!(
+        call_resp.get("result").is_some(),
+        "bad-args no-store search call must yield a result frame; got: {call_resp}"
+    );
+    let is_error = call_resp
+        .pointer("/result/isError")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    assert!(
+        is_error,
+        "search without store and invalid args must return isError=true; got: {call_resp}"
+    );
+
+    let text = first_text_content(&call_resp);
+    let envelope: Response = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("invalid-args response must be a Response: {e}; text={text}"));
+
+    assert!(matches!(envelope.status, ResponseStatus::Rejected));
+    assert!(matches!(envelope.verb, ResponseVerb::Search));
+    assert!(envelope.data.is_none());
+    let err = envelope.error.expect("rejected envelope must carry error");
+    assert_eq!(err["code"], "InvalidArgs");
+    assert_eq!(err["data"]["field"], "args");
+    assert!(
+        err["data"]["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("missing field"),
+        "reason should include serde's missing-field detail: {err}"
+    );
+}
+
 /// Calling `search` with malformed/missing required args returns `isError = true`.
 #[tokio::test]
 async fn search_tool_invalid_args_returns_error() {
@@ -382,6 +439,64 @@ async fn search_tool_invalid_args_returns_error() {
         "reason should include serde's missing-field detail: {err}"
     );
     assert_eq!(envelope.operation_id.0.len(), 26);
+}
+
+#[tokio::test]
+async fn known_unwired_core_verb_invalid_args_returns_invalid_args_envelope() {
+    let (server_half, client_half) = tokio::io::duplex(65_536);
+    let _server_task = tokio::spawn(async move {
+        CairnMcpHandler::with_store(Arc::new(EmptyStore), CairnConfig::default())
+            .serve(server_half)
+            .await
+            .expect("server init")
+            .waiting()
+            .await
+            .ok();
+    });
+
+    let (client_read, mut client_write) = tokio::io::split(client_half);
+    let mut client_reader = BufReader::new(client_read);
+
+    do_initialize(&mut client_write, &mut client_reader).await;
+
+    send_frame(
+        &mut client_write,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"retrieve","arguments":{"target":"record"}}}"#,
+    )
+    .await;
+
+    let call_resp = recv_frame(&mut client_reader).await;
+    assert!(
+        call_resp.get("result").is_some(),
+        "bad-args known unwired verb must yield result frame; got: {call_resp}"
+    );
+    let is_error = call_resp
+        .pointer("/result/isError")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    assert!(
+        is_error,
+        "bad-args known unwired verb must return isError=true; got: {call_resp}"
+    );
+
+    let text = first_text_content(&call_resp);
+    let envelope: Response = serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("invalid-args response must be a Response: {e}; text={text}"));
+
+    assert!(matches!(envelope.status, ResponseStatus::Rejected));
+    assert!(matches!(envelope.verb, ResponseVerb::Retrieve));
+    assert_eq!(envelope.operation_id.0.len(), 26);
+    assert!(envelope.data.is_none());
+    let err = envelope.error.expect("rejected envelope must carry error");
+    assert_eq!(err["code"], "InvalidArgs");
+    assert_eq!(err["data"]["field"], "args");
+    assert!(
+        err["data"]["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("missing field"),
+        "reason should include serde's missing-field detail: {err}"
+    );
 }
 
 #[tokio::test]

--- a/crates/cairn-mcp/tests/search_tool.rs
+++ b/crates/cairn-mcp/tests/search_tool.rs
@@ -19,7 +19,9 @@ use cairn_core::contract::memory_store::{
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::domain::record::MemoryRecord;
 use cairn_core::domain::{RecordId, TargetId};
-use cairn_core::generated::envelope::{Response, ResponseData, ResponseStatus, ResponseVerb};
+use cairn_core::generated::envelope::{
+    Response, ResponseData, ResponsePolicyTraceResult, ResponseStatus, ResponseVerb,
+};
 use cairn_mcp::handler::CairnMcpHandler;
 use rmcp::ServiceExt as _;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -228,10 +230,26 @@ async fn search_tool_with_store_returns_success_envelope() {
         26,
         "operation_id must be a ULID"
     );
-    assert!(
-        envelope.policy_trace.is_empty(),
-        "empty fixture store should not add policy trace entries"
+    assert_eq!(
+        envelope.policy_trace.len(),
+        3,
+        "successful search should forward core policy trace entries"
     );
+    assert_eq!(envelope.policy_trace[0].gate, "search.scope");
+    assert!(matches!(
+        envelope.policy_trace[0].result,
+        ResponsePolicyTraceResult::Pass
+    ));
+    assert_eq!(envelope.policy_trace[1].gate, "search.capability");
+    assert!(matches!(
+        envelope.policy_trace[1].result,
+        ResponsePolicyTraceResult::Pass
+    ));
+    assert_eq!(envelope.policy_trace[2].gate, "search.read_filter");
+    assert!(matches!(
+        envelope.policy_trace[2].result,
+        ResponsePolicyTraceResult::Pass
+    ));
     assert!(envelope.error.is_none());
     assert!(envelope.target.is_none());
 

--- a/crates/cairn-mcp/tests/verb_parity.rs
+++ b/crates/cairn-mcp/tests/verb_parity.rs
@@ -2,6 +2,7 @@
 //! embed the verb name in content text — matching the CLI exit-2 branch.
 #![allow(missing_docs)]
 
+use cairn_core::generated::envelope::{Response, ResponseStatus};
 use cairn_mcp::generated::TOOLS;
 use cairn_mcp::handler::dispatch_stub;
 use rmcp::model::{Content, RawContent};
@@ -18,6 +19,19 @@ fn content_to_text(content: &[Content]) -> String {
         })
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn first_text_content(content: &[Content]) -> &str {
+    content
+        .iter()
+        .find_map(|c| {
+            if let RawContent::Text(t) = &**c {
+                Some(t.text.as_str())
+            } else {
+                None
+            }
+        })
+        .expect("expected text content")
 }
 
 #[test]
@@ -75,4 +89,19 @@ fn unknown_verb_triggers_handler_error_branch() {
         content_text.contains("not yet implemented"),
         "dispatch_stub content must mention placeholder message; got: {content_text}"
     );
+}
+
+#[test]
+fn known_stub_content_is_parseable_response_envelope() {
+    for tool in TOOLS {
+        let result = dispatch_stub(tool.name);
+        let text = first_text_content(&result.content);
+        let envelope: Response = serde_json::from_str(text).unwrap_or_else(|e| {
+            panic!("{} stub must be Response JSON: {e}; text={text}", tool.name)
+        });
+        assert!(matches!(envelope.status, ResponseStatus::Aborted));
+        assert_eq!(envelope.operation_id.0.len(), 26);
+        let err = envelope.error.expect("aborted envelope must carry error");
+        assert_eq!(err["code"], "Internal");
+    }
 }

--- a/docs/superpowers/specs/2026-05-11-issue-66-mcp-typed-envelopes-design.md
+++ b/docs/superpowers/specs/2026-05-11-issue-66-mcp-typed-envelopes-design.md
@@ -1,0 +1,243 @@
+# Issue #66 — MCP typed verb envelopes and responses
+
+- **Issue:** [#66](https://github.com/windoliver/cairn/issues/66)
+- **Parent epic:** [#10](https://github.com/windoliver/cairn/issues/10)
+- **Phase / priority:** v0.1 minimum substrate · P0
+- **Brief sections:** §8.0 Core verbs, §8.0.a status and handshake, §8.0.b shared envelope, §15 wire compatibility
+- **Date:** 2026-05-11
+
+## 1. Goal
+
+Map MCP `tools/call` requests for the eight core `cairn.mcp.v1` verbs into
+generated typed verb arguments and canonical response envelopes.
+
+The current MCP adapter already handles stdio lifecycle, `tools/list`,
+capability-aware status, prelude `handshake`, graph extension tools, and a
+wired `search` path. The remaining issue #66 gap is that core verb calls still
+return either bare `SearchData` or ad hoc text errors instead of the shared
+§8.0.b response envelope with `verb`, `status`, `operation_id`, typed `data`
+or typed `error`, and `policy_trace`.
+
+After this work, MCP callers should be able to parse the first text content
+item of any known core verb result as `cairn_core::generated::envelope::Response`.
+That gives the MCP surface the same machine-readable operation ID and error
+shape as CLI and SDK.
+
+## 2. Decision
+
+MCP tool inputs stay as per-verb `Args` schemas. The MCP adapter maps every
+known core tool call into generated `RequestVerb` and `RequestArgs` values,
+then hands those typed values to the runtime path that owns any required
+`SignedIntent` construction or verification.
+
+This preserves the existing MCP UX: model clients call a tool named `search`
+with `{query, mode, ...}`, not a redundant envelope containing `verb:
+"search"`. The canonical response envelope remains the machine-readable output
+contract. The adapter must not invent fake signatures to satisfy the request
+schema; if a signed runtime path is unavailable, the known verb returns a typed
+aborted response instead of bypassing identity checks.
+
+## 3. Current base
+
+`origin/main` already includes:
+
+- `crates/cairn-mcp/src/handler.rs` with `CairnMcpHandler`, stdio `rmcp`
+  integration, status advertisement, prelude `handshake`, graph tools, and a
+  store-wired `search` dispatcher.
+- `crates/cairn-mcp/src/generated/mod.rs` with one `ToolDecl` per core verb,
+  per-verb input schemas, and auth/capability override metadata.
+- `cairn_core::generated::envelope::{Request, RequestArgs, RequestVerb,
+  Response, ResponseData, ResponseStatus, ResponseVerb}` generated from the
+  IDL.
+- `crates/cairn-sdk/src/transport.rs` with SDK-side validators and response
+  projection helpers that can serve as parity references.
+- `crates/cairn-cli/src/verbs/envelope.rs` and `crates/cairn-cli/src/verbs/signed.rs`
+  with canonical CLI response construction helpers.
+
+Baseline verification on `codex/issue-66`:
+
+- `cargo check -p cairn-mcp` passes.
+
+## 4. Scope
+
+### In scope
+
+- Add adapter-owned helpers that map known core MCP tool names to typed
+  request/response verb enums.
+- Deserialize `CallToolRequestParams.arguments` into generated per-verb args
+  with schema-equivalent validation where direct Rust construction bypasses
+  generated checks.
+- Convert successful `search` dispatch into a full `Response` envelope rather
+  than bare `SearchData`.
+- Convert malformed core-verb payloads into typed `InvalidArgs` rejected
+  response envelopes.
+- Convert unsupported but known core verbs into typed `Internal` aborted
+  response envelopes that preserve the requested `verb` and a fresh
+  `operation_id`.
+- Preserve `operation_id` on every committed, rejected, or aborted core-verb
+  response emitted through MCP.
+- Keep existing capability rejection behavior, but return the typed
+  `CapabilityUnavailable` envelope shape instead of plain text.
+
+### Out of scope
+
+- Replacing MCP tool input schemas with the full request envelope.
+- Implementing the remaining unwired verb runtimes.
+- Changing graph extension tools or prelude `handshake` behavior.
+- Adding new IDL fields for MCP request IDs.
+- Changing capability advertisement rules from issue #53.
+- Reworking `rmcp` transport lifecycle from issue #64.
+
+## 5. Architecture
+
+Add a focused MCP envelope adapter module:
+
+```text
+crates/cairn-mcp/src/verb_envelope.rs
+  -> core_verb_for_tool(name) -> Option<RequestVerb>
+  -> response_verb(RequestVerb) -> ResponseVerb
+  -> parse_args(RequestVerb, arguments) -> Result<RequestArgs, Response>
+  -> committed(ResponseVerb, ResponseData, policy_trace) -> Response
+  -> rejected_invalid_args(ResponseVerb, field, reason) -> Response
+  -> rejected_capability_unavailable(ResponseVerb, capability) -> Response
+  -> aborted_internal(ResponseVerb, message) -> Response
+  -> call_result_from_response(Response) -> CallToolResult
+```
+
+`handler.rs` keeps transport routing. It should only decide whether a call is
+a prelude tool, graph extension tool, unknown tool, wired `search`, or a known
+core verb that is not wired yet. Envelope construction and serialization move
+out of the transport method so tests can exercise them directly.
+
+The helper should serialize canonical `Response` JSON as the first
+`Content::text` item. For committed envelopes use `CallToolResult::success`;
+for rejected or aborted envelopes use `CallToolResult::error`. This keeps MCP
+`isError` meaningful while preserving the typed Cairn payload inside content.
+
+## 6. Request Mapping
+
+Known core tools are exactly the `TOOLS` entries generated from the IDL:
+
+- `ingest` -> `RequestVerb::Ingest`
+- `search` -> `RequestVerb::Search`
+- `retrieve` -> `RequestVerb::Retrieve`
+- `summarize` -> `RequestVerb::Summarize`
+- `assemble_hot` -> `RequestVerb::AssembleHot`
+- `capture_trace` -> `RequestVerb::CaptureTrace`
+- `lint` -> `RequestVerb::Lint`
+- `forget` -> `RequestVerb::Forget`
+
+For issue #66, MCP calls continue to provide the `args` object only. The
+adapter deserializes that object to the generated args type for the selected
+verb and wraps it in `RequestArgs`. Full signed-intent construction and
+verification remain owned by the verb execution path. Where a runtime is still
+stubbed or cannot safely construct a signed envelope from configured MCP
+identity context, the adapter returns an aborted typed envelope.
+
+Malformed args reject before dispatch. The error body must be:
+
+```json
+{
+  "code": "InvalidArgs",
+  "message": "invalid args: <field>: <reason>",
+  "data": { "field": "<field>", "reason": "<reason>" }
+}
+```
+
+Unknown tool names stay outside the typed core verb path and may remain MCP
+plain `isError` responses listing available tools.
+
+## 7. Response Mapping
+
+Every known core verb call returns a JSON object matching
+`cairn_core::generated::envelope::Response`.
+
+Committed `search` response:
+
+- `contract = "cairn.mcp.v1"`
+- `verb = "search"`
+- `status = "committed"`
+- `operation_id` is a fresh ULID until the lower store/WAL path supplies one.
+- `policy_trace` comes from `SearchOutcome.policy_trace`.
+- `data` is `ResponseData::Search(SearchData)`.
+- `target = null` / omitted.
+
+Rejected errors:
+
+- `InvalidArgs`, `InvalidFilter`, and `CapabilityUnavailable` use
+  `status = "rejected"` and the IDL-defined `error.data` shape.
+- `policy_trace` is present, even if empty.
+- `operation_id` is present.
+
+Aborted errors:
+
+- Store or transport-adjacent execution failures use `status = "aborted"` and
+  `error.code = "Internal"` unless a more specific existing IDL error applies.
+- Known but unwired verbs use this path instead of `dispatch_stub` text.
+
+All response serialization must avoid non-finite floats in search hits or score
+explain fields, matching the CLI and SDK envelope sanitization precedent.
+
+## 8. Capability And Auth Semantics
+
+This issue does not create new policy decisions. It preserves existing
+capability gates:
+
+- `search.mode` is checked against the same store/config capabilities used by
+  `status_response`.
+- `search.explain = true` must continue to fail closed if
+  `cairn.mcp.v1.policy_trace` is not advertised.
+- `retrieve`, `forget`, and other per-mode capability checks remain tied to
+  the runtime that implements them. Until their MCP dispatch is wired, they
+  return typed `Internal` aborted envelopes rather than advertising success.
+
+Auth override metadata in `ToolDecl` remains a declaration surface. Issue #66
+does not add a new authorization engine inside the adapter.
+
+## 9. Testing Strategy
+
+Use TDD. Add failing tests before implementation:
+
+1. `search` success over the full MCP wire protocol returns `isError` absent
+   or false and the first text content parses as `Response` with
+   `verb=search`, `status=committed`, `operation_id`, `policy_trace`, and
+   typed `SearchData`.
+2. Malformed `search` arguments over MCP return `isError=true` and the first
+   text content parses as `Response` with `status=rejected`,
+   `verb=search`, and `error.code=InvalidArgs`.
+3. Store-vector capability rejection for semantic search returns
+   `isError=true` and a parseable `CapabilityUnavailable` response envelope
+   preserving `error.data.capability`.
+4. A known unwired core verb such as `retrieve` returns `isError=true` and a
+   parseable `Internal` aborted response envelope with `verb=retrieve` and a
+   valid `operation_id`.
+5. Direct unit tests for name-to-verb mapping cover all eight core verbs and
+   reject non-core tools like `handshake` and `graph.neighbours`.
+
+Focused verification:
+
+- `cargo test -p cairn-mcp search_tool handler_rejection smoke`
+- `cargo test -p cairn-mcp verb_envelope`
+- `cargo check -p cairn-mcp`
+
+Final verification should scale to touched crates:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy -p cairn-mcp --all-targets -- -D warnings`
+- `cargo test -p cairn-mcp`
+- `cargo run -p cairn-idl --bin cairn-codegen -- --check` if generated code or
+  schema references change
+
+## 10. Completion Criteria
+
+Issue #66 is complete when:
+
+- Every known core MCP verb result is represented as a typed Cairn response
+  envelope, including unwired verbs.
+- MCP `search` success, malformed payloads, and capability rejections are
+  parseable as generated `Response` values.
+- `operation_id` is present on all MCP core verb committed/rejected/aborted
+  envelopes.
+- Existing prelude and graph tool behavior is unchanged.
+- Tests prove MCP response envelopes preserve Cairn error codes, capability
+  hints, and correlation IDs.


### PR DESCRIPTION
## Summary
- Map MCP core tool calls through generated request argument types before dispatch.
- Return generated `Response` envelopes for search success/errors and known-but-unwired core verbs.
- Add real `cairn mcp` subprocess e2e coverage for typed error envelopes over JSON-RPC stdin/stdout.

Closes #66.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy -p cairn-cli -p cairn-mcp --all-targets -- -D warnings`
- `cargo test -p cairn-cli --test mcp_handshake_e2e`
- `cargo test -p cairn-cli`
- `cargo test -p cairn-mcp`
- `git diff --check origin/main...HEAD`
