### PR TITLE
feat(trace): classify Proactive + Terminal capture payloads (brief §9.3)

### DIFF
--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -289,7 +289,19 @@ async fn run_handler_inner(
             // squash gate, and a malformed envelope is rejected with
             // `MalformedEnvelope` before we open `sources/`.
             match dispatch(event, &DefaultRegistry) {
-                DispatchDecision::Bypass(BypassReason::NonTerminalFamily) => {}
+                // Non-terminal families (Hook, Proactive, Ide, …) and the
+                // terminal-state bypass variants all flow raw bytes through
+                // Extract unchanged at P0. Squash is also admitted: trace
+                // replay re-ingests previously captured terminal payloads
+                // whose bytes are already on disk under `sources/`, so the
+                // squash binder cannot rewrite them and the importer treats
+                // the squash decision as "accept and proceed".
+                DispatchDecision::Bypass(
+                    BypassReason::NonTerminalFamily
+                    | BypassReason::TerminalNonInteractive
+                    | BypassReason::TerminalLegacyMissingContext,
+                )
+                | DispatchDecision::Squash(_) => {}
                 DispatchDecision::Bypass(BypassReason::MalformedEnvelope) => {
                     failed_turns.push((
                         session_str.clone(),
@@ -300,17 +312,14 @@ async fn run_handler_inner(
                     break;
                 }
                 other => {
-                    // classify() already rejected non-hook payloads; reaching
-                    // any other dispatch decision means the classifier and
-                    // dispatch driver disagree about routing. Surface as a
-                    // turn-level failure rather than silently proceeding.
+                    // `DispatchDecision` and `BypassReason` are
+                    // `#[non_exhaustive]`. A future routing variant that we
+                    // do not yet admit must fail closed: surface a
+                    // turn-level error rather than silently proceeding.
                     failed_turns.push((
                         session_str.clone(),
                         turn_str.clone(),
-                        format!(
-                            "dispatch {}: unexpected decision {other:?} for hook payload",
-                            event.event_id
-                        ),
+                        format!("dispatch {}: unexpected decision {other:?}", event.event_id),
                     ));
                     group_failed = true;
                     break;
@@ -402,7 +411,7 @@ async fn run_handler_inner(
             // the duration of the `project` call only, which completes before
             // `text` is dropped. This is safe because both live in the same
             // `for` iteration scope.
-            let resolved = ResolvedBody::from_trace_hook(&text);
+            let resolved = ResolvedBody::from_trace_capture(&text);
 
             let mut record = match project(event, classified, &resolved, &link) {
                 Ok(r) => r,

--- a/crates/cairn-cli/tests/capture_trace_verb.rs
+++ b/crates/cairn-cli/tests/capture_trace_verb.rs
@@ -7,6 +7,7 @@ use cairn_cli::verbs::capture_trace::{read_jsonl_events, run_handler};
 use cairn_core::domain::{
     ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs,
     ChainRole, Identity, PayloadHash, Rfc3339Timestamp, SessionId, SourceFamily,
+    capture::TerminalContext,
 };
 
 /// Build a minimal valid `Hook` [`CaptureEvent`] for use in tests.
@@ -288,6 +289,148 @@ fn write_fixture(vault: &Path, jsonl_path: &Path) {
             &post_ref,
             &sha256_hex(post_body),
         ),
+        make_event(
+            id_stop,
+            "Stop",
+            session,
+            turn,
+            "2026-05-02T00:00:04Z",
+            None,
+            &stop_ref,
+            &sha256_hex(stop_body),
+        ),
+    ];
+
+    let mut f = std::fs::File::create(jsonl_path).expect("create JSONL file");
+    for ev in &events {
+        let line = serde_json::to_string(ev).expect("serialize event");
+        writeln!(f, "{line}").expect("write JSONL line");
+    }
+}
+
+/// Write a single turn that includes both a proactive agent message and a
+/// terminal-backed tool output. This exercises the non-hook trace-event
+/// classifications that complete issue #77's event coverage.
+#[allow(
+    clippy::too_many_lines,
+    reason = "fixture: six events × full struct literals for non-hook variants"
+)]
+fn write_agent_and_tool_output_fixture(vault: &Path, jsonl_path: &Path) {
+    let session = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    let turn = "turn-1";
+    let tool_id = "toolu_test_01";
+
+    let id_user = ULID_A;
+    let id_pre = ULID_B;
+    let id_agent = "01ARZ3NDEKTSV4RRFFQ69G5FAJ";
+    let id_post = "01ARZ3NDEKTSV4RRFFQ69G5FAC";
+    let id_output = "01ARZ3NDEKTSV4RRFFQ69G5FAK";
+    let id_stop = "01ARZ3NDEKTSV4RRFFQ69G5FAD";
+
+    let user_body = "Please run the deployment check";
+    let pre_body = r#"{"tool":"bash","input":{"command":"./deploy-check.sh"}}"#;
+    let agent_body = "I will summarize the deployment output for review.";
+    let post_body = r#"{"tool":"bash","status":"completed"}"#;
+    let output_body = "Deploy output complete: 12 services healthy, 0 errors.";
+    let stop_body = "session ended";
+
+    let user_ref = write_source(vault, &format!("{id_user}.txt"), user_body);
+    let pre_ref = write_source(vault, &format!("{id_pre}.txt"), pre_body);
+    let agent_ref = write_source(vault, &format!("{id_agent}.txt"), agent_body);
+    let post_ref = write_source(vault, &format!("{id_post}.txt"), post_body);
+    let output_ref = write_source(vault, &format!("{id_output}.txt"), output_body);
+    let stop_ref = write_source(vault, &format!("{id_stop}.txt"), stop_body);
+
+    let proactive_sensor = Identity::parse("snr:local:proactive:claude-code:v1")
+        .expect("invariant: valid proactive sensor id");
+    let terminal_sensor =
+        Identity::parse("snr:local:terminal:default:v1").expect("invariant: valid terminal id");
+
+    let events = vec![
+        make_event(
+            id_user,
+            "UserPromptSubmit",
+            session,
+            turn,
+            "2026-05-02T00:00:01Z",
+            None,
+            &user_ref,
+            &sha256_hex(user_body),
+        ),
+        make_event(
+            id_pre,
+            "PreToolUse",
+            session,
+            turn,
+            "2026-05-02T00:00:02Z",
+            Some(tool_id.to_owned()),
+            &pre_ref,
+            &sha256_hex(pre_body),
+        ),
+        CaptureEvent {
+            event_id: CaptureEventId::parse(id_agent).expect("invariant: valid ULID"),
+            sensor_id: proactive_sensor,
+            capture_mode: CaptureMode::Proactive,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: Identity::parse("agt:claude-code:opus-4-7:reviewer:v1")
+                    .expect("invariant: valid agent identity"),
+                at: Rfc3339Timestamp::parse("2026-05-02T00:00:02.500Z")
+                    .expect("invariant: valid RFC-3339"),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some(session.to_owned()),
+                turn_id: Some(turn.to_owned()),
+                tool_id: None,
+            }),
+            payload_hash: PayloadHash::parse(format!("sha256:{}", sha256_hex(agent_body)))
+                .expect("invariant: valid sha256 hash"),
+            payload_ref: agent_ref,
+            captured_at: Rfc3339Timestamp::parse("2026-05-02T00:00:02.500Z")
+                .expect("invariant: valid RFC-3339"),
+            payload: CapturePayload::Proactive {
+                kind: "feedback".into(),
+                rationale: "agent produced a user-visible summary".into(),
+            },
+            source_family: SourceFamily::Proactive,
+        },
+        make_event(
+            id_post,
+            "PostToolUse",
+            session,
+            turn,
+            "2026-05-02T00:00:03Z",
+            Some(tool_id.to_owned()),
+            &post_ref,
+            &sha256_hex(post_body),
+        ),
+        CaptureEvent {
+            event_id: CaptureEventId::parse(id_output).expect("invariant: valid ULID"),
+            sensor_id: terminal_sensor.clone(),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: terminal_sensor,
+                at: Rfc3339Timestamp::parse("2026-05-02T00:00:03.500Z")
+                    .expect("invariant: valid RFC-3339"),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some(session.to_owned()),
+                turn_id: Some(turn.to_owned()),
+                tool_id: Some(tool_id.to_owned()),
+            }),
+            payload_hash: PayloadHash::parse(format!("sha256:{}", sha256_hex(output_body)))
+                .expect("invariant: valid sha256 hash"),
+            payload_ref: output_ref,
+            captured_at: Rfc3339Timestamp::parse("2026-05-02T00:00:03.500Z")
+                .expect("invariant: valid RFC-3339"),
+            payload: CapturePayload::Terminal {
+                command: "./deploy-check.sh".into(),
+                exit_code: Some(0),
+                context: Some(TerminalContext::InteractiveTty),
+            },
+            source_family: SourceFamily::Terminal,
+        },
         make_event(
             id_stop,
             "Stop",
@@ -871,6 +1014,71 @@ async fn capture_trace_blocks_secret_body_before_persisting_turn() {
             assert!(
                 !tx.turn_summary_exists(&session_id, turn)?,
                 "privacy-blocked turn must not create a summary"
+            );
+            Ok(())
+        })
+        .await
+        .expect("store query should succeed");
+}
+
+#[tokio::test]
+#[allow(
+    clippy::expect_used,
+    reason = "test: panics surface broken invariants immediately"
+)]
+async fn agent_message_and_tool_output_persist_and_redact() {
+    let vault = tempfile::tempdir().expect("tempdir");
+    let store = open_test_store_in_memory().await;
+    let jsonl_path = vault.path().join("trace.jsonl");
+
+    write_agent_and_tool_output_fixture(vault.path(), &jsonl_path);
+
+    let resp = run_handler(&store, vault.path(), &jsonl_path)
+        .await
+        .expect("run_handler should succeed");
+
+    assert!(
+        resp.failed_turns.is_empty(),
+        "expected no failures, got: {:?}",
+        resp.failed_turns
+    );
+
+    let session_id = SessionId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAV").expect("valid session_id");
+
+    store
+        .with_tx(move |tx| {
+            let rows = tx.list_trace_events(&session_id, "turn-1")?;
+            assert_eq!(rows.len(), 6, "expected 6 trace events, got {}", rows.len());
+
+            let _agent = rows
+                .iter()
+                .find(|r| {
+                    r.extra_frontmatter
+                        .get("trace_event")
+                        .and_then(|v| v.as_str())
+                        == Some("agent_message")
+                })
+                .expect("agent_message row");
+
+            let output = rows
+                .iter()
+                .find(|r| {
+                    r.extra_frontmatter
+                        .get("trace_event")
+                        .and_then(|v| v.as_str())
+                        == Some("tool_output")
+                })
+                .expect("tool_output row");
+            assert_eq!(
+                output.extra_frontmatter["trace"]["parent_event_id"]
+                    .as_str()
+                    .expect("parent_event_id present"),
+                ULID_B,
+                "tool_output should attach to the pre_tool event"
+            );
+            assert!(
+                tx.turn_summary_exists(&session_id, "turn-1")?,
+                "turn summary should exist after Stop event"
             );
             Ok(())
         })

--- a/crates/cairn-core/src/pipeline/capture_trace.rs
+++ b/crates/cairn-core/src/pipeline/capture_trace.rs
@@ -59,15 +59,16 @@ impl ProjectedTraceBlocks {
 
 /// Map a [`CaptureEvent`] to a [`TraceEvent`]. Static rules; no LLM.
 ///
-/// **P0 supports only the four hook payloads** routed by hook name
-/// (brief §9.3): `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`.
-/// The remaining `TraceEvent` variants — `AgentMessage`, `ToolOutput`,
-/// `TurnSummary` — are produced by other paths: `AgentMessage` and
-/// `ToolOutput` await sensor adapters (issue #84); `TurnSummary` is
-/// generated post-hoc by [`crate::pipeline::turn::summarize_turn`] and
-/// never reaches `classify`. Until those land, JSONL streams that
-/// include them will fail their entire turn at the importer (the
-/// importer fails closed rather than persisting a partial set).
+/// P0 recognizes hook-backed user/tool lifecycle events plus two existing
+/// non-hook capture families used by the trace importer:
+///
+/// - `CapturePayload::Hook`: `UserPromptSubmit`, `PreToolUse`,
+///   `PostToolUse`, `Stop`
+/// - `CapturePayload::Proactive`: `AgentMessage`
+/// - `CapturePayload::Terminal` with `refs.tool_id`: `ToolOutput`
+///
+/// `TurnSummary` is generated post-hoc by
+/// [`crate::pipeline::turn::summarize_turn`] and never reaches `classify`.
 ///
 /// # Errors
 ///
@@ -82,6 +83,14 @@ pub fn classify(event: &CaptureEvent) -> Result<TraceEvent, TraceProjectError> {
             "Stop" => Ok(TraceEvent::Stop),
             _ => Err(TraceProjectError::Unclassifiable),
         },
+        CapturePayload::Proactive { .. } => Ok(TraceEvent::AgentMessage),
+        CapturePayload::Terminal { .. } => event
+            .refs
+            .as_ref()
+            .and_then(|refs| refs.tool_id.as_ref())
+            .map_or(Err(TraceProjectError::Unclassifiable), |_| {
+                Ok(TraceEvent::ToolOutput)
+            }),
         _ => Err(TraceProjectError::Unclassifiable),
     }
 }
@@ -335,6 +344,71 @@ mod tests {
         }
     }
 
+    fn mk_proactive_event() -> CaptureEvent {
+        CaptureEvent {
+            event_id: CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAW")
+                .expect("invariant: fixed ULID is valid"),
+            sensor_id: Identity::parse("snr:local:proactive:claude-code:v1")
+                .expect("invariant: fixed sensor identity is valid"),
+            capture_mode: CaptureMode::Proactive,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: Identity::parse("agt:claude-code:opus-4-7:reviewer:v1")
+                    .expect("invariant: fixed agent identity is valid"),
+                at: ts(),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some("sess".into()),
+                turn_id: Some("turn".into()),
+                tool_id: None,
+            }),
+            payload_hash: PayloadHash::parse(
+                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+            .expect("invariant: well-formed sha256 hash"),
+            payload_ref: "sources/proactive/01ARZ3NDEKTSV4RRFFQ69G5FAW.txt".into(),
+            captured_at: ts(),
+            payload: CapturePayload::Proactive {
+                kind: "feedback".into(),
+                rationale: "high-salience correction".into(),
+            },
+            source_family: SourceFamily::Proactive,
+        }
+    }
+
+    fn mk_terminal_event() -> CaptureEvent {
+        CaptureEvent {
+            event_id: CaptureEventId::parse("01ARZ3NDEKTSV4RRFFQ69G5FAX")
+                .expect("invariant: fixed ULID is valid"),
+            sensor_id: Identity::parse("snr:local:terminal:default:v1")
+                .expect("invariant: fixed sensor identity is valid"),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: Identity::parse("snr:local:terminal:default:v1")
+                    .expect("invariant: fixed sensor identity is valid"),
+                at: ts(),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some("sess".into()),
+                turn_id: Some("turn".into()),
+                tool_id: Some("toolu_test_01".into()),
+            }),
+            payload_hash: PayloadHash::parse(
+                "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+            .expect("invariant: well-formed sha256 hash"),
+            payload_ref: "sources/terminal/01ARZ3NDEKTSV4RRFFQ69G5FAX.txt".into(),
+            captured_at: ts(),
+            payload: CapturePayload::Terminal {
+                command: "bash".into(),
+                exit_code: Some(0),
+                context: Some(crate::domain::capture::TerminalContext::InteractiveTty),
+            },
+            source_family: SourceFamily::Terminal,
+        }
+    }
+
     #[test]
     fn body_truncates_at_cap() {
         let big = "x".repeat(TRACE_BODY_CAP + 100);
@@ -384,6 +458,22 @@ mod tests {
     #[test]
     fn classifies_stop() {
         assert_eq!(classify(&mk_hook_event("Stop")).unwrap(), TraceEvent::Stop);
+    }
+
+    #[test]
+    fn classifies_proactive_as_agent_message() {
+        assert_eq!(
+            classify(&mk_proactive_event()).unwrap(),
+            TraceEvent::AgentMessage
+        );
+    }
+
+    #[test]
+    fn classifies_terminal_as_tool_output() {
+        assert_eq!(
+            classify(&mk_terminal_event()).unwrap(),
+            TraceEvent::ToolOutput
+        );
     }
 
     #[test]

--- a/crates/cairn-core/src/pipeline/extract/body.rs
+++ b/crates/cairn-core/src/pipeline/extract/body.rs
@@ -174,20 +174,18 @@ impl<'a> ResolvedBody<'a> {
     /// Construct from hash-verified bytes read from `sources/` by the
     /// trace-capture pipeline (brief §5.0). The caller must have already
     /// verified `sha256(bytes) == event.payload_hash` before calling this
-    /// constructor. Intended for hook events that are **not** user-utterance
-    /// hooks (e.g. `PreToolUse`, `PostToolUse`, `Stop`) — those hooks carry
-    /// tool/agent content rather than direct user text, so `HookUtterance`
-    /// is not an appropriate source tag. The source is recorded as
-    /// `HookUtterance` because that is the closest match for
-    /// harness-captured hook payload bytes; a future task will introduce a
-    /// dedicated `HookCapture` or `TracePayload` variant.
+    /// constructor. Intended for trace-event payload bytes that are not
+    /// direct user utterances, such as tool lifecycle hooks, proactive agent
+    /// messages, and terminal-backed tool output. The source is recorded as
+    /// `HookUtterance` because that is the closest existing body-source tag;
+    /// a future task will introduce a dedicated trace-capture source.
     ///
     /// **Do not use outside the `capture_trace` verb pipeline.** Every other
     /// body resolution path should go through the typed constructors
     /// (`from_user_ingest`, `from_hook_utterance`) which enforce
     /// payload-variant invariants.
     #[must_use]
-    pub fn from_trace_hook(text: &'a str) -> Self {
+    pub fn from_trace_capture(text: &'a str) -> Self {
         Self {
             text,
             source: BodySource::HookUtterance,


### PR DESCRIPTION
## Summary
- Extends `classify()` in `cairn-core::pipeline::capture_trace` to recognize `CapturePayload::Proactive` → `TraceEvent::AgentMessage` and `CapturePayload::Terminal` (with `refs.tool_id`) → `TraceEvent::ToolOutput`, alongside existing hook events.
- Renames `ResolvedBody::from_trace_hook` → `from_trace_capture` to match broader scope (no longer hook-only).
- Adds unit + integration tests covering both new variants end-to-end through the `capture_trace` verb.

Brief refs: §9.3 (trace classification), §5.0 (capture pipeline).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo check --workspace --all-targets --locked`
- [x] `cargo nextest run --workspace --locked --no-fail-fast` — all relevant suites pass. One pre-existing failure (`cairn-mcp::mcp_conformance conformance_envelope_replay`) is a stale fixture from #337 on main, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)