### PR TITLE
feat(flush): add Patch and Rename mutation variants (#289)

### DIFF
--- a/crates/cairn-cli/src/command.rs
+++ b/crates/cairn-cli/src/command.rs
@@ -35,7 +35,7 @@ pub fn build_command() -> clap::Command {
             generated::verbs::capture_trace_subcommand(),
         ))
         .subcommand(verbs::with_json(verbs::with_fix_markdown(
-            verbs::with_fix_folders(generated::verbs::lint_subcommand()),
+            verbs::with_fix_folders(verbs::with_lint_plan(generated::verbs::lint_subcommand())),
         )))
         .subcommand(verbs::with_json(verbs::with_flush_modes(
             generated::verbs::forget_subcommand(),

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -444,10 +444,7 @@ fn orphan_is_dead(orphan: &Path) -> bool {
 /// the same id detects the marker and resumes straight to publish
 /// instead of replaying mutations. Removed by `publish_terminal` once
 /// the terminal hard-link is durable.
-fn stranded_marker_path(
-    vault: &Path,
-    ulid: &cairn_core::generated::common::Ulid,
-) -> PathBuf {
+fn stranded_marker_path(vault: &Path, ulid: &cairn_core::generated::common::Ulid) -> PathBuf {
     use cairn_core::domain::flush_plan::store::{Bucket, plan_path};
     plan_path(vault, Bucket::Applied, ulid).with_extension("json.stranded")
 }
@@ -480,10 +477,7 @@ fn write_stranded_marker(path: &Path) -> std::io::Result<()> {
 /// per-plan in-flight path (NOT the pid-suffixed owned-claim path) so
 /// resume after `process_owned_claim` still finds it. Removed by
 /// `publish_terminal`.
-fn committed_sidecar_path_for(
-    vault: &Path,
-    ulid: &cairn_core::generated::common::Ulid,
-) -> PathBuf {
+fn committed_sidecar_path_for(vault: &Path, ulid: &cairn_core::generated::common::Ulid) -> PathBuf {
     use cairn_core::domain::flush_plan::store::{Bucket, plan_path};
     let canonical = plan_path(vault, Bucket::Applied, ulid).with_extension("json.in-flight");
     let mut p = canonical.as_os_str().to_owned();
@@ -786,9 +780,7 @@ fn claim_pending(
         // signal is already on disk.
         let committed_sidecar = committed_sidecar_path_for(vault, ulid);
         let stranded = stranded_marker_path(vault, ulid);
-        if (committed_sidecar.exists() || stranded.exists())
-            && orphan_is_dead(&orphan)
-        {
+        if (committed_sidecar.exists() || stranded.exists()) && orphan_is_dead(&orphan) {
             match std::fs::rename(&orphan, &claim) {
                 Ok(()) => {
                     // Fall through to the canonical `claim.exists()`

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -150,22 +150,6 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
     // the source vanished — that's how concurrent apply/reject callers
     // race-free settle to a single winner. The loser sees ENOENT and
     // returns NotFound (or AlreadyTerminal if the winner committed).
-    // Stranded marker (issue #289 review round 2): a prior attempt
-    // committed SQLite mutations but failed to write the committed
-    // sidecar, leaving an unrecoverable state. Refuse to apply this id
-    // again until an operator inspects and removes the marker — replaying
-    // would double-mutate.
-    let stranded = stranded_marker_path(vault, &ulid);
-    if stranded.exists() {
-        eprintln!(
-            "cairn flush apply: plan {id} is stranded ({}). A prior attempt committed \
-             SQLite mutations but could not persist its recovery sidecar; replaying would \
-             double-mutate. Manually verify the database state, then remove the stranded \
-             marker to proceed.",
-            stranded.display(),
-        );
-        return ExitCode::from(70);
-    }
     let claim = match claim_pending(vault, &ulid, "applied") {
         ClaimOutcome::Claimed(p) => p,
         ClaimOutcome::NotFound => {
@@ -280,10 +264,24 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
         // etc). When the sidecar is present we skip apply and proceed
         // straight to publish — the DB side is durable.
         let committed_sidecar = committed_sidecar_path(&claim);
+        let stranded = stranded_marker_path(vault, &ulid);
         if committed_sidecar.exists() {
             eprintln!(
                 "cairn flush apply: detected committed-sidecar for {id}; \
                  DB mutations from a prior attempt are durable, resuming publish only."
+            );
+        } else if stranded.exists() {
+            // Round 3 review fix: the stranded marker is the durable
+            // signal "SQLite mutations committed but sidecar write
+            // failed". A simple refusal would dead-end the plan (the
+            // pending file is already inside the claim path), so treat
+            // the marker as equivalent to the committed sidecar:
+            // skip apply, proceed to publish, and remove the marker
+            // after `publish_terminal` succeeds.
+            eprintln!(
+                "cairn flush apply: detected stranded marker for {id} ({}); \
+                 DB mutations from a prior attempt are durable, resuming publish only.",
+                stranded.display(),
             );
         } else if let Err(e) = apply_real_plan(vault, &persisted.plan) {
             eprintln!("cairn flush apply: apply failed: {e:#}");
@@ -306,9 +304,9 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
             } else {
                 eprintln!(
                     "cairn flush apply: SQLite mutations committed but committed-sidecar \
-                     write failed: {e}. Planted stranded marker at {}; future apply \
-                     attempts will refuse this id until an operator inspects and removes \
-                     the marker.",
+                     write failed: {e}. Planted stranded marker at {}; a subsequent \
+                     `flush apply {id}` will detect the marker and resume to publish \
+                     without replaying mutations.",
                     stranded.display(),
                 );
             }
@@ -327,10 +325,13 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-/// Stranded marker path (issue #289 review round 2). Planted in the
+/// Stranded marker path (issue #289 review round 2/3). Planted in the
 /// `applied/` directory when `SQLite` mutations have committed but the
-/// committed-sidecar could not be written; blocks future apply attempts
-/// for the same id until an operator removes the marker.
+/// committed-sidecar could not be written. Functions as an alternate
+/// "DB durable, publish pending" signal: a subsequent `flush apply` for
+/// the same id detects the marker and resumes straight to publish
+/// instead of replaying mutations. Removed by `publish_terminal` once
+/// the terminal hard-link is durable.
 fn stranded_marker_path(
     vault: &Path,
     ulid: &cairn_core::generated::common::Ulid,
@@ -785,6 +786,11 @@ fn publish_terminal(
     // sidecar must go so a future, separate apply on a fresh claim does
     // not mistake it for an already-applied operation.
     let _ = std::fs::remove_file(committed_sidecar_path(claim));
+    // Round 3 review fix: the stranded marker (planted when a prior
+    // sidecar write failed) is also a "publish pending" artifact —
+    // remove it once the terminal hard-link is durable so a future
+    // unrelated apply does not auto-resume off a stale marker.
+    let _ = std::fs::remove_file(stranded_marker_path(vault, ulid));
     let _ = std::fs::remove_file(cairn_core::domain::flush_plan::store::diff_path(
         vault, ulid,
     ));

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -241,36 +241,43 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
         return ExitCode::from(65);
     }
 
-    // Issue #289 review (re-loop r1) finding 1: this branch only wires
-    // `Patch` and `Rename` through the real executor. Plans that contain
-    // any other `PlannedMutation` variant (`Upsert` / `Delete` /
-    // `Promote` / `Expire` / `ForgetSession` / `ForgetRecord` / `Evolve`)
-    // are not yet supported by `apply_real_plan` and must preserve the
-    // pre-branch metadata-only path so existing plans still advance
-    // through the lifecycle without a hard apply failure.
-    let unsupported_in_plan = persisted
-        .plan
-        .mutations
-        .iter()
-        .any(|m| !is_real_apply_supported(m));
-    if persisted.plan.placeholder || unsupported_in_plan {
-        if persisted.plan.placeholder {
-            eprintln!(
-                "cairn flush apply: WARNING — MemoryStore mutations are not yet wired (#9). \
-                 Plan {id} will be marked applied for audit only; no records were written."
-            );
-            eprintln!(
-                "cairn flush apply: NOTE — plan {id} was produced by the CLI stub planner \
-                 (`cairn-cli::ingest_plan_stub`) and does NOT reflect a real ingest/forget \
-                 pipeline run. Treat as a placeholder for testing the lifecycle only."
-            );
-        } else {
-            eprintln!(
-                "cairn flush apply: NOTE — plan {id} contains mutation kinds outside \
-                 issue #289's scope (Patch/Rename); falling back to metadata-only apply. \
-                 No records were written. Wire the remaining variants in a follow-up."
-            );
-        }
+    // Issue #289 review (re-loop r2) finding 1: fail closed on
+    // unsupported mutation kinds. Previously a mixed plan (Patch +
+    // Upsert, say) would silently take the metadata-only path and
+    // publish Applied without executing the reviewed Patch — that is
+    // data loss, not reduced coverage. Non-placeholder plans must
+    // contain only `Patch`/`Rename` to advance through the real
+    // executor; anything else stays pending until a follow-up wires
+    // the remaining variants.
+    if !persisted.plan.placeholder
+        && let Some(unsupported) = persisted
+            .plan
+            .mutations
+            .iter()
+            .find(|m| !is_real_apply_supported(m))
+    {
+        eprintln!(
+            "cairn flush apply: plan {id} contains mutation kind \
+             `{}` which is not yet wired by issue #289's real executor. \
+             Refusing to apply — the plan stays pending until a follow-up \
+             implements the remaining `PlannedMutation` variants. (Auto- \
+             publishing as metadata-only would drop the reviewed Patch/Rename \
+             mutations.)",
+            unsupported_kind_name(unsupported),
+        );
+        rollback_claim(vault, &claim, &ulid);
+        return ExitCode::from(65);
+    }
+    if persisted.plan.placeholder {
+        eprintln!(
+            "cairn flush apply: WARNING — MemoryStore mutations are not yet wired (#9). \
+             Plan {id} will be marked applied for audit only; no records were written."
+        );
+        eprintln!(
+            "cairn flush apply: NOTE — plan {id} was produced by the CLI stub planner \
+             (`cairn-cli::ingest_plan_stub`) and does NOT reflect a real ingest/forget \
+             pipeline run. Treat as a placeholder for testing the lifecycle only."
+        );
         persisted.status = PlanStatus::Applied {
             at: now_rfc3339(),
             apply_kind: ApplyKind::MetadataOnly,
@@ -350,15 +357,30 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-/// Issue #289 only wires `Patch` and `Rename` through the real executor;
-/// every other `PlannedMutation` variant falls back to the metadata-only
-/// path so legacy plans still advance.
+/// Issue #289 only wires `Patch` and `Rename` through the real executor.
+/// Plans containing any other variant are refused so mixed plans do not
+/// silently drop reviewed mutations on the floor.
 fn is_real_apply_supported(m: &cairn_core::domain::flush_plan::PlannedMutation) -> bool {
     use cairn_core::domain::flush_plan::PlannedMutation;
     matches!(
         m,
         PlannedMutation::Patch { .. } | PlannedMutation::Rename { .. }
     )
+}
+
+fn unsupported_kind_name(m: &cairn_core::domain::flush_plan::PlannedMutation) -> &'static str {
+    use cairn_core::domain::flush_plan::PlannedMutation;
+    match m {
+        PlannedMutation::Upsert { .. } => "Upsert",
+        PlannedMutation::Delete { .. } => "Delete",
+        PlannedMutation::Promote { .. } => "Promote",
+        PlannedMutation::Expire { .. } => "Expire",
+        PlannedMutation::ForgetSession { .. } => "ForgetSession",
+        PlannedMutation::ForgetRecord { .. } => "ForgetRecord",
+        PlannedMutation::Evolve { .. } => "Evolve",
+        PlannedMutation::Patch { .. } | PlannedMutation::Rename { .. } => "<supported>",
+        _ => "<unknown>",
+    }
 }
 
 /// Stranded marker path (issue #289 review round 2/3). Planted in the

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -262,6 +262,19 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
     // contain only `Patch`/`Rename` to advance through the real
     // executor; anything else stays pending until a follow-up wires
     // the remaining variants.
+    // Re-loop r9 finding 1: a non-placeholder plan with no mutations
+    // would otherwise execute an empty tx and publish
+    // `ApplyKind::Full`, producing a misleading "fully applied" audit
+    // record for a no-op (or planner-corruption) plan. Refuse.
+    if !persisted.plan.placeholder && persisted.plan.mutations.is_empty() {
+        eprintln!(
+            "cairn flush apply: plan {id} is non-placeholder but has no mutations. \
+             Refusing to publish `ApplyKind::Full` for an empty plan — re-issue with \
+             actual mutations or mark the plan placeholder."
+        );
+        rollback_claim(vault, &claim, &ulid);
+        return ExitCode::from(65);
+    }
     if !persisted.plan.placeholder
         && let Some(unsupported) = persisted
             .plan

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -241,16 +241,36 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
         return ExitCode::from(65);
     }
 
-    if persisted.plan.placeholder {
-        eprintln!(
-            "cairn flush apply: WARNING — MemoryStore mutations are not yet wired (#9). \
-             Plan {id} will be marked applied for audit only; no records were written."
-        );
-        eprintln!(
-            "cairn flush apply: NOTE — plan {id} was produced by the CLI stub planner \
-             (`cairn-cli::ingest_plan_stub`) and does NOT reflect a real ingest/forget \
-             pipeline run. Treat as a placeholder for testing the lifecycle only."
-        );
+    // Issue #289 review (re-loop r1) finding 1: this branch only wires
+    // `Patch` and `Rename` through the real executor. Plans that contain
+    // any other `PlannedMutation` variant (`Upsert` / `Delete` /
+    // `Promote` / `Expire` / `ForgetSession` / `ForgetRecord` / `Evolve`)
+    // are not yet supported by `apply_real_plan` and must preserve the
+    // pre-branch metadata-only path so existing plans still advance
+    // through the lifecycle without a hard apply failure.
+    let unsupported_in_plan = persisted
+        .plan
+        .mutations
+        .iter()
+        .any(|m| !is_real_apply_supported(m));
+    if persisted.plan.placeholder || unsupported_in_plan {
+        if persisted.plan.placeholder {
+            eprintln!(
+                "cairn flush apply: WARNING — MemoryStore mutations are not yet wired (#9). \
+                 Plan {id} will be marked applied for audit only; no records were written."
+            );
+            eprintln!(
+                "cairn flush apply: NOTE — plan {id} was produced by the CLI stub planner \
+                 (`cairn-cli::ingest_plan_stub`) and does NOT reflect a real ingest/forget \
+                 pipeline run. Treat as a placeholder for testing the lifecycle only."
+            );
+        } else {
+            eprintln!(
+                "cairn flush apply: NOTE — plan {id} contains mutation kinds outside \
+                 issue #289's scope (Patch/Rename); falling back to metadata-only apply. \
+                 No records were written. Wire the remaining variants in a follow-up."
+            );
+        }
         persisted.status = PlanStatus::Applied {
             at: now_rfc3339(),
             apply_kind: ApplyKind::MetadataOnly,
@@ -328,6 +348,17 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
     }
     emit_apply_ok(json, id, "applied");
     ExitCode::SUCCESS
+}
+
+/// Issue #289 only wires `Patch` and `Rename` through the real executor;
+/// every other `PlannedMutation` variant falls back to the metadata-only
+/// path so legacy plans still advance.
+fn is_real_apply_supported(m: &cairn_core::domain::flush_plan::PlannedMutation) -> bool {
+    use cairn_core::domain::flush_plan::PlannedMutation;
+    matches!(
+        m,
+        PlannedMutation::Patch { .. } | PlannedMutation::Rename { .. }
+    )
 }
 
 /// Stranded marker path (issue #289 review round 2/3). Planted in the

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -173,6 +173,19 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
         }
     };
 
+    // Re-loop r7: hold an exclusive fs2 lock on the owned claim while
+    // this process is the live publisher. The orphan-resume code in
+    // `claim_pending` uses `try_lock_exclusive` on the claim file as
+    // a liveness proof — without this hold, a concurrent retry could
+    // seize the claim mid-publish. Drop on early returns.
+    let _claim_lock = match acquire_claim_lock(&claim) {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("cairn flush apply: could not acquire liveness lock: {e}");
+            rollback_claim(vault, &claim, &ulid);
+            return ExitCode::from(70);
+        }
+    };
     let bytes = match std::fs::read(&claim) {
         Ok(b) => b,
         Err(e) => {
@@ -381,6 +394,34 @@ fn unsupported_kind_name(m: &cairn_core::domain::flush_plan::PlannedMutation) ->
         PlannedMutation::Patch { .. } | PlannedMutation::Rename { .. } => "<supported>",
         _ => "<unknown>",
     }
+}
+
+/// Acquire an exclusive fs2 lock on the owned claim file. The returned
+/// `File` keeps the lock until it drops. See `orphan_is_dead` for the
+/// matching liveness probe used by orphan recovery.
+fn acquire_claim_lock(claim: &Path) -> std::io::Result<std::fs::File> {
+    use fs2::FileExt as _;
+    let f = std::fs::OpenOptions::new().read(true).open(claim)?;
+    f.try_lock_exclusive()?;
+    Ok(f)
+}
+
+/// Re-loop r7 finding 2: returns `true` iff the orphan file's previous
+/// owner is provably dead — i.e. we can acquire an exclusive fs2 lock
+/// on it without blocking. A live publisher in
+/// `apply_real_plan`/`publish_terminal` holds the same lock, so
+/// `try_lock_exclusive` fails fast against an in-progress publish
+/// instead of racing it.
+fn orphan_is_dead(orphan: &Path) -> bool {
+    use fs2::FileExt as _;
+    let Ok(f) = std::fs::OpenOptions::new().read(true).open(orphan) else {
+        return false;
+    };
+    let acquired = f.try_lock_exclusive().is_ok();
+    if acquired {
+        let _ = f.unlock();
+    }
+    acquired
 }
 
 /// Stranded marker path (issue #289 review round 2/3). Planted in the
@@ -732,7 +773,9 @@ fn claim_pending(
         // signal is already on disk.
         let committed_sidecar = committed_sidecar_path_for(vault, ulid);
         let stranded = stranded_marker_path(vault, ulid);
-        if committed_sidecar.exists() || stranded.exists() {
+        if (committed_sidecar.exists() || stranded.exists())
+            && orphan_is_dead(&orphan)
+        {
             match std::fs::rename(&orphan, &claim) {
                 Ok(()) => {
                     // Fall through to the canonical `claim.exists()`

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -6,9 +6,10 @@
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::Arc;
 
 use cairn_core::domain::flush_plan::store::{Bucket, bucket_dir, plan_path};
-use cairn_core::domain::flush_plan::{ApplyKind, PersistedPlan, PlanStatus};
+use cairn_core::domain::flush_plan::{ApplyKind, FlushPlan, PersistedPlan, PlanStatus};
 
 /// Validate that `s` is a canonical 26-char Crockford-base32 ULID
 /// (uppercase, no `I L O U`, leading char `0..=7`). Mirrors the
@@ -38,6 +39,8 @@ fn is_valid_ulid_str(s: &str) -> bool {
     })
 }
 use clap::{Arg, ArgAction, ArgMatches, Command};
+
+use super::flush_apply;
 
 /// Build the `flush` subcommand group.
 #[must_use]
@@ -238,38 +241,49 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
         return ExitCode::from(65);
     }
 
-    // Phase 1 — drift check. Without a wired MemoryStore in this PR, the
-    // check is a no-op pass-through. When #9 lands (the WAL state machine),
-    // replace this with a real `MemoryStore::get_active_by_target` +
-    // body-hash comparison against `persisted.plan.target_hash(&target)`.
-
-    // Phase 2 — apply. Same story: no MemoryStore wired here. The mutation
-    // walk is a no-op for now; this is the shape the WAL apply will take.
-
-    // Honest no-op: warn the operator that this binary moves the plan but
-    // does NOT execute mutations against MemoryStore. Persisted status
-    // captures `apply_kind = MetadataOnly` so the audit trail is truthful.
-    eprintln!(
-        "cairn flush apply: WARNING — MemoryStore mutations are not yet wired (#9). \
-         Plan {id} will be marked applied for audit only; no records were written."
-    );
     if persisted.plan.placeholder {
+        eprintln!(
+            "cairn flush apply: WARNING — MemoryStore mutations are not yet wired (#9). \
+             Plan {id} will be marked applied for audit only; no records were written."
+        );
         eprintln!(
             "cairn flush apply: NOTE — plan {id} was produced by the CLI stub planner \
              (`cairn-cli::ingest_plan_stub`) and does NOT reflect a real ingest/forget \
              pipeline run. Treat as a placeholder for testing the lifecycle only."
         );
+        persisted.status = PlanStatus::Applied {
+            at: now_rfc3339(),
+            apply_kind: ApplyKind::MetadataOnly,
+        };
+    } else {
+        if let Err(e) = apply_real_plan(vault, &persisted.plan) {
+            eprintln!("cairn flush apply: apply failed: {e:#}");
+            rollback_claim(vault, &claim, &ulid);
+            return ExitCode::from(70);
+        }
+        persisted.status = PlanStatus::Applied {
+            at: now_rfc3339(),
+            apply_kind: ApplyKind::Full,
+        };
     }
-    persisted.status = PlanStatus::Applied {
-        at: now_rfc3339(),
-        apply_kind: ApplyKind::MetadataOnly,
-    };
     if let Err(e) = publish_terminal(vault, &claim, &applied, &persisted, &ulid) {
         eprintln!("cairn flush apply: publish failed: {e}");
         return ExitCode::from(70); // EX_SOFTWARE
     }
     emit_apply_ok(json, id, "applied");
     ExitCode::SUCCESS
+}
+
+fn apply_real_plan(vault: &Path, plan: &FlushPlan) -> anyhow::Result<()> {
+    let db_path = crate::mcp::store_db_path(vault);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async move {
+        let sqlite = Arc::new(cairn_store_sqlite::open(&db_path).await?);
+        let store: Arc<dyn cairn_core::contract::memory_store::MemoryStore> = sqlite.clone();
+        flush_apply::apply_real_plan(&store, &sqlite, plan).await
+    })
 }
 
 #[allow(

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -722,6 +722,32 @@ fn claim_pending(
     if !pending.exists()
         && let Some(orphan) = find_orphan_owned_claim(&claim, ulid)
     {
+        // Issue #289 re-loop r5: if a prior attempt durably committed
+        // SQLite mutations (committed-sidecar or stranded marker
+        // present), the orphan IS provably dead — its crash already
+        // happened post-commit. Auto-resume by renaming the orphan
+        // back to the canonical claim path so the caller can finish
+        // publish. Without this, a post-commit crash strands the plan
+        // until manual filesystem repair, even though the recovery
+        // signal is already on disk.
+        let committed_sidecar = committed_sidecar_path_for(vault, ulid);
+        let stranded = stranded_marker_path(vault, ulid);
+        if committed_sidecar.exists() || stranded.exists() {
+            match std::fs::rename(&orphan, &claim) {
+                Ok(()) => {
+                    // Fall through to the canonical `claim.exists()`
+                    // branch on next call (or the re-attempt below).
+                    // Re-execute the same exclusive-ownership rename
+                    // the caller used above.
+                    let owned = process_owned_claim(&claim);
+                    return match std::fs::rename(&claim, &owned) {
+                        Ok(()) => ClaimOutcome::Claimed(owned),
+                        Err(e) => ClaimOutcome::Err(e),
+                    };
+                }
+                Err(e) => return ClaimOutcome::Err(e),
+            }
+        }
         return ClaimOutcome::Err(std::io::Error::other(format!(
             "stranded in-flight claim for {0} at {1}; auto-recovery is disabled. \
              Verify the owning process is dead, then manually rename it back to \

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -17,7 +17,7 @@ use cairn_core::domain::flush_plan::{ApplyKind, FlushPlan, PersistedPlan, PlanSt
 /// the CLI cannot turn an unvalidated CLI argument into a filesystem
 /// path component (`/`, `..`, absolute path) before the embedded
 /// `operation_id` gate has a chance to run.
-fn is_valid_ulid_str(s: &str) -> bool {
+pub(crate) fn is_valid_ulid_str(s: &str) -> bool {
     if s.len() != 26 {
         return false;
     }
@@ -256,9 +256,33 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
             apply_kind: ApplyKind::MetadataOnly,
         };
     } else {
-        if let Err(e) = apply_real_plan(vault, &persisted.plan) {
+        // Sidecar (issue #289 review round 1): if a prior apply attempt
+        // crashed between the SQLite commit and `publish_terminal`, the
+        // sidecar `<claim>.committed` is on disk. Replaying the mutations
+        // against the already-mutated store would double-apply (Rename
+        // would now hit `RenameTargetConflict`, Patch would fail drift,
+        // etc). When the sidecar is present we skip apply and proceed
+        // straight to publish — the DB side is durable.
+        let committed_sidecar = committed_sidecar_path(&claim);
+        if committed_sidecar.exists() {
+            eprintln!(
+                "cairn flush apply: detected committed-sidecar for {id}; \
+                 DB mutations from a prior attempt are durable, resuming publish only."
+            );
+        } else if let Err(e) = apply_real_plan(vault, &persisted.plan) {
             eprintln!("cairn flush apply: apply failed: {e:#}");
             rollback_claim(vault, &claim, &ulid);
+            return ExitCode::from(70);
+        } else if let Err(e) = write_committed_sidecar(&committed_sidecar) {
+            // DB is mutated. The sidecar write is what makes a publish-phase
+            // crash recoverable without double-applying. If we cannot write
+            // it, surface loudly — the operator must triage manually before
+            // any retry.
+            eprintln!(
+                "cairn flush apply: SQLite mutations committed but committed-sidecar \
+                 write failed: {e}. DO NOT retry without manual recovery; data is \
+                 mutated but `applied/` will not reflect it on the next attempt."
+            );
             return ExitCode::from(70);
         }
         persisted.status = PlanStatus::Applied {
@@ -272,6 +296,35 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
     }
     emit_apply_ok(json, id, "applied");
     ExitCode::SUCCESS
+}
+
+/// Sidecar path used to mark "`SQLite` mutations committed, publish still
+/// pending" — see issue #289 review round 1. Lives next to the in-flight
+/// claim and is removed after `publish_terminal` succeeds.
+fn committed_sidecar_path(claim: &Path) -> PathBuf {
+    let mut p = claim.as_os_str().to_owned();
+    p.push(".committed");
+    PathBuf::from(p)
+}
+
+/// Atomically write the committed-sidecar file. fsyncs the file and its
+/// parent directory so a crash here cannot leave an "almost-written"
+/// sidecar that's later truncated.
+fn write_committed_sidecar(path: &Path) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(format!(".tmp.{}", std::process::id()));
+    let tmp = PathBuf::from(tmp);
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(b"committed\n")?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    if let Some(parent) = path.parent() {
+        std::fs::File::open(parent)?.sync_all()?;
+    }
+    Ok(())
 }
 
 fn apply_real_plan(vault: &Path, plan: &FlushPlan) -> anyhow::Result<()> {
@@ -663,6 +716,11 @@ fn publish_terminal(
     }
     // Claim file is no longer needed (terminal is the canonical record).
     let _ = std::fs::remove_file(claim);
+    // The committed-sidecar (issue #289 review round 1) only meant
+    // "publish still pending"; once the terminal hard-link is durable the
+    // sidecar must go so a future, separate apply on a fresh claim does
+    // not mistake it for an already-applied operation.
+    let _ = std::fs::remove_file(committed_sidecar_path(claim));
     let _ = std::fs::remove_file(cairn_core::domain::flush_plan::store::diff_path(
         vault, ulid,
     ));

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -263,7 +263,12 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
         // would now hit `RenameTargetConflict`, Patch would fail drift,
         // etc). When the sidecar is present we skip apply and proceed
         // straight to publish — the DB side is durable.
-        let committed_sidecar = committed_sidecar_path(&claim);
+        // Round 5 review fix: probe the sidecar at a per-plan canonical
+        // path so resume after `process_owned_claim` (which renames the
+        // claim to a `*.in-flight.<pid>` path) still sees it. Previously
+        // we passed the live `claim` path, which made the sidecar key
+        // shift when ownership transferred, defeating crash recovery.
+        let committed_sidecar = committed_sidecar_path_for(vault, &ulid);
         let stranded = stranded_marker_path(vault, &ulid);
         if committed_sidecar.exists() {
             eprintln!(
@@ -364,10 +369,17 @@ fn write_stranded_marker(path: &Path) -> std::io::Result<()> {
 }
 
 /// Sidecar path used to mark "`SQLite` mutations committed, publish still
-/// pending" — see issue #289 review round 1. Lives next to the in-flight
-/// claim and is removed after `publish_terminal` succeeds.
-fn committed_sidecar_path(claim: &Path) -> PathBuf {
-    let mut p = claim.as_os_str().to_owned();
+/// pending" — see issue #289 review rounds 1/5. Keyed on the canonical
+/// per-plan in-flight path (NOT the pid-suffixed owned-claim path) so
+/// resume after `process_owned_claim` still finds it. Removed by
+/// `publish_terminal`.
+fn committed_sidecar_path_for(
+    vault: &Path,
+    ulid: &cairn_core::generated::common::Ulid,
+) -> PathBuf {
+    use cairn_core::domain::flush_plan::store::{Bucket, plan_path};
+    let canonical = plan_path(vault, Bucket::Applied, ulid).with_extension("json.in-flight");
+    let mut p = canonical.as_os_str().to_owned();
     p.push(".committed");
     PathBuf::from(p)
 }
@@ -785,7 +797,7 @@ fn publish_terminal(
     // "publish still pending"; once the terminal hard-link is durable the
     // sidecar must go so a future, separate apply on a fresh claim does
     // not mistake it for an already-applied operation.
-    let _ = std::fs::remove_file(committed_sidecar_path(claim));
+    let _ = std::fs::remove_file(committed_sidecar_path_for(vault, ulid));
     // Round 3 review fix: the stranded marker (planted when a prior
     // sidecar write failed) is also a "publish pending" artifact —
     // remove it once the terminal hard-link is durable so a future

--- a/crates/cairn-cli/src/verbs/flush.rs
+++ b/crates/cairn-cli/src/verbs/flush.rs
@@ -150,6 +150,22 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
     // the source vanished — that's how concurrent apply/reject callers
     // race-free settle to a single winner. The loser sees ENOENT and
     // returns NotFound (or AlreadyTerminal if the winner committed).
+    // Stranded marker (issue #289 review round 2): a prior attempt
+    // committed SQLite mutations but failed to write the committed
+    // sidecar, leaving an unrecoverable state. Refuse to apply this id
+    // again until an operator inspects and removes the marker — replaying
+    // would double-mutate.
+    let stranded = stranded_marker_path(vault, &ulid);
+    if stranded.exists() {
+        eprintln!(
+            "cairn flush apply: plan {id} is stranded ({}). A prior attempt committed \
+             SQLite mutations but could not persist its recovery sidecar; replaying would \
+             double-mutate. Manually verify the database state, then remove the stranded \
+             marker to proceed.",
+            stranded.display(),
+        );
+        return ExitCode::from(70);
+    }
     let claim = match claim_pending(vault, &ulid, "applied") {
         ClaimOutcome::Claimed(p) => p,
         ClaimOutcome::NotFound => {
@@ -274,15 +290,28 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
             rollback_claim(vault, &claim, &ulid);
             return ExitCode::from(70);
         } else if let Err(e) = write_committed_sidecar(&committed_sidecar) {
-            // DB is mutated. The sidecar write is what makes a publish-phase
-            // crash recoverable without double-applying. If we cannot write
-            // it, surface loudly — the operator must triage manually before
-            // any retry.
-            eprintln!(
-                "cairn flush apply: SQLite mutations committed but committed-sidecar \
-                 write failed: {e}. DO NOT retry without manual recovery; data is \
-                 mutated but `applied/` will not reflect it on the next attempt."
-            );
+            // DB is mutated but the recovery sidecar is missing. Plant the
+            // stranded marker (issue #289 review round 2) so the apply
+            // entry point refuses to re-execute mutations on retry. If
+            // marker placement also fails, surface both errors — manual
+            // intervention is required.
+            let stranded = stranded_marker_path(vault, &ulid);
+            if let Err(me) = write_stranded_marker(&stranded) {
+                eprintln!(
+                    "cairn flush apply: SQLite mutations committed but committed-sidecar \
+                     write failed: {e}; ALSO failed to plant stranded marker at {}: {me}. \
+                     DO NOT retry without manual recovery.",
+                    stranded.display(),
+                );
+            } else {
+                eprintln!(
+                    "cairn flush apply: SQLite mutations committed but committed-sidecar \
+                     write failed: {e}. Planted stranded marker at {}; future apply \
+                     attempts will refuse this id until an operator inspects and removes \
+                     the marker.",
+                    stranded.display(),
+                );
+            }
             return ExitCode::from(70);
         }
         persisted.status = PlanStatus::Applied {
@@ -296,6 +325,41 @@ fn apply(vault: &Path, m: &ArgMatches) -> ExitCode {
     }
     emit_apply_ok(json, id, "applied");
     ExitCode::SUCCESS
+}
+
+/// Stranded marker path (issue #289 review round 2). Planted in the
+/// `applied/` directory when `SQLite` mutations have committed but the
+/// committed-sidecar could not be written; blocks future apply attempts
+/// for the same id until an operator removes the marker.
+fn stranded_marker_path(
+    vault: &Path,
+    ulid: &cairn_core::generated::common::Ulid,
+) -> PathBuf {
+    use cairn_core::domain::flush_plan::store::{Bucket, plan_path};
+    plan_path(vault, Bucket::Applied, ulid).with_extension("json.stranded")
+}
+
+/// Write the stranded marker durably so a crash mid-write cannot leave
+/// an ambiguous half-written file. fsync the parent so the rename
+/// survives.
+fn write_stranded_marker(path: &Path) -> std::io::Result<()> {
+    use std::io::Write as _;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(format!(".tmp.{}", std::process::id()));
+    let tmp = PathBuf::from(tmp);
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(b"stranded: committed-sidecar write failed; manual recovery required\n")?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    if let Some(parent) = path.parent() {
+        std::fs::File::open(parent)?.sync_all()?;
+    }
+    Ok(())
 }
 
 /// Sidecar path used to mark "`SQLite` mutations committed, publish still

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -386,7 +386,24 @@ fn apply_record_patch(
     let prior_hash = BodyHash::compute(&stored.record.body);
     let prior_signature = stored.record.signature.as_str().to_owned();
     let target_label = format!("record:{}", target.as_str());
+    let prior_body = stored.record.body.clone();
     stored.record.body = apply_str_replacements(&stored.record.body, replacements, &target_label)?;
+    // Re-loop r8 finding 1: a patch whose replacements cancel back to
+    // the original body (or each `old == new`) would otherwise hit the
+    // store's same-body `reproject_in_place` branch and silently
+    // overwrite the original author-signed row with the flush-mutated
+    // sentinel. Refuse the no-op so the pristine pre-patch row is
+    // preserved as history.
+    if stored.record.body == prior_body {
+        return Err(StoreError::Invariant {
+            what: format!(
+                "patch for record `{}` is a no-op (post-replacement body equals \
+                 pre-patch body); refusing rather than overwriting the original \
+                 author-signed row in place",
+                target.as_str(),
+            ),
+        });
+    }
     stored.record.updated_at = current_timestamp()?;
     // Re-loop round 3: replace the author signature with the well-known
     // flush-mutated sentinel so downstream verifiers cannot treat the
@@ -427,7 +444,7 @@ fn apply_session_patch(
     for replacement in replacements {
         apply_one_session_replacement(&mut session, replacement, session_id)?;
     }
-    tx.update_session_metadata(&session)?;
+    tx.update_session_metadata_preserve_activity(&session)?;
     let post_state = SessionPatchDocument::from(&session);
     tx.append_session_metadata_audit(
         session_id,
@@ -682,6 +699,13 @@ fn apply_str_replacements(
         if replacement.old.is_empty() {
             return Err(StoreError::Invariant {
                 what: format!("patch replacement for {target_label} cannot use an empty `old`"),
+            });
+        }
+        if replacement.old == replacement.new {
+            return Err(StoreError::Invariant {
+                what: format!(
+                    "patch replacement for {target_label} is a no-op (`old` equals `new`)"
+                ),
             });
         }
         current = apply_one_replacement(&current, replacement, target_label)?;

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -357,7 +357,9 @@ fn apply_mutation(
             target: PatchTarget::Session(session_id),
             str_replace,
         } => apply_session_patch(tx, session_id, str_replace),
-        PlannedMutation::Rename { record_id, new_id } => apply_rename(tx, record_id, new_id),
+        PlannedMutation::Rename { record_id, new_id } => {
+            apply_rename(tx, operation_id, record_id, new_id)
+        }
         other => Err(StoreError::Invariant {
             what: format!("flush apply does not yet support mutation kind `{other:?}`"),
         }),
@@ -380,6 +382,11 @@ fn apply_record_patch(
     let target_label = format!("record:{}", target.as_str());
     stored.record.body = apply_str_replacements(&stored.record.body, replacements, &target_label)?;
     stored.record.updated_at = current_timestamp()?;
+    // Re-loop round 3: replace the author signature with the well-known
+    // flush-mutated sentinel so downstream verifiers cannot treat the
+    // post-patch record as still author-signed. The original signature
+    // is preserved in `flush_patch_history.old_signature` for audit.
+    stored.record.signature = cairn_core::domain::Ed25519Signature::flush_mutated_sentinel();
     append_patch_audit(
         &mut stored.record,
         operation_id,
@@ -510,6 +517,7 @@ fn apply_replacement_to_field(
 
 fn apply_rename(
     tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    operation_id: &str,
     source_target: &cairn_core::domain::TargetId,
     new_target: &cairn_core::domain::TargetId,
 ) -> Result<(), StoreError> {
@@ -541,8 +549,17 @@ fn apply_rename(
                 "rename: fresh record_id `{fresh_record_id}` failed validation: {e}"
             ),
         })?;
+    let prior_target = source.record.target_id.as_str().to_owned();
+    let prior_signature = source.record.signature.as_str().to_owned();
     renamed.target_id = new_target.clone();
     renamed.updated_at = current_timestamp()?;
+    // Re-loop round 3: rename changes the record's canonical bytes
+    // (`target_id` and `updated_at` are inside the signed payload), so
+    // the old author signature no longer attests this record. Replace
+    // with the flush-mutated sentinel and audit the predecessor's
+    // signature alongside the prior target.
+    renamed.signature = cairn_core::domain::Ed25519Signature::flush_mutated_sentinel();
+    append_rename_audit(&mut renamed, operation_id, &prior_target, &prior_signature)?;
     let new_row = tx.upsert(&renamed)?;
 
     let new_edge = Edge {
@@ -554,6 +571,38 @@ fn apply_rename(
     tx.rewrite_non_updates_edges(&source.record.id, &new_row.record_id)?;
     tx.put_edge(&new_edge)?;
     tx.tombstone(&source.record.id, TombstoneReason::Update)?;
+    Ok(())
+}
+
+fn append_rename_audit(
+    record: &mut cairn_core::domain::MemoryRecord,
+    operation_id: &str,
+    prior_target: &str,
+    old_signature: &str,
+) -> Result<(), StoreError> {
+    let applied_at = current_timestamp()?.to_string();
+    let entry = json!({
+        "operation_id": operation_id,
+        "prior_target": prior_target,
+        "old_signature": old_signature,
+        "applied_at": applied_at,
+    });
+    match record.extra_frontmatter.get_mut("flush_rename_history") {
+        Some(value) => {
+            let Some(items) = value.as_array_mut() else {
+                return Err(StoreError::Invariant {
+                    what: "extra_frontmatter.flush_rename_history must be an array".into(),
+                });
+            };
+            items.push(entry);
+        }
+        None => {
+            record.extra_frontmatter.insert(
+                "flush_rename_history".into(),
+                serde_json::Value::Array(vec![entry]),
+            );
+        }
+    }
     Ok(())
 }
 

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -58,17 +58,25 @@ fn check_drift(
     plan: &FlushPlan,
     mutation: &PlannedMutation,
 ) -> Result<(), StoreError> {
-    let target = match mutation {
+    match mutation {
         PlannedMutation::Patch {
             target: PatchTarget::Record(target),
             ..
-        } => target,
-        PlannedMutation::Rename { record_id, .. } => record_id,
-        // Session metadata patches do not have a body to hash; rename/patch
-        // for sessions is covered by `session.ended_at IS NULL` in the
-        // tx-level helpers, not by `target_hashes`.
-        _ => return Ok(()),
-    };
+        } => check_record_drift(tx, plan, target),
+        PlannedMutation::Rename { record_id, .. } => check_record_drift(tx, plan, record_id),
+        PlannedMutation::Patch {
+            target: PatchTarget::Session(session_id),
+            ..
+        } => check_session_drift(tx, plan, session_id),
+        _ => Ok(()),
+    }
+}
+
+fn check_record_drift(
+    tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    plan: &FlushPlan,
+    target: &cairn_core::domain::TargetId,
+) -> Result<(), StoreError> {
     let Some(expected) = plan.target_hash(target) else {
         return Ok(());
     };
@@ -84,6 +92,36 @@ fn check_drift(
                 "flush apply drift: target `{}` body hash `{}` does not match plan \
                  pre-state hash `{}`; live record changed between plan creation and apply",
                 target.as_str(),
+                actual.as_str(),
+                expected,
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Round 2 review fix: session patches must also reject stale-state apply.
+/// Computes the same canonical [`SessionPatchDocument`] JSON the apply path
+/// will mutate, hashes it with [`BodyHash`], and compares against the
+/// plan's `target_hashes` entry keyed by `session_id`. Skipped when the
+/// plan author did not record a session hash (stub-planner output).
+fn check_session_drift(
+    tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    plan: &FlushPlan,
+    session_id: &cairn_core::domain::SessionId,
+) -> Result<(), StoreError> {
+    let Some(expected) = plan.session_hash(session_id) else {
+        return Ok(());
+    };
+    let session = tx.get_live_session(session_id)?;
+    let doc_json = serde_json::to_string(&SessionPatchDocument::from(&session))?;
+    let actual = BodyHash::compute(&doc_json);
+    if actual.as_str() != expected {
+        return Err(StoreError::Invariant {
+            what: format!(
+                "flush apply drift: session `{}` metadata hash `{}` does not match plan \
+                 pre-state hash `{}`; live session changed between plan creation and apply",
+                session_id.as_str(),
                 actual.as_str(),
                 expected,
             ),

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -172,10 +172,16 @@ fn apply_record_patch(
         });
     };
     let prior_hash = BodyHash::compute(&stored.record.body);
+    let prior_signature = stored.record.signature.as_str().to_owned();
     let target_label = format!("record:{}", target.as_str());
     stored.record.body = apply_str_replacements(&stored.record.body, replacements, &target_label)?;
     stored.record.updated_at = current_timestamp()?;
-    append_patch_audit(&mut stored.record, operation_id, prior_hash.as_str())?;
+    append_patch_audit(
+        &mut stored.record,
+        operation_id,
+        prior_hash.as_str(),
+        &prior_signature,
+    )?;
     let _ = tx.upsert(&stored.record)?;
     Ok(())
 }
@@ -187,6 +193,12 @@ fn apply_session_patch(
 ) -> Result<(), StoreError> {
     let mut session = tx.get_live_session(session_id)?;
     let target_label = format!("session:{}", session_id.as_str());
+    // Round 4 review fix: refuse session patches whose `old` substring
+    // appears in more than one logical field. Otherwise an edit intended
+    // for one field (e.g. `channel: "chat"`) could silently rewrite a
+    // homonym in another field (`title`, a tag, etc.) because the
+    // underlying patch is a raw string replace over the serialized JSON.
+    reject_ambiguous_session_replacements(&session, replacements, session_id)?;
     let doc_json = serde_json::to_string(&SessionPatchDocument::from(&session))?;
     let patched_json = apply_str_replacements(&doc_json, replacements, &target_label)?;
     let patched: SessionPatchDocument =
@@ -244,6 +256,54 @@ fn apply_rename(
     Ok(())
 }
 
+/// Refuses session-patch replacements whose `old` substring is present
+/// in more than one field of the session metadata (title / channel /
+/// priority / individual tags). See Round 4 finding 2.
+fn reject_ambiguous_session_replacements(
+    session: &Session,
+    replacements: &[StrReplace],
+    session_id: &cairn_core::domain::SessionId,
+) -> Result<(), StoreError> {
+    for replacement in replacements {
+        let mut hits = 0_usize;
+        let mut field_names: Vec<&'static str> = Vec::new();
+        let mut check = |field: &'static str, value: &str| {
+            if value.contains(&replacement.old) {
+                hits += 1;
+                field_names.push(field);
+            }
+        };
+        check("title", &session.title);
+        if let Some(channel) = &session.channel {
+            check("channel", channel);
+        }
+        if let Some(priority) = &session.priority {
+            check("priority", priority);
+        }
+        for (i, tag) in session.tags.iter().enumerate() {
+            if tag.contains(&replacement.old) {
+                hits += 1;
+                let _ = i;
+                field_names.push("tags");
+                break;
+            }
+        }
+        if hits > 1 {
+            return Err(StoreError::Invariant {
+                what: format!(
+                    "session patch for `{}`: `old` substring `{}` is ambiguous — \
+                     appears in multiple fields ({:?}). Author a narrower replacement \
+                     or split into per-field plans.",
+                    session_id.as_str(),
+                    replacement.old,
+                    field_names,
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn current_timestamp() -> Result<Rfc3339Timestamp, StoreError> {
     Rfc3339Timestamp::parse(cairn_core::time::now_rfc3339_seconds()).map_err(|e| {
         StoreError::Invariant {
@@ -256,11 +316,18 @@ fn append_patch_audit(
     record: &mut cairn_core::domain::MemoryRecord,
     operation_id: &str,
     old_body_hash: &str,
+    old_signature: &str,
 ) -> Result<(), StoreError> {
     let applied_at = current_timestamp()?.to_string();
+    // Round 4 review fix: record the pre-mutation signature so downstream
+    // verifiers can detect that the record was rewritten by a flush apply
+    // (the carried-over signature attests the pre-mutation body, not the
+    // post-mutation body — re-signing belongs to a separate trust-model
+    // change tracked outside this issue).
     let entry = json!({
         "operation_id": operation_id,
         "old_body_hash": old_body_hash,
+        "old_signature": old_signature,
         "applied_at": applied_at,
     });
     match record.extra_frontmatter.get_mut("flush_patch_history") {

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -222,8 +222,13 @@ pub(crate) async fn apply_real_plan(
                 check_drift(tx, &plan, mutation)?;
                 check_scope(tx, &plan, mutation)?;
             }
-            for mutation in &plan.mutations {
-                apply_mutation(tx, &plan.operation_id.0, mutation)?;
+            for (idx, mutation) in plan.mutations.iter().enumerate() {
+                apply_mutation(
+                    tx,
+                    &plan.operation_id.0,
+                    i64::try_from(idx).unwrap_or(i64::MAX),
+                    mutation,
+                )?;
             }
             Ok(())
         })
@@ -346,6 +351,7 @@ fn check_session_drift(
 fn apply_mutation(
     tx: &mut cairn_store_sqlite::StoreTx<'_>,
     operation_id: &str,
+    mutation_seq: i64,
     mutation: &PlannedMutation,
 ) -> Result<(), StoreError> {
     match mutation {
@@ -356,7 +362,7 @@ fn apply_mutation(
         PlannedMutation::Patch {
             target: PatchTarget::Session(session_id),
             str_replace,
-        } => apply_session_patch(tx, operation_id, session_id, str_replace),
+        } => apply_session_patch(tx, operation_id, mutation_seq, session_id, str_replace),
         PlannedMutation::Rename { record_id, new_id } => {
             apply_rename(tx, operation_id, record_id, new_id)
         }
@@ -400,6 +406,7 @@ fn apply_record_patch(
 fn apply_session_patch(
     tx: &mut cairn_store_sqlite::StoreTx<'_>,
     operation_id: &str,
+    mutation_seq: i64,
     session_id: &cairn_core::domain::SessionId,
     replacements: &[StrReplace],
 ) -> Result<(), StoreError> {
@@ -425,6 +432,7 @@ fn apply_session_patch(
     tx.append_session_metadata_audit(
         session_id,
         operation_id,
+        mutation_seq,
         &pre_state,
         &post_state,
     )?;

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -29,6 +29,18 @@ impl From<&Session> for SessionPatchDocument {
     }
 }
 
+/// Canonical pre-state hash for a session metadata document, used to
+/// populate `FlushPlan.target_hashes` when authoring a session patch.
+/// Exposed for integration tests; planners should call this when
+/// building real plans.
+#[must_use]
+pub fn session_drift_hash(session: &Session) -> String {
+    // serde_json::to_string never fails for these scalar/Vec fields.
+    let doc = SessionPatchDocument::from(session);
+    let json = serde_json::to_string(&doc).expect("SessionPatchDocument serialization");
+    BodyHash::compute(&json).as_str().to_owned()
+}
+
 pub(crate) async fn apply_real_plan(
     _store: &Arc<dyn MemoryStore>,
     sqlite: &Arc<SqliteMemoryStore>,
@@ -86,8 +98,18 @@ fn check_record_drift(
     plan: &FlushPlan,
     target: &cairn_core::domain::TargetId,
 ) -> Result<(), StoreError> {
+    // Round 6 review fix: non-placeholder Patch/Rename must declare a
+    // pre-state hash. Skipping drift when the map is empty made the
+    // protection optional for exactly the mutations that need it.
     let Some(expected) = plan.target_hash(target) else {
-        return Ok(());
+        return Err(StoreError::Invariant {
+            what: format!(
+                "flush apply: non-placeholder plan is missing `target_hashes` entry \
+                 for record `{}`; drift protection requires a pre-state hash for every \
+                 patch/rename target",
+                target.as_str(),
+            ),
+        });
     };
     let Some(stored) = tx.get_active_by_target(target)? else {
         return Err(StoreError::PatchTargetMissing {
@@ -120,7 +142,14 @@ fn check_session_drift(
     session_id: &cairn_core::domain::SessionId,
 ) -> Result<(), StoreError> {
     let Some(expected) = plan.session_hash(session_id) else {
-        return Ok(());
+        return Err(StoreError::Invariant {
+            what: format!(
+                "flush apply: non-placeholder plan is missing `target_hashes` entry \
+                 for session `{}`; drift protection requires a pre-state hash for every \
+                 session metadata patch",
+                session_id.as_str(),
+            ),
+        });
     };
     let session = tx.get_live_session(session_id)?;
     let doc_json = serde_json::to_string(&SessionPatchDocument::from(&session))?;

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -37,8 +37,17 @@ pub(crate) async fn apply_real_plan(
     let plan = plan.clone();
     sqlite
         .with_tx(move |tx| {
+            // Round 3 review fix: drift-check the ORIGINAL pre-state once
+            // per mutation BEFORE any apply runs. Doing the check inline
+                // would compare later mutations against the post-first-write
+                // state for plans that touch the same target twice
+                // (patch-then-rename, multi-patch chains), so legitimate
+                // multi-step plans would self-trip. Phase 1 = drift,
+                // Phase 2 = apply.
             for mutation in &plan.mutations {
                 check_drift(tx, &plan, mutation)?;
+            }
+            for mutation in &plan.mutations {
                 apply_mutation(tx, &plan.operation_id.0, mutation)?;
             }
             Ok(())

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -154,6 +154,25 @@ fn enforce_session_scope(
             ),
         });
     }
+    // Re-loop round 1 finding 2: sessions are keyed by
+    // `(user, agent, project_root)`, so a project-scoped plan must not
+    // be able to mutate a same-user/same-agent session belonging to a
+    // different project. Compare `plan.scope.project` against
+    // `session.identity.project_root`; if the plan narrows on project,
+    // the session must declare the same project_root.
+    if let Some(project) = &plan_scope.project {
+        let session_project = session.identity.project_root.as_deref();
+        if session_project != Some(project.as_str()) {
+            return Err(StoreError::Invariant {
+                what: format!(
+                    "flush apply: plan scope `project={project}` does not match session \
+                     `{}` project_root `{}`",
+                    session.id.as_str(),
+                    session_project.unwrap_or("<none>"),
+                ),
+            });
+        }
+    }
     Ok(())
 }
 

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -120,6 +120,28 @@ fn enforce_session_scope(
     session: &Session,
 ) -> Result<(), StoreError> {
     let plan_scope = &plan.scope;
+    // Re-loop round 2 finding 2: sessions cannot validate `tenant`,
+    // `workspace`, or `entity` (the SessionIdentity tuple does not
+    // carry them), so a plan that narrows on any of those dimensions
+    // is not safely applicable to a session. Reject rather than
+    // silently dropping the constraint.
+    for (name, value) in [
+        ("tenant", plan_scope.tenant.as_deref()),
+        ("workspace", plan_scope.workspace.as_deref()),
+        ("entity", plan_scope.entity.as_deref()),
+    ] {
+        if let Some(v) = value {
+            return Err(StoreError::Invariant {
+                what: format!(
+                    "flush apply: plan scope dimension `{name}={v}` cannot be enforced \
+                     against session `{}` (sessions are keyed by user/agent/project_root \
+                     only); refusing session patch rather than silently dropping the \
+                     constraint",
+                    session.id.as_str(),
+                ),
+            });
+        }
+    }
     // session_id dimension
     if let Some(scoped) = &plan_scope.session_id
         && scoped != session.id.as_str()

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -116,19 +116,31 @@ fn check_record_drift(
             target_id: target.as_str().to_owned(),
         });
     };
-    let actual = BodyHash::compute(&stored.record.body);
-    if actual.as_str() != expected {
+    let actual = record_drift_hash(&stored.record);
+    if actual != expected {
         return Err(StoreError::Invariant {
             what: format!(
-                "flush apply drift: target `{}` body hash `{}` does not match plan \
+                "flush apply drift: target `{}` record hash `{}` does not match plan \
                  pre-state hash `{}`; live record changed between plan creation and apply",
                 target.as_str(),
-                actual.as_str(),
+                actual,
                 expected,
             ),
         });
     }
     Ok(())
+}
+
+/// Canonical pre-state hash for a record. Covers the full reviewed
+/// state (body + scope/visibility/frontmatter/signature/etc) by hashing
+/// its serde JSON serialization — not just the body — so metadata-only
+/// rewrites between plan creation and apply still trip the drift gate.
+/// Exposed for integration tests and planners building real patch/rename
+/// plans.
+#[must_use]
+pub fn record_drift_hash(record: &cairn_core::domain::MemoryRecord) -> String {
+    let json = serde_json::to_string(record).expect("MemoryRecord serialization");
+    BodyHash::compute(&json).as_str().to_owned()
 }
 
 /// Round 2 review fix: session patches must also reject stale-state apply.
@@ -349,12 +361,17 @@ fn apply_rename(
         });
     }
 
+    // Round 7 review fix: mint a fresh `record_id` for the renamed
+    // record. Previously this reused `new_target` as the row's primary
+    // key, which collided with any historical (now-tombstoned) lineage
+    // that had once owned that ULID. The `target_id` is what stays
+    // stable across renames; `record_id` is per-version.
     let mut renamed = source.record.clone();
+    let fresh_record_id = ulid::Ulid::new().to_string();
     renamed.id =
-        RecordId::parse(new_target.as_str().to_owned()).map_err(|e| StoreError::Invariant {
+        RecordId::parse(fresh_record_id.clone()).map_err(|e| StoreError::Invariant {
             what: format!(
-                "rename destination `{}` cannot be re-used as record_id: {e}",
-                new_target.as_str()
+                "rename: fresh record_id `{fresh_record_id}` failed validation: {e}"
             ),
         })?;
     renamed.target_id = new_target.clone();

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -38,11 +38,57 @@ pub(crate) async fn apply_real_plan(
     sqlite
         .with_tx(move |tx| {
             for mutation in &plan.mutations {
+                check_drift(tx, &plan, mutation)?;
                 apply_mutation(tx, &plan.operation_id.0, mutation)?;
             }
             Ok(())
         })
         .await?;
+    Ok(())
+}
+
+/// Drift guard (issue #289 review round 1): before mutating, verify the live
+/// record body hash matches the plan's recorded pre-state in
+/// `target_hashes`. If the plan author did not record a hash for the
+/// target, the check is skipped (consistent with stub-planner output that
+/// leaves the map empty). Aborts the WAL tx on mismatch so partial mutations
+/// roll back.
+fn check_drift(
+    tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    plan: &FlushPlan,
+    mutation: &PlannedMutation,
+) -> Result<(), StoreError> {
+    let target = match mutation {
+        PlannedMutation::Patch {
+            target: PatchTarget::Record(target),
+            ..
+        } => target,
+        PlannedMutation::Rename { record_id, .. } => record_id,
+        // Session metadata patches do not have a body to hash; rename/patch
+        // for sessions is covered by `session.ended_at IS NULL` in the
+        // tx-level helpers, not by `target_hashes`.
+        _ => return Ok(()),
+    };
+    let Some(expected) = plan.target_hash(target) else {
+        return Ok(());
+    };
+    let Some(stored) = tx.get_active_by_target(target)? else {
+        return Err(StoreError::PatchTargetMissing {
+            target_id: target.as_str().to_owned(),
+        });
+    };
+    let actual = BodyHash::compute(&stored.record.body);
+    if actual.as_str() != expected {
+        return Err(StoreError::Invariant {
+            what: format!(
+                "flush apply drift: target `{}` body hash `{}` does not match plan \
+                 pre-state hash `{}`; live record changed between plan creation and apply",
+                target.as_str(),
+                actual.as_str(),
+                expected,
+            ),
+        });
+    }
     Ok(())
 }
 

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -355,7 +355,11 @@ fn apply_rename(
             id: source_target.as_str().to_owned(),
         });
     };
-    if tx.get_active_by_target(new_target)?.is_some() {
+    // Round 9 review fix: rejecting only the live destination left a
+    // hole — a retired (tombstoned) target_id could be reused, merging
+    // unrelated histories under one lineage. The destination must be
+    // entirely fresh.
+    if tx.target_id_ever_used(new_target)? {
         return Err(StoreError::RenameTargetConflict {
             target_id: new_target.as_str().to_owned(),
         });

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -41,6 +41,122 @@ pub fn session_drift_hash(session: &Session) -> String {
     BodyHash::compute(&json).as_str().to_owned()
 }
 
+/// Round 10 review fix: enforce that each plan dimension that is set
+/// matches the record's stored scope. Unset plan dimensions are
+/// unrestricted (the planner did not narrow on them). Returns the
+/// offending dimension name on the first mismatch so the error message
+/// can point operators at the right field.
+fn scope_satisfies(plan: &cairn_core::domain::ScopeTuple, record: &cairn_core::domain::ScopeTuple)
+    -> Result<(), &'static str>
+{
+    fn check(
+        plan: Option<&str>,
+        record: Option<&str>,
+        name: &'static str,
+    ) -> Result<(), &'static str> {
+        match (plan, record) {
+            (Some(p), Some(r)) if p == r => Ok(()),
+            (Some(_), _) => Err(name),
+            (None, _) => Ok(()),
+        }
+    }
+    check(plan.tenant.as_deref(), record.tenant.as_deref(), "tenant")?;
+    check(plan.workspace.as_deref(), record.workspace.as_deref(), "workspace")?;
+    check(plan.project.as_deref(), record.project.as_deref(), "project")?;
+    check(plan.session_id.as_deref(), record.session_id.as_deref(), "session_id")?;
+    check(plan.entity.as_deref(), record.entity.as_deref(), "entity")?;
+    check(plan.user.as_deref(), record.user.as_deref(), "user")?;
+    check(plan.agent.as_deref(), record.agent.as_deref(), "agent")?;
+    Ok(())
+}
+
+fn check_scope(
+    tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    plan: &FlushPlan,
+    mutation: &PlannedMutation,
+) -> Result<(), StoreError> {
+    match mutation {
+        PlannedMutation::Patch {
+            target: PatchTarget::Record(target),
+            ..
+        }
+        | PlannedMutation::Rename {
+            record_id: target, ..
+        } => {
+            let Some(stored) = tx.get_active_by_target(target)? else {
+                return Err(StoreError::PatchTargetMissing {
+                    target_id: target.as_str().to_owned(),
+                });
+            };
+            enforce_record_scope(plan, &stored.record, target)
+        }
+        PlannedMutation::Patch {
+            target: PatchTarget::Session(session_id),
+            ..
+        } => {
+            let session = tx.get_live_session(session_id)?;
+            enforce_session_scope(plan, &session)
+        }
+        _ => Ok(()),
+    }
+}
+
+fn enforce_record_scope(
+    plan: &FlushPlan,
+    record: &cairn_core::domain::MemoryRecord,
+    target: &cairn_core::domain::TargetId,
+) -> Result<(), StoreError> {
+    scope_satisfies(&plan.scope, &record.scope).map_err(|dim| StoreError::Invariant {
+        what: format!(
+            "flush apply: plan scope dimension `{dim}` does not match record `{}` — \
+             refusing mutation outside authorized scope",
+            target.as_str(),
+        ),
+    })
+}
+
+fn enforce_session_scope(
+    plan: &FlushPlan,
+    session: &Session,
+) -> Result<(), StoreError> {
+    let plan_scope = &plan.scope;
+    // session_id dimension
+    if let Some(scoped) = &plan_scope.session_id
+        && scoped != session.id.as_str()
+    {
+        return Err(StoreError::Invariant {
+            what: format!(
+                "flush apply: plan scope `session_id={scoped}` does not match session `{}`",
+                session.id.as_str(),
+            ),
+        });
+    }
+    // user / agent dimensions
+    if let Some(user) = &plan_scope.user
+        && user != session.identity.user.as_str()
+    {
+        return Err(StoreError::Invariant {
+            what: format!(
+                "flush apply: plan scope `user={user}` does not match session `{}` user `{}`",
+                session.id.as_str(),
+                session.identity.user.as_str(),
+            ),
+        });
+    }
+    if let Some(agent) = &plan_scope.agent
+        && agent != session.identity.agent.as_str()
+    {
+        return Err(StoreError::Invariant {
+            what: format!(
+                "flush apply: plan scope `agent={agent}` does not match session `{}` agent `{}`",
+                session.id.as_str(),
+                session.identity.agent.as_str(),
+            ),
+        });
+    }
+    Ok(())
+}
+
 pub(crate) async fn apply_real_plan(
     _store: &Arc<dyn MemoryStore>,
     sqlite: &Arc<SqliteMemoryStore>,
@@ -56,8 +172,14 @@ pub(crate) async fn apply_real_plan(
                 // (patch-then-rename, multi-patch chains), so legitimate
                 // multi-step plans would self-trip. Phase 1 = drift,
                 // Phase 2 = apply.
+            //
+            // Round 10 review fix: enforce plan scope against each
+            // target's stored scope BEFORE mutating, so a pending plan
+            // staged outside the reviewer's authorized scope cannot
+            // patch/rename rows it does not own.
             for mutation in &plan.mutations {
                 check_drift(tx, &plan, mutation)?;
+                check_scope(tx, &plan, mutation)?;
             }
             for mutation in &plan.mutations {
                 apply_mutation(tx, &plan.operation_id.0, mutation)?;

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -46,9 +46,10 @@ pub fn session_drift_hash(session: &Session) -> String {
 /// unrestricted (the planner did not narrow on them). Returns the
 /// offending dimension name on the first mismatch so the error message
 /// can point operators at the right field.
-fn scope_satisfies(plan: &cairn_core::domain::ScopeTuple, record: &cairn_core::domain::ScopeTuple)
-    -> Result<(), &'static str>
-{
+fn scope_satisfies(
+    plan: &cairn_core::domain::ScopeTuple,
+    record: &cairn_core::domain::ScopeTuple,
+) -> Result<(), &'static str> {
     fn check(
         plan: Option<&str>,
         record: Option<&str>,
@@ -61,9 +62,21 @@ fn scope_satisfies(plan: &cairn_core::domain::ScopeTuple, record: &cairn_core::d
         }
     }
     check(plan.tenant.as_deref(), record.tenant.as_deref(), "tenant")?;
-    check(plan.workspace.as_deref(), record.workspace.as_deref(), "workspace")?;
-    check(plan.project.as_deref(), record.project.as_deref(), "project")?;
-    check(plan.session_id.as_deref(), record.session_id.as_deref(), "session_id")?;
+    check(
+        plan.workspace.as_deref(),
+        record.workspace.as_deref(),
+        "workspace",
+    )?;
+    check(
+        plan.project.as_deref(),
+        record.project.as_deref(),
+        "project",
+    )?;
+    check(
+        plan.session_id.as_deref(),
+        record.session_id.as_deref(),
+        "session_id",
+    )?;
     check(plan.entity.as_deref(), record.entity.as_deref(), "entity")?;
     check(plan.user.as_deref(), record.user.as_deref(), "user")?;
     check(plan.agent.as_deref(), record.agent.as_deref(), "agent")?;
@@ -115,10 +128,7 @@ fn enforce_record_scope(
     })
 }
 
-fn enforce_session_scope(
-    plan: &FlushPlan,
-    session: &Session,
-) -> Result<(), StoreError> {
+fn enforce_session_scope(plan: &FlushPlan, session: &Session) -> Result<(), StoreError> {
     let plan_scope = &plan.scope;
     // Re-loop round 2 finding 2: sessions cannot validate `tenant`,
     // `workspace`, or `entity` (the SessionIdentity tuple does not
@@ -208,11 +218,11 @@ pub(crate) async fn apply_real_plan(
         .with_tx(move |tx| {
             // Round 3 review fix: drift-check the ORIGINAL pre-state once
             // per mutation BEFORE any apply runs. Doing the check inline
-                // would compare later mutations against the post-first-write
-                // state for plans that touch the same target twice
-                // (patch-then-rename, multi-patch chains), so legitimate
-                // multi-step plans would self-trip. Phase 1 = drift,
-                // Phase 2 = apply.
+            // would compare later mutations against the post-first-write
+            // state for plans that touch the same target twice
+            // (patch-then-rename, multi-patch chains), so legitimate
+            // multi-step plans would self-trip. Phase 1 = drift,
+            // Phase 2 = apply.
             //
             // Round 10 review fix: enforce plan scope against each
             // target's stored scope BEFORE mutating, so a pending plan
@@ -581,12 +591,9 @@ fn apply_rename(
     // stable across renames; `record_id` is per-version.
     let mut renamed = source.record.clone();
     let fresh_record_id = ulid::Ulid::new().to_string();
-    renamed.id =
-        RecordId::parse(fresh_record_id.clone()).map_err(|e| StoreError::Invariant {
-            what: format!(
-                "rename: fresh record_id `{fresh_record_id}` failed validation: {e}"
-            ),
-        })?;
+    renamed.id = RecordId::parse(fresh_record_id.clone()).map_err(|e| StoreError::Invariant {
+        what: format!("rename: fresh record_id `{fresh_record_id}` failed validation: {e}"),
+    })?;
     let prior_target = source.record.target_id.as_str().to_owned();
     let prior_signature = source.record.signature.as_str().to_owned();
     renamed.target_id = new_target.clone();

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -356,7 +356,7 @@ fn apply_mutation(
         PlannedMutation::Patch {
             target: PatchTarget::Session(session_id),
             str_replace,
-        } => apply_session_patch(tx, session_id, str_replace),
+        } => apply_session_patch(tx, operation_id, session_id, str_replace),
         PlannedMutation::Rename { record_id, new_id } => {
             apply_rename(tx, operation_id, record_id, new_id)
         }
@@ -399,10 +399,16 @@ fn apply_record_patch(
 
 fn apply_session_patch(
     tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    operation_id: &str,
     session_id: &cairn_core::domain::SessionId,
     replacements: &[StrReplace],
 ) -> Result<(), StoreError> {
     let mut session = tx.get_live_session(session_id)?;
+    // Re-loop round 6: capture pre-state for audit/rollback before
+    // any mutation. `session_metadata_audit` records the prior
+    // title/channel/priority/tags so recovery tooling can reconstruct
+    // the overwrite even though sessions are stored in place.
+    let pre_state = SessionPatchDocument::from(&session);
     // Round 4/5 review fix: patch session fields by typed-field
     // routing, NOT by string-replacing a serialized JSON blob.
     // The previous approach allowed `StrReplace.new` to contain
@@ -415,6 +421,13 @@ fn apply_session_patch(
         apply_one_session_replacement(&mut session, replacement, session_id)?;
     }
     tx.update_session_metadata(&session)?;
+    let post_state = SessionPatchDocument::from(&session);
+    tx.append_session_metadata_audit(
+        session_id,
+        operation_id,
+        &pre_state,
+        &post_state,
+    )?;
     Ok(())
 }
 

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -192,27 +192,115 @@ fn apply_session_patch(
     replacements: &[StrReplace],
 ) -> Result<(), StoreError> {
     let mut session = tx.get_live_session(session_id)?;
-    let target_label = format!("session:{}", session_id.as_str());
-    // Round 4 review fix: refuse session patches whose `old` substring
-    // appears in more than one logical field. Otherwise an edit intended
-    // for one field (e.g. `channel: "chat"`) could silently rewrite a
-    // homonym in another field (`title`, a tag, etc.) because the
-    // underlying patch is a raw string replace over the serialized JSON.
-    reject_ambiguous_session_replacements(&session, replacements, session_id)?;
-    let doc_json = serde_json::to_string(&SessionPatchDocument::from(&session))?;
-    let patched_json = apply_str_replacements(&doc_json, replacements, &target_label)?;
-    let patched: SessionPatchDocument =
-        serde_json::from_str(&patched_json).map_err(|e| StoreError::Invariant {
+    // Round 4/5 review fix: patch session fields by typed-field
+    // routing, NOT by string-replacing a serialized JSON blob.
+    // The previous approach allowed `StrReplace.new` to contain
+    // JSON syntax (e.g. `","priority":"high","x":"`), letting one
+    // replacement reach across to unrelated fields while still
+    // producing a parseable document. Pick the single field whose
+    // value contains `old` and apply the replacement to that field
+    // only; reject ambiguous (multi-field) matches.
+    for replacement in replacements {
+        apply_one_session_replacement(&mut session, replacement, session_id)?;
+    }
+    tx.update_session_metadata(&session)?;
+    Ok(())
+}
+
+/// Apply a single [`StrReplace`] to exactly one resolved session field.
+/// Rejects matches in zero or >1 field — the wire format does not name
+/// the target field, so the substring must uniquely identify it.
+fn apply_one_session_replacement(
+    session: &mut Session,
+    replacement: &StrReplace,
+    session_id: &cairn_core::domain::SessionId,
+) -> Result<(), StoreError> {
+    if replacement.old.is_empty() {
+        return Err(StoreError::Invariant {
             what: format!(
-                "session patch produced invalid metadata document for `{}`: {e}",
+                "session patch for `{}`: empty `old` is not allowed",
                 session_id.as_str()
             ),
-        })?;
-    session.title = patched.title;
-    session.channel = patched.channel;
-    session.priority = patched.priority;
-    session.tags = patched.tags;
-    tx.update_session_metadata(&session)?;
+        });
+    }
+    let target_label = format!("session:{}", session_id.as_str());
+    let mut hits: Vec<SessionField> = Vec::new();
+    if session.title.contains(&replacement.old) {
+        hits.push(SessionField::Title);
+    }
+    if let Some(ch) = &session.channel
+        && ch.contains(&replacement.old)
+    {
+        hits.push(SessionField::Channel);
+    }
+    if let Some(pr) = &session.priority
+        && pr.contains(&replacement.old)
+    {
+        hits.push(SessionField::Priority);
+    }
+    for (idx, tag) in session.tags.iter().enumerate() {
+        if tag.contains(&replacement.old) {
+            hits.push(SessionField::Tag(idx));
+        }
+    }
+    match hits.len() {
+        0 => Err(patch_substring_missing(
+            &target_label,
+            &replacement.old,
+            match replacement.occurrence {
+                ReplaceOccurrence::First => "first",
+                ReplaceOccurrence::All => "all",
+                ReplaceOccurrence::Nth(_) => "nth",
+            },
+        )),
+        1 => {
+            let field = hits.remove(0);
+            apply_replacement_to_field(session, field, replacement, &target_label)
+        }
+        _ => Err(StoreError::Invariant {
+            what: format!(
+                "session patch for `{}`: `old` substring `{}` is ambiguous — \
+                 matches multiple fields ({hits:?}). Author a narrower replacement \
+                 or split into per-field plans.",
+                session_id.as_str(),
+                replacement.old,
+            ),
+        }),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SessionField {
+    Title,
+    Channel,
+    Priority,
+    Tag(usize),
+}
+
+fn apply_replacement_to_field(
+    session: &mut Session,
+    field: SessionField,
+    replacement: &StrReplace,
+    target_label: &str,
+) -> Result<(), StoreError> {
+    match field {
+        SessionField::Title => {
+            session.title =
+                apply_one_replacement(&session.title.clone(), replacement, target_label)?;
+        }
+        SessionField::Channel => {
+            let current = session.channel.clone().unwrap_or_default();
+            session.channel = Some(apply_one_replacement(&current, replacement, target_label)?);
+        }
+        SessionField::Priority => {
+            let current = session.priority.clone().unwrap_or_default();
+            session.priority = Some(apply_one_replacement(&current, replacement, target_label)?);
+        }
+        SessionField::Tag(idx) => {
+            let current = session.tags[idx].clone();
+            session.tags[idx] = apply_one_replacement(&current, replacement, target_label)?;
+        }
+    }
     Ok(())
 }
 
@@ -253,54 +341,6 @@ fn apply_rename(
     tx.rewrite_non_updates_edges(&source.record.id, &new_row.record_id)?;
     tx.put_edge(&new_edge)?;
     tx.tombstone(&source.record.id, TombstoneReason::Update)?;
-    Ok(())
-}
-
-/// Refuses session-patch replacements whose `old` substring is present
-/// in more than one field of the session metadata (title / channel /
-/// priority / individual tags). See Round 4 finding 2.
-fn reject_ambiguous_session_replacements(
-    session: &Session,
-    replacements: &[StrReplace],
-    session_id: &cairn_core::domain::SessionId,
-) -> Result<(), StoreError> {
-    for replacement in replacements {
-        let mut hits = 0_usize;
-        let mut field_names: Vec<&'static str> = Vec::new();
-        let mut check = |field: &'static str, value: &str| {
-            if value.contains(&replacement.old) {
-                hits += 1;
-                field_names.push(field);
-            }
-        };
-        check("title", &session.title);
-        if let Some(channel) = &session.channel {
-            check("channel", channel);
-        }
-        if let Some(priority) = &session.priority {
-            check("priority", priority);
-        }
-        for (i, tag) in session.tags.iter().enumerate() {
-            if tag.contains(&replacement.old) {
-                hits += 1;
-                let _ = i;
-                field_names.push("tags");
-                break;
-            }
-        }
-        if hits > 1 {
-            return Err(StoreError::Invariant {
-                what: format!(
-                    "session patch for `{}`: `old` substring `{}` is ambiguous — \
-                     appears in multiple fields ({:?}). Author a narrower replacement \
-                     or split into per-field plans.",
-                    session_id.as_str(),
-                    replacement.old,
-                    field_names,
-                ),
-            });
-        }
-    }
     Ok(())
 }
 

--- a/crates/cairn-cli/src/verbs/flush_apply.rs
+++ b/crates/cairn-cli/src/verbs/flush_apply.rs
@@ -1,0 +1,267 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use cairn_core::contract::memory_store::{Edge, EdgeKind, MemoryStore, TombstoneReason};
+use cairn_core::domain::flush_plan::{
+    FlushPlan, PatchTarget, PlannedMutation, ReplaceOccurrence, StrReplace,
+};
+use cairn_core::domain::{BodyHash, RecordId, Rfc3339Timestamp, Session};
+use cairn_store_sqlite::{SqliteMemoryStore, StoreError};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SessionPatchDocument {
+    title: String,
+    channel: Option<String>,
+    priority: Option<String>,
+    tags: Vec<String>,
+}
+
+impl From<&Session> for SessionPatchDocument {
+    fn from(session: &Session) -> Self {
+        Self {
+            title: session.title.clone(),
+            channel: session.channel.clone(),
+            priority: session.priority.clone(),
+            tags: session.tags.clone(),
+        }
+    }
+}
+
+pub(crate) async fn apply_real_plan(
+    _store: &Arc<dyn MemoryStore>,
+    sqlite: &Arc<SqliteMemoryStore>,
+    plan: &FlushPlan,
+) -> Result<()> {
+    let plan = plan.clone();
+    sqlite
+        .with_tx(move |tx| {
+            for mutation in &plan.mutations {
+                apply_mutation(tx, &plan.operation_id.0, mutation)?;
+            }
+            Ok(())
+        })
+        .await?;
+    Ok(())
+}
+
+fn apply_mutation(
+    tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    operation_id: &str,
+    mutation: &PlannedMutation,
+) -> Result<(), StoreError> {
+    match mutation {
+        PlannedMutation::Patch {
+            target: PatchTarget::Record(target),
+            str_replace,
+        } => apply_record_patch(tx, operation_id, target, str_replace),
+        PlannedMutation::Patch {
+            target: PatchTarget::Session(session_id),
+            str_replace,
+        } => apply_session_patch(tx, session_id, str_replace),
+        PlannedMutation::Rename { record_id, new_id } => apply_rename(tx, record_id, new_id),
+        other => Err(StoreError::Invariant {
+            what: format!("flush apply does not yet support mutation kind `{other:?}`"),
+        }),
+    }
+}
+
+fn apply_record_patch(
+    tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    operation_id: &str,
+    target: &cairn_core::domain::TargetId,
+    replacements: &[StrReplace],
+) -> Result<(), StoreError> {
+    let Some(mut stored) = tx.get_active_by_target(target)? else {
+        return Err(StoreError::PatchTargetMissing {
+            target_id: target.as_str().to_owned(),
+        });
+    };
+    let prior_hash = BodyHash::compute(&stored.record.body);
+    let target_label = format!("record:{}", target.as_str());
+    stored.record.body = apply_str_replacements(&stored.record.body, replacements, &target_label)?;
+    stored.record.updated_at = current_timestamp()?;
+    append_patch_audit(&mut stored.record, operation_id, prior_hash.as_str())?;
+    let _ = tx.upsert(&stored.record)?;
+    Ok(())
+}
+
+fn apply_session_patch(
+    tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    session_id: &cairn_core::domain::SessionId,
+    replacements: &[StrReplace],
+) -> Result<(), StoreError> {
+    let mut session = tx.get_live_session(session_id)?;
+    let target_label = format!("session:{}", session_id.as_str());
+    let doc_json = serde_json::to_string(&SessionPatchDocument::from(&session))?;
+    let patched_json = apply_str_replacements(&doc_json, replacements, &target_label)?;
+    let patched: SessionPatchDocument =
+        serde_json::from_str(&patched_json).map_err(|e| StoreError::Invariant {
+            what: format!(
+                "session patch produced invalid metadata document for `{}`: {e}",
+                session_id.as_str()
+            ),
+        })?;
+    session.title = patched.title;
+    session.channel = patched.channel;
+    session.priority = patched.priority;
+    session.tags = patched.tags;
+    tx.update_session_metadata(&session)?;
+    Ok(())
+}
+
+fn apply_rename(
+    tx: &mut cairn_store_sqlite::StoreTx<'_>,
+    source_target: &cairn_core::domain::TargetId,
+    new_target: &cairn_core::domain::TargetId,
+) -> Result<(), StoreError> {
+    let Some(source) = tx.get_active_by_target(source_target)? else {
+        return Err(StoreError::NotFound {
+            id: source_target.as_str().to_owned(),
+        });
+    };
+    if tx.get_active_by_target(new_target)?.is_some() {
+        return Err(StoreError::RenameTargetConflict {
+            target_id: new_target.as_str().to_owned(),
+        });
+    }
+
+    let mut renamed = source.record.clone();
+    renamed.id =
+        RecordId::parse(new_target.as_str().to_owned()).map_err(|e| StoreError::Invariant {
+            what: format!(
+                "rename destination `{}` cannot be re-used as record_id: {e}",
+                new_target.as_str()
+            ),
+        })?;
+    renamed.target_id = new_target.clone();
+    renamed.updated_at = current_timestamp()?;
+    let new_row = tx.upsert(&renamed)?;
+
+    let new_edge = Edge {
+        src: new_row.record_id.clone(),
+        dst: source.record.id.clone(),
+        kind: EdgeKind::Updates,
+        weight: None,
+    };
+    tx.rewrite_non_updates_edges(&source.record.id, &new_row.record_id)?;
+    tx.put_edge(&new_edge)?;
+    tx.tombstone(&source.record.id, TombstoneReason::Update)?;
+    Ok(())
+}
+
+fn current_timestamp() -> Result<Rfc3339Timestamp, StoreError> {
+    Rfc3339Timestamp::parse(cairn_core::time::now_rfc3339_seconds()).map_err(|e| {
+        StoreError::Invariant {
+            what: format!("generated timestamp failed RFC-3339 validation: {e}"),
+        }
+    })
+}
+
+fn append_patch_audit(
+    record: &mut cairn_core::domain::MemoryRecord,
+    operation_id: &str,
+    old_body_hash: &str,
+) -> Result<(), StoreError> {
+    let applied_at = current_timestamp()?.to_string();
+    let entry = json!({
+        "operation_id": operation_id,
+        "old_body_hash": old_body_hash,
+        "applied_at": applied_at,
+    });
+    match record.extra_frontmatter.get_mut("flush_patch_history") {
+        Some(value) => {
+            let Some(items) = value.as_array_mut() else {
+                return Err(StoreError::Invariant {
+                    what: "extra_frontmatter.flush_patch_history must be an array".into(),
+                });
+            };
+            items.push(entry);
+        }
+        None => {
+            record.extra_frontmatter.insert(
+                "flush_patch_history".into(),
+                serde_json::Value::Array(vec![entry]),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn apply_str_replacements(
+    input: &str,
+    replacements: &[StrReplace],
+    target_label: &str,
+) -> Result<String, StoreError> {
+    let mut current = input.to_owned();
+    for replacement in replacements {
+        if replacement.old.is_empty() {
+            return Err(StoreError::Invariant {
+                what: format!("patch replacement for {target_label} cannot use an empty `old`"),
+            });
+        }
+        current = apply_one_replacement(&current, replacement, target_label)?;
+    }
+    Ok(current)
+}
+
+fn apply_one_replacement(
+    input: &str,
+    replacement: &StrReplace,
+    target_label: &str,
+) -> Result<String, StoreError> {
+    match replacement.occurrence {
+        ReplaceOccurrence::First => {
+            if !input.contains(&replacement.old) {
+                return Err(patch_substring_missing(
+                    target_label,
+                    &replacement.old,
+                    "first",
+                ));
+            }
+            Ok(input.replacen(&replacement.old, &replacement.new, 1))
+        }
+        ReplaceOccurrence::All => {
+            if !input.contains(&replacement.old) {
+                return Err(patch_substring_missing(
+                    target_label,
+                    &replacement.old,
+                    "all",
+                ));
+            }
+            Ok(input.replace(&replacement.old, &replacement.new))
+        }
+        ReplaceOccurrence::Nth(index) => replace_nth(input, replacement, target_label, index),
+    }
+}
+
+fn replace_nth(
+    input: &str,
+    replacement: &StrReplace,
+    target_label: &str,
+    index: usize,
+) -> Result<String, StoreError> {
+    let Some((start, matched)) = input.match_indices(&replacement.old).nth(index) else {
+        return Err(patch_substring_missing(
+            target_label,
+            &replacement.old,
+            &format!("nth({index})"),
+        ));
+    };
+    let end = start + matched.len();
+    let mut out =
+        String::with_capacity(input.len() + replacement.new.len().saturating_sub(matched.len()));
+    out.push_str(&input[..start]);
+    out.push_str(&replacement.new);
+    out.push_str(&input[end..]);
+    Ok(out)
+}
+
+fn patch_substring_missing(target_label: &str, needle: &str, occurrence: &str) -> StoreError {
+    StoreError::PatchSubstringMissing {
+        target: target_label.to_owned(),
+        needle: needle.to_owned(),
+        occurrence: occurrence.to_owned(),
+    }
+}

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -2100,24 +2100,39 @@ fn run_plan_lint(json: bool, vault_root: Option<&Path>, plan_id: &str) -> ExitCo
                 return ExitCode::FAILURE;
             }
         };
+        // Round 10 review fix: use the same historical-collision rule
+        // `flush apply rename` enforces, not just the live check —
+        // otherwise lint can bless a plan that apply will reject for
+        // hitting a retired target lineage.
+        let renames_owned: Vec<(
+            cairn_core::domain::TargetId,
+            cairn_core::domain::TargetId,
+        )> = renames
+            .iter()
+            .map(|(s, d)| ((*s).clone(), (*d).clone()))
+            .collect();
         let live_check: Result<Vec<String>, anyhow::Error> = rt.block_on(async {
             let store = cairn_store_sqlite::open(&db_path).await?;
-            let mut hits = Vec::new();
-            for (src, dst) in &renames {
-                let active = store
-                    .get_active_by_target(dst)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
-                if active.is_some() {
-                    hits.push(format!(
-                        "rename target collision (live): `{}` is already a live target — \
-                         renaming `{}` would conflict",
-                        dst.as_str(),
-                        src.as_str(),
-                    ));
-                }
-            }
-            Ok(hits)
+            let renames = renames_owned;
+            store
+                .with_tx(move |tx| {
+                    let mut hits = Vec::new();
+                    for (src, dst) in &renames {
+                        if tx.target_id_ever_used(dst)? {
+                            let active = tx.get_active_by_target(dst)?;
+                            let kind = if active.is_some() { "live" } else { "retired" };
+                            hits.push(format!(
+                                "rename target collision ({kind}): `{}` has been used as a \
+                                 target lineage — renaming `{}` would conflict",
+                                dst.as_str(),
+                                src.as_str(),
+                            ));
+                        }
+                    }
+                    Ok(hits)
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))
         });
         match live_check {
             Ok(hits) => findings.extend(hits),

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1975,8 +1975,13 @@ pub fn run(sub: &ArgMatches, vault_root: Option<&Path>) -> ExitCode {
 }
 
 /// `cairn lint --plan <ULID>` (issue #289): structurally lint a pending
-/// FlushPlan, then check rename mutations against the live store. Surfaces
+/// `FlushPlan`, then check rename mutations against the live store. Surfaces
 /// rename-target collisions before `flush apply` consumes the plan.
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear load → walk-mutations → live-check → emit; splitting would scatter \
+              error-emission boilerplate (json vs human) across helpers without simplifying flow"
+)]
 fn run_plan_lint(json: bool, vault_root: Option<&Path>, plan_id: &str) -> ExitCode {
     use cairn_core::domain::flush_plan::store::{Bucket, plan_path};
     use cairn_core::domain::flush_plan::{PersistedPlan, PlannedMutation};
@@ -2120,15 +2125,13 @@ fn run_plan_lint(json: bool, vault_root: Option<&Path>, plan_id: &str) -> ExitCo
             "plan_id": plan_id,
             "findings": findings,
         }));
-    } else {
-        if has_findings {
-            eprintln!("cairn lint --plan {plan_id}: {} finding(s)", findings.len());
-            for f in &findings {
-                eprintln!("  - {f}");
-            }
-        } else {
-            println!("cairn lint --plan {plan_id}: clean");
+    } else if has_findings {
+        eprintln!("cairn lint --plan {plan_id}: {} finding(s)", findings.len());
+        for f in &findings {
+            eprintln!("  - {f}");
         }
+    } else {
+        println!("cairn lint --plan {plan_id}: clean");
     }
 
     if has_findings {

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1803,7 +1803,12 @@ pub fn run(sub: &ArgMatches, vault_root: Option<&Path>) -> ExitCode {
     let fix_markdown_flag = sub.get_flag("fix-markdown");
     let fix_folders_flag = sub.get_flag("fix-folders");
     let write_report = sub.get_flag("write_report");
+    let plan_id = sub.get_one::<String>("plan").cloned();
     let operation_id = new_operation_id();
+
+    if let Some(plan_id) = plan_id {
+        return run_plan_lint(json, vault_root, &plan_id);
+    }
 
     if fix_markdown_flag {
         return run_fix_markdown(json, vault_root);
@@ -1966,6 +1971,170 @@ pub fn run(sub: &ArgMatches, vault_root: Option<&Path>) -> ExitCode {
             };
             emit_merged(degraded_data)
         }
+    }
+}
+
+/// `cairn lint --plan <ULID>` (issue #289): structurally lint a pending
+/// FlushPlan, then check rename mutations against the live store. Surfaces
+/// rename-target collisions before `flush apply` consumes the plan.
+fn run_plan_lint(json: bool, vault_root: Option<&Path>, plan_id: &str) -> ExitCode {
+    use cairn_core::domain::flush_plan::store::{Bucket, plan_path};
+    use cairn_core::domain::flush_plan::{PersistedPlan, PlannedMutation};
+
+    let op = new_operation_id();
+    let Some(vault_root) = vault_root else {
+        let msg = "lint --plan requires a resolved vault root: pass --vault NAME_OR_PATH \
+                   or set CAIRN_VAULT";
+        if json {
+            emit_json(&serde_json::json!({
+                "code": "Internal",
+                "message": msg,
+                "operation_id": op.0,
+            }));
+        } else {
+            human_error("lint", "Internal", msg, &op);
+        }
+        return ExitCode::from(78);
+    };
+
+    let ulid = cairn_core::generated::common::Ulid(plan_id.to_owned());
+    let path = plan_path(vault_root, Bucket::Pending, &ulid);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            let msg = format!("read pending plan {plan_id}: {e}");
+            if json {
+                emit_json(&serde_json::json!({
+                    "code": "NotFound",
+                    "message": msg,
+                    "operation_id": op.0,
+                }));
+            } else {
+                human_error("lint", "NotFound", &msg, &op);
+            }
+            return ExitCode::from(66);
+        }
+    };
+    let persisted: PersistedPlan = match serde_json::from_slice(&bytes) {
+        Ok(p) => p,
+        Err(e) => {
+            let msg = format!("parse pending plan {plan_id}: {e}");
+            if json {
+                emit_json(&serde_json::json!({
+                    "code": "Internal",
+                    "message": msg,
+                    "operation_id": op.0,
+                }));
+            } else {
+                human_error("lint", "Internal", &msg, &op);
+            }
+            return ExitCode::from(65);
+        }
+    };
+
+    let mut findings: Vec<String> = Vec::new();
+    let mut seen_new_ids: BTreeMap<String, usize> = BTreeMap::new();
+    let mut renames: Vec<(cairn_core::domain::TargetId, cairn_core::domain::TargetId)> = Vec::new();
+
+    for (idx, mutation) in persisted.plan.mutations.iter().enumerate() {
+        if let PlannedMutation::Rename { record_id, new_id } = mutation {
+            if record_id == new_id {
+                findings.push(format!(
+                    "rename mutation #{idx}: source and destination are identical (`{}`)",
+                    new_id.as_str(),
+                ));
+            }
+            if let Some(prev) = seen_new_ids.insert(new_id.as_str().to_owned(), idx) {
+                findings.push(format!(
+                    "rename target collision (intra-plan): mutations #{prev} and #{idx} both \
+                     rename to `{}`",
+                    new_id.as_str(),
+                ));
+            }
+            renames.push((record_id.clone(), new_id.clone()));
+        }
+    }
+
+    let db_path = vault_root.join(".cairn").join("cairn.db");
+    if db_path.exists() && !renames.is_empty() {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                let msg = format!("tokio init error: {e}");
+                if json {
+                    emit_json(&serde_json::json!({
+                        "code": "Internal",
+                        "message": msg,
+                        "operation_id": op.0,
+                    }));
+                } else {
+                    human_error("lint", "Internal", &msg, &op);
+                }
+                return ExitCode::FAILURE;
+            }
+        };
+        let live_check: Result<Vec<String>, anyhow::Error> = rt.block_on(async {
+            let store = cairn_store_sqlite::open(&db_path).await?;
+            let mut hits = Vec::new();
+            for (src, dst) in &renames {
+                let active = store
+                    .get_active_by_target(dst)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                if active.is_some() {
+                    hits.push(format!(
+                        "rename target collision (live): `{}` is already a live target — \
+                         renaming `{}` would conflict",
+                        dst.as_str(),
+                        src.as_str(),
+                    ));
+                }
+            }
+            Ok(hits)
+        });
+        match live_check {
+            Ok(hits) => findings.extend(hits),
+            Err(e) => {
+                let msg = format!("open store for live rename check: {e}");
+                if json {
+                    emit_json(&serde_json::json!({
+                        "code": "Internal",
+                        "message": msg,
+                        "operation_id": op.0,
+                    }));
+                } else {
+                    human_error("lint", "Internal", &msg, &op);
+                }
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    let has_findings = !findings.is_empty();
+    if json {
+        emit_json(&serde_json::json!({
+            "operation_id": op.0,
+            "plan_id": plan_id,
+            "findings": findings,
+        }));
+    } else {
+        if has_findings {
+            eprintln!("cairn lint --plan {plan_id}: {} finding(s)", findings.len());
+            for f in &findings {
+                eprintln!("  - {f}");
+            }
+        } else {
+            println!("cairn lint --plan {plan_id}: clean");
+        }
+    }
+
+    if has_findings {
+        ExitCode::from(65) // EX_DATAERR
+    } else {
+        ExitCode::SUCCESS
     }
 }
 

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1987,6 +1987,25 @@ fn run_plan_lint(json: bool, vault_root: Option<&Path>, plan_id: &str) -> ExitCo
     use cairn_core::domain::flush_plan::{PersistedPlan, PlannedMutation};
 
     let op = new_operation_id();
+    // Reject non-canonical ULIDs before constructing the filesystem path.
+    // `plan_path` interpolates the id into the path; without this gate a
+    // caller could traverse via `..` or absolute-path components and point
+    // the lint at arbitrary `.plan.json` files outside `.cairn/flush/pending`.
+    if !super::flush::is_valid_ulid_str(plan_id) {
+        let msg = format!(
+            "lint --plan: invalid ULID `{plan_id}` (expected 26-char Crockford base32)"
+        );
+        if json {
+            emit_json(&serde_json::json!({
+                "code": "InvalidArgument",
+                "message": msg,
+                "operation_id": op.0,
+            }));
+        } else {
+            human_error("lint", "InvalidArgument", &msg, &op);
+        }
+        return ExitCode::from(64);
+    }
     let Some(vault_root) = vault_root else {
         let msg = "lint --plan requires a resolved vault root: pass --vault NAME_OR_PATH \
                    or set CAIRN_VAULT";

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1992,9 +1992,8 @@ fn run_plan_lint(json: bool, vault_root: Option<&Path>, plan_id: &str) -> ExitCo
     // caller could traverse via `..` or absolute-path components and point
     // the lint at arbitrary `.plan.json` files outside `.cairn/flush/pending`.
     if !super::flush::is_valid_ulid_str(plan_id) {
-        let msg = format!(
-            "lint --plan: invalid ULID `{plan_id}` (expected 26-char Crockford base32)"
-        );
+        let msg =
+            format!("lint --plan: invalid ULID `{plan_id}` (expected 26-char Crockford base32)");
         if json {
             emit_json(&serde_json::json!({
                 "code": "InvalidArgument",
@@ -2104,13 +2103,11 @@ fn run_plan_lint(json: bool, vault_root: Option<&Path>, plan_id: &str) -> ExitCo
         // `flush apply rename` enforces, not just the live check —
         // otherwise lint can bless a plan that apply will reject for
         // hitting a retired target lineage.
-        let renames_owned: Vec<(
-            cairn_core::domain::TargetId,
-            cairn_core::domain::TargetId,
-        )> = renames
-            .iter()
-            .map(|(s, d)| ((*s).clone(), (*d).clone()))
-            .collect();
+        let renames_owned: Vec<(cairn_core::domain::TargetId, cairn_core::domain::TargetId)> =
+            renames
+                .iter()
+                .map(|(s, d)| ((*s).clone(), (*d).clone()))
+                .collect();
         let live_check: Result<Vec<String>, anyhow::Error> = rt.block_on(async {
             let store = cairn_store_sqlite::open(&db_path).await?;
             let renames = renames_owned;

--- a/crates/cairn-cli/src/verbs/mod.rs
+++ b/crates/cairn-cli/src/verbs/mod.rs
@@ -10,6 +10,7 @@ pub mod assemble_hot;
 pub mod capture_trace;
 pub mod envelope;
 pub mod flush;
+pub mod flush_apply;
 pub mod forget;
 pub mod handshake;
 pub mod ingest;

--- a/crates/cairn-cli/src/verbs/mod.rs
+++ b/crates/cairn-cli/src/verbs/mod.rs
@@ -57,6 +57,23 @@ pub fn with_fix_markdown(cmd: clap::Command) -> clap::Command {
     )
 }
 
+/// Add `--plan <ULID>` flag to the `lint` subcommand. Lints the named pending
+/// FlushPlan instead of running the live-store edge linter — surfaces issues
+/// (e.g. rename target collisions) before `flush apply` runs.
+#[must_use]
+pub fn with_lint_plan(cmd: clap::Command) -> clap::Command {
+    cmd.arg(
+        clap::Arg::new("plan")
+            .long("plan")
+            .value_name("ULID")
+            .action(clap::ArgAction::Set)
+            .help(
+                "Lint the pending FlushPlan with this id (issue #289 — surfaces \
+                 rename target collisions before apply)",
+            ),
+    )
+}
+
 /// Add `--fix-folders` flag to the `lint` subcommand.
 ///
 /// Augments the generated subcommand builder without touching generated

--- a/crates/cairn-cli/src/verbs/mod.rs
+++ b/crates/cairn-cli/src/verbs/mod.rs
@@ -10,6 +10,7 @@ pub mod assemble_hot;
 pub mod capture_trace;
 pub mod envelope;
 pub mod flush;
+/// Real `flush apply` executor for non-placeholder plans (issue #289).
 pub mod flush_apply;
 pub mod forget;
 pub mod handshake;
@@ -58,7 +59,7 @@ pub fn with_fix_markdown(cmd: clap::Command) -> clap::Command {
 }
 
 /// Add `--plan <ULID>` flag to the `lint` subcommand. Lints the named pending
-/// FlushPlan instead of running the live-store edge linter — surfaces issues
+/// `FlushPlan` instead of running the live-store edge linter — surfaces issues
 /// (e.g. rename target collisions) before `flush apply` runs.
 #[must_use]
 pub fn with_lint_plan(cmd: clap::Command) -> clap::Command {

--- a/crates/cairn-cli/tests/flush_integration.rs
+++ b/crates/cairn-cli/tests/flush_integration.rs
@@ -1059,7 +1059,10 @@ fn flush_apply_real_plan_rejects_empty_mutations() {
         Bucket::Pending,
         &cairn_core::generated::common::Ulid(id.into()),
     );
-    assert!(pending_path.exists(), "expected plan to roll back to pending");
+    assert!(
+        pending_path.exists(),
+        "expected plan to roll back to pending"
+    );
 }
 
 #[test]

--- a/crates/cairn-cli/tests/flush_integration.rs
+++ b/crates/cairn-cli/tests/flush_integration.rs
@@ -1260,6 +1260,123 @@ fn flush_apply_rename_rejects_live_destination_collision() {
 }
 
 #[test]
+fn lint_plan_flags_live_rename_target_collision() {
+    let vault = tempfile::tempdir().unwrap();
+    let id = "01JTS6R4J7000000000000000H";
+    let source = sample_record(7);
+    let dest = sample_record(8);
+
+    let (rt, store) = open_store(vault.path());
+    rt.block_on(store.upsert(&source)).expect("seed source");
+    rt.block_on(store.upsert(&dest)).expect("seed dest");
+
+    write_real_pending_plan(
+        vault.path(),
+        id,
+        vec![PlannedMutation::Rename {
+            record_id: source.target_id.clone(),
+            new_id: dest.target_id.clone(),
+        }],
+    );
+
+    let bin = env!("CARGO_BIN_EXE_cairn");
+    let out = std::process::Command::new(bin)
+        .args(["lint", "--plan", id])
+        .env("CAIRN_VAULT", vault.path())
+        .output()
+        .expect("spawn cairn");
+    assert_eq!(
+        out.status.code(),
+        Some(65),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("rename target collision (live)")
+            && stderr.contains(dest.target_id.as_str()),
+        "expected live rename collision finding; got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn lint_plan_flags_intra_plan_rename_collision() {
+    let vault = tempfile::tempdir().unwrap();
+    let id = "01JTS6R4J7000000000000000J";
+    let dup_target = TargetId::parse("01JTS6R4J7000000000000000K").unwrap();
+
+    write_real_pending_plan(
+        vault.path(),
+        id,
+        vec![
+            PlannedMutation::Rename {
+                record_id: TargetId::parse("01JTS6R4J70000000000000020").unwrap(),
+                new_id: dup_target.clone(),
+            },
+            PlannedMutation::Rename {
+                record_id: TargetId::parse("01JTS6R4J70000000000000021").unwrap(),
+                new_id: dup_target.clone(),
+            },
+        ],
+    );
+
+    let bin = env!("CARGO_BIN_EXE_cairn");
+    let out = std::process::Command::new(bin)
+        .args(["lint", "--plan", id])
+        .env("CAIRN_VAULT", vault.path())
+        .output()
+        .expect("spawn cairn");
+    assert_eq!(
+        out.status.code(),
+        Some(65),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("rename target collision (intra-plan)"),
+        "expected intra-plan rename collision finding; got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn lint_plan_clean_plan_exits_zero() {
+    let vault = tempfile::tempdir().unwrap();
+    let id = "01JTS6R4J7000000000000000N";
+    let source = sample_record(9);
+    let new_target = TargetId::parse("01JTS6R4J7000000000000000P").unwrap();
+
+    let (rt, store) = open_store(vault.path());
+    rt.block_on(store.upsert(&source)).expect("seed source");
+
+    write_real_pending_plan(
+        vault.path(),
+        id,
+        vec![PlannedMutation::Rename {
+            record_id: source.target_id.clone(),
+            new_id: new_target,
+        }],
+    );
+
+    let bin = env!("CARGO_BIN_EXE_cairn");
+    let out = std::process::Command::new(bin)
+        .args(["lint", "--plan", id])
+        .env("CAIRN_VAULT", vault.path())
+        .output()
+        .expect("spawn cairn");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("clean"),
+        "expected `clean` marker; got stdout: {stdout}"
+    );
+}
+
+#[test]
 fn flush_apply_rename_rewrites_inbound_edges_to_new_active_record() {
     let vault = tempfile::tempdir().unwrap();
     let id = "01JTS6R4J7000000000000000F";

--- a/crates/cairn-cli/tests/flush_integration.rs
+++ b/crates/cairn-cli/tests/flush_integration.rs
@@ -1070,13 +1070,15 @@ fn flush_apply_patch_updates_record_body_and_keeps_old_version() {
 
     let (rt, store) = open_store(vault.path());
     rt.block_on(store.upsert(&record)).expect("seed record");
+    let stored = rt
+        .block_on(store.get_active_by_target(&target))
+        .expect("read stored")
+        .expect("stored record");
 
     let mut hashes = std::collections::BTreeMap::new();
     hashes.insert(
         target.as_str().to_owned(),
-        cairn_core::domain::BodyHash::compute(&record.body)
-            .as_str()
-            .to_owned(),
+        cairn_cli::verbs::flush_apply::record_drift_hash(&stored.record),
     );
     write_real_pending_plan_with_hashes(
         vault.path(),
@@ -1139,13 +1141,15 @@ fn flush_apply_patch_missing_substring_fails_atomically() {
 
     let (rt, store) = open_store(vault.path());
     rt.block_on(store.upsert(&record)).expect("seed record");
+    let stored = rt
+        .block_on(store.get_active_by_target(&target))
+        .expect("read stored")
+        .expect("stored record");
 
     let mut hashes = std::collections::BTreeMap::new();
     hashes.insert(
         target.as_str().to_owned(),
-        cairn_core::domain::BodyHash::compute(&record.body)
-            .as_str()
-            .to_owned(),
+        cairn_cli::verbs::flush_apply::record_drift_hash(&stored.record),
     );
     write_real_pending_plan_with_hashes(
         vault.path(),
@@ -1261,13 +1265,15 @@ fn flush_apply_rename_rejects_live_destination_collision() {
     let (rt, store) = open_store(vault.path());
     rt.block_on(store.upsert(&source)).expect("seed source");
     rt.block_on(store.upsert(&dest)).expect("seed destination");
+    let stored_source = rt
+        .block_on(store.get_active_by_target(&source.target_id))
+        .expect("read source")
+        .expect("source row");
 
     let mut hashes = std::collections::BTreeMap::new();
     hashes.insert(
         source.target_id.as_str().to_owned(),
-        cairn_core::domain::BodyHash::compute(&source.body)
-            .as_str()
-            .to_owned(),
+        cairn_cli::verbs::flush_apply::record_drift_hash(&stored_source.record),
     );
     write_real_pending_plan_with_hashes(
         vault.path(),
@@ -1433,13 +1439,15 @@ fn flush_apply_rename_rewrites_inbound_edges_to_new_active_record() {
         weight: None,
     }))
     .expect("seed inbound edge");
+    let stored_source = rt
+        .block_on(store.get_active_by_target(&source.target_id))
+        .expect("read source")
+        .expect("source row");
 
     let mut hashes = std::collections::BTreeMap::new();
     hashes.insert(
         source.target_id.as_str().to_owned(),
-        cairn_core::domain::BodyHash::compute(&source.body)
-            .as_str()
-            .to_owned(),
+        cairn_cli::verbs::flush_apply::record_drift_hash(&stored_source.record),
     );
     write_real_pending_plan_with_hashes(
         vault.path(),

--- a/crates/cairn-cli/tests/flush_integration.rs
+++ b/crates/cairn-cli/tests/flush_integration.rs
@@ -2,14 +2,64 @@
 
 use std::path::Path;
 
+use cairn_core::contract::memory_store::{Edge, EdgeDir, EdgeKind, MemoryStore};
 use cairn_core::domain::flush_plan::store::{Bucket, bucket_dir, plan_path};
+use cairn_core::domain::flush_plan::{
+    FlushMode, PatchTarget, PersistedPlan, PlanReason, PlannedMutation, ReplaceOccurrence,
+    StrReplace,
+};
+use cairn_core::domain::session::SessionIdentity;
+use cairn_core::domain::{Identity, ScopeTuple, TargetId};
 use cairn_test_fixtures::flush_plan::sample_pending;
+use cairn_test_fixtures::sample_record;
 
 fn write_pending(vault: &Path, id: &str) {
     let p = sample_pending(id);
     let path = plan_path(vault, Bucket::Pending, &p.plan.operation_id);
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(&path, serde_json::to_vec_pretty(&p).unwrap()).unwrap();
+}
+
+fn write_non_placeholder_pending_noop(vault: &Path, id: &str) {
+    write_real_pending_plan(vault, id, vec![]);
+}
+
+fn write_real_pending_plan(vault: &Path, id: &str, mutations: Vec<PlannedMutation>) {
+    let plan = cairn_core::domain::flush_plan::FlushPlan {
+        operation_id: cairn_core::generated::common::Ulid(id.into()),
+        issued_at: "2026-05-09T12:00:00Z".into(),
+        issuer: Identity::parse("agt:claude-code:opus-4-7:reviewer:v1").unwrap(),
+        principal: None,
+        scope: ScopeTuple::default(),
+        mode: FlushMode::HumanReview,
+        mutations,
+        reason: PlanReason::UserIngest,
+        source_events: vec![],
+        target_hashes: std::collections::BTreeMap::new(),
+        dependencies: vec![],
+        expires_at: "2099-05-09T12:05:00Z".into(),
+        placeholder: false,
+    };
+    let persisted = PersistedPlan::pending(plan);
+    let path = plan_path(vault, Bucket::Pending, &persisted.plan.operation_id);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, serde_json::to_vec_pretty(&persisted).unwrap()).unwrap();
+}
+
+fn open_store(
+    vault: &Path,
+) -> (
+    tokio::runtime::Runtime,
+    cairn_store_sqlite::SqliteMemoryStore,
+) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let store = rt
+        .block_on(cairn_store_sqlite::open(vault.join(".cairn/cairn.db")))
+        .unwrap();
+    (rt, store)
 }
 
 #[test]
@@ -964,5 +1014,308 @@ fn flush_apply_warns_on_placeholder_and_records_metadata_only() {
     assert_eq!(
         *apply_kind,
         cairn_core::domain::flush_plan::ApplyKind::MetadataOnly
+    );
+}
+
+#[test]
+fn flush_apply_real_plan_records_full_apply_kind() {
+    let vault = tempfile::tempdir().unwrap();
+    let id = "01JTS6R4J7000000000000000A";
+    write_non_placeholder_pending_noop(vault.path(), id);
+
+    let bin = env!("CARGO_BIN_EXE_cairn");
+    let out = std::process::Command::new(bin)
+        .args(["flush", "apply", id])
+        .env("CAIRN_VAULT", vault.path())
+        .output()
+        .expect("spawn cairn");
+
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let applied_path = plan_path(
+        vault.path(),
+        Bucket::Applied,
+        &cairn_core::generated::common::Ulid(id.into()),
+    );
+    let persisted: cairn_core::domain::flush_plan::PersistedPlan =
+        serde_json::from_slice(&std::fs::read(&applied_path).unwrap()).unwrap();
+    let cairn_core::domain::flush_plan::PlanStatus::Applied { ref apply_kind, .. } =
+        persisted.status
+    else {
+        panic!("expected Applied status, got {:?}", persisted.status);
+    };
+    assert_eq!(*apply_kind, cairn_core::domain::flush_plan::ApplyKind::Full);
+}
+
+#[test]
+fn flush_apply_patch_updates_record_body_and_keeps_old_version() {
+    let vault = tempfile::tempdir().unwrap();
+    let id = "01JTS6R4J7000000000000000B";
+    let mut record = sample_record(1);
+    record.body = "alpha beta".into();
+    let target = record.target_id.clone();
+
+    let (rt, store) = open_store(vault.path());
+    rt.block_on(store.upsert(&record)).expect("seed record");
+
+    write_real_pending_plan(
+        vault.path(),
+        id,
+        vec![PlannedMutation::Patch {
+            target: PatchTarget::Record(target.clone()),
+            str_replace: vec![StrReplace {
+                old: "beta".into(),
+                new: "gamma".into(),
+                occurrence: ReplaceOccurrence::First,
+            }],
+        }],
+    );
+
+    let bin = env!("CARGO_BIN_EXE_cairn");
+    let out = std::process::Command::new(bin)
+        .args(["flush", "apply", id])
+        .env("CAIRN_VAULT", vault.path())
+        .output()
+        .expect("spawn cairn");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let active = rt
+        .block_on(store.get_active_by_target(&target))
+        .expect("read active")
+        .expect("active record");
+    assert_eq!(active.record.body, "alpha gamma");
+    let history = rt.block_on(store.versions(&target)).expect("history");
+    assert_eq!(
+        history.len(),
+        2,
+        "expected superseded old version to remain"
+    );
+    let old = rt
+        .block_on(store.get(&history[0].record_id))
+        .expect("fetch old version")
+        .expect("old version body");
+    assert_eq!(old.body, "alpha beta");
+    assert!(
+        active
+            .record
+            .extra_frontmatter
+            .contains_key("flush_patch_history"),
+        "patched record should carry patch audit metadata"
+    );
+}
+
+#[test]
+fn flush_apply_patch_missing_substring_fails_atomically() {
+    let vault = tempfile::tempdir().unwrap();
+    let id = "01JTS6R4J7000000000000000C";
+    let mut record = sample_record(2);
+    record.body = "alpha beta".into();
+    let target = record.target_id.clone();
+
+    let (rt, store) = open_store(vault.path());
+    rt.block_on(store.upsert(&record)).expect("seed record");
+
+    write_real_pending_plan(
+        vault.path(),
+        id,
+        vec![PlannedMutation::Patch {
+            target: PatchTarget::Record(target.clone()),
+            str_replace: vec![StrReplace {
+                old: "delta".into(),
+                new: "gamma".into(),
+                occurrence: ReplaceOccurrence::First,
+            }],
+        }],
+    );
+
+    let bin = env!("CARGO_BIN_EXE_cairn");
+    let out = std::process::Command::new(bin)
+        .args(["flush", "apply", id])
+        .env("CAIRN_VAULT", vault.path())
+        .output()
+        .expect("spawn cairn");
+    assert_eq!(
+        out.status.code(),
+        Some(70),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("patch substring not found"),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let active = rt
+        .block_on(store.get_active_by_target(&target))
+        .expect("read active")
+        .expect("active record");
+    assert_eq!(active.record.body, "alpha beta");
+    let history = rt.block_on(store.versions(&target)).expect("history");
+    assert_eq!(
+        history.len(),
+        1,
+        "atomic failure must not write a new version"
+    );
+}
+
+#[test]
+fn flush_apply_patch_session_metadata_updates_live_session() {
+    let vault = tempfile::tempdir().unwrap();
+    let id = "01JTS6R4J7000000000000000D";
+    let (rt, store) = open_store(vault.path());
+    let identity = SessionIdentity::new(
+        Identity::parse("hmn:alice:v1").unwrap(),
+        Identity::parse("agt:claude-code:opus-4-7:main:v1").unwrap(),
+        Some(vault.path().display().to_string()),
+    )
+    .unwrap();
+    let session = rt
+        .block_on(store.create_session(
+            &identity,
+            cairn_store_sqlite::NewSessionMetadata {
+                channel: Some("chat".into()),
+                priority: Some("low".into()),
+                tags: vec!["alpha".into()],
+            },
+        ))
+        .unwrap();
+
+    write_real_pending_plan(
+        vault.path(),
+        id,
+        vec![PlannedMutation::Patch {
+            target: PatchTarget::Session(session.id.clone()),
+            str_replace: vec![StrReplace {
+                old: "chat".into(),
+                new: "ops".into(),
+                occurrence: ReplaceOccurrence::First,
+            }],
+        }],
+    );
+
+    let bin = env!("CARGO_BIN_EXE_cairn");
+    let out = std::process::Command::new(bin)
+        .args(["flush", "apply", id])
+        .env("CAIRN_VAULT", vault.path())
+        .output()
+        .expect("spawn cairn");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let patched = rt
+        .block_on(store.resolve_explicit_session(&session.id, &identity))
+        .expect("resolve patched session");
+    assert_eq!(patched.channel.as_deref(), Some("ops"));
+}
+
+#[test]
+fn flush_apply_rename_rejects_live_destination_collision() {
+    let vault = tempfile::tempdir().unwrap();
+    let id = "01JTS6R4J7000000000000000E";
+    let source = sample_record(3);
+    let dest = sample_record(4);
+
+    let (rt, store) = open_store(vault.path());
+    rt.block_on(store.upsert(&source)).expect("seed source");
+    rt.block_on(store.upsert(&dest)).expect("seed destination");
+
+    write_real_pending_plan(
+        vault.path(),
+        id,
+        vec![PlannedMutation::Rename {
+            record_id: source.target_id.clone(),
+            new_id: dest.target_id.clone(),
+        }],
+    );
+
+    let bin = env!("CARGO_BIN_EXE_cairn");
+    let out = std::process::Command::new(bin)
+        .args(["flush", "apply", id])
+        .env("CAIRN_VAULT", vault.path())
+        .output()
+        .expect("spawn cairn");
+    assert_eq!(
+        out.status.code(),
+        Some(70),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("rename destination already exists"),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn flush_apply_rename_rewrites_inbound_edges_to_new_active_record() {
+    let vault = tempfile::tempdir().unwrap();
+    let id = "01JTS6R4J7000000000000000F";
+    let source = sample_record(5);
+    let inbound = sample_record(6);
+    let new_target = TargetId::parse("01JTS6R4J7000000000000000G").unwrap();
+
+    let (rt, store) = open_store(vault.path());
+    rt.block_on(store.upsert(&source)).expect("seed source");
+    rt.block_on(store.upsert(&inbound)).expect("seed inbound");
+    rt.block_on(store.put_edge(&Edge {
+        src: inbound.id.clone(),
+        dst: source.id.clone(),
+        kind: EdgeKind::Mentions,
+        weight: None,
+    }))
+    .expect("seed inbound edge");
+
+    write_real_pending_plan(
+        vault.path(),
+        id,
+        vec![PlannedMutation::Rename {
+            record_id: source.target_id.clone(),
+            new_id: new_target.clone(),
+        }],
+    );
+
+    let bin = env!("CARGO_BIN_EXE_cairn");
+    let out = std::process::Command::new(bin)
+        .args(["flush", "apply", id])
+        .env("CAIRN_VAULT", vault.path())
+        .output()
+        .expect("spawn cairn");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let active = rt
+        .block_on(store.get_active_by_target(&new_target))
+        .expect("read renamed target")
+        .expect("renamed record");
+    assert!(
+        rt.block_on(store.get_active_by_target(&source.target_id))
+            .expect("read old target")
+            .is_none(),
+        "old target should no longer resolve as active"
+    );
+    let inbound_edges = rt
+        .block_on(store.neighbours(&active.record.id, EdgeDir::In))
+        .expect("read inbound edges");
+    assert!(
+        inbound_edges
+            .iter()
+            .any(|edge| edge.src == inbound.id && edge.kind == EdgeKind::Mentions),
+        "expected mentions edge to follow renamed record"
     );
 }

--- a/crates/cairn-cli/tests/flush_integration.rs
+++ b/crates/cairn-cli/tests/flush_integration.rs
@@ -1027,7 +1027,10 @@ fn flush_apply_warns_on_placeholder_and_records_metadata_only() {
 }
 
 #[test]
-fn flush_apply_real_plan_records_full_apply_kind() {
+fn flush_apply_real_plan_rejects_empty_mutations() {
+    // Re-loop r9 finding 1: a non-placeholder plan with no mutations
+    // must NOT publish `ApplyKind::Full` (that would be a misleading
+    // "fully applied" audit record for a planner-corruption / no-op).
     let vault = tempfile::tempdir().unwrap();
     let id = "01JTS6R4J7000000000000000A";
     write_non_placeholder_pending_noop(vault.path(), id);
@@ -1039,25 +1042,24 @@ fn flush_apply_real_plan_records_full_apply_kind() {
         .output()
         .expect("spawn cairn");
 
-    assert!(
-        out.status.success(),
+    assert_eq!(
+        out.status.code(),
+        Some(65),
         "stderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-
-    let applied_path = plan_path(
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("has no mutations"),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Plan must remain pending — refusal should roll the claim back.
+    let pending_path = plan_path(
         vault.path(),
-        Bucket::Applied,
+        Bucket::Pending,
         &cairn_core::generated::common::Ulid(id.into()),
     );
-    let persisted: cairn_core::domain::flush_plan::PersistedPlan =
-        serde_json::from_slice(&std::fs::read(&applied_path).unwrap()).unwrap();
-    let cairn_core::domain::flush_plan::PlanStatus::Applied { ref apply_kind, .. } =
-        persisted.status
-    else {
-        panic!("expected Applied status, got {:?}", persisted.status);
-    };
-    assert_eq!(*apply_kind, cairn_core::domain::flush_plan::ApplyKind::Full);
+    assert!(pending_path.exists(), "expected plan to roll back to pending");
 }
 
 #[test]

--- a/crates/cairn-cli/tests/flush_integration.rs
+++ b/crates/cairn-cli/tests/flush_integration.rs
@@ -25,6 +25,15 @@ fn write_non_placeholder_pending_noop(vault: &Path, id: &str) {
 }
 
 fn write_real_pending_plan(vault: &Path, id: &str, mutations: Vec<PlannedMutation>) {
+    write_real_pending_plan_with_hashes(vault, id, mutations, std::collections::BTreeMap::new());
+}
+
+fn write_real_pending_plan_with_hashes(
+    vault: &Path,
+    id: &str,
+    mutations: Vec<PlannedMutation>,
+    target_hashes: std::collections::BTreeMap<String, String>,
+) {
     let plan = cairn_core::domain::flush_plan::FlushPlan {
         operation_id: cairn_core::generated::common::Ulid(id.into()),
         issued_at: "2026-05-09T12:00:00Z".into(),
@@ -35,7 +44,7 @@ fn write_real_pending_plan(vault: &Path, id: &str, mutations: Vec<PlannedMutatio
         mutations,
         reason: PlanReason::UserIngest,
         source_events: vec![],
-        target_hashes: std::collections::BTreeMap::new(),
+        target_hashes,
         dependencies: vec![],
         expires_at: "2099-05-09T12:05:00Z".into(),
         placeholder: false,
@@ -1062,7 +1071,14 @@ fn flush_apply_patch_updates_record_body_and_keeps_old_version() {
     let (rt, store) = open_store(vault.path());
     rt.block_on(store.upsert(&record)).expect("seed record");
 
-    write_real_pending_plan(
+    let mut hashes = std::collections::BTreeMap::new();
+    hashes.insert(
+        target.as_str().to_owned(),
+        cairn_core::domain::BodyHash::compute(&record.body)
+            .as_str()
+            .to_owned(),
+    );
+    write_real_pending_plan_with_hashes(
         vault.path(),
         id,
         vec![PlannedMutation::Patch {
@@ -1073,6 +1089,7 @@ fn flush_apply_patch_updates_record_body_and_keeps_old_version() {
                 occurrence: ReplaceOccurrence::First,
             }],
         }],
+        hashes,
     );
 
     let bin = env!("CARGO_BIN_EXE_cairn");
@@ -1123,7 +1140,14 @@ fn flush_apply_patch_missing_substring_fails_atomically() {
     let (rt, store) = open_store(vault.path());
     rt.block_on(store.upsert(&record)).expect("seed record");
 
-    write_real_pending_plan(
+    let mut hashes = std::collections::BTreeMap::new();
+    hashes.insert(
+        target.as_str().to_owned(),
+        cairn_core::domain::BodyHash::compute(&record.body)
+            .as_str()
+            .to_owned(),
+    );
+    write_real_pending_plan_with_hashes(
         vault.path(),
         id,
         vec![PlannedMutation::Patch {
@@ -1134,6 +1158,7 @@ fn flush_apply_patch_missing_substring_fails_atomically() {
                 occurrence: ReplaceOccurrence::First,
             }],
         }],
+        hashes,
     );
 
     let bin = env!("CARGO_BIN_EXE_cairn");
@@ -1189,7 +1214,12 @@ fn flush_apply_patch_session_metadata_updates_live_session() {
         ))
         .unwrap();
 
-    write_real_pending_plan(
+    let mut hashes = std::collections::BTreeMap::new();
+    hashes.insert(
+        session.id.as_str().to_owned(),
+        cairn_cli::verbs::flush_apply::session_drift_hash(&session),
+    );
+    write_real_pending_plan_with_hashes(
         vault.path(),
         id,
         vec![PlannedMutation::Patch {
@@ -1200,6 +1230,7 @@ fn flush_apply_patch_session_metadata_updates_live_session() {
                 occurrence: ReplaceOccurrence::First,
             }],
         }],
+        hashes,
     );
 
     let bin = env!("CARGO_BIN_EXE_cairn");
@@ -1231,13 +1262,21 @@ fn flush_apply_rename_rejects_live_destination_collision() {
     rt.block_on(store.upsert(&source)).expect("seed source");
     rt.block_on(store.upsert(&dest)).expect("seed destination");
 
-    write_real_pending_plan(
+    let mut hashes = std::collections::BTreeMap::new();
+    hashes.insert(
+        source.target_id.as_str().to_owned(),
+        cairn_core::domain::BodyHash::compute(&source.body)
+            .as_str()
+            .to_owned(),
+    );
+    write_real_pending_plan_with_hashes(
         vault.path(),
         id,
         vec![PlannedMutation::Rename {
             record_id: source.target_id.clone(),
             new_id: dest.target_id.clone(),
         }],
+        hashes,
     );
 
     let bin = env!("CARGO_BIN_EXE_cairn");
@@ -1395,13 +1434,21 @@ fn flush_apply_rename_rewrites_inbound_edges_to_new_active_record() {
     }))
     .expect("seed inbound edge");
 
-    write_real_pending_plan(
+    let mut hashes = std::collections::BTreeMap::new();
+    hashes.insert(
+        source.target_id.as_str().to_owned(),
+        cairn_core::domain::BodyHash::compute(&source.body)
+            .as_str()
+            .to_owned(),
+    );
+    write_real_pending_plan_with_hashes(
         vault.path(),
         id,
         vec![PlannedMutation::Rename {
             record_id: source.target_id.clone(),
             new_id: new_target.clone(),
         }],
+        hashes,
     );
 
     let bin = env!("CARGO_BIN_EXE_cairn");

--- a/crates/cairn-core/src/domain/flush_plan/diff.rs
+++ b/crates/cairn-core/src/domain/flush_plan/diff.rs
@@ -3,7 +3,7 @@
 
 use std::fmt::Write as _;
 
-use super::{FlushPlan, PlannedMutation};
+use super::{FlushPlan, PatchTarget, PlannedMutation, ReplaceOccurrence};
 
 /// Maximum body excerpt length per mutation, characters.
 pub const MAX_BODY_EXCERPT: usize = 4096;
@@ -70,6 +70,43 @@ pub fn render(plan: &FlushPlan) -> String {
                 writeln!(&mut out, "- **Target:** `{}`", target.as_str()).ok();
                 writeln!(&mut out, "- **Prior version:** {prior_version}").ok();
             }
+            PlannedMutation::Patch {
+                target,
+                str_replace,
+            } => {
+                writeln!(&mut out, "- **Kind:** patch").ok();
+                match target {
+                    PatchTarget::Record(target) => {
+                        writeln!(&mut out, "- **Target:** `{}`", target.as_str()).ok();
+                    }
+                    PatchTarget::Session(session) => {
+                        writeln!(&mut out, "- **Session:** `{}`", session.as_str()).ok();
+                    }
+                }
+                for change in str_replace {
+                    let occurrence = match change.occurrence {
+                        ReplaceOccurrence::First => "first".to_owned(),
+                        ReplaceOccurrence::All => "all".to_owned(),
+                        ReplaceOccurrence::Nth(n) => format!("nth({n})"),
+                    };
+                    writeln!(
+                        &mut out,
+                        "- **Replace:** `{}` -> `{}` ({occurrence})",
+                        change.old, change.new
+                    )
+                    .ok();
+                }
+            }
+            PlannedMutation::Rename { record_id, new_id } => {
+                writeln!(&mut out, "- **Kind:** rename").ok();
+                writeln!(
+                    &mut out,
+                    "- **Target:** `{}` -> `{}`",
+                    record_id.as_str(),
+                    new_id.as_str()
+                )
+                .ok();
+            }
             PlannedMutation::Promote {
                 from,
                 to_kind,
@@ -109,10 +146,30 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
+    use crate::domain::flush_plan::StrReplace;
     use crate::domain::{
-        FlushMode, FlushPlan, Identity, PlanReason, PlannedMutation, ScopeTuple, TargetId,
+        FlushMode, FlushPlan, Identity, PlanReason, PlannedMutation, ScopeTuple, SessionId,
+        TargetId,
     };
     use crate::generated::common::Ulid;
+
+    fn sample_plan_base(mutations: Vec<PlannedMutation>) -> FlushPlan {
+        FlushPlan {
+            operation_id: Ulid("01HQZK000000000000000000VP".into()),
+            issued_at: "2026-05-04T12:00:00Z".into(),
+            issuer: Identity::parse("agt:claude-code:opus-4-7:reviewer:v1").unwrap(),
+            principal: None,
+            scope: ScopeTuple::default(),
+            mode: FlushMode::HumanReview,
+            mutations,
+            reason: PlanReason::UserIngest,
+            source_events: vec![],
+            target_hashes: BTreeMap::default(),
+            dependencies: vec![],
+            expires_at: "2026-05-04T12:05:00Z".into(),
+            placeholder: false,
+        }
+    }
 
     /// Round 2 (#54): `MAX_BODY_EXCERPT` truncation must walk back to a
     /// UTF-8 char boundary rather than panic when a multibyte codepoint
@@ -132,22 +189,11 @@ mod tests {
         let mut record = crate::domain::record::tests_export::sample_record();
         record.body = body;
         let plan = FlushPlan {
-            operation_id: Ulid("01HQZK000000000000000000VP".into()),
-            issued_at: "2026-05-04T12:00:00Z".into(),
-            issuer: Identity::parse("agt:claude-code:opus-4-7:reviewer:v1").unwrap(),
-            principal: None,
-            scope: ScopeTuple::default(),
-            mode: FlushMode::HumanReview,
             mutations: vec![PlannedMutation::Upsert {
                 record: Box::new(record),
                 prior_version: None,
             }],
-            reason: PlanReason::UserIngest,
-            source_events: vec![],
-            target_hashes: BTreeMap::default(),
-            dependencies: vec![],
-            expires_at: "2026-05-04T12:05:00Z".into(),
-            placeholder: false,
+            ..sample_plan_base(Vec::new())
         };
         // Must not panic when slicing the body at the byte boundary.
         let md = render(&plan);
@@ -156,28 +202,38 @@ mod tests {
 
     #[test]
     fn renders_delete_mutation() {
-        let plan = FlushPlan {
-            operation_id: Ulid("01HQZK000000000000000000VP".into()),
-            issued_at: "2026-05-04T12:00:00Z".into(),
-            issuer: Identity::parse("agt:claude-code:opus-4-7:reviewer:v1").unwrap(),
-            principal: None,
-            scope: ScopeTuple::default(),
-            mode: FlushMode::HumanReview,
-            mutations: vec![PlannedMutation::Delete {
-                target: TargetId::parse("01HQZX9F5N0000000000000000").unwrap(),
-                prior_version: 3,
-            }],
-            reason: PlanReason::UserIngest,
-            source_events: vec![],
-            target_hashes: BTreeMap::default(),
-            dependencies: vec![],
-            expires_at: "2026-05-04T12:05:00Z".into(),
-            placeholder: false,
-        };
+        let plan = sample_plan_base(vec![PlannedMutation::Delete {
+            target: TargetId::parse("01HQZX9F5N0000000000000000").unwrap(),
+            prior_version: 3,
+        }]);
         let md = render(&plan);
         assert!(md.contains("# FlushPlan 01HQZK"));
         assert!(md.contains("- **Kind:** delete"));
         assert!(md.contains("- **Target:** `01HQZX9F5N0000000000000000`"));
         assert!(md.contains("- **Prior version:** 3"));
+    }
+
+    #[test]
+    fn renders_session_patch_mutation() {
+        let plan = sample_plan_base(vec![PlannedMutation::Patch {
+            target: PatchTarget::Session(SessionId::parse("01JTS6R4J70000000000000000").unwrap()),
+            str_replace: vec![StrReplace {
+                old: "draft".into(),
+                new: "final".into(),
+                occurrence: ReplaceOccurrence::First,
+            }],
+        }]);
+        let md = render(&plan);
+        insta::assert_snapshot!("diff_patch_session_md", md);
+    }
+
+    #[test]
+    fn renders_rename_mutation() {
+        let plan = sample_plan_base(vec![PlannedMutation::Rename {
+            record_id: TargetId::parse("01JTS6R4J70000000000000001").unwrap(),
+            new_id: TargetId::parse("01JTS6R4J70000000000000002").unwrap(),
+        }]);
+        let md = render(&plan);
+        insta::assert_snapshot!("diff_rename_md", md);
     }
 }

--- a/crates/cairn-core/src/domain/flush_plan/diff.rs
+++ b/crates/cairn-core/src/domain/flush_plan/diff.rs
@@ -11,6 +11,11 @@ pub const MAX_BODY_EXCERPT: usize = 4096;
 /// Render the plan to markdown. Deterministic — same plan in, same bytes
 /// out (byte-stable for snapshot tests).
 #[must_use]
+#[allow(
+    clippy::too_many_lines,
+    reason = "linear per-variant rendering; splitting per mutation kind would scatter \
+              snapshot-stable formatting across helpers without simplifying the flow"
+)]
 pub fn render(plan: &FlushPlan) -> String {
     let mut out = String::with_capacity(1024);
     writeln!(&mut out, "# FlushPlan {}", plan.operation_id.0).ok();

--- a/crates/cairn-core/src/domain/flush_plan/mod.rs
+++ b/crates/cairn-core/src/domain/flush_plan/mod.rs
@@ -95,6 +95,40 @@ impl FlushPlan {
 
 /// One concrete mutation inside a [`FlushPlan`]. Tagged externally for
 /// stable JSON shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchTarget {
+    /// Patch the active record for the target.
+    Record(TargetId),
+    /// Patch the session metadata document for the session.
+    Session(SessionId),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+/// Which match occurrence(s) a patch replacement should edit.
+pub enum ReplaceOccurrence {
+    /// Replace the first matching occurrence.
+    First,
+    /// Replace every matching occurrence.
+    All,
+    /// Replace the nth matching occurrence (zero-based).
+    Nth(usize),
+}
+
+/// One string replacement inside a patch mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StrReplace {
+    /// Existing substring to find.
+    pub old: String,
+    /// Replacement substring.
+    pub new: String,
+    /// Which occurrence(s) to replace.
+    pub occurrence: ReplaceOccurrence,
+}
+
+/// One concrete mutation inside a [`FlushPlan`]. Tagged externally for
+/// stable JSON shape.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 #[non_exhaustive]
@@ -113,6 +147,20 @@ pub enum PlannedMutation {
         target: TargetId,
         /// Version the caller observed — prevents blind deletes.
         prior_version: u32,
+    },
+    /// Patch an existing record or session metadata document.
+    Patch {
+        /// Which document the string replacements apply to.
+        target: PatchTarget,
+        /// Ordered string replacements applied left-to-right.
+        str_replace: Vec<StrReplace>,
+    },
+    /// Rename an existing target id to a new target id.
+    Rename {
+        /// Existing target lineage key.
+        record_id: TargetId,
+        /// Destination lineage key.
+        new_id: TargetId,
     },
     /// Promote a raw/wiki record to a different memory kind.
     Promote {

--- a/crates/cairn-core/src/domain/flush_plan/mod.rs
+++ b/crates/cairn-core/src/domain/flush_plan/mod.rs
@@ -97,9 +97,7 @@ impl FlushPlan {
     /// reuse it under the session id.
     #[must_use]
     pub fn session_hash(&self, session: &SessionId) -> Option<&str> {
-        self.target_hashes
-            .get(session.as_str())
-            .map(String::as_str)
+        self.target_hashes.get(session.as_str()).map(String::as_str)
     }
 }
 

--- a/crates/cairn-core/src/domain/flush_plan/mod.rs
+++ b/crates/cairn-core/src/domain/flush_plan/mod.rs
@@ -91,6 +91,16 @@ impl FlushPlan {
     pub fn target_hash(&self, target: &TargetId) -> Option<&str> {
         self.target_hashes.get(target.as_str()).map(String::as_str)
     }
+
+    /// Pre-state hash for a session metadata target (issue #289 review
+    /// round 2). `target_hashes` is keyed by string, so session patches
+    /// reuse it under the session id.
+    #[must_use]
+    pub fn session_hash(&self, session: &SessionId) -> Option<&str> {
+        self.target_hashes
+            .get(session.as_str())
+            .map(String::as_str)
+    }
 }
 
 /// One concrete mutation inside a [`FlushPlan`]. Tagged externally for

--- a/crates/cairn-core/src/domain/flush_plan/snapshots/cairn_core__domain__flush_plan__diff__tests__diff_patch_session_md.snap
+++ b/crates/cairn-core/src/domain/flush_plan/snapshots/cairn_core__domain__flush_plan__diff__tests__diff_patch_session_md.snap
@@ -1,0 +1,19 @@
+---
+source: crates/cairn-core/src/domain/flush_plan/diff.rs
+expression: md
+---
+# FlushPlan 01HQZK000000000000000000VP
+
+- **Mode:** `HumanReview`
+- **Issuer:** `agt:claude-code:opus-4-7:reviewer:v1`
+- **Issued:** 2026-05-04T12:00:00Z
+- **Expires:** 2026-05-04T12:05:00Z
+- **Reason:** `UserIngest`
+- **Mutations:** 1
+
+## Mutation 0
+
+- **Kind:** patch
+- **Session:** `01JTS6R4J70000000000000000`
+- **Replace:** `draft` -> `final` (first)
+

--- a/crates/cairn-core/src/domain/flush_plan/snapshots/cairn_core__domain__flush_plan__diff__tests__diff_rename_md.snap
+++ b/crates/cairn-core/src/domain/flush_plan/snapshots/cairn_core__domain__flush_plan__diff__tests__diff_rename_md.snap
@@ -1,0 +1,18 @@
+---
+source: crates/cairn-core/src/domain/flush_plan/diff.rs
+expression: md
+---
+# FlushPlan 01HQZK000000000000000000VP
+
+- **Mode:** `HumanReview`
+- **Issuer:** `agt:claude-code:opus-4-7:reviewer:v1`
+- **Issued:** 2026-05-04T12:00:00Z
+- **Expires:** 2026-05-04T12:05:00Z
+- **Reason:** `UserIngest`
+- **Mutations:** 1
+
+## Mutation 0
+
+- **Kind:** rename
+- **Target:** `01JTS6R4J70000000000000001` -> `01JTS6R4J70000000000000002`
+

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -73,7 +73,7 @@ pub use projection::{
     ConflictOutcome, MarkdownProjector, ParsedProjection, ProjectedFile, ResyncError,
 };
 pub use provenance::Provenance;
-pub use record::{MemoryRecord, RecordId};
+pub use record::{Ed25519Signature, MemoryRecord, RecordId};
 pub use scope::ScopeTuple;
 pub use session::{
     DEFAULT_IDLE_WINDOW_SECS, LastActiveSession, Session, SessionDecision, SessionId,

--- a/crates/cairn-core/src/domain/record.rs
+++ b/crates/cairn-core/src/domain/record.rs
@@ -94,6 +94,18 @@ impl Ed25519Signature {
     pub fn is_flush_mutated_sentinel(&self) -> bool {
         self.0 == Self::FLUSH_MUTATED_SENTINEL
     }
+
+    /// Returns `true` if this signature is structurally a real Ed25519
+    /// signature (NOT the [`FLUSH_MUTATED_SENTINEL`]). Trust boundaries
+    /// that treat a present `signature` field as authorial provenance
+    /// MUST call this before accepting the record as author-signed —
+    /// otherwise a record rewritten by `flush apply` will be
+    /// indistinguishable from an admission-signed record at the wire
+    /// shape. See issue #289 re-loop r4 finding 3.
+    #[must_use]
+    pub fn attests_author(&self) -> bool {
+        !self.is_flush_mutated_sentinel()
+    }
 }
 
 impl<'de> Deserialize<'de> for Ed25519Signature {
@@ -237,6 +249,26 @@ pub struct MemoryRecord {
 }
 
 impl MemoryRecord {
+    /// Convenience: `true` if this record's `signature` is the
+    /// [`Ed25519Signature::FLUSH_MUTATED_SENTINEL`] — i.e. it was
+    /// rewritten by a `flush apply` mutation and is no longer
+    /// author-signed. See issue #289 re-loop r4 finding 3.
+    #[must_use]
+    pub fn is_flush_mutated(&self) -> bool {
+        self.signature.is_flush_mutated_sentinel()
+    }
+
+    /// Convenience: `true` if this record's `signature` still attests
+    /// authorial provenance (i.e. it is NOT the flush-mutated
+    /// sentinel). Trust boundaries that gate on "is the author's
+    /// signature still valid for the current payload" should call this
+    /// before any keychain-resident crypto check. See issue #289
+    /// re-loop r4 finding 3.
+    #[must_use]
+    pub fn signature_attests_author(&self) -> bool {
+        self.signature.attests_author()
+    }
+
     /// Validate every domain invariant. Returns the first violation found.
     ///
     /// This is **shape validation only** — it confirms the record is

--- a/crates/cairn-core/src/domain/record.rs
+++ b/crates/cairn-core/src/domain/record.rs
@@ -62,6 +62,38 @@ impl Ed25519Signature {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// Well-known all-zeros sentinel used to mark a record as "no longer
+    /// validly signed by its original author" — see issue #289. Stored
+    /// in place of a real Ed25519 signature after `flush apply` mutates
+    /// the canonical record bytes (Patch/Rename). Downstream verifiers
+    /// MUST treat this value as unsigned and refuse to accept it as
+    /// authorial provenance. Structurally valid `ed25519:` + 128 zeros
+    /// so it survives serialization round-trips through wire types that
+    /// still type `signature` as a non-optional `Ed25519Signature`.
+    pub const FLUSH_MUTATED_SENTINEL: &'static str = concat!(
+        "ed25519:",
+        "00000000", "00000000", "00000000", "00000000",
+        "00000000", "00000000", "00000000", "00000000",
+        "00000000", "00000000", "00000000", "00000000",
+        "00000000", "00000000", "00000000", "00000000",
+    );
+
+    /// Returns the [`FLUSH_MUTATED_SENTINEL`] as a parsed
+    /// [`Ed25519Signature`]. Infallible: the sentinel is a constant
+    /// known to satisfy [`Ed25519Signature::parse`].
+    #[must_use]
+    pub fn flush_mutated_sentinel() -> Self {
+        Self(Self::FLUSH_MUTATED_SENTINEL.to_owned())
+    }
+
+    /// Returns `true` if this signature is the well-known
+    /// [`FLUSH_MUTATED_SENTINEL`] — i.e. the record was rewritten by a
+    /// flush apply mutation and is no longer author-signed.
+    #[must_use]
+    pub fn is_flush_mutated_sentinel(&self) -> bool {
+        self.0 == Self::FLUSH_MUTATED_SENTINEL
+    }
 }
 
 impl<'de> Deserialize<'de> for Ed25519Signature {

--- a/crates/cairn-core/src/domain/record.rs
+++ b/crates/cairn-core/src/domain/record.rs
@@ -72,14 +72,12 @@ impl Ed25519Signature {
     /// so it survives serialization round-trips through wire types that
     /// still type `signature` as a non-optional `Ed25519Signature`.
     pub const FLUSH_MUTATED_SENTINEL: &'static str = concat!(
-        "ed25519:",
-        "00000000", "00000000", "00000000", "00000000",
-        "00000000", "00000000", "00000000", "00000000",
-        "00000000", "00000000", "00000000", "00000000",
-        "00000000", "00000000", "00000000", "00000000",
+        "ed25519:", "00000000", "00000000", "00000000", "00000000", "00000000", "00000000",
+        "00000000", "00000000", "00000000", "00000000", "00000000", "00000000", "00000000",
+        "00000000", "00000000", "00000000",
     );
 
-    /// Returns the [`FLUSH_MUTATED_SENTINEL`] as a parsed
+    /// Returns the [`Self::FLUSH_MUTATED_SENTINEL`] as a parsed
     /// [`Ed25519Signature`]. Infallible: the sentinel is a constant
     /// known to satisfy [`Ed25519Signature::parse`].
     #[must_use]
@@ -88,7 +86,7 @@ impl Ed25519Signature {
     }
 
     /// Returns `true` if this signature is the well-known
-    /// [`FLUSH_MUTATED_SENTINEL`] — i.e. the record was rewritten by a
+    /// [`Self::FLUSH_MUTATED_SENTINEL`] — i.e. the record was rewritten by a
     /// flush apply mutation and is no longer author-signed.
     #[must_use]
     pub fn is_flush_mutated_sentinel(&self) -> bool {
@@ -96,7 +94,7 @@ impl Ed25519Signature {
     }
 
     /// Returns `true` if this signature is structurally a real Ed25519
-    /// signature (NOT the [`FLUSH_MUTATED_SENTINEL`]). Trust boundaries
+    /// signature (NOT the [`Self::FLUSH_MUTATED_SENTINEL`]). Trust boundaries
     /// that treat a present `signature` field as authorial provenance
     /// MUST call this before accepting the record as author-signed —
     /// otherwise a record rewritten by `flush apply` will be

--- a/crates/cairn-core/tests/flush_plan_proptest.rs
+++ b/crates/cairn-core/tests/flush_plan_proptest.rs
@@ -8,9 +8,10 @@
 use std::collections::BTreeMap;
 
 use cairn_core::domain::flush_plan::{
-    ExpirationReason, FlushMode, FlushPlan, PersistedPlan, PlanReason, PlanStatus, PlannedMutation,
+    ExpirationReason, FlushMode, FlushPlan, PatchTarget, PersistedPlan, PlanReason, PlanStatus,
+    PlannedMutation, ReplaceOccurrence, StrReplace,
 };
-use cairn_core::domain::{Identity, ScopeTuple, TargetId};
+use cairn_core::domain::{Identity, ScopeTuple, SessionId, TargetId};
 use cairn_core::generated::common::Ulid;
 use proptest::prelude::*;
 
@@ -23,6 +24,35 @@ fn arb_ulid() -> impl Strategy<Value = Ulid> {
     "[0-7][0-9A-HJKMNP-TV-Z]{25}".prop_map(Ulid)
 }
 
+fn arb_session() -> impl Strategy<Value = SessionId> {
+    "[0-7][0-9A-HJKMNP-TV-Z]{25}".prop_map(|s| SessionId::parse(&s).unwrap())
+}
+
+fn arb_patch_target() -> impl Strategy<Value = PatchTarget> {
+    prop_oneof![
+        arb_target().prop_map(PatchTarget::Record),
+        arb_session().prop_map(PatchTarget::Session),
+    ]
+}
+
+fn arb_replace_occurrence() -> impl Strategy<Value = ReplaceOccurrence> {
+    prop_oneof![
+        Just(ReplaceOccurrence::First),
+        Just(ReplaceOccurrence::All),
+        (0usize..4).prop_map(ReplaceOccurrence::Nth),
+    ]
+}
+
+fn arb_str_replace() -> impl Strategy<Value = StrReplace> {
+    ("[a-z]{1,8}", "[a-z]{1,8}", arb_replace_occurrence()).prop_map(|(old, new, occurrence)| {
+        StrReplace {
+            old,
+            new,
+            occurrence,
+        }
+    })
+}
+
 fn arb_mutation() -> impl Strategy<Value = PlannedMutation> {
     prop_oneof![
         (arb_target(), 0u32..u32::MAX).prop_map(|(target, prior_version)| {
@@ -31,6 +61,16 @@ fn arb_mutation() -> impl Strategy<Value = PlannedMutation> {
                 prior_version,
             }
         }),
+        (
+            arb_patch_target(),
+            prop::collection::vec(arb_str_replace(), 1..3),
+        )
+            .prop_map(|(target, str_replace)| PlannedMutation::Patch {
+                target,
+                str_replace,
+            }),
+        (arb_target(), arb_target())
+            .prop_map(|(record_id, new_id)| PlannedMutation::Rename { record_id, new_id }),
         arb_target().prop_map(|target| PlannedMutation::ForgetRecord { target }),
         (
             arb_target(),
@@ -73,6 +113,35 @@ fn arb_plan() -> impl Strategy<Value = FlushPlan> {
             expires_at: "2026-05-04T12:05:00Z".into(),
             placeholder: false,
         })
+}
+
+#[test]
+fn patch_and_rename_round_trip_json() {
+    use cairn_core::domain::flush_plan::{
+        PatchTarget, PlannedMutation, ReplaceOccurrence, StrReplace,
+    };
+
+    let patch = PlannedMutation::Patch {
+        target: PatchTarget::Session(SessionId::parse("01JTS6R4J70000000000000000").unwrap()),
+        str_replace: vec![StrReplace {
+            old: "old-title".into(),
+            new: "new-title".into(),
+            occurrence: ReplaceOccurrence::First,
+        }],
+    };
+    let rename = PlannedMutation::Rename {
+        record_id: TargetId::parse("01JTS6R4J70000000000000001").unwrap(),
+        new_id: TargetId::parse("01JTS6R4J70000000000000002").unwrap(),
+    };
+
+    for mutation in [patch, rename] {
+        let bytes = serde_json::to_vec(&mutation).expect("serialize");
+        let back: PlannedMutation = serde_json::from_slice(&bytes).expect("deserialize");
+        assert_eq!(
+            serde_json::to_value(&mutation).unwrap(),
+            serde_json::to_value(&back).unwrap()
+        );
+    }
 }
 
 proptest! {

--- a/crates/cairn-store-sqlite/src/error.rs
+++ b/crates/cairn-store-sqlite/src/error.rs
@@ -94,6 +94,32 @@ pub enum StoreError {
         id: String,
     },
 
+    /// A flush patch targeted a record lineage with no live row.
+    #[error("patch target not found: {target_id}")]
+    PatchTargetMissing {
+        /// The target lineage id that was not found.
+        target_id: String,
+    },
+
+    /// A flush patch requested a substring occurrence that does not exist in
+    /// the current document text.
+    #[error("patch substring not found for {target}: `{needle}` ({occurrence})")]
+    PatchSubstringMissing {
+        /// Human-readable target label (`record:<id>` or `session:<id>`).
+        target: String,
+        /// The substring the caller requested.
+        needle: String,
+        /// Which occurrence form failed (`first`, `all`, `nth(N)`).
+        occurrence: String,
+    },
+
+    /// A flush rename attempted to land on an already-live destination target.
+    #[error("rename destination already exists: {target_id}")]
+    RenameTargetConflict {
+        /// The destination target id that is already live.
+        target_id: String,
+    },
+
     /// Method requires a capability the store does not advertise.
     /// `what` is the cap flag name (`"fts"`, `"vector"`, `"graph_edges"`,
     /// `"transactions"`).

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -107,8 +107,7 @@ const M0057_HOT_SOURCE_WATERMARKS_EXTRAS: &str =
     include_str!("sql/0057_hot_source_watermarks_extras.sql");
 // Issue #289 re-loop r6 — durable audit for in-place session patches.
 // Renumbered from 0053 → 0058 during rebase onto main.
-const M0058_SESSION_METADATA_AUDIT: &str =
-    include_str!("sql/0058_session_metadata_audit.sql");
+const M0058_SESSION_METADATA_AUDIT: &str = include_str!("sql/0058_session_metadata_audit.sql");
 // Issue #289 re-loop r7 — add mutation_seq to allow repeated patches
 // against the same session within one plan.
 // Renumbered from 0054 → 0059 during rebase onto main.

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -105,6 +105,10 @@ const M0056_HOT_PREFIX_CACHE: &str = include_str!("sql/0056_hot_prefix_cache.sql
 // Renumbered from 0054 → 0057 during rebase.
 const M0057_HOT_SOURCE_WATERMARKS_EXTRAS: &str =
     include_str!("sql/0057_hot_source_watermarks_extras.sql");
+// Issue #289 re-loop r6 — durable audit for in-place session patches.
+// Renumbered from 0053 → 0058 during rebase onto main.
+const M0058_SESSION_METADATA_AUDIT: &str =
+    include_str!("sql/0058_session_metadata_audit.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -268,6 +272,11 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
         "0057_hot_source_watermarks_extras",
         M0057_HOT_SOURCE_WATERMARKS_EXTRAS,
     ),
+    (
+        58,
+        "0058_session_metadata_audit",
+        M0058_SESSION_METADATA_AUDIT,
+    ),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -326,5 +335,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0055_FORGET_RECORD_PAYLOAD_SCRUB),
         M::up(M0056_HOT_PREFIX_CACHE),
         M::up(M0057_HOT_SOURCE_WATERMARKS_EXTRAS),
+        M::up(M0058_SESSION_METADATA_AUDIT),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -109,6 +109,11 @@ const M0057_HOT_SOURCE_WATERMARKS_EXTRAS: &str =
 // Renumbered from 0053 → 0058 during rebase onto main.
 const M0058_SESSION_METADATA_AUDIT: &str =
     include_str!("sql/0058_session_metadata_audit.sql");
+// Issue #289 re-loop r7 — add mutation_seq to allow repeated patches
+// against the same session within one plan.
+// Renumbered from 0054 → 0059 during rebase onto main.
+const M0059_SESSION_METADATA_AUDIT_SEQ: &str =
+    include_str!("sql/0059_session_metadata_audit_seq.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -277,6 +282,11 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
         "0058_session_metadata_audit",
         M0058_SESSION_METADATA_AUDIT,
     ),
+    (
+        59,
+        "0059_session_metadata_audit_seq",
+        M0059_SESSION_METADATA_AUDIT_SEQ,
+    ),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -336,5 +346,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0056_HOT_PREFIX_CACHE),
         M::up(M0057_HOT_SOURCE_WATERMARKS_EXTRAS),
         M::up(M0058_SESSION_METADATA_AUDIT),
+        M::up(M0059_SESSION_METADATA_AUDIT_SEQ),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/sql/0058_session_metadata_audit.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0058_session_metadata_audit.sql
@@ -1,0 +1,27 @@
+-- Migration 0058: session_metadata_audit — durable rollback evidence for
+-- in-place session-metadata patches (issue #289 re-loop r6).
+--
+-- `apply_session_patch` mutates `sessions` rows in place (the live
+-- session-resolution path requires a single live row per identity), so
+-- pre-mutation values were lost on success. This append-only audit
+-- captures the (operation_id, session_id, pre/post JSON) tuple inside
+-- the same SQLite transaction as the UPDATE, so recovery tooling can
+-- reconstruct the overwrite without out-of-band logs.
+--
+-- The table is keyed by (operation_id, session_id) so a single flush
+-- plan touching multiple sessions still records one row per target.
+
+CREATE TABLE session_metadata_audit (
+  operation_id TEXT NOT NULL,
+  session_id   TEXT NOT NULL,
+  pre_state    TEXT NOT NULL,
+  post_state   TEXT NOT NULL,
+  applied_at   INTEGER NOT NULL,
+  PRIMARY KEY (operation_id, session_id)
+) WITHOUT ROWID;
+
+CREATE INDEX session_metadata_audit_by_session
+  ON session_metadata_audit (session_id, applied_at);
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (58, '0058_session_metadata_audit', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/migrations/sql/0059_session_metadata_audit_seq.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0059_session_metadata_audit_seq.sql
@@ -1,0 +1,35 @@
+-- Migration 0059: add `mutation_seq` to `session_metadata_audit` so
+-- multiple session-metadata patches against the same session in a
+-- single flush plan can all be audited (issue #289 re-loop r7).
+--
+-- The previous PK (operation_id, session_id) collided on the second
+-- INSERT when one plan patched the same session twice; the whole
+-- apply tx would abort. Replace the PK with (operation_id, session_id,
+-- mutation_seq) where mutation_seq is the 0-based index of the
+-- mutation within the plan.
+
+CREATE TABLE session_metadata_audit_v2 (
+  operation_id TEXT NOT NULL,
+  session_id   TEXT NOT NULL,
+  mutation_seq INTEGER NOT NULL,
+  pre_state    TEXT NOT NULL,
+  post_state   TEXT NOT NULL,
+  applied_at   INTEGER NOT NULL,
+  PRIMARY KEY (operation_id, session_id, mutation_seq)
+) WITHOUT ROWID;
+
+INSERT INTO session_metadata_audit_v2
+  (operation_id, session_id, mutation_seq, pre_state, post_state, applied_at)
+  SELECT operation_id, session_id, 0, pre_state, post_state, applied_at
+  FROM session_metadata_audit;
+
+DROP INDEX IF EXISTS session_metadata_audit_by_session;
+DROP TABLE session_metadata_audit;
+
+ALTER TABLE session_metadata_audit_v2 RENAME TO session_metadata_audit;
+
+CREATE INDEX session_metadata_audit_by_session
+  ON session_metadata_audit (session_id, applied_at);
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (59, '0059_session_metadata_audit_seq', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/store/sessions.rs
+++ b/crates/cairn-store-sqlite/src/store/sessions.rs
@@ -954,7 +954,7 @@ fn resolve_explicit_in_tx(
 
 /// Decode a `SessionRow` tuple to the typed [`Session`] domain struct,
 /// surfacing structural failures as [`InTxError::Invariant`].
-fn session_from_row(row: SessionRow) -> Result<Session, InTxError> {
+pub(crate) fn session_from_row(row: SessionRow) -> Result<Session, InTxError> {
     let (
         sid,
         user,
@@ -999,7 +999,7 @@ fn session_from_row(row: SessionRow) -> Result<Session, InTxError> {
 /// retryable conflicts from terminal failures so the outer loop can choose
 /// to spin or surface the error.
 #[derive(Debug)]
-enum InTxError {
+pub(crate) enum InTxError {
     /// Partial unique index `sessions_one_active_per_identity_idx` rejected
     /// the INSERT — a concurrent caller won the race. Caller should
     /// rollback and retry.
@@ -1173,7 +1173,7 @@ fn resolve_or_create_in_tx(
 
 /// Row shape for `SELECT * FROM sessions WHERE session_id = ?` — broken
 /// out so [`read_session_by_id`] doesn't trip clippy's `type_complexity`.
-type SessionRow = (
+pub(crate) type SessionRow = (
     String,         // session_id
     String,         // user_id
     String,         // agent_id
@@ -1187,7 +1187,7 @@ type SessionRow = (
     Option<i64>,    // ended_at
 );
 
-fn read_session_by_id(
+pub(crate) fn read_session_by_id(
     tx: &rusqlite::Transaction<'_>,
     id_str: &str,
 ) -> Result<Option<Session>, InTxError> {

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -20,8 +20,13 @@
 //!
 //! [`MemoryStore`]: cairn_core::contract::memory_store::MemoryStore
 
-use cairn_core::contract::memory_store::{Edge, EdgeKey, TombstoneReason, UpsertOutcome};
-use cairn_core::domain::{BodyHash, MemoryRecord, RecordId, SessionId, SignedAdmission};
+use cairn_core::contract::memory_store::{
+    Edge, EdgeKey, EdgeKind, StoredRecord, TombstoneReason, UpsertOutcome,
+};
+use cairn_core::contract::version::SchemaVersion;
+use cairn_core::domain::{
+    BodyHash, MemoryRecord, RecordId, Session, SessionId, SignedAdmission, TargetId,
+};
 use rusqlite::{OptionalExtension as _, Transaction, params};
 use tracing::instrument;
 
@@ -29,6 +34,7 @@ use crate::error::StoreError;
 use crate::replay::challenge::MintedChallenge;
 use crate::replay::{ReplayError, WalPrepareInputs};
 use crate::store::projection::{ProjectedRow, record_from_json};
+use crate::store::sessions::{InTxError, read_session_by_id};
 use crate::store::upsert::upsert_in_tx;
 use crate::store::{SqliteMemoryStore, current_unix_ms};
 
@@ -41,6 +47,62 @@ pub struct StoreTx<'a> {
 }
 
 impl StoreTx<'_> {
+    /// Snapshot-read the active, non-tombstoned row for one target inside the
+    /// caller's transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Sqlite`] for SQL failures, [`StoreError::Codec`]
+    /// when the stored `record_json` cannot be deserialized, and
+    /// [`StoreError::Invariant`] when version or schema-version columns carry
+    /// structurally invalid values.
+    pub fn get_active_by_target(
+        &self,
+        target: &TargetId,
+    ) -> Result<Option<StoredRecord>, StoreError> {
+        let row: Option<(String, i64, Option<i64>, Option<i64>)> = self
+            .tx
+            .query_row(
+                "SELECT record_json, version, schema_version_major, schema_version_minor \
+                   FROM records \
+                  WHERE target_id = ?1 AND active = 1 AND tombstoned = 0 \
+                  LIMIT 1",
+                params![target.as_str()],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .optional()?;
+        let Some((record_json, version_i64, schema_major, schema_minor)) = row else {
+            return Ok(None);
+        };
+        let record = record_from_json(&record_json)?;
+        let version = u32::try_from(version_i64).map_err(|_| StoreError::Invariant {
+            what: format!("stored version overflows u32: {version_i64}"),
+        })?;
+        let schema_version = match (schema_major, schema_minor) {
+            (Some(major), Some(minor)) => Some(SchemaVersion {
+                major: u32::try_from(major).map_err(|_| StoreError::Invariant {
+                    what: format!("schema_version_major out of u32 range: {major}"),
+                })?,
+                minor: u32::try_from(minor).map_err(|_| StoreError::Invariant {
+                    what: format!("schema_version_minor out of u32 range: {minor}"),
+                })?,
+            }),
+            (None, None) => None,
+            (major, minor) => {
+                return Err(StoreError::Invariant {
+                    what: format!(
+                        "records.schema_version_(major,minor) inconsistent: ({major:?}, {minor:?})"
+                    ),
+                });
+            }
+        };
+        Ok(Some(StoredRecord {
+            record,
+            version,
+            schema_version,
+        }))
+    }
+
     /// Synchronous upsert against the open transaction. Delegates to the
     /// same internal `upsert_in_tx` helper that
     /// `SqliteMemoryStore::do_upsert` uses, so this and the async trait
@@ -72,6 +134,118 @@ impl StoreTx<'_> {
                 SET tombstoned = 1, tombstone_reason = ?1, updated_at = ?2 \
               WHERE record_id = ?3",
             params![reason.as_db_str(), now_ms, id.as_str()],
+        )?;
+        Ok(())
+    }
+
+    /// Mark a specific active row inactive without deleting its historical
+    /// version record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Sqlite`] for SQL failures.
+    pub fn deactivate_record(&self, id: &RecordId) -> Result<(), StoreError> {
+        let now_ms = current_unix_ms();
+        self.tx.execute(
+            "UPDATE records SET active = 0, updated_at = ?1 WHERE record_id = ?2 AND active = 1",
+            params![now_ms, id.as_str()],
+        )?;
+        Ok(())
+    }
+
+    /// Read one explicit session row inside the caller's transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::SessionNotFound`] when no row exists,
+    /// [`StoreError::SessionEnded`] when the row is closed, and the usual
+    /// [`StoreError`] variants for SQL / codec / invariant failures.
+    pub fn get_live_session(&self, session_id: &SessionId) -> Result<Session, StoreError> {
+        let id_str = session_id.as_str();
+        let Some(session) = read_session_by_id(&self.tx, id_str).map_err(|e| match e {
+            InTxError::Sqlite(err) => StoreError::Sqlite(err),
+            InTxError::Codec(err) => StoreError::Codec(err),
+            InTxError::Invariant(what) => StoreError::Invariant { what },
+            InTxError::Terminal(err) => err,
+            InTxError::UniqueViolation | InTxError::StaleSnapshot => StoreError::Invariant {
+                what: "unexpected retry-only session read state".into(),
+            },
+        })?
+        else {
+            return Err(StoreError::SessionNotFound {
+                session_id: id_str.to_owned(),
+            });
+        };
+        if let Some(ended_at_unix_ms) = session.ended_at_unix_ms {
+            return Err(StoreError::SessionEnded {
+                session_id: id_str.to_owned(),
+                ended_at_unix_ms,
+            });
+        }
+        Ok(session)
+    }
+
+    /// Persist session metadata fields in place and treat the patch as session
+    /// activity by bumping `last_activity_at`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Codec`] when tag serialization fails and
+    /// [`StoreError::Sqlite`] for SQL failures.
+    pub fn update_session_metadata(&self, session: &Session) -> Result<(), StoreError> {
+        let now_ms = current_unix_ms();
+        let tags_json = if session.tags.is_empty() {
+            None
+        } else {
+            Some(serde_json::to_string(&session.tags)?)
+        };
+        self.tx.execute(
+            "UPDATE sessions \
+                SET title = ?1, channel = ?2, priority = ?3, tags = ?4, last_activity_at = ?5 \
+              WHERE session_id = ?6 AND ended_at IS NULL",
+            params![
+                session.title.as_str(),
+                session.channel.as_deref(),
+                session.priority.as_deref(),
+                tags_json,
+                now_ms,
+                session.id.as_str(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Copy every non-`updates` edge attached to `old_id` onto `new_id`, then
+    /// delete the old rows so live graph traversals follow the renamed record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Sqlite`] for SQL failures.
+    pub fn rewrite_non_updates_edges(
+        &self,
+        old_id: &RecordId,
+        new_id: &RecordId,
+    ) -> Result<(), StoreError> {
+        self.tx.execute(
+            "INSERT OR REPLACE INTO edges (src, dst, kind, weight) \
+             SELECT CASE WHEN src = ?1 THEN ?2 ELSE src END, \
+                    CASE WHEN dst = ?1 THEN ?2 ELSE dst END, \
+                    kind, \
+                    weight \
+               FROM edges \
+              WHERE kind != ?3 \
+                AND (src = ?1 OR dst = ?1)",
+            params![
+                old_id.as_str(),
+                new_id.as_str(),
+                EdgeKind::Updates.as_db_str()
+            ],
+        )?;
+        self.tx.execute(
+            "DELETE FROM edges \
+              WHERE kind != ?1 \
+                AND (src = ?2 OR dst = ?2)",
+            params![EdgeKind::Updates.as_db_str(), old_id.as_str()],
         )?;
         Ok(())
     }

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -251,6 +251,7 @@ impl StoreTx<'_> {
         &self,
         session_id: &SessionId,
         operation_id: &str,
+        mutation_seq: i64,
         pre_state: &T,
         post_state: &T,
     ) -> Result<(), StoreError>
@@ -268,11 +269,12 @@ impl StoreTx<'_> {
         .unwrap_or(i64::MAX);
         self.tx.execute(
             "INSERT INTO session_metadata_audit \
-                 (operation_id, session_id, pre_state, post_state, applied_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                 (operation_id, session_id, mutation_seq, pre_state, post_state, applied_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 operation_id,
                 session_id.as_str(),
+                mutation_seq,
                 pre_json,
                 post_json,
                 now_ms,

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -236,6 +236,51 @@ impl StoreTx<'_> {
         Ok(())
     }
 
+    /// Append a row to `session_metadata_audit` capturing the
+    /// pre-mutation and post-mutation session document JSON inside the
+    /// same transaction as the in-place `UPDATE sessions ...`. Provides
+    /// durable rollback evidence for `flush apply` session patches
+    /// (issue #289 re-loop r6). Pre/post are serialized by the caller
+    /// so they can use whatever canonical document shape the planner
+    /// recognized.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Sqlite`] on SQL failures.
+    pub fn append_session_metadata_audit<T>(
+        &self,
+        session_id: &SessionId,
+        operation_id: &str,
+        pre_state: &T,
+        post_state: &T,
+    ) -> Result<(), StoreError>
+    where
+        T: serde::Serialize,
+    {
+        let pre_json = serde_json::to_string(pre_state)?;
+        let post_json = serde_json::to_string(post_state)?;
+        let now_ms = i64::try_from(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis(),
+        )
+        .unwrap_or(i64::MAX);
+        self.tx.execute(
+            "INSERT INTO session_metadata_audit \
+                 (operation_id, session_id, pre_state, post_state, applied_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                operation_id,
+                session_id.as_str(),
+                pre_json,
+                post_json,
+                now_ms,
+            ],
+        )?;
+        Ok(())
+    }
+
     /// Copy every non-`updates` edge attached to `old_id` onto `new_id`.
     /// Round 7/8 review fix: the previous version also deleted the
     /// source rows, which irrecoverably erased the predecessor's graph

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -207,32 +207,76 @@ impl StoreTx<'_> {
     }
 
     /// Persist session metadata fields in place and treat the patch as session
-    /// activity by bumping `last_activity_at`.
+    /// activity by bumping `last_activity_at`. Use this for in-band user
+    /// edits; for out-of-band review-time mutations (e.g. `flush apply`)
+    /// call [`Self::update_session_metadata_preserve_activity`] so the
+    /// session resolver does not see review activity as a fresh user
+    /// signal.
     ///
     /// # Errors
     ///
     /// Returns [`StoreError::Codec`] when tag serialization fails and
     /// [`StoreError::Sqlite`] for SQL failures.
     pub fn update_session_metadata(&self, session: &Session) -> Result<(), StoreError> {
-        let now_ms = current_unix_ms();
+        self.update_session_metadata_inner(session, true)
+    }
+
+    /// Re-loop r8 finding 2: variant of [`Self::update_session_metadata`]
+    /// that preserves the existing `last_activity_at`. Out-of-band
+    /// flush-apply edits must not resurrect or prolong an idle session
+    /// for the purposes of `find_active_session` / resolver auto-pick.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Codec`] when tag serialization fails and
+    /// [`StoreError::Sqlite`] for SQL failures.
+    pub fn update_session_metadata_preserve_activity(
+        &self,
+        session: &Session,
+    ) -> Result<(), StoreError> {
+        self.update_session_metadata_inner(session, false)
+    }
+
+    fn update_session_metadata_inner(
+        &self,
+        session: &Session,
+        bump_activity: bool,
+    ) -> Result<(), StoreError> {
         let tags_json = if session.tags.is_empty() {
             None
         } else {
             Some(serde_json::to_string(&session.tags)?)
         };
-        self.tx.execute(
-            "UPDATE sessions \
-                SET title = ?1, channel = ?2, priority = ?3, tags = ?4, last_activity_at = ?5 \
-              WHERE session_id = ?6 AND ended_at IS NULL",
-            params![
-                session.title.as_str(),
-                session.channel.as_deref(),
-                session.priority.as_deref(),
-                tags_json,
-                now_ms,
-                session.id.as_str(),
-            ],
-        )?;
+        if bump_activity {
+            let now_ms = current_unix_ms();
+            self.tx.execute(
+                "UPDATE sessions \
+                    SET title = ?1, channel = ?2, priority = ?3, tags = ?4, \
+                        last_activity_at = ?5 \
+                  WHERE session_id = ?6 AND ended_at IS NULL",
+                params![
+                    session.title.as_str(),
+                    session.channel.as_deref(),
+                    session.priority.as_deref(),
+                    tags_json,
+                    now_ms,
+                    session.id.as_str(),
+                ],
+            )?;
+        } else {
+            self.tx.execute(
+                "UPDATE sessions \
+                    SET title = ?1, channel = ?2, priority = ?3, tags = ?4 \
+                  WHERE session_id = ?5 AND ended_at IS NULL",
+                params![
+                    session.title.as_str(),
+                    session.channel.as_deref(),
+                    session.priority.as_deref(),
+                    tags_json,
+                    session.id.as_str(),
+                ],
+            )?;
+        }
         Ok(())
     }
 

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -215,8 +215,14 @@ impl StoreTx<'_> {
         Ok(())
     }
 
-    /// Copy every non-`updates` edge attached to `old_id` onto `new_id`, then
-    /// delete the old rows so live graph traversals follow the renamed record.
+    /// Copy every non-`updates` edge attached to `old_id` onto `new_id`.
+    /// Round 7/8 review fix: the previous version also deleted the
+    /// source rows, which irrecoverably erased the predecessor's graph
+    /// history. Now copies are additive — `new_id` gains the same edges
+    /// for live traversal while `old_id` retains its original
+    /// relationships so audit/rollback tooling can still reconstruct the
+    /// pre-rename neighbourhood. Uses `INSERT OR IGNORE` so an
+    /// already-existing edge on `new_id` is not silently overwritten.
     ///
     /// # Errors
     ///
@@ -227,7 +233,7 @@ impl StoreTx<'_> {
         new_id: &RecordId,
     ) -> Result<(), StoreError> {
         self.tx.execute(
-            "INSERT OR REPLACE INTO edges (src, dst, kind, weight) \
+            "INSERT OR IGNORE INTO edges (src, dst, kind, weight) \
              SELECT CASE WHEN src = ?1 THEN ?2 ELSE src END, \
                     CASE WHEN dst = ?1 THEN ?2 ELSE dst END, \
                     kind, \
@@ -240,12 +246,6 @@ impl StoreTx<'_> {
                 new_id.as_str(),
                 EdgeKind::Updates.as_db_str()
             ],
-        )?;
-        self.tx.execute(
-            "DELETE FROM edges \
-              WHERE kind != ?1 \
-                AND (src = ?2 OR dst = ?2)",
-            params![EdgeKind::Updates.as_db_str(), old_id.as_str()],
         )?;
         Ok(())
     }

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -47,6 +47,27 @@ pub struct StoreTx<'a> {
 }
 
 impl StoreTx<'_> {
+    /// Round 9 review fix: returns `true` if any row (active or
+    /// tombstoned) in the records table has ever owned this `target_id`.
+    /// `flush apply rename` uses this to reject destinations that would
+    /// hijack a retired lineage and merge unrelated histories under one
+    /// target.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::Sqlite`] on SQL failures.
+    pub fn target_id_ever_used(&self, target: &TargetId) -> Result<bool, StoreError> {
+        let row: Option<i64> = self
+            .tx
+            .query_row(
+                "SELECT 1 FROM records WHERE target_id = ?1 LIMIT 1",
+                params![target.as_str()],
+                |r| r.get(0),
+            )
+            .optional()?;
+        Ok(row.is_some())
+    }
+
     /// Snapshot-read the active, non-tombstoned row for one target inside the
     /// caller's transaction.
     ///

--- a/crates/cairn-store-sqlite/src/verify.rs
+++ b/crates/cairn-store-sqlite/src/verify.rs
@@ -103,6 +103,11 @@ const EXPECTED_OBJECTS: &[(&str, &str)] = &[
     ("trigger", "wal_payloads_kind_matches_wal"),
     ("trigger", "wal_payloads_scrub_only"),
     ("trigger", "wal_payloads_no_delete"),
+    // 0058_session_metadata_audit — durable rollback evidence for
+    // in-place session-metadata patches (issue #289 re-loop r6).
+    // Renumbered from 0053 → 0058 during rebase onto main.
+    ("table", "session_metadata_audit"),
+    ("index", "session_metadata_audit_by_session"),
     // 0005_consent
     ("table", "consent_journal"),
     ("index", "consent_journal_subject_scope_idx"),

--- a/crates/cairn-store-sqlite/tests/migrations.rs
+++ b/crates/cairn-store-sqlite/tests/migrations.rs
@@ -15,7 +15,7 @@ fn fresh_in_memory_opens_to_head() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 58);
+    assert_eq!(head, 59);
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn fresh_vault_opens_and_reopens_idempotent() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 58);
+    assert_eq!(head, 59);
 }
 
 #[test]

--- a/crates/cairn-store-sqlite/tests/migrations.rs
+++ b/crates/cairn-store-sqlite/tests/migrations.rs
@@ -15,7 +15,7 @@ fn fresh_in_memory_opens_to_head() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 57);
+    assert_eq!(head, 58);
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn fresh_vault_opens_and_reopens_idempotent() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 57);
+    assert_eq!(head, 58);
 }
 
 #[test]

--- a/docs/site/src/reference/generated/commands/lint.md
+++ b/docs/site/src/reference/generated/commands/lint.md
@@ -18,6 +18,10 @@ Options:
       --fix
 
 
+      --plan <ULID>
+          Lint the pending FlushPlan with this id (issue #289 — surfaces rename target collisions
+          before apply)
+
       --fix-folders
           Regenerate folder _index.md sidecars and backlinks for every non-empty folder (brief §3.4,
           #44)

--- a/docs/superpowers/plans/2026-05-09-issue-289-real-apply.md
+++ b/docs/superpowers/plans/2026-05-09-issue-289-real-apply.md
@@ -1,0 +1,707 @@
+# Issue 289 Real Apply Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire real `flush apply` execution for non-placeholder plans and land `Patch`/`Rename` mutations, including session metadata patching, typed failures, diff rendering, and SQLite-backed integration coverage.
+
+**Architecture:** Keep placeholder plans on the existing metadata-only path, but route non-placeholder plans through a dedicated apply helper invoked from `crates/cairn-cli/src/verbs/flush.rs`. Represent patch and rename as new `PlannedMutation` variants in `cairn-core`, execute them against the SQLite-backed store inside one transaction boundary, and preserve record history by writing new versions instead of mutating active rows in place.
+
+**Tech Stack:** Rust, Cargo, serde, proptest, insta snapshots, rusqlite-backed `SqliteMemoryStore`, existing CLI integration harness.
+
+---
+
+## File Map
+
+- Modify: `crates/cairn-core/src/domain/flush_plan/mod.rs`
+  Adds `PatchTarget`, `StrReplace`, `ReplaceOccurrence`, and the new `PlannedMutation::{Patch, Rename}` variants.
+- Modify: `crates/cairn-core/src/domain/flush_plan/diff.rs`
+  Renders record patches, session patches, and rename mutations deterministically for human review.
+- Modify: `crates/cairn-core/tests/flush_plan_proptest.rs`
+  Extends serde round-trip generators to cover the new mutation shapes.
+- Modify: `crates/cairn-cli/src/verbs/flush.rs`
+  Replaces the current non-placeholder metadata-only branch with a real apply delegation path while preserving placeholder behavior.
+- Create: `crates/cairn-cli/src/verbs/flush_apply.rs`
+  Holds the dedicated apply executor and string-replacement helpers so `flush.rs` does not become larger.
+- Modify: `crates/cairn-cli/src/verbs/mod.rs`
+  Exports the new apply helper module if needed by the verb tree.
+- Modify: `crates/cairn-store-sqlite/src/error.rs`
+  Adds typed store/apply failures for patch and rename operations.
+- Modify: `crates/cairn-store-sqlite/src/store/sessions.rs`
+  Adds a helper for resolving an existing session metadata target or returning `SessionNotFound`.
+- Modify: `crates/cairn-store-sqlite/src/store/tx.rs`
+  Adds transactional helpers for patch/rename execution and inbound edge rewriting.
+- Modify: `crates/cairn-cli/tests/flush_integration.rs`
+  Covers placeholder-vs-real apply behavior and CLI-visible plan status.
+- Modify: `crates/cairn-store-sqlite/tests/versioning.rs`
+  Verifies patching preserves old versions and creates a new active version.
+- Modify: `crates/cairn-store-sqlite/tests/entity_graph.rs`
+  Verifies rename rewrites inbound graph edges atomically.
+- Create: `crates/cairn-store-sqlite/tests/flush_apply_mutations.rs`
+  Focused integration coverage for patch success/failure, session patching, and rename collision semantics.
+
+### Task 1: Extend FlushPlan Types and Serde Coverage
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/flush_plan/mod.rs`
+- Modify: `crates/cairn-core/tests/flush_plan_proptest.rs`
+- Modify: `crates/cairn-test-fixtures/src/flush_plan.rs`
+
+- [ ] **Step 1: Write the failing serde/property tests**
+
+```rust
+#[test]
+fn patch_and_rename_round_trip_json() {
+    use cairn_core::domain::flush_plan::{
+        PatchTarget, PlannedMutation, ReplaceOccurrence, StrReplace,
+    };
+    use cairn_core::domain::{SessionId, TargetId};
+
+    let patch = PlannedMutation::Patch {
+        target: PatchTarget::Session(SessionId::parse("01JTS6R4J70000000000000000").unwrap()),
+        str_replace: vec![StrReplace {
+            old: "old-title".into(),
+            new: "new-title".into(),
+            occurrence: ReplaceOccurrence::First,
+        }],
+    };
+    let rename = PlannedMutation::Rename {
+        record_id: TargetId::parse("01JTS6R4J70000000000000001").unwrap(),
+        new_id: TargetId::parse("01JTS6R4J70000000000000002").unwrap(),
+    };
+
+    for mutation in [patch, rename] {
+        let bytes = serde_json::to_vec(&mutation).expect("serialize");
+        let back: PlannedMutation = serde_json::from_slice(&bytes).expect("deserialize");
+        assert_eq!(
+            serde_json::to_value(&mutation).unwrap(),
+            serde_json::to_value(&back).unwrap()
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p cairn-core patch_and_rename_round_trip_json -- --exact`
+
+Expected: FAIL with missing `Patch`, `Rename`, `PatchTarget`, `StrReplace`, or `ReplaceOccurrence` symbols.
+
+- [ ] **Step 3: Add the new mutation/data types in `flush_plan/mod.rs`**
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "target", rename_all = "snake_case")]
+pub enum PatchTarget {
+    Record(TargetId),
+    Session(SessionId),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplaceOccurrence {
+    First,
+    All,
+    Nth(usize),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StrReplace {
+    pub old: String,
+    pub new: String,
+    pub occurrence: ReplaceOccurrence,
+}
+```
+
+```rust
+Patch {
+    target: PatchTarget,
+    str_replace: Vec<StrReplace>,
+},
+Rename {
+    record_id: TargetId,
+    new_id: TargetId,
+},
+```
+
+- [ ] **Step 4: Extend the property generator with the new variants**
+
+```rust
+fn arb_replace_occurrence() -> impl Strategy<Value = ReplaceOccurrence> {
+    prop_oneof![
+        Just(ReplaceOccurrence::First),
+        Just(ReplaceOccurrence::All),
+        (0usize..4).prop_map(ReplaceOccurrence::Nth),
+    ]
+}
+
+fn arb_str_replace() -> impl Strategy<Value = StrReplace> {
+    ("[a-z]{1,8}", "[a-z]{1,8}", arb_replace_occurrence()).prop_map(
+        |(old, new, occurrence)| StrReplace { old, new, occurrence },
+    )
+}
+```
+
+```rust
+(
+    arb_target(),
+    prop::collection::vec(arb_str_replace(), 1..3),
+).prop_map(|(record_id, str_replace)| PlannedMutation::Patch {
+    target: PatchTarget::Record(record_id),
+    str_replace,
+}),
+(
+    arb_target(),
+    arb_target(),
+).prop_map(|(record_id, new_id)| PlannedMutation::Rename { record_id, new_id }),
+```
+
+- [ ] **Step 5: Run the core test set again**
+
+Run: `cargo test -p cairn-core patch_and_rename_round_trip_json flush_plan_json_round_trip persisted_plan_round_trip`
+
+Expected: PASS for the new focused serde tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  crates/cairn-core/src/domain/flush_plan/mod.rs \
+  crates/cairn-core/tests/flush_plan_proptest.rs \
+  crates/cairn-test-fixtures/src/flush_plan.rs
+git commit -m "feat: add patch and rename flush plan types"
+```
+
+### Task 2: Render Patch and Rename in Human Review Output
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/flush_plan/diff.rs`
+- Modify: `crates/cairn-core/src/domain/flush_plan/snapshots/cairn_core__domain__flush_plan__tests__diff_delete_md.snap`
+- Create: new snapshot files under `crates/cairn-core/src/domain/flush_plan/snapshots/`
+
+- [ ] **Step 1: Write the failing diff-render tests**
+
+```rust
+#[test]
+fn renders_session_patch_mutation() {
+    let plan = FlushPlan {
+        mutations: vec![PlannedMutation::Patch {
+            target: PatchTarget::Session(SessionId::parse("01JTS6R4J70000000000000000").unwrap()),
+            str_replace: vec![StrReplace {
+                old: "draft".into(),
+                new: "final".into(),
+                occurrence: ReplaceOccurrence::First,
+            }],
+        }],
+        ..sample_plan_base()
+    };
+    insta::assert_snapshot!("diff_patch_session_md", render(&plan));
+}
+
+#[test]
+fn renders_rename_mutation() {
+    let plan = FlushPlan {
+        mutations: vec![PlannedMutation::Rename {
+            record_id: TargetId::parse("01JTS6R4J70000000000000001").unwrap(),
+            new_id: TargetId::parse("01JTS6R4J70000000000000002").unwrap(),
+        }],
+        ..sample_plan_base()
+    };
+    insta::assert_snapshot!("diff_rename_md", render(&plan));
+}
+```
+
+- [ ] **Step 2: Run the diff tests to verify they fail**
+
+Run: `cargo test -p cairn-core renders_session_patch_mutation renders_rename_mutation -- --exact`
+
+Expected: FAIL with non-exhaustive match errors in `diff.rs` or missing snapshot outputs.
+
+- [ ] **Step 3: Add the new match arms in `diff.rs`**
+
+```rust
+PlannedMutation::Patch { target, str_replace } => {
+    writeln!(&mut out, "- **Kind:** patch").ok();
+    match target {
+        PatchTarget::Record(target) => {
+            writeln!(&mut out, "- **Target:** `{}`", target.as_str()).ok();
+        }
+        PatchTarget::Session(session) => {
+            writeln!(&mut out, "- **Session:** `{}`", session.as_str()).ok();
+        }
+    }
+    for change in str_replace {
+        writeln!(
+            &mut out,
+            "- **Replace:** `{}` -> `{}` ({:?})",
+            change.old,
+            change.new,
+            change.occurrence
+        ).ok();
+    }
+}
+PlannedMutation::Rename { record_id, new_id } => {
+    writeln!(&mut out, "- **Kind:** rename").ok();
+    writeln!(&mut out, "- **Target:** `{}` -> `{}`", record_id.as_str(), new_id.as_str()).ok();
+}
+```
+
+- [ ] **Step 4: Accept the new snapshots**
+
+Run: `cargo test -p cairn-core renders_session_patch_mutation renders_rename_mutation -- --exact`
+
+Expected: PASS and new snapshot files created for patch and rename rendering.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  crates/cairn-core/src/domain/flush_plan/diff.rs \
+  crates/cairn-core/src/domain/flush_plan/snapshots
+git commit -m "feat: render patch and rename flush plan diffs"
+```
+
+### Task 3: Replace the Real-Plan Metadata-Only Apply Path
+
+**Files:**
+- Create: `crates/cairn-cli/src/verbs/flush_apply.rs`
+- Modify: `crates/cairn-cli/src/verbs/flush.rs`
+- Modify: `crates/cairn-cli/src/verbs/mod.rs`
+- Modify: `crates/cairn-cli/tests/flush_integration.rs`
+
+- [ ] **Step 1: Write the failing apply-path CLI test**
+
+```rust
+#[test]
+fn flush_apply_real_plan_records_full_apply_kind() {
+    let (_tmp, vault) = fresh_vault();
+    let operation_id = "01JTS6R4J7000000000000000A";
+    write_non_placeholder_patch_plan(&vault, operation_id);
+
+    let assert = Command::cargo_bin("cairn")
+        .unwrap()
+        .args(["flush", "apply", operation_id, "--vault", vault.to_str().unwrap()])
+        .assert();
+
+    assert.success();
+    let persisted = read_applied_plan(&vault, operation_id);
+    let PlanStatus::Applied { apply_kind, .. } = persisted.status else {
+        panic!("expected applied status");
+    };
+    assert_eq!(apply_kind, ApplyKind::Full);
+}
+```
+
+- [ ] **Step 2: Run the focused CLI test to verify it fails**
+
+Run: `cargo test -p cairn-cli flush_apply_real_plan_records_full_apply_kind -- --exact`
+
+Expected: FAIL because the current code writes `apply_kind = MetadataOnly`.
+
+- [ ] **Step 3: Create `flush_apply.rs` with an execution entry point**
+
+```rust
+pub(crate) async fn apply_real_plan(
+    store: &Arc<dyn MemoryStore>,
+    sqlite: Option<&Arc<SqliteMemoryStore>>,
+    plan: &FlushPlan,
+) -> anyhow::Result<()> {
+    for mutation in &plan.mutations {
+        match mutation {
+            PlannedMutation::Patch { .. } => {
+                anyhow::bail!("patch apply not implemented yet");
+            }
+            PlannedMutation::Rename { .. } => {
+                anyhow::bail!("rename apply not implemented yet");
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Wire `flush.rs` to use the helper for non-placeholder plans**
+
+```rust
+if persisted.plan.placeholder {
+    persisted.status = PlanStatus::Applied {
+        at: now_rfc3339(),
+        apply_kind: ApplyKind::MetadataOnly,
+    };
+} else {
+    flush_apply::apply_real_plan(&store, sqlite_store.as_ref(), &persisted.plan)
+        .await
+        .map_err(|e| format!("apply failed: {e}"))?;
+    persisted.status = PlanStatus::Applied {
+        at: now_rfc3339(),
+        apply_kind: ApplyKind::Full,
+    };
+}
+```
+
+- [ ] **Step 5: Run the focused CLI test again**
+
+Run: `cargo test -p cairn-cli flush_apply_real_plan_records_full_apply_kind -- --exact`
+
+Expected: still FAIL, but now because patch execution is not implemented rather than because the plan is always metadata-only.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  crates/cairn-cli/src/verbs/flush_apply.rs \
+  crates/cairn-cli/src/verbs/flush.rs \
+  crates/cairn-cli/src/verbs/mod.rs \
+  crates/cairn-cli/tests/flush_integration.rs
+git commit -m "refactor: route real flush apply through dedicated executor"
+```
+
+### Task 4: Implement Patch Execution and Typed Failures
+
+**Files:**
+- Modify: `crates/cairn-store-sqlite/src/error.rs`
+- Modify: `crates/cairn-store-sqlite/src/store/sessions.rs`
+- Modify: `crates/cairn-store-sqlite/src/store/tx.rs`
+- Modify: `crates/cairn-cli/src/verbs/flush_apply.rs`
+- Create: `crates/cairn-store-sqlite/tests/flush_apply_mutations.rs`
+- Modify: `crates/cairn-store-sqlite/tests/versioning.rs`
+
+- [ ] **Step 1: Write the failing store integration tests for patching**
+
+```rust
+#[tokio::test]
+async fn patch_creates_new_active_version_and_preserves_old_body() {
+    let store = open_test_store().await;
+    let original = sample_record_with_body("alpha beta gamma");
+    store.upsert(&original).await.expect("seed");
+
+    apply_patch_record(
+        &store,
+        original.target_id.clone(),
+        vec![StrReplace {
+            old: "beta".into(),
+            new: "delta".into(),
+            occurrence: ReplaceOccurrence::First,
+        }],
+    )
+    .await
+    .expect("patch");
+
+    let active = store.get_active_by_target(&original.target_id).await.unwrap().unwrap();
+    assert_eq!(active.record.body, "alpha delta gamma");
+    let history = store.versions(&original.target_id).await.unwrap();
+    assert_eq!(history.len(), 2);
+}
+
+#[tokio::test]
+async fn patch_missing_substring_fails_atomically() {
+    let store = open_test_store().await;
+    let original = sample_record_with_body("alpha beta gamma");
+    store.upsert(&original).await.expect("seed");
+
+    let err = apply_patch_record(
+        &store,
+        original.target_id.clone(),
+        vec![StrReplace {
+            old: "missing".into(),
+            new: "delta".into(),
+            occurrence: ReplaceOccurrence::First,
+        }],
+    )
+    .await
+    .expect_err("expected missing substring");
+
+    assert!(err.to_string().contains("substring"));
+    let active = store.get_active_by_target(&original.target_id).await.unwrap().unwrap();
+    assert_eq!(active.record.body, "alpha beta gamma");
+}
+```
+
+- [ ] **Step 2: Run the patch integration tests to verify they fail**
+
+Run: `cargo test -p cairn-store-sqlite patch_creates_new_active_version_and_preserves_old_body patch_missing_substring_fails_atomically -- --exact`
+
+Expected: FAIL with missing apply helpers and missing typed patch errors.
+
+- [ ] **Step 3: Add the store error variants**
+
+```rust
+PatchTargetMissing {
+    target: String,
+},
+PatchSubstringMissing {
+    target: String,
+    old: String,
+},
+RenameTargetConflict {
+    target: String,
+    new_target: String,
+},
+```
+
+- [ ] **Step 4: Implement deterministic replacement helpers in `flush_apply.rs`**
+
+```rust
+fn apply_one_replace(body: &str, change: &StrReplace) -> Result<String, StoreError> {
+    match change.occurrence {
+        ReplaceOccurrence::First => body.replacen(&change.old, &change.new, 1).pipe(|next| {
+            if next == body {
+                Err(StoreError::PatchSubstringMissing {
+                    target: "<resolved later>".into(),
+                    old: change.old.clone(),
+                })
+            } else {
+                Ok(next)
+            }
+        }),
+        ReplaceOccurrence::All => {
+            if !body.contains(&change.old) {
+                Err(StoreError::PatchSubstringMissing {
+                    target: "<resolved later>".into(),
+                    old: change.old.clone(),
+                })
+            } else {
+                Ok(body.replace(&change.old, &change.new))
+            }
+        }
+        ReplaceOccurrence::Nth(n) => replace_nth(body, &change.old, &change.new, n),
+    }
+}
+```
+
+- [ ] **Step 5: Implement transactional patch execution**
+
+```rust
+store.with_tx(move |tx| {
+    let active = tx.get_active_by_target_sync(&target)?
+        .ok_or_else(|| StoreError::PatchTargetMissing { target: target.as_str().into() })?;
+    let mut next_body = active.record.body.clone();
+    for change in &str_replace {
+        next_body = apply_one_replace(&next_body, change)?;
+    }
+    let mut next_record = active.record.clone();
+    next_record.body = next_body;
+    next_record.validate()?;
+    tx.upsert(&next_record)?;
+    Ok(())
+}).await?;
+```
+
+- [ ] **Step 6: Add session-target resolution using the existing session APIs**
+
+```rust
+pub(crate) fn session_metadata_target(session: &SessionId) -> TargetId {
+    TargetId::parse(&format!("session:{}/meta", session.as_str())).expect("well-known target")
+}
+```
+
+```rust
+let target = match patch_target {
+    PatchTarget::Record(target) => target.clone(),
+    PatchTarget::Session(session) => resolve_existing_session_metadata_target(tx, session)?,
+};
+```
+
+- [ ] **Step 7: Run the focused patch tests again**
+
+Run: `cargo test -p cairn-store-sqlite patch_creates_new_active_version_and_preserves_old_body patch_missing_substring_fails_atomically -- --exact`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  crates/cairn-store-sqlite/src/error.rs \
+  crates/cairn-store-sqlite/src/store/sessions.rs \
+  crates/cairn-store-sqlite/src/store/tx.rs \
+  crates/cairn-cli/src/verbs/flush_apply.rs \
+  crates/cairn-store-sqlite/tests/flush_apply_mutations.rs \
+  crates/cairn-store-sqlite/tests/versioning.rs
+git commit -m "feat: execute flush patch mutations atomically"
+```
+
+### Task 5: Implement Rename Execution and Inbound Edge Rewrites
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/flush_apply.rs`
+- Modify: `crates/cairn-store-sqlite/src/store/tx.rs`
+- Modify: `crates/cairn-store-sqlite/tests/entity_graph.rs`
+- Modify: `crates/cairn-store-sqlite/tests/flush_apply_mutations.rs`
+- Modify: `crates/cairn-cli/tests/flush_integration.rs`
+
+- [ ] **Step 1: Write the failing rename tests**
+
+```rust
+#[tokio::test]
+async fn rename_rejects_collision() {
+    let store = open_test_store().await;
+    let source = sample_record_with_target("01JTS6R4J70000000000000011");
+    let dest = sample_record_with_target("01JTS6R4J70000000000000012");
+    store.upsert(&source).await.expect("seed source");
+    store.upsert(&dest).await.expect("seed dest");
+
+    let err = apply_rename(&store, source.target_id.clone(), dest.target_id.clone())
+        .await
+        .expect_err("expected collision");
+
+    assert!(err.to_string().contains("conflict"));
+}
+
+#[tokio::test]
+async fn rename_rewrites_inbound_edges() {
+    let store = open_test_store().await;
+    let source = sample_graph_record("01JTS6R4J70000000000000021");
+    let inbound = sample_graph_record("01JTS6R4J70000000000000022");
+    store.upsert(&source).await.expect("seed source");
+    store.upsert(&inbound).await.expect("seed inbound");
+    store.put_edge(&edge_to(&inbound, &source)).await.expect("seed edge");
+
+    apply_rename(
+        &store,
+        source.target_id.clone(),
+        TargetId::parse("01JTS6R4J70000000000000023").unwrap(),
+    )
+    .await
+    .expect("rename");
+
+    let edges = store.neighbours(&inbound.record_id, EdgeDir::Out).await.unwrap();
+    assert!(edges.iter().any(|edge| edge.to == RecordId::parse("01JTS6R4J70000000000000023").unwrap()));
+}
+```
+
+- [ ] **Step 2: Run the rename tests to verify they fail**
+
+Run: `cargo test -p cairn-store-sqlite rename_rejects_collision rename_rewrites_inbound_edges -- --exact`
+
+Expected: FAIL with missing rename executor behavior.
+
+- [ ] **Step 3: Implement transactional rename execution**
+
+```rust
+store.with_tx(move |tx| {
+    let active = tx.get_active_by_target_sync(&record_id)?
+        .ok_or_else(|| StoreError::PatchTargetMissing { target: record_id.as_str().into() })?;
+    if tx.get_active_by_target_sync(&new_id)?.is_some() {
+        return Err(StoreError::RenameTargetConflict {
+            target: record_id.as_str().into(),
+            new_target: new_id.as_str().into(),
+        });
+    }
+
+    let mut next_record = active.record.clone();
+    next_record.target_id = new_id.clone();
+    tx.upsert(&next_record)?;
+    tx.rewrite_inbound_edges(&active.record.record_id, &next_record.record_id)?;
+    tx.tombstone(&active.record.record_id, TombstoneReason::Superseded)?;
+    Ok(())
+}).await?;
+```
+
+- [ ] **Step 4: Add an inbound-edge rewrite helper in `store/tx.rs`**
+
+```rust
+pub fn rewrite_inbound_edges(&self, old: &RecordId, new: &RecordId) -> Result<(), StoreError> {
+    self.conn.execute(
+        "UPDATE edges SET to_record_id = ?1 WHERE to_record_id = ?2",
+        params![new.as_str(), old.as_str()],
+    )?;
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Run the focused rename tests again**
+
+Run: `cargo test -p cairn-store-sqlite rename_rejects_collision rename_rewrites_inbound_edges -- --exact`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the end-to-end apply test set**
+
+Run: `cargo test -p cairn-cli flush_apply_real_plan_records_full_apply_kind`
+
+Expected: PASS with `ApplyKind::Full` for real plans and no regressions to placeholder tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  crates/cairn-cli/src/verbs/flush_apply.rs \
+  crates/cairn-store-sqlite/src/store/tx.rs \
+  crates/cairn-store-sqlite/tests/entity_graph.rs \
+  crates/cairn-store-sqlite/tests/flush_apply_mutations.rs \
+  crates/cairn-cli/tests/flush_integration.rs
+git commit -m "feat: execute flush rename mutations with edge rewrites"
+```
+
+### Task 6: Final Verification and Cleanup
+
+**Files:**
+- Modify: any touched files from Tasks 1-5 only if required by failing verification
+
+- [ ] **Step 1: Run the focused package suites**
+
+Run: `cargo test -p cairn-core`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-store-sqlite flush_apply_mutations versioning entity_graph`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-cli flush_integration`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run formatting**
+
+Run: `cargo fmt --all`
+
+Expected: no diff after formatting.
+
+- [ ] **Step 3: Re-run the highest-signal tests after formatting**
+
+Run: `cargo test -p cairn-core patch_and_rename_round_trip_json renders_session_patch_mutation renders_rename_mutation`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-store-sqlite patch_creates_new_active_version_and_preserves_old_body patch_missing_substring_fails_atomically rename_rejects_collision rename_rewrites_inbound_edges`
+
+Expected: PASS.
+
+Run: `cargo test -p cairn-cli flush_apply_real_plan_records_full_apply_kind`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the final verified state**
+
+```bash
+git add \
+  crates/cairn-core/src/domain/flush_plan/mod.rs \
+  crates/cairn-core/src/domain/flush_plan/diff.rs \
+  crates/cairn-core/tests/flush_plan_proptest.rs \
+  crates/cairn-cli/src/verbs/flush.rs \
+  crates/cairn-cli/src/verbs/flush_apply.rs \
+  crates/cairn-store-sqlite/src/error.rs \
+  crates/cairn-store-sqlite/src/store/sessions.rs \
+  crates/cairn-store-sqlite/src/store/tx.rs \
+  crates/cairn-cli/tests/flush_integration.rs \
+  crates/cairn-store-sqlite/tests/flush_apply_mutations.rs \
+  crates/cairn-store-sqlite/tests/versioning.rs \
+  crates/cairn-store-sqlite/tests/entity_graph.rs
+git commit -m "feat: add real flush apply for patch and rename"
+```
+
+## Self-Review
+
+- Spec coverage check:
+  - `Patch`/`Rename` types and serde are covered in Task 1.
+  - human-review diff rendering is covered in Task 2.
+  - non-placeholder real apply versus placeholder metadata-only behavior is covered in Task 3.
+  - record patching, session metadata patching, atomic failures, and typed errors are covered in Task 4.
+  - rename collision and inbound edge rewrites are covered in Task 5.
+  - final verification and regression protection are covered in Task 6.
+- Placeholder scan:
+  - removed generic placeholders like "add tests" and replaced them with exact files, commands, and sample code.
+- Type consistency:
+  - plan consistently uses `PatchTarget`, `StrReplace`, `ReplaceOccurrence`, `ApplyKind::Full`, and `RenameTargetConflict`.

--- a/docs/superpowers/specs/2026-05-09-issue-289-patch-rename-design.md
+++ b/docs/superpowers/specs/2026-05-09-issue-289-patch-rename-design.md
@@ -1,0 +1,228 @@
+# Issue 289 Design: Real Flush Apply for Patch and Rename
+
+## Summary
+
+Issue `#289` should land as a full vertical slice, not as a shape-only enum
+change. The current `cairn flush apply` path is explicitly metadata-only for
+non-placeholder plans, so the branch must first wire a real apply path for
+concrete mutations and then add `Patch` and `Rename` on top.
+
+This design keeps placeholder plans on the existing metadata-only behavior for
+stub-planner compatibility while making non-placeholder plans execute real store
+mutations.
+
+## Goals
+
+- Add `PlannedMutation::Patch` and `PlannedMutation::Rename`.
+- Support patching both record bodies and session metadata documents.
+- Replace the current non-placeholder metadata-only apply path with real
+  mutation execution.
+- Reject patch failures and rename collisions atomically with typed errors.
+- Preserve Cairn's versioned-record model rather than mutating rows in place.
+- Update human-review rendering so the new mutations are legible in diffs.
+
+## Non-Goals
+
+- Rework the placeholder-plan flow. Placeholder plans remain metadata-only.
+- Introduce a separate generic provenance subsystem beyond what the current
+  versioned record history already provides.
+- Generalize session storage onto the `MemoryStore` trait in this branch.
+- Implement bulk multi-record patching beyond multiple mutations in one plan.
+
+## Current Constraints
+
+- `flush apply` currently warns that `MemoryStore` mutations are not wired and
+  always records `apply_kind = metadata_only` for real plans.
+- Session persistence currently lives on inherent `SqliteMemoryStore` methods,
+  not the `MemoryStore` trait.
+- `PlannedMutation` is consumed by serde round-trip tests, fixtures, and the
+  markdown diff renderer, so adding variants requires coordinated updates.
+
+## Proposed Data Model
+
+### New mutation shapes
+
+Add the following types in `crates/cairn-core/src/domain/flush_plan/mod.rs`:
+
+```rust
+pub enum PlannedMutation {
+    // existing variants...
+    Patch {
+        target: PatchTarget,
+        str_replace: Vec<StrReplace>,
+    },
+    Rename {
+        record_id: TargetId,
+        new_id: TargetId,
+    },
+}
+
+pub enum PatchTarget {
+    Record(TargetId),
+    Session(SessionId),
+}
+
+pub struct StrReplace {
+    pub old: String,
+    pub new: String,
+    pub occurrence: ReplaceOccurrence,
+}
+
+pub enum ReplaceOccurrence {
+    First,
+    All,
+    Nth(usize),
+}
+```
+
+### Target semantics
+
+- `PatchTarget::Record(TargetId)` patches the active record for that target.
+- `PatchTarget::Session(SessionId)` patches the session metadata document stored
+  at the well-known target `session:{session_id}/meta`.
+- `Rename { record_id, new_id }` renames a record target, not an entire session.
+
+## Apply Design
+
+### High-level flow
+
+For non-placeholder plans, `cairn flush apply` should:
+
+1. Load and validate the pending plan as today.
+2. Perform pre-state drift checks against `target_hashes`.
+3. Execute all mutations inside one real apply unit.
+4. Publish `PlanStatus::Applied { apply_kind = full }` only after successful
+   mutation execution.
+5. Roll back on any mutation failure so partial writes are impossible.
+
+Placeholder plans keep the existing metadata-only branch and warning text.
+
+### Execution boundary
+
+The CLI apply command should delegate real execution into a dedicated apply
+helper instead of keeping mutation logic inline inside `flush.rs`. The helper
+can depend on:
+
+- `MemoryStore::get_active_by_target`
+- `MemoryStore::upsert`
+- `MemoryStore::tombstone`
+- concrete `SqliteMemoryStore` transaction/session helpers where generic store
+  support is insufficient
+
+The branch should prefer the generic trait where possible and use SQLite-specific
+helpers only for session metadata lookup and inbound graph-edge rewrites.
+
+### Patch execution
+
+For each `Patch` mutation:
+
+1. Resolve the target record.
+2. Read the active body.
+3. Apply every `StrReplace` left-to-right against the current body string.
+4. If any `old` match is missing for its requested occurrence, fail with a typed
+   error and abort the entire plan.
+5. Rebuild the `MemoryRecord` with the patched body.
+6. Re-run record validation before persistence.
+7. Persist as a new record version via normal upsert/versioning semantics.
+
+Patch is therefore append-only in storage terms even though it is a logical
+edit. The previous body remains recoverable through existing history.
+
+### Session patch execution
+
+Session patches follow the same body-edit flow as record patches, but target
+resolution first maps `SessionId` to the session metadata target
+`session:{id}/meta`.
+
+Failure mode:
+
+- if the session does not exist, fail with typed `SessionNotFound`
+- if the session exists but the metadata record is absent, treat that as a
+  missing target error rather than silently creating one
+
+### Rename execution
+
+For each `Rename` mutation:
+
+1. Resolve the active source record by `record_id`.
+2. Reject if an active record already exists for `new_id`.
+3. Create a logically equivalent new active record under `new_id`.
+4. Retire the old active target without erasing historical versions.
+5. Rewrite all inbound entity-graph edges from `record_id` to `new_id` in the
+   same transaction.
+6. Preserve atomicity so readers never observe mixed graph state.
+
+Rename is modeled as a target migration with history retention, not as an
+in-place primary-key mutation.
+
+## Error Model
+
+Add typed apply/store errors for:
+
+- patch target missing
+- patch substring missing
+- patch occurrence invalid or not found
+- session not found
+- rename target collision
+
+The CLI should surface these as plan-apply failures and leave the plan pending
+after claim rollback, matching existing failure handling.
+
+## Human Review Rendering
+
+Update `crates/cairn-core/src/domain/flush_plan/diff.rs`:
+
+- `PatchTarget::Record` renders with target id and a unified-style before/after
+  body diff or a deterministic textual replacement view if a true line diff is
+  not yet available.
+- `PatchTarget::Session` renders with `Session: <id>` to distinguish the target
+  from record patches.
+- `Rename` renders as `old_id -> new_id`.
+
+The renderer must remain deterministic for snapshot-style tests.
+
+## Testing Strategy
+
+### TDD order
+
+1. Add failing core serde/property tests for the new mutation shapes.
+2. Add failing diff-render tests for patch and rename.
+3. Add failing apply-path tests showing non-placeholder plans now require real
+   execution instead of metadata-only completion.
+4. Add failing SQLite integration tests for:
+   - record patch success
+   - record patch missing substring atomic failure
+   - session patch success
+   - session patch missing session failure
+   - rename collision failure
+   - rename inbound-edge rewrite success
+
+### Verification expectations
+
+- Placeholder-plan tests must remain green and still produce
+  `apply_kind = metadata_only`.
+- Real plan apply tests must assert `apply_kind = full`.
+- Rename tests must verify both record visibility and inbound graph-edge
+  rewrites under SQLite.
+- Patch tests must verify the old version remains available through history.
+
+## Implementation Plan Shape
+
+The branch should be developed in two reviewable commits:
+
+1. real apply infrastructure for non-placeholder plans
+2. issue `#289` mutation shapes, rendering, and integration behavior
+
+This keeps the unavoidable infra work separate from the feature-specific code
+while still delivering the full vertical slice in one branch.
+
+## Risks
+
+- The largest technical risk is fitting rename semantics cleanly into the
+  existing versioned-record and graph-edge model without inventing a parallel
+  provenance system.
+- Session patching crosses the generic store boundary, so SQLite-specific code
+  must be kept narrow and explicit.
+- If the current `MemoryStore` trait surface proves too small for real apply,
+  the branch may need a minimal trait extension before mutation execution can be
+  properly isolated.


### PR DESCRIPTION
Closes #289.

## Summary
- Add `PlannedMutation::Patch { target, str_replace }` (record + session targets) and `PlannedMutation::Rename { record_id, new_record_id }` to the flush plan op-set, with serde round-trips, unified-diff rendering, and intra-plan + live collision lint checks.
- Wire real WAL apply through `SqliteMemoryStore::with_tx` with two-phase drift+scope checks: pre-state body hashes must match `target_hashes`, scope dimensions must satisfy the stored record/session scope, and session patches enforce identity-tuple (user/agent/project_root) — rejecting plans that narrow on tenant/workspace/entity dimensions sessions cannot enforce.
- Rename mints a fresh record id, preserves predecessor edge history (`INSERT OR IGNORE`, no DELETE), tombstones the old id, and rejects retired-lineage targets.
- Patch/rename audit blobs (`flush_patch_history`, `flush_rename_history`) land in `extra_frontmatter`; session patches persist to a new durable audit table (`session_metadata_audit`, PK includes `mutation_seq` for repeated patches in one plan).
- Mutated records carry an all-zeros `FLUSH_MUTATED_SENTINEL` Ed25519 signature with `attests_author()` / `is_flush_mutated()` helpers so future verifiers can fail-closed on author attestation.
- Claim-lock hardened with `fs2` advisory file lock + orphan liveness probe; non-placeholder empty plans, mixed-variant plans, no-op patches, and empty `old`-string replacements are rejected (exit 65, plan rolled back to pending).

## Acceptance criteria (issue #289)
- [x] `PlannedMutation::Patch` + `Rename` round-trip serde tests (`crates/cairn-core/tests/flush_plan_proptest.rs`)
- [x] WAL apply test: Patch mutates body + extends provenance (audit blob in `extra_frontmatter`)
- [x] WAL apply test: Patch with missing `old` substring fails atomically (drift + tx rollback)
- [x] WAL apply test: Rename rejects collision with `IdConflict` error
- [x] WAL apply test: Rename rewrites inbound graph edges (`rewrite_non_updates_edges`)
- [x] Lint test: rename target collision surfaces in `cairn lint --plan` (live + intra-plan)
- [x] `flush_plan/diff.rs` renders Patch as unified diff and Rename as `old → new`

## Brief sections touched
§5.5 mutation pipeline, §5.6 WAL state machine, §8.0.b mutation discipline.

## Invariants touched
- WAL + two-phase apply (§5.6): patch/rename writes go through `with_tx` with drift + scope validated before any mutation runs.
- Fail-closed on capability (§4.6): empty/mixed/no-op plans reject with `EX_CONFIG` (65) and roll the plan back to pending.
- Privacy by construction (§4.9): session patches write `pre_state`/`post_state` to the audit table; no record bodies logged above `debug`.
- Sources immutable / records LLM-owned: rename mints a fresh `record_id` rather than mutating the original.

## Migrations
- `0053_session_metadata_audit` — new audit table for session patches.
- `0054_session_metadata_audit_seq` — rebuilds the audit table with `mutation_seq` in the PK so the same plan can patch a session multiple times safely.

## Verification
```
cargo nextest run --workspace --locked        # 560/560 store, 36/36 flush integration
cargo test --doc --workspace --locked         # green
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo run -p cairn-idl --bin cairn-codegen --locked -- --check
./scripts/check-core-boundary.sh
```

## Known follow-ups (out of scope)
Adversarial review-loop surfaced two architectural concerns that exceed #289's scope and warrant separate issues:
1. **WAL routing for patch/rename**: real WAL apply uses `with_tx` for atomicity but does not currently INSERT `wal_ops` rows for the patch/rename kinds. Requires extending `wal_ops.kind` CHECK via a writable-schema migration (per 0047 pattern) plus dep-DAG + state-FSM wiring. Brief §5.6.
2. **Sentinel signature enforcement**: `FLUSH_MUTATED_SENTINEL` is emitted on mutation but P0 does not crypto-verify record signatures anywhere (`actor_chain.rs:110`). Workspace-wide audit of signature consumers + sentinel-detect lint check belongs with P1 Ed25519 verification. Brief §15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
