### PR TITLE
feat(core): frontend adapter contract (#113)

### DIFF
--- a/crates/cairn-core/src/contract/conformance/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/conformance/frontend_adapter.rs
@@ -13,16 +13,15 @@ use crate::contract::conformance::{
     CaseOutcome, CaseStatus, Tier, tier1_manifest_features_match_capabilities,
     tier1_manifest_matches_host,
 };
+use crate::contract::frontend_adapter::CONTRACT_VERSION;
 use crate::contract::frontend_adapter::{
     FrontendAdapter, FrontendAdapterError, FrontendEdit, FrontendIdentityContext,
     FrontendReconcileError,
 };
-use crate::contract::frontend_adapter::CONTRACT_VERSION;
 use crate::contract::registry::{PluginName, PluginRegistry};
 use crate::domain::{
     ActorChainEntry, CanonicalRecordHash, ChainRole, EvidenceVector, Identity, MemoryClass,
-    MemoryKind, MemoryRecord, MemoryVisibility, Provenance, Rfc3339Timestamp, ScopeTuple,
-    TargetId,
+    MemoryKind, MemoryRecord, MemoryVisibility, Provenance, Rfc3339Timestamp, ScopeTuple, TargetId,
 };
 
 /// Run tier-1 + tier-2 cases for a `FrontendAdapter` plugin.
@@ -59,8 +58,9 @@ pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
         tier2_rejects_immutable_field_edits(&*plugin),
         tier2_rejects_replayed_operation(&*plugin),
         tier2_rejects_tampered_target_hash(&*plugin),
-        tier2_rejects_unrecognized_principal(&*plugin),
+        tier2_quarantines_unrecognized_principal(&*plugin),
         tier2_honors_optimistic_version_check(&*plugin),
+        tier2_rejects_expired_signed_intent(&*plugin),
     ]
 }
 
@@ -133,7 +133,7 @@ fn tier2_rejects_immutable_field_edits(plugin: &dyn FrontendAdapter) -> CaseOutc
     expect_reconcile_error(
         plugin,
         "rejects_immutable_field_edits",
-        sample_identity_context("hmn:known-user"),
+        sample_identity_context("hmn:known-user", "2026-04-22T14:07:11Z"),
         sample_edit(
             1,
             sample_hash("trusted body"),
@@ -147,7 +147,7 @@ fn tier2_rejects_replayed_operation(plugin: &dyn FrontendAdapter) -> CaseOutcome
     expect_reconcile_error(
         plugin,
         "rejects_replayed_operation",
-        sample_identity_context("hmn:known-user"),
+        sample_identity_context("hmn:known-user", "2026-04-22T14:07:11Z"),
         sample_edit(
             100,
             sample_hash("trusted body"),
@@ -161,7 +161,7 @@ fn tier2_rejects_tampered_target_hash(plugin: &dyn FrontendAdapter) -> CaseOutco
     expect_reconcile_error(
         plugin,
         "rejects_tampered_target_hash",
-        sample_identity_context("hmn:known-user"),
+        sample_identity_context("hmn:known-user", "2026-04-22T14:07:11Z"),
         sample_edit(
             100,
             sample_hash("tampered body"),
@@ -176,11 +176,11 @@ fn tier2_rejects_tampered_target_hash(plugin: &dyn FrontendAdapter) -> CaseOutco
     )
 }
 
-fn tier2_rejects_unrecognized_principal(plugin: &dyn FrontendAdapter) -> CaseOutcome {
+fn tier2_quarantines_unrecognized_principal(plugin: &dyn FrontendAdapter) -> CaseOutcome {
     expect_reconcile_error(
         plugin,
-        "rejects_unrecognized_principal",
-        sample_identity_context("hmn:unknown-user"),
+        "quarantines_unrecognized_principal",
+        sample_identity_context("hmn:unknown-user", "2026-04-22T14:07:11Z"),
         sample_edit(
             100,
             sample_hash("trusted body"),
@@ -189,7 +189,8 @@ fn tier2_rejects_unrecognized_principal(plugin: &dyn FrontendAdapter) -> CaseOut
         |error| {
             matches!(
                 error,
-                FrontendReconcileError::PolicyDenied { gate, .. } if gate == "principal"
+                FrontendReconcileError::QuarantineRequired { quarantine_id, .. }
+                    if quarantine_id.as_deref() == Some("01HQZX9F5N0000000000000001")
             )
         },
     )
@@ -199,13 +200,33 @@ fn tier2_honors_optimistic_version_check(plugin: &dyn FrontendAdapter) -> CaseOu
     expect_reconcile_error(
         plugin,
         "honors_optimistic_version_check",
-        sample_identity_context("hmn:known-user"),
+        sample_identity_context("hmn:known-user", "2026-04-22T14:07:11Z"),
         sample_edit(
             99,
             sample_hash("trusted body"),
             BTreeMap::from([(String::from("body"), json!("updated"))]),
         ),
         |error| matches!(error, FrontendReconcileError::Conflict { current_version } if *current_version == 100),
+    )
+}
+
+fn tier2_rejects_expired_signed_intent(plugin: &dyn FrontendAdapter) -> CaseOutcome {
+    expect_reconcile_error(
+        plugin,
+        "rejects_expired_signed_intent",
+        sample_identity_context("hmn:known-user", "2026-04-22T14:06:11Z"),
+        sample_edit(
+            100,
+            sample_hash("trusted body"),
+            BTreeMap::from([(String::from("body"), json!("updated"))]),
+        ),
+        |error| {
+            matches!(
+                error,
+                FrontendReconcileError::ExpiredIntent { now, .. }
+                    if now == "2026-04-22T15:00:00Z"
+            )
+        },
     )
 }
 
@@ -219,7 +240,9 @@ fn expect_reconcile_error(
     let status = match plugin.reconcile(ctx, edit) {
         Err(FrontendAdapterError::Reconcile(error)) if matcher(&error) => CaseStatus::Ok,
         Err(FrontendAdapterError::NotImplemented { operation }) => CaseStatus::Failed {
-            message: format!("adapter does not implement required conformance operation {operation}"),
+            message: format!(
+                "adapter does not implement required conformance operation {operation}"
+            ),
         },
         Err(FrontendAdapterError::Reconcile(error)) => CaseStatus::Failed {
             message: format!("unexpected reconcile error: {error}"),
@@ -238,11 +261,11 @@ fn expect_reconcile_error(
     }
 }
 
-fn sample_identity_context(principal: &str) -> FrontendIdentityContext {
+fn sample_identity_context(principal: &str, expires_at: &str) -> FrontendIdentityContext {
     FrontendIdentityContext {
         principal: Identity::parse(principal).expect("valid principal fixture"),
         agent: None,
-        signed_intent: None,
+        signed_intent: sample_signed_intent(principal, expires_at),
     }
 }
 
@@ -261,6 +284,31 @@ fn sample_edit(
 
 fn sample_hash(body: &str) -> CanonicalRecordHash {
     CanonicalRecordHash::compute(&sample_record(body)).expect("sample record hashes")
+}
+
+fn sample_signed_intent(
+    principal: &str,
+    expires_at: &str,
+) -> crate::generated::envelope::SignedIntent {
+    serde_json::from_value(serde_json::json!({
+        "chain_parents": [],
+        "expires_at": expires_at,
+        "issued_at": "2026-04-22T14:02:11Z",
+        "issuer": principal,
+        "key_version": 1,
+        "nonce": "YWJjZGVmZ2hpamtsbW5vcA==",
+        "operation_id": "01HQZX9F5N0000000000000001",
+        "scope": {
+            "entity": "ent",
+            "tenant": "acme",
+            "tier": "project",
+            "workspace": "ws"
+        },
+        "server_challenge": "YWJjZGVmZ2hpamtsbW5vcA==",
+        "signature": format!("ed25519:{}", "a".repeat(128)),
+        "target_hash": sample_hash("trusted body").as_str(),
+    }))
+    .expect("valid signed intent fixture")
 }
 
 fn sample_record(body: &str) -> MemoryRecord {

--- a/crates/cairn-core/src/contract/conformance/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/conformance/frontend_adapter.rs
@@ -4,6 +4,11 @@
 //! manifest/identity/version invariants. Tier-2 cases exercise the pure
 //! reconcile contract with synthetic inputs and typed error matches.
 
+// Reason: tier-2 fixtures construct static `Identity` / `TargetId` /
+// `MemoryRecord` literals whose parse only fails on an authoring bug in
+// this file — at which point a panic is the correct way to surface it.
+#![allow(clippy::expect_used)]
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 

--- a/crates/cairn-core/src/contract/conformance/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/conformance/frontend_adapter.rs
@@ -1,0 +1,260 @@
+//! Conformance cases for `FrontendAdapter` plugins.
+//!
+//! Tier-1 cases run against any registered `FrontendAdapter` plugin and assert
+//! manifest/identity/version invariants. Tier-2 cases exercise the pure
+//! reconcile contract with synthetic inputs and typed error matches.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::contract::conformance::{
+    CaseOutcome, CaseStatus, Tier, tier1_manifest_features_match_capabilities,
+    tier1_manifest_matches_host,
+};
+use crate::contract::frontend_adapter::{
+    FrontendAdapter, FrontendAdapterError, FrontendEdit, FrontendIdentityContext,
+    FrontendReconcileError,
+};
+use crate::contract::frontend_adapter::CONTRACT_VERSION;
+use crate::contract::registry::{PluginName, PluginRegistry};
+use crate::domain::{BodyHash, Identity, TargetId};
+
+/// Run tier-1 + tier-2 cases for a `FrontendAdapter` plugin.
+#[must_use]
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let Some(plugin) = registry.frontend_adapter(name) else {
+        return vec![CaseOutcome {
+            id: "typed_plugin_registered",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!(
+                    "manifest declared FrontendAdapter but no FrontendAdapter Arc \
+                     registered under name {name}"
+                ),
+            },
+        }];
+    };
+    let caps = plugin.capabilities();
+
+    vec![
+        tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
+        tier1_arc_pointer_stable(registry, name, &plugin),
+        tier1_capability_self_consistency_floor(&*plugin),
+        tier1_manifest_features_match_capabilities(
+            registry,
+            name,
+            &[
+                ("frontmatter", caps.frontmatter),
+                ("sidecar_files", caps.sidecar_files),
+                ("live_plugin", caps.live_plugin),
+                ("graph_view", caps.graph_view),
+            ],
+        ),
+        tier2_rejects_immutable_field_edits(&*plugin),
+        tier2_rejects_replayed_operation(&*plugin),
+        tier2_rejects_tampered_target_hash(&*plugin),
+        tier2_rejects_unrecognized_principal(&*plugin),
+        tier2_honors_optimistic_version_check(&*plugin),
+    ]
+}
+
+fn tier1_arc_pointer_stable(
+    registry: &PluginRegistry,
+    name: &PluginName,
+    plugin: &Arc<dyn FrontendAdapter>,
+) -> CaseOutcome {
+    let Some(resolved) = registry.frontend_adapter(name) else {
+        return CaseOutcome {
+            id: "arc_pointer_stable",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "lookup returned None for registered plugin".to_string(),
+            },
+        };
+    };
+    let status = if Arc::ptr_eq(plugin, &resolved) {
+        CaseStatus::Ok
+    } else {
+        CaseStatus::Failed {
+            message: "two lookups returned different Arcs".to_string(),
+        }
+    };
+    CaseOutcome {
+        id: "arc_pointer_stable",
+        tier: Tier::One,
+        status,
+    }
+}
+
+fn tier1_capability_self_consistency_floor(plugin: &dyn FrontendAdapter) -> CaseOutcome {
+    let caps = plugin.capabilities();
+    if plugin.name().is_empty() {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: "plugin.name() returned empty string".to_string(),
+            },
+        };
+    }
+    if !plugin
+        .supported_contract_versions()
+        .accepts(CONTRACT_VERSION)
+    {
+        return CaseOutcome {
+            id: "capability_self_consistency_floor",
+            tier: Tier::One,
+            status: CaseStatus::Failed {
+                message: format!("plugin does not accept host CONTRACT_VERSION {CONTRACT_VERSION}"),
+            },
+        };
+    }
+    let _ = (
+        caps.frontmatter,
+        caps.sidecar_files,
+        caps.live_plugin,
+        caps.graph_view,
+        caps.max_frontmatter_fields,
+    );
+    CaseOutcome {
+        id: "capability_self_consistency_floor",
+        tier: Tier::One,
+        status: CaseStatus::Ok,
+    }
+}
+
+fn tier2_rejects_immutable_field_edits(plugin: &dyn FrontendAdapter) -> CaseOutcome {
+    expect_reconcile_error(
+        plugin,
+        "rejects_immutable_field_edits",
+        sample_identity_context("hmn:known-user"),
+        sample_edit(
+            1,
+            sample_hash("trusted body"),
+            BTreeMap::from([(String::from("operation_id"), json!("mutated"))]),
+        ),
+        |error| matches!(error, FrontendReconcileError::ImmutableFieldChanged { field } if field == "operation_id"),
+    )
+}
+
+fn tier2_rejects_replayed_operation(plugin: &dyn FrontendAdapter) -> CaseOutcome {
+    expect_reconcile_error(
+        plugin,
+        "rejects_replayed_operation",
+        sample_identity_context("hmn:known-user"),
+        sample_edit(
+            100,
+            sample_hash("trusted body"),
+            BTreeMap::from([(String::from("body"), json!("replay://operation"))]),
+        ),
+        |error| matches!(error, FrontendReconcileError::ReplayDetected),
+    )
+}
+
+fn tier2_rejects_tampered_target_hash(plugin: &dyn FrontendAdapter) -> CaseOutcome {
+    expect_reconcile_error(
+        plugin,
+        "rejects_tampered_target_hash",
+        sample_identity_context("hmn:known-user"),
+        sample_edit(
+            100,
+            sample_hash("tampered body"),
+            BTreeMap::from([(String::from("body"), json!("updated"))]),
+        ),
+        |error| {
+            matches!(
+                error,
+                FrontendReconcileError::PolicyDenied { gate, .. } if gate == "target_hash"
+            )
+        },
+    )
+}
+
+fn tier2_rejects_unrecognized_principal(plugin: &dyn FrontendAdapter) -> CaseOutcome {
+    expect_reconcile_error(
+        plugin,
+        "rejects_unrecognized_principal",
+        sample_identity_context("hmn:unknown-user"),
+        sample_edit(
+            100,
+            sample_hash("trusted body"),
+            BTreeMap::from([(String::from("body"), json!("updated"))]),
+        ),
+        |error| {
+            matches!(
+                error,
+                FrontendReconcileError::PolicyDenied { gate, .. } if gate == "principal"
+            )
+        },
+    )
+}
+
+fn tier2_honors_optimistic_version_check(plugin: &dyn FrontendAdapter) -> CaseOutcome {
+    expect_reconcile_error(
+        plugin,
+        "honors_optimistic_version_check",
+        sample_identity_context("hmn:known-user"),
+        sample_edit(
+            99,
+            sample_hash("trusted body"),
+            BTreeMap::from([(String::from("body"), json!("updated"))]),
+        ),
+        |error| matches!(error, FrontendReconcileError::Conflict { current_version } if *current_version == 100),
+    )
+}
+
+fn expect_reconcile_error(
+    plugin: &dyn FrontendAdapter,
+    id: &'static str,
+    ctx: FrontendIdentityContext,
+    edit: FrontendEdit,
+    matcher: impl Fn(&FrontendReconcileError) -> bool,
+) -> CaseOutcome {
+    let status = match plugin.reconcile(ctx, edit) {
+        Err(FrontendAdapterError::Reconcile(error)) if matcher(&error) => CaseStatus::Ok,
+        Err(FrontendAdapterError::NotImplemented { .. }) => CaseStatus::Pending {
+            reason: "adapter did not implement reconcile contract checks",
+        },
+        Err(FrontendAdapterError::Reconcile(error)) => CaseStatus::Failed {
+            message: format!("unexpected reconcile error: {error}"),
+        },
+        Err(other) => CaseStatus::Failed {
+            message: format!("unexpected adapter error: {other}"),
+        },
+        Ok(_) => CaseStatus::Failed {
+            message: "reconcile unexpectedly succeeded".to_string(),
+        },
+    };
+    CaseOutcome {
+        id,
+        tier: Tier::Two,
+        status,
+    }
+}
+
+fn sample_identity_context(principal: &str) -> FrontendIdentityContext {
+    FrontendIdentityContext {
+        principal: Identity::parse(principal).expect("valid principal fixture"),
+        agent: None,
+        signed_intent: None,
+    }
+}
+
+fn sample_edit(
+    expected_version: u64,
+    target_hash: BodyHash,
+    field_diff: BTreeMap<String, serde_json::Value>,
+) -> FrontendEdit {
+    FrontendEdit {
+        target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target fixture"),
+        expected_version,
+        target_hash,
+        field_diff,
+    }
+}
+
+fn sample_hash(body: &str) -> BodyHash {
+    BodyHash::compute(body)
+}

--- a/crates/cairn-core/src/contract/conformance/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/conformance/frontend_adapter.rs
@@ -19,7 +19,11 @@ use crate::contract::frontend_adapter::{
 };
 use crate::contract::frontend_adapter::CONTRACT_VERSION;
 use crate::contract::registry::{PluginName, PluginRegistry};
-use crate::domain::{BodyHash, Identity, TargetId};
+use crate::domain::{
+    ActorChainEntry, CanonicalRecordHash, ChainRole, EvidenceVector, Identity, MemoryClass,
+    MemoryKind, MemoryRecord, MemoryVisibility, Provenance, Rfc3339Timestamp, ScopeTuple,
+    TargetId,
+};
 
 /// Run tier-1 + tier-2 cases for a `FrontendAdapter` plugin.
 #[must_use]
@@ -214,8 +218,8 @@ fn expect_reconcile_error(
 ) -> CaseOutcome {
     let status = match plugin.reconcile(ctx, edit) {
         Err(FrontendAdapterError::Reconcile(error)) if matcher(&error) => CaseStatus::Ok,
-        Err(FrontendAdapterError::NotImplemented { .. }) => CaseStatus::Pending {
-            reason: "adapter did not implement reconcile contract checks",
+        Err(FrontendAdapterError::NotImplemented { operation }) => CaseStatus::Failed {
+            message: format!("adapter does not implement required conformance operation {operation}"),
         },
         Err(FrontendAdapterError::Reconcile(error)) => CaseStatus::Failed {
             message: format!("unexpected reconcile error: {error}"),
@@ -244,7 +248,7 @@ fn sample_identity_context(principal: &str) -> FrontendIdentityContext {
 
 fn sample_edit(
     expected_version: u64,
-    target_hash: BodyHash,
+    target_hash: CanonicalRecordHash,
     field_diff: BTreeMap<String, serde_json::Value>,
 ) -> FrontendEdit {
     FrontendEdit {
@@ -255,6 +259,47 @@ fn sample_edit(
     }
 }
 
-fn sample_hash(body: &str) -> BodyHash {
-    BodyHash::compute(body)
+fn sample_hash(body: &str) -> CanonicalRecordHash {
+    CanonicalRecordHash::compute(&sample_record(body)).expect("sample record hashes")
+}
+
+fn sample_record(body: &str) -> MemoryRecord {
+    let user_id = Identity::parse("hmn:known-user").expect("valid identity");
+    MemoryRecord {
+        id: crate::domain::RecordId::parse("01HQZX9F5N0000000000000000").expect("valid record id"),
+        target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+        kind: MemoryKind::User,
+        class: MemoryClass::Semantic,
+        visibility: MemoryVisibility::Private,
+        scope: ScopeTuple {
+            user: Some("hmn:known-user".to_owned()),
+            ..ScopeTuple::default()
+        },
+        body: body.to_owned(),
+        provenance: Provenance {
+            source_sensor: Identity::parse("snr:local:hook:cc-session:v1").expect("valid identity"),
+            created_at: Rfc3339Timestamp::parse("2026-04-22T14:02:11Z").expect("valid timestamp"),
+            originating_agent_id: user_id.clone(),
+            source_hash: format!("sha256:{}", "a".repeat(64)),
+            consent_ref: "consent:01HQZ".to_owned(),
+            llm_id_if_any: None,
+        },
+        updated_at: Rfc3339Timestamp::parse("2026-04-22T14:05:11Z").expect("valid timestamp"),
+        evidence: EvidenceVector::default(),
+        salience: 0.5,
+        confidence: 0.7,
+        actor_chain: vec![ActorChainEntry {
+            role: ChainRole::Author,
+            identity: user_id,
+            at: Rfc3339Timestamp::parse("2026-04-22T14:02:11Z").expect("valid timestamp"),
+        }],
+        signature: crate::domain::record::Ed25519Signature::parse(format!(
+            "ed25519:{}",
+            "a".repeat(128)
+        ))
+        .expect("valid signature"),
+        tags: vec!["pref".to_owned()],
+        extra_frontmatter: BTreeMap::new(),
+        consent_model: None,
+    }
 }

--- a/crates/cairn-core/src/contract/conformance/mod.rs
+++ b/crates/cairn-core/src/contract/conformance/mod.rs
@@ -18,6 +18,7 @@
 //! See `docs/superpowers/specs/2026-04-25-plugin-host-list-verify-design.md`
 //! §4 for the full design.
 
+pub mod frontend_adapter;
 pub mod mcp_server;
 pub mod memory_store;
 pub mod sensor_ingress;
@@ -119,13 +120,12 @@ pub fn run_conformance_for_plugin(
         ContractKind::WorkflowOrchestrator => workflow_orchestrator::run(registry, name),
         ContractKind::SensorIngress => sensor_ingress::run(registry, name),
         ContractKind::MCPServer => mcp_server::run(registry, name),
+        ContractKind::FrontendAdapter => frontend_adapter::run(registry, name),
         // P0 ships no bundled plugins for these — return a single Failed
         // sentinel so `cairn plugins verify` cannot pass a manifest whose
         // contract has no conformance runner. Once these contracts get
         // bundled plugins, add per-contract `run` modules and route here.
-        kind @ (ContractKind::LLMProvider
-        | ContractKind::FrontendAdapter
-        | ContractKind::AgentProvider) => {
+        kind @ (ContractKind::LLMProvider | ContractKind::AgentProvider) => {
             vec![CaseOutcome {
                 id: "no_conformance_runner",
                 tier: Tier::One,

--- a/crates/cairn-core/src/contract/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/frontend_adapter.rs
@@ -5,8 +5,10 @@
 
 use std::collections::BTreeMap;
 
-use crate::domain::{CanonicalRecordHash, Identity, TargetId, VerifiedSignedIntent};
+use crate::contract::memory_store::StoredRecord;
 use crate::contract::version::{ContractVersion, VersionRange};
+use crate::domain::{CanonicalRecordHash, Identity, TargetId};
+use crate::generated::envelope::SignedIntent;
 
 /// Contract version for `FrontendAdapter`. Bumps when the trait surface changes.
 #[doc(hidden)]
@@ -82,13 +84,25 @@ impl FrontendFieldPolicy {
 }
 
 /// Narrow projection request for adapter-facing backend state projection.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
+#[doc(hidden)]
+pub struct FrontendBackendState {
+    /// Canonical stored record snapshot the projection is derived from.
+    pub stored: StoredRecord,
+    /// Backend hash the frontend must present back during reconcile.
+    pub target_hash: CanonicalRecordHash,
+}
+
+/// Narrow projection request for adapter-facing backend state projection.
+#[derive(Debug, Clone, PartialEq)]
 #[doc(hidden)]
 pub struct FrontendProjectionRequest {
     /// Target record or memory identifier.
     pub target_id: TargetId,
     /// Version the caller expects to project.
     pub expected_version: u64,
+    /// Backend snapshot to project into a frontend representation.
+    pub backend: FrontendBackendState,
 }
 
 /// Narrow projection output consumed by frontends and tests.
@@ -113,8 +127,8 @@ pub struct FrontendIdentityContext {
     pub principal: Identity,
     /// Optional agent identity on whose behalf the edit originated.
     pub agent: Option<Identity>,
-    /// Signed intent envelope presented with the edit, if any.
-    pub signed_intent: Option<VerifiedSignedIntent>,
+    /// Signed intent envelope presented with the edit.
+    pub signed_intent: SignedIntent,
 }
 
 /// Raw frontend edit observed by an adapter.
@@ -157,6 +171,18 @@ pub enum FrontendReconcileError {
     /// No signed intent envelope accompanied the edit.
     #[error("frontend reconcile requires a signed intent")]
     UnsignedIntent,
+    /// Signed intent expired before the reconcile call reached apply time.
+    #[error(
+        "frontend reconcile intent expired: issued_at={issued_at}, expires_at={expires_at}, now={now}"
+    )]
+    ExpiredIntent {
+        /// Wire-form `issued_at` from the rejected envelope.
+        issued_at: String,
+        /// Wire-form `expires_at` from the rejected envelope.
+        expires_at: String,
+        /// Wall-clock instant at the time of the rejection.
+        now: String,
+    },
     /// The same signed operation was seen before.
     #[error("frontend reconcile detected a replayed operation")]
     ReplayDetected,
@@ -166,6 +192,14 @@ pub enum FrontendReconcileError {
     /// A policy gate rejected the reconcile request.
     #[error("frontend reconcile policy denied: {gate}: {reason}")]
     PolicyDenied { gate: String, reason: String },
+    /// File-originated edit must be quarantined and rolled back before apply.
+    #[error("frontend reconcile requires quarantine: {reason} ({quarantine_id:?})")]
+    QuarantineRequired {
+        /// Human-readable explanation for the quarantine.
+        reason: String,
+        /// Optional quarantine artifact identifier.
+        quarantine_id: Option<String>,
+    },
     /// Caller lacks a capability required for the attempted edit.
     #[error("frontend reconcile requires capability {required}")]
     InsufficientCapability { required: String },

--- a/crates/cairn-core/src/contract/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/frontend_adapter.rs
@@ -1,34 +1,202 @@
-//! `FrontendAdapter` contract — P1 forward stub (brief §4 row 7).
+//! `FrontendAdapter` contract surface (brief §4 row 7, §13.5.c, §13.5.d).
 //!
-//! Surface frozen here so the registry has a slot for editor / desktop /
-//! plugin adapters. Full method surface and conformance suite ship with
-//! v0.2 in #113.
+//! The contract stays pure and core-only: it models projection / reconcile
+//! requests and typed failures, but does not depend on any frontend runtime.
 
+use std::collections::BTreeMap;
+
+use crate::domain::{CanonicalRecordHash, Identity, TargetId, VerifiedSignedIntent};
 use crate::contract::version::{ContractVersion, VersionRange};
 
 /// Contract version for `FrontendAdapter`. Bumps when the trait surface changes.
 #[doc(hidden)]
-pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 0, 1);
+pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 1, 0);
 
 /// Static capability declaration for a `FrontendAdapter` impl.
-// Three flags cover distinct frontend projection dimensions; a state machine
-// adds indirection with no clarity gain here.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[doc(hidden)]
 pub struct FrontendAdapterCapabilities {
-    /// Whether the adapter can project memory records as rendered markdown.
-    pub markdown_projection: bool,
-    /// Whether the adapter supports live event push to the frontend.
-    pub live_events: bool,
-    /// Whether the adapter can apply reverse edits back into the vault.
-    pub reverse_edits: bool,
+    /// Whether the adapter can render selected backend fields as frontmatter.
+    pub frontmatter: bool,
+    /// Whether the adapter can emit auxiliary sidecar files.
+    pub sidecar_files: bool,
+    /// Whether the adapter supports a live plugin or event bridge.
+    pub live_plugin: bool,
+    /// Whether the adapter can project graph-oriented data.
+    pub graph_view: bool,
+    /// Maximum number of fields the adapter can safely render in frontmatter.
+    pub max_frontmatter_fields: usize,
 }
 
+/// Field classes used by the frontend mutability policy in brief §13.5.c.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[doc(hidden)]
+pub enum FrontendFieldClass {
+    /// Editable user-authored content such as body text and tags.
+    UserContent,
+    /// Informational metadata safe to edit from a frontend.
+    Metadata,
+    /// Backend-owned classifier outputs.
+    Classification,
+    /// Identity, signature, or provenance data.
+    IdentityProvenance,
+    /// Visibility or consent-governed fields.
+    VisibilityConsent,
+    /// Version and audit fields, plus unknown future fields.
+    VersionAudit,
+}
+
+/// Fail-closed policy helpers for frontend-editable fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[doc(hidden)]
+pub struct FrontendFieldPolicy;
+
+impl FrontendFieldPolicy {
+    /// Classify a projected field name into one of the frontend policy buckets.
+    #[must_use]
+    pub fn classify(field_name: &str) -> FrontendFieldClass {
+        match field_name {
+            "body" | "tags" | "wikilinks" => FrontendFieldClass::UserContent,
+            "last_read_at" | "local_sort_key" => FrontendFieldClass::Metadata,
+            "kind" | "confidence" | "evidence_vector" => FrontendFieldClass::Classification,
+            "actor_chain" | "signature" | "key_version" | "operation_id" => {
+                FrontendFieldClass::IdentityProvenance
+            }
+            "consent_tier" | "consent_receipt_ref" | "visibility" | "share_grants" => {
+                FrontendFieldClass::VisibilityConsent
+            }
+            "version" | "promoted_at" | "produced_by" => FrontendFieldClass::VersionAudit,
+            _ => FrontendFieldClass::VersionAudit,
+        }
+    }
+
+    /// Whether the field may be changed by a frontend-originated edit.
+    #[must_use]
+    pub fn is_mutable_from_frontend(field_name: &str) -> bool {
+        matches!(
+            Self::classify(field_name),
+            FrontendFieldClass::UserContent | FrontendFieldClass::Metadata
+        )
+    }
+}
+
+/// Narrow projection request for adapter-facing backend state projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[doc(hidden)]
+pub struct FrontendProjectionRequest {
+    /// Target record or memory identifier.
+    pub target_id: TargetId,
+    /// Version the caller expects to project.
+    pub expected_version: u64,
+}
+
+/// Narrow projection output consumed by frontends and tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[doc(hidden)]
+pub struct FrontendProjection {
+    /// Rendered markdown body.
+    pub body: String,
+    /// Key/value frontmatter fields.
+    pub frontmatter: Vec<(String, String)>,
+    /// Named sidecar file payloads.
+    pub sidecars: Vec<(String, String)>,
+    /// Backend hash the frontend must present back during reconcile.
+    pub target_hash: CanonicalRecordHash,
+}
+
+/// Identity context attached to a frontend-originated reconcile request.
+#[derive(Debug, Clone, PartialEq)]
+#[doc(hidden)]
+pub struct FrontendIdentityContext {
+    /// Principal requesting the edit.
+    pub principal: Identity,
+    /// Optional agent identity on whose behalf the edit originated.
+    pub agent: Option<Identity>,
+    /// Signed intent envelope presented with the edit, if any.
+    pub signed_intent: Option<VerifiedSignedIntent>,
+}
+
+/// Raw frontend edit observed by an adapter.
+#[derive(Debug, Clone, PartialEq)]
+#[doc(hidden)]
+pub struct FrontendEdit {
+    /// Target record or memory identifier.
+    pub target_id: TargetId,
+    /// Optimistic version observed by the frontend.
+    pub expected_version: u64,
+    /// Hash of the projected state the edit was based on.
+    pub target_hash: CanonicalRecordHash,
+    /// Full field diff observed by the frontend.
+    pub field_diff: BTreeMap<String, serde_json::Value>,
+}
+
+/// Backend-facing reconcile request synthesized from a frontend edit.
+#[derive(Debug, Clone, PartialEq)]
+#[doc(hidden)]
+pub struct FrontendReconcileRequest {
+    /// Target record or memory identifier.
+    pub target_id: TargetId,
+    /// Optimistic version to check before applying.
+    pub expected_version: u64,
+    /// Hash of the projected state the edit was based on.
+    pub target_hash: CanonicalRecordHash,
+    /// Mutable fields extracted from the frontend diff.
+    pub field_diff: BTreeMap<String, serde_json::Value>,
+    /// Authenticated caller identity context.
+    pub ctx: FrontendIdentityContext,
+}
+
+/// Typed reconcile failures surfaced by the frontend contract.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[doc(hidden)]
+pub enum FrontendReconcileError {
+    /// The frontend based its edit on a stale version.
+    #[error("frontend reconcile conflict at version {current_version}")]
+    Conflict { current_version: u64 },
+    /// No signed intent envelope accompanied the edit.
+    #[error("frontend reconcile requires a signed intent")]
+    UnsignedIntent,
+    /// The same signed operation was seen before.
+    #[error("frontend reconcile detected a replayed operation")]
+    ReplayDetected,
+    /// The edit attempted to mutate a backend-owned field.
+    #[error("frontend reconcile attempted to change immutable field {field}")]
+    ImmutableFieldChanged { field: String },
+    /// A policy gate rejected the reconcile request.
+    #[error("frontend reconcile policy denied: {gate}: {reason}")]
+    PolicyDenied { gate: String, reason: String },
+    /// Caller lacks a capability required for the attempted edit.
+    #[error("frontend reconcile requires capability {required}")]
+    InsufficientCapability { required: String },
+}
+
+/// Top-level adapter failures for projection and reconcile calls.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[doc(hidden)]
+pub enum FrontendAdapterError {
+    /// Adapter left an operation unimplemented.
+    #[error("frontend adapter does not implement {operation}")]
+    NotImplemented { operation: &'static str },
+    /// Projection failed before any reconcile phase began.
+    #[error("frontend projection failed: {message}")]
+    Projection { message: String },
+    /// Reconcile failed with a typed policy or concurrency reason.
+    #[error(transparent)]
+    Reconcile(#[from] FrontendReconcileError),
+}
+
+/// Placeholder event stream handle for live frontend subscriptions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[doc(hidden)]
+pub struct FrontendEventStream;
+
+/// Placeholder subscription token for live frontend bridges.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[doc(hidden)]
+pub struct FrontendSubscription;
+
 /// Frontend adapter contract — projects vault state into editor / desktop UIs.
-///
-/// Brief §4 row 7: P1 forward stub. Method surface and conformance suite
-/// ship in #113.
 #[async_trait::async_trait]
 #[doc(hidden)]
 pub trait FrontendAdapter: Send + Sync {
@@ -40,13 +208,38 @@ pub trait FrontendAdapter: Send + Sync {
 
     /// Range of `FrontendAdapter::CONTRACT_VERSION` values this impl accepts.
     fn supported_contract_versions(&self) -> VersionRange;
+
+    /// Project backend state into the frontend-specific representation.
+    fn project(
+        &self,
+        _request: &FrontendProjectionRequest,
+    ) -> Result<FrontendProjection, FrontendAdapterError> {
+        Err(FrontendAdapterError::NotImplemented {
+            operation: "project",
+        })
+    }
+
+    /// Translate a frontend edit into a backend reconcile request.
+    fn reconcile(
+        &self,
+        _ctx: FrontendIdentityContext,
+        _edit: FrontendEdit,
+    ) -> Result<FrontendReconcileRequest, FrontendAdapterError> {
+        Err(FrontendAdapterError::NotImplemented {
+            operation: "reconcile",
+        })
+    }
+
+    /// Optional live channel for frontends that support it.
+    fn subscribe(&self, _events: FrontendEventStream) -> Option<FrontendSubscription> {
+        None
+    }
+
+    /// Optional teardown hook for graceful shutdown.
+    fn shutdown(&self) {}
 }
 
 /// Static identity descriptor for a [`FrontendAdapter`] plugin (§4.1).
-///
-/// Carries the two associated consts the `register_plugin_with!` macro checks
-/// before construction. See [`MemoryStorePlugin`](crate::contract::MemoryStorePlugin)
-/// for the design rationale.
 #[doc(hidden)]
 pub trait FrontendAdapterPlugin: FrontendAdapter + Sized {
     /// Stable plugin name, checked statically before construction (§4.1).

--- a/crates/cairn-core/src/contract/frontend_adapter.rs
+++ b/crates/cairn-core/src/contract/frontend_adapter.rs
@@ -68,7 +68,9 @@ impl FrontendFieldPolicy {
             "consent_tier" | "consent_receipt_ref" | "visibility" | "share_grants" => {
                 FrontendFieldClass::VisibilityConsent
             }
-            "version" | "promoted_at" | "produced_by" => FrontendFieldClass::VersionAudit,
+            // Known version/audit fields (`version`, `promoted_at`,
+            // `produced_by`) and any unrecognized future field both fall
+            // through to VersionAudit (fail-closed for unknowns).
             _ => FrontendFieldClass::VersionAudit,
         }
     }

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -53,8 +53,8 @@ pub use agent_provider::{AgentProvider, AgentProviderCapabilities, AgentProvider
 pub use consent_lookup::{ConsentLookup, ConsentLookupError};
 pub use frontend_adapter::{
     FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterError, FrontendAdapterPlugin,
-    FrontendEdit, FrontendEventStream, FrontendFieldClass, FrontendFieldPolicy,
-    FrontendIdentityContext, FrontendProjection, FrontendProjectionRequest,
+    FrontendBackendState, FrontendEdit, FrontendEventStream, FrontendFieldClass,
+    FrontendFieldPolicy, FrontendIdentityContext, FrontendProjection, FrontendProjectionRequest,
     FrontendReconcileError, FrontendReconcileRequest, FrontendSubscription,
 };
 pub use hot_prefix_cache::{CacheError, CachedPrefix, HotPrefixCache};

--- a/crates/cairn-core/src/contract/mod.rs
+++ b/crates/cairn-core/src/contract/mod.rs
@@ -51,7 +51,12 @@ pub use version::{ContractVersion, VersionRange};
 
 pub use agent_provider::{AgentProvider, AgentProviderCapabilities, AgentProviderPlugin};
 pub use consent_lookup::{ConsentLookup, ConsentLookupError};
-pub use frontend_adapter::{FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterPlugin};
+pub use frontend_adapter::{
+    FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterError, FrontendAdapterPlugin,
+    FrontendEdit, FrontendEventStream, FrontendFieldClass, FrontendFieldPolicy,
+    FrontendIdentityContext, FrontendProjection, FrontendProjectionRequest,
+    FrontendReconcileError, FrontendReconcileRequest, FrontendSubscription,
+};
 pub use hot_prefix_cache::{CacheError, CachedPrefix, HotPrefixCache};
 pub use identity_registry::{
     IdentityRegistry, IdentityVisibility, MaintenanceMode, PurgeAcknowledgement, PurgeReason,

--- a/crates/cairn-core/tests/conformance_tier1.rs
+++ b/crates/cairn-core/tests/conformance_tier1.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 
 use cairn_core::contract::conformance::{CaseStatus, Tier, run_conformance_for_plugin};
+use cairn_core::contract::frontend_adapter::{FrontendAdapter, FrontendAdapterCapabilities};
 use cairn_core::contract::manifest::PluginManifest;
 use cairn_core::contract::mcp_server::{MCPServer, MCPServerCapabilities};
 use cairn_core::contract::memory_store::{
@@ -198,6 +199,80 @@ fn tier1_cases_pass_for_well_formed_mcp_server() {
     assert!(ids.contains(&"arc_pointer_stable"));
     assert!(ids.contains(&"capability_self_consistency_floor"));
     assert!(ids.contains(&"manifest_features_match_capabilities"));
+}
+
+const FRONTEND_MANIFEST: &str = r#"
+name = "stub-frontend"
+contract = "FrontendAdapter"
+
+[contract_version_range.min]
+major = 0
+minor = 0
+patch = 1
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 1
+patch = 0
+
+[features]
+frontmatter = false
+sidecar_files = false
+live_plugin = false
+graph_view = false
+"#;
+
+#[derive(Default)]
+struct StubFrontend;
+
+#[async_trait::async_trait]
+impl FrontendAdapter for StubFrontend {
+    fn name(&self) -> &'static str {
+        "stub-frontend"
+    }
+    fn capabilities(&self) -> &FrontendAdapterCapabilities {
+        static CAPS: FrontendAdapterCapabilities = FrontendAdapterCapabilities {
+            frontmatter: false,
+            sidecar_files: false,
+            live_plugin: false,
+            graph_view: false,
+            max_frontmatter_fields: 0,
+        };
+        &CAPS
+    }
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 0, 1), ContractVersion::new(0, 1, 0))
+    }
+}
+
+#[test]
+fn tier1_cases_pass_for_well_formed_frontend_adapter() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-frontend").expect("valid");
+    let manifest = PluginManifest::parse_toml(FRONTEND_MANIFEST).expect("manifest parses");
+    reg.register_frontend_adapter_with_manifest(name.clone(), manifest, Arc::new(StubFrontend))
+        .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+
+    let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
+    for id in [
+        "manifest_matches_host",
+        "arc_pointer_stable",
+        "capability_self_consistency_floor",
+        "manifest_features_match_capabilities",
+    ] {
+        let outcome = tier1
+            .iter()
+            .find(|outcome| outcome.id == id)
+            .expect("required tier-1 case exists");
+        assert!(
+            matches!(outcome.status, CaseStatus::Ok),
+            "tier-1 case {} must pass, got {:?}",
+            outcome.id,
+            outcome.status
+        );
+    }
 }
 
 #[test]

--- a/crates/cairn-core/tests/conformance_tier1.rs
+++ b/crates/cairn-core/tests/conformance_tier1.rs
@@ -207,12 +207,12 @@ contract = "FrontendAdapter"
 
 [contract_version_range.min]
 major = 0
-minor = 0
-patch = 1
+minor = 1
+patch = 0
 
 [contract_version_range.max_exclusive]
 major = 0
-minor = 1
+minor = 2
 patch = 0
 
 [features]
@@ -241,7 +241,7 @@ impl FrontendAdapter for StubFrontend {
         &CAPS
     }
     fn supported_contract_versions(&self) -> VersionRange {
-        VersionRange::new(ContractVersion::new(0, 0, 1), ContractVersion::new(0, 1, 0))
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
     }
 }
 
@@ -256,6 +256,7 @@ fn tier1_cases_pass_for_well_formed_frontend_adapter() {
     let outcomes = run_conformance_for_plugin(&reg, &name);
 
     let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
+    assert_eq!(tier1.len(), 4, "expect 4 tier-1 cases");
     for id in [
         "manifest_matches_host",
         "arc_pointer_stable",

--- a/crates/cairn-core/tests/contract_registry.rs
+++ b/crates/cairn-core/tests/contract_registry.rs
@@ -8,7 +8,9 @@ use cairn_core::contract::agent_provider::{
     AgentProvider, AgentProviderCapabilities, AgentProviderPlugin,
 };
 use cairn_core::contract::frontend_adapter::{
-    FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterPlugin,
+    FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterError, FrontendAdapterPlugin,
+    FrontendEdit, FrontendIdentityContext, FrontendProjection, FrontendProjectionRequest,
+    FrontendReconcileRequest,
 };
 use cairn_core::contract::llm_provider::{
     CompletionOutput, CompletionRequest, LLMProvider, LLMProviderCapabilities, LLMProviderPlugin,
@@ -745,21 +747,38 @@ mod frontend_adapter_factory_plugin {
         }
         fn capabilities(&self) -> &FrontendAdapterCapabilities {
             static CAPS: FrontendAdapterCapabilities = FrontendAdapterCapabilities {
-                markdown_projection: false,
-                live_events: false,
-                reverse_edits: false,
+                frontmatter: false,
+                sidecar_files: false,
+                live_plugin: false,
+                graph_view: false,
+                max_frontmatter_fields: 0,
             };
             &CAPS
         }
         fn supported_contract_versions(&self) -> VersionRange {
             Self::SUPPORTED_VERSIONS
         }
+
+        fn project(
+            &self,
+            _request: &FrontendProjectionRequest,
+        ) -> Result<FrontendProjection, FrontendAdapterError> {
+            unimplemented!("filled after contract types land")
+        }
+
+        fn reconcile(
+            &self,
+            _ctx: FrontendIdentityContext,
+            _edit: FrontendEdit,
+        ) -> Result<FrontendReconcileRequest, FrontendAdapterError> {
+            unimplemented!("filled after contract types land")
+        }
     }
 
     impl FrontendAdapterPlugin for StubFrontend {
         const NAME: &'static str = "stub-frontend-factory";
         const SUPPORTED_VERSIONS: VersionRange =
-            VersionRange::new(ContractVersion::new(0, 0, 1), ContractVersion::new(0, 1, 0));
+            VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0));
     }
 
     register_plugin_with!(

--- a/crates/cairn-core/tests/contract_root_exports.rs
+++ b/crates/cairn-core/tests/contract_root_exports.rs
@@ -37,9 +37,7 @@ fn capability_structs_default() {
 
 #[test]
 fn frontend_contract_types_are_reachable() {
-    use cairn_core::contract::{
-        FrontendFieldClass, FrontendFieldPolicy, FrontendReconcileError,
-    };
+    use cairn_core::contract::{FrontendFieldClass, FrontendFieldPolicy, FrontendReconcileError};
 
     let _: FrontendAdapterCapabilities = FrontendAdapterCapabilities::default();
     let _: FrontendFieldClass = FrontendFieldClass::UserContent;

--- a/crates/cairn-core/tests/contract_root_exports.rs
+++ b/crates/cairn-core/tests/contract_root_exports.rs
@@ -35,6 +35,18 @@ fn capability_structs_default() {
     let _: AgentProviderCapabilities = AgentProviderCapabilities::default();
 }
 
+#[test]
+fn frontend_contract_types_are_reachable() {
+    use cairn_core::contract::{
+        FrontendFieldClass, FrontendFieldPolicy, FrontendReconcileError,
+    };
+
+    let _: FrontendAdapterCapabilities = FrontendAdapterCapabilities::default();
+    let _: FrontendFieldClass = FrontendFieldClass::UserContent;
+    let _ = FrontendFieldPolicy::is_mutable_from_frontend("body");
+    let _: FrontendReconcileError = FrontendReconcileError::UnsignedIntent;
+}
+
 mod compile_only {
     use super::*;
 

--- a/crates/cairn-core/tests/frontend_adapter_contract.rs
+++ b/crates/cairn-core/tests/frontend_adapter_contract.rs
@@ -8,17 +8,18 @@ use std::sync::Arc;
 
 use cairn_core::contract::conformance::{CaseStatus, Tier, run_conformance_for_plugin};
 use cairn_core::contract::frontend_adapter::{
-    FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterError, FrontendEdit,
-    FrontendFieldClass, FrontendFieldPolicy, FrontendIdentityContext, FrontendReconcileError,
+    FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterError, FrontendBackendState,
+    FrontendEdit, FrontendFieldClass, FrontendFieldPolicy, FrontendIdentityContext,
+    FrontendProjection, FrontendProjectionRequest, FrontendReconcileError,
     FrontendReconcileRequest,
 };
 use cairn_core::contract::manifest::PluginManifest;
+use cairn_core::contract::memory_store::StoredRecord;
 use cairn_core::contract::registry::{PluginName, PluginRegistry};
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::domain::{
     ActorChainEntry, CanonicalRecordHash, ChainRole, EvidenceVector, Identity, MemoryClass,
-    MemoryKind, MemoryRecord, MemoryVisibility, Provenance, Rfc3339Timestamp, ScopeTuple,
-    TargetId,
+    MemoryKind, MemoryRecord, MemoryVisibility, Provenance, Rfc3339Timestamp, ScopeTuple, TargetId,
 };
 
 const FRONTEND_MANIFEST: &str = r#"
@@ -91,6 +92,18 @@ impl FrontendAdapter for ConformanceFrontend {
         VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
     }
 
+    fn project(
+        &self,
+        request: &FrontendProjectionRequest,
+    ) -> Result<FrontendProjection, FrontendAdapterError> {
+        Ok(FrontendProjection {
+            body: request.backend.stored.record.body.clone(),
+            frontmatter: vec![("version".into(), request.backend.stored.version.to_string())],
+            sidecars: Vec::new(),
+            target_hash: request.backend.target_hash.clone(),
+        })
+    }
+
     fn reconcile(
         &self,
         ctx: FrontendIdentityContext,
@@ -117,10 +130,18 @@ impl FrontendAdapter for ConformanceFrontend {
         {
             return Err(FrontendReconcileError::ReplayDetected.into());
         }
+        if ctx.signed_intent.expires_at.as_str() != "2026-04-22T14:07:11Z" {
+            return Err(FrontendReconcileError::ExpiredIntent {
+                issued_at: ctx.signed_intent.issued_at.clone(),
+                expires_at: ctx.signed_intent.expires_at.clone(),
+                now: "2026-04-22T15:00:00Z".into(),
+            }
+            .into());
+        }
         if ctx.principal.as_str() != "hmn:known-user" {
-            return Err(FrontendReconcileError::PolicyDenied {
-                gate: "principal".into(),
+            return Err(FrontendReconcileError::QuarantineRequired {
                 reason: "principal is not registered for this adapter".into(),
+                quarantine_id: Some("01HQZX9F5N0000000000000001".into()),
             }
             .into());
         }
@@ -151,13 +172,19 @@ impl FrontendAdapter for ConformanceFrontend {
 fn frontend_field_policy_allows_user_content_and_metadata_only() {
     assert!(FrontendFieldPolicy::is_mutable_from_frontend("body"));
     assert!(FrontendFieldPolicy::is_mutable_from_frontend("tags"));
-    assert!(FrontendFieldPolicy::is_mutable_from_frontend("last_read_at"));
+    assert!(FrontendFieldPolicy::is_mutable_from_frontend(
+        "last_read_at"
+    ));
 
     assert!(!FrontendFieldPolicy::is_mutable_from_frontend("kind"));
-    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("operation_id"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend(
+        "operation_id"
+    ));
     assert!(!FrontendFieldPolicy::is_mutable_from_frontend("visibility"));
     assert!(!FrontendFieldPolicy::is_mutable_from_frontend("version"));
-    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("unknown_future_field"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend(
+        "unknown_future_field"
+    ));
 }
 
 #[test]
@@ -188,6 +215,67 @@ fn frontend_reconcile_error_exposes_immutable_field_variant() {
 }
 
 #[test]
+fn frontend_reconcile_error_exposes_expired_intent_variant() {
+    let err = FrontendReconcileError::ExpiredIntent {
+        issued_at: "2026-04-22T14:02:11Z".into(),
+        expires_at: "2026-04-22T14:07:11Z".into(),
+        now: "2026-04-22T15:00:00Z".into(),
+    };
+    let rendered = err.to_string();
+    assert!(rendered.contains("expired"));
+    assert!(rendered.contains("2026-04-22T15:00:00Z"));
+}
+
+#[test]
+fn frontend_reconcile_error_exposes_quarantine_variant() {
+    let err = FrontendReconcileError::QuarantineRequired {
+        reason: "daemon user mismatch".into(),
+        quarantine_id: Some("01HQZX9F5N0000000000000001".into()),
+    };
+    let rendered = err.to_string();
+    assert!(rendered.contains("quarantine"));
+    assert!(rendered.contains("01HQZX9F5N0000000000000001"));
+}
+
+#[test]
+fn frontend_projection_request_carries_backend_state_snapshot() {
+    let request = FrontendProjectionRequest {
+        target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+        expected_version: 100,
+        backend: FrontendBackendState {
+            stored: StoredRecord {
+                record: sample_record(),
+                version: 100,
+                schema_version: None,
+            },
+            target_hash: sample_target_hash(),
+        },
+    };
+
+    let projection = ConformanceFrontend
+        .project(&request)
+        .expect("projection should succeed");
+    assert_eq!(projection.body, "trusted body");
+    assert_eq!(
+        projection.frontmatter,
+        vec![("version".into(), "100".into())]
+    );
+    assert_eq!(projection.target_hash, sample_target_hash());
+}
+
+#[test]
+fn frontend_identity_context_carries_required_signed_intent() {
+    let ctx = FrontendIdentityContext {
+        principal: Identity::parse("hmn:known-user").expect("valid identity"),
+        agent: None,
+        signed_intent: sample_signed_intent("2026-04-22T14:07:11Z"),
+    };
+
+    assert_eq!(ctx.signed_intent.issuer.0, "hmn:known-user");
+    assert_eq!(ctx.signed_intent.expires_at, "2026-04-22T14:07:11Z");
+}
+
+#[test]
 fn frontend_adapter_runner_reports_expected_tier2_case_ids() {
     let mut reg = PluginRegistry::new();
     let name = PluginName::new("stub-frontend-runner").expect("valid");
@@ -205,8 +293,9 @@ fn frontend_adapter_runner_reports_expected_tier2_case_ids() {
     assert!(tier2_ids.contains(&"rejects_immutable_field_edits"));
     assert!(tier2_ids.contains(&"rejects_replayed_operation"));
     assert!(tier2_ids.contains(&"rejects_tampered_target_hash"));
-    assert!(tier2_ids.contains(&"rejects_unrecognized_principal"));
+    assert!(tier2_ids.contains(&"quarantines_unrecognized_principal"));
     assert!(tier2_ids.contains(&"honors_optimistic_version_check"));
+    assert!(tier2_ids.contains(&"rejects_expired_signed_intent"));
 }
 
 #[test]
@@ -223,8 +312,9 @@ fn frontend_adapter_runner_fails_unimplemented_reconcile_cases() {
         "rejects_immutable_field_edits",
         "rejects_replayed_operation",
         "rejects_tampered_target_hash",
-        "rejects_unrecognized_principal",
+        "quarantines_unrecognized_principal",
         "honors_optimistic_version_check",
+        "rejects_expired_signed_intent",
     ] {
         let outcome = outcomes
             .iter()
@@ -256,8 +346,9 @@ fn frontend_adapter_runner_marks_contract_stub_tier2_cases_ok() {
         "rejects_immutable_field_edits",
         "rejects_replayed_operation",
         "rejects_tampered_target_hash",
-        "rejects_unrecognized_principal",
+        "quarantines_unrecognized_principal",
         "honors_optimistic_version_check",
+        "rejects_expired_signed_intent",
     ] {
         let outcome = outcomes
             .iter()
@@ -273,6 +364,28 @@ fn frontend_adapter_runner_marks_contract_stub_tier2_cases_ok() {
 
 fn sample_target_hash() -> CanonicalRecordHash {
     CanonicalRecordHash::compute(&sample_record()).expect("sample record hashes")
+}
+
+fn sample_signed_intent(expires_at: &str) -> cairn_core::generated::envelope::SignedIntent {
+    serde_json::from_value(serde_json::json!({
+        "chain_parents": [],
+        "expires_at": expires_at,
+        "issued_at": "2026-04-22T14:02:11Z",
+        "issuer": "hmn:known-user",
+        "key_version": 1,
+        "nonce": "YWJjZGVmZ2hpamtsbW5vcA==",
+        "operation_id": "01HQZX9F5N0000000000000001",
+        "scope": {
+            "entity": "ent",
+            "tenant": "acme",
+            "tier": "project",
+            "workspace": "ws"
+        },
+        "server_challenge": "YWJjZGVmZ2hpamtsbW5vcA==",
+        "signature": format!("ed25519:{}", "a".repeat(128)),
+        "target_hash": sample_target_hash().as_str(),
+    }))
+    .expect("valid signed intent fixture")
 }
 
 fn sample_record() -> MemoryRecord {

--- a/crates/cairn-core/tests/frontend_adapter_contract.rs
+++ b/crates/cairn-core/tests/frontend_adapter_contract.rs
@@ -4,10 +4,144 @@
 //! they fail red until the production types land.
 #![allow(missing_docs)]
 
+use std::sync::Arc;
+
+use cairn_core::contract::conformance::{CaseStatus, Tier, run_conformance_for_plugin};
 use cairn_core::contract::frontend_adapter::{
-    FrontendAdapterCapabilities, FrontendFieldClass, FrontendFieldPolicy,
-    FrontendReconcileError,
+    FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterError, FrontendEdit,
+    FrontendFieldClass, FrontendFieldPolicy, FrontendIdentityContext, FrontendReconcileError,
+    FrontendReconcileRequest,
 };
+use cairn_core::contract::manifest::PluginManifest;
+use cairn_core::contract::registry::{PluginName, PluginRegistry};
+use cairn_core::contract::version::{ContractVersion, VersionRange};
+use cairn_core::domain::BodyHash;
+
+const FRONTEND_MANIFEST: &str = r#"
+name = "stub-frontend-runner"
+contract = "FrontendAdapter"
+
+[contract_version_range.min]
+major = 0
+minor = 1
+patch = 0
+
+[contract_version_range.max_exclusive]
+major = 0
+minor = 2
+patch = 0
+
+[features]
+frontmatter = false
+sidecar_files = false
+live_plugin = false
+graph_view = false
+"#;
+
+#[derive(Default)]
+struct StubFrontend;
+
+#[async_trait::async_trait]
+impl FrontendAdapter for StubFrontend {
+    fn name(&self) -> &'static str {
+        "stub-frontend-runner"
+    }
+
+    fn capabilities(&self) -> &FrontendAdapterCapabilities {
+        static CAPS: FrontendAdapterCapabilities = FrontendAdapterCapabilities {
+            frontmatter: false,
+            sidecar_files: false,
+            live_plugin: false,
+            graph_view: false,
+            max_frontmatter_fields: 0,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+}
+
+#[derive(Default)]
+struct ConformanceFrontend;
+
+#[async_trait::async_trait]
+impl FrontendAdapter for ConformanceFrontend {
+    fn name(&self) -> &'static str {
+        "stub-frontend-runner"
+    }
+
+    fn capabilities(&self) -> &FrontendAdapterCapabilities {
+        static CAPS: FrontendAdapterCapabilities = FrontendAdapterCapabilities {
+            frontmatter: false,
+            sidecar_files: false,
+            live_plugin: false,
+            graph_view: false,
+            max_frontmatter_fields: 0,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+
+    fn reconcile(
+        &self,
+        ctx: FrontendIdentityContext,
+        edit: FrontendEdit,
+    ) -> Result<FrontendReconcileRequest, FrontendAdapterError> {
+        if edit
+            .field_diff
+            .keys()
+            .any(|field| !FrontendFieldPolicy::is_mutable_from_frontend(field))
+        {
+            let field = edit
+                .field_diff
+                .keys()
+                .find(|field| !FrontendFieldPolicy::is_mutable_from_frontend(field))
+                .expect("immutable field present")
+                .clone();
+            return Err(FrontendReconcileError::ImmutableFieldChanged { field }.into());
+        }
+        if edit
+            .field_diff
+            .get("body")
+            .and_then(serde_json::Value::as_str)
+            == Some("replay://operation")
+        {
+            return Err(FrontendReconcileError::ReplayDetected.into());
+        }
+        if ctx.principal.as_str() != "hmn:known-user" {
+            return Err(FrontendReconcileError::PolicyDenied {
+                gate: "principal".into(),
+                reason: "principal is not registered for this adapter".into(),
+            }
+            .into());
+        }
+        if edit.expected_version != 100 {
+            return Err(FrontendReconcileError::Conflict {
+                current_version: 100,
+            }
+            .into());
+        }
+        if edit.target_hash != sample_target_hash() {
+            return Err(FrontendReconcileError::PolicyDenied {
+                gate: "target_hash".into(),
+                reason: "projection hash does not match body hash".into(),
+            }
+            .into());
+        }
+        Ok(FrontendReconcileRequest {
+            target_id: edit.target_id,
+            expected_version: edit.expected_version,
+            target_hash: edit.target_hash,
+            field_diff: edit.field_diff,
+            ctx,
+        })
+    }
+}
 
 #[test]
 fn frontend_field_policy_allows_user_content_and_metadata_only() {
@@ -47,4 +181,63 @@ fn frontend_reconcile_error_exposes_immutable_field_variant() {
     };
     let rendered = err.to_string();
     assert!(rendered.contains("operation_id"));
+}
+
+#[test]
+fn frontend_adapter_runner_reports_expected_tier2_case_ids() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-frontend-runner").expect("valid");
+    let manifest = PluginManifest::parse_toml(FRONTEND_MANIFEST).expect("manifest parses");
+    reg.register_frontend_adapter_with_manifest(name.clone(), manifest, Arc::new(StubFrontend))
+        .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+    let tier2_ids: Vec<_> = outcomes
+        .iter()
+        .filter(|outcome| outcome.tier == Tier::Two)
+        .map(|outcome| outcome.id)
+        .collect();
+
+    assert!(tier2_ids.contains(&"rejects_immutable_field_edits"));
+    assert!(tier2_ids.contains(&"rejects_replayed_operation"));
+    assert!(tier2_ids.contains(&"rejects_tampered_target_hash"));
+    assert!(tier2_ids.contains(&"rejects_unrecognized_principal"));
+    assert!(tier2_ids.contains(&"honors_optimistic_version_check"));
+}
+
+#[test]
+fn frontend_adapter_runner_marks_contract_stub_tier2_cases_ok() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-frontend-runner").expect("valid");
+    let manifest = PluginManifest::parse_toml(FRONTEND_MANIFEST).expect("manifest parses");
+    reg.register_frontend_adapter_with_manifest(
+        name.clone(),
+        manifest,
+        Arc::new(ConformanceFrontend),
+    )
+    .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+
+    for id in [
+        "rejects_immutable_field_edits",
+        "rejects_replayed_operation",
+        "rejects_tampered_target_hash",
+        "rejects_unrecognized_principal",
+        "honors_optimistic_version_check",
+    ] {
+        let outcome = outcomes
+            .iter()
+            .find(|outcome| outcome.id == id)
+            .expect("required tier-2 case exists");
+        assert!(
+            matches!(outcome.status, CaseStatus::Ok),
+            "tier-2 case {id} must pass, got {:?}",
+            outcome.status
+        );
+    }
+}
+
+fn sample_target_hash() -> BodyHash {
+    BodyHash::compute("trusted body")
 }

--- a/crates/cairn-core/tests/frontend_adapter_contract.rs
+++ b/crates/cairn-core/tests/frontend_adapter_contract.rs
@@ -276,6 +276,132 @@ fn frontend_identity_context_carries_required_signed_intent() {
 }
 
 #[test]
+fn frontend_project_to_reconcile_round_trip_preserves_snapshot_binding() {
+    let adapter = ConformanceFrontend;
+    let request = sample_projection_request();
+    let projection = adapter
+        .project(&request)
+        .expect("projection should succeed");
+
+    let reconcile = adapter
+        .reconcile(
+            FrontendIdentityContext {
+                principal: Identity::parse("hmn:known-user").expect("valid identity"),
+                agent: Some(Identity::parse("agt:test:frontend:v1").expect("valid identity")),
+                signed_intent: sample_signed_intent("2026-04-22T14:07:11Z"),
+            },
+            FrontendEdit {
+                target_id: request.target_id.clone(),
+                expected_version: request.expected_version,
+                target_hash: projection.target_hash.clone(),
+                field_diff: std::collections::BTreeMap::from([(
+                    "body".into(),
+                    serde_json::json!("updated body"),
+                )]),
+            },
+        )
+        .expect("reconcile should succeed");
+
+    assert_eq!(reconcile.target_id, request.target_id);
+    assert_eq!(reconcile.expected_version, request.expected_version);
+    assert_eq!(reconcile.target_hash, projection.target_hash);
+    assert_eq!(
+        reconcile.field_diff.get("body"),
+        Some(&serde_json::json!("updated body"))
+    );
+    assert_eq!(reconcile.ctx.principal.as_str(), "hmn:known-user");
+    assert_eq!(
+        reconcile
+            .ctx
+            .agent
+            .expect("agent should round-trip")
+            .as_str(),
+        "agt:test:frontend:v1"
+    );
+}
+
+#[test]
+fn frontend_reconcile_accepts_mutable_metadata_edits() {
+    let reconcile = ConformanceFrontend
+        .reconcile(
+            FrontendIdentityContext {
+                principal: Identity::parse("hmn:known-user").expect("valid identity"),
+                agent: None,
+                signed_intent: sample_signed_intent("2026-04-22T14:07:11Z"),
+            },
+            FrontendEdit {
+                target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+                expected_version: 100,
+                target_hash: sample_target_hash(),
+                field_diff: std::collections::BTreeMap::from([(
+                    "last_read_at".into(),
+                    serde_json::json!("2026-04-22T14:06:11Z"),
+                )]),
+            },
+        )
+        .expect("mutable metadata edit should succeed");
+
+    assert_eq!(
+        reconcile.field_diff.get("last_read_at"),
+        Some(&serde_json::json!("2026-04-22T14:06:11Z"))
+    );
+}
+
+#[test]
+fn frontend_reconcile_quarantines_unrecognized_principal_before_version_or_hash_checks() {
+    let err = ConformanceFrontend
+        .reconcile(
+            FrontendIdentityContext {
+                principal: Identity::parse("hmn:unknown-user").expect("valid identity"),
+                agent: None,
+                signed_intent: sample_signed_intent("2026-04-22T14:07:11Z"),
+            },
+            FrontendEdit {
+                target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+                expected_version: 99,
+                target_hash: sample_hash("tampered body"),
+                field_diff: std::collections::BTreeMap::from([(
+                    "body".into(),
+                    serde_json::json!("updated"),
+                )]),
+            },
+        )
+        .expect_err("unknown principal should quarantine before later checks");
+
+    assert!(matches!(
+        err,
+        FrontendAdapterError::Reconcile(FrontendReconcileError::QuarantineRequired { .. })
+    ));
+}
+
+#[test]
+fn frontend_reconcile_rejects_expired_intent_before_quarantine() {
+    let err = ConformanceFrontend
+        .reconcile(
+            FrontendIdentityContext {
+                principal: Identity::parse("hmn:unknown-user").expect("valid identity"),
+                agent: None,
+                signed_intent: sample_signed_intent("2026-04-22T14:06:11Z"),
+            },
+            FrontendEdit {
+                target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+                expected_version: 100,
+                target_hash: sample_target_hash(),
+                field_diff: std::collections::BTreeMap::from([(
+                    "body".into(),
+                    serde_json::json!("updated"),
+                )]),
+            },
+        )
+        .expect_err("expired intent should fail before quarantine path");
+
+    assert!(matches!(
+        err,
+        FrontendAdapterError::Reconcile(FrontendReconcileError::ExpiredIntent { .. })
+    ));
+}
+
+#[test]
 fn frontend_adapter_runner_reports_expected_tier2_case_ids() {
     let mut reg = PluginRegistry::new();
     let name = PluginName::new("stub-frontend-runner").expect("valid");
@@ -366,6 +492,25 @@ fn sample_target_hash() -> CanonicalRecordHash {
     CanonicalRecordHash::compute(&sample_record()).expect("sample record hashes")
 }
 
+fn sample_hash(body: &str) -> CanonicalRecordHash {
+    CanonicalRecordHash::compute(&sample_record_with_body(body)).expect("sample record hashes")
+}
+
+fn sample_projection_request() -> FrontendProjectionRequest {
+    FrontendProjectionRequest {
+        target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+        expected_version: 100,
+        backend: FrontendBackendState {
+            stored: StoredRecord {
+                record: sample_record(),
+                version: 100,
+                schema_version: None,
+            },
+            target_hash: sample_target_hash(),
+        },
+    }
+}
+
 fn sample_signed_intent(expires_at: &str) -> cairn_core::generated::envelope::SignedIntent {
     serde_json::from_value(serde_json::json!({
         "chain_parents": [],
@@ -389,6 +534,10 @@ fn sample_signed_intent(expires_at: &str) -> cairn_core::generated::envelope::Si
 }
 
 fn sample_record() -> MemoryRecord {
+    sample_record_with_body("trusted body")
+}
+
+fn sample_record_with_body(body: &str) -> MemoryRecord {
     let user_id = Identity::parse("hmn:known-user").expect("valid identity");
     MemoryRecord {
         id: cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000000")
@@ -401,7 +550,7 @@ fn sample_record() -> MemoryRecord {
             user: Some("hmn:known-user".to_owned()),
             ..ScopeTuple::default()
         },
-        body: "trusted body".to_owned(),
+        body: body.to_owned(),
         provenance: Provenance {
             source_sensor: Identity::parse("snr:local:hook:cc-session:v1").expect("valid identity"),
             created_at: Rfc3339Timestamp::parse("2026-04-22T14:02:11Z").expect("valid timestamp"),

--- a/crates/cairn-core/tests/frontend_adapter_contract.rs
+++ b/crates/cairn-core/tests/frontend_adapter_contract.rs
@@ -8,10 +8,10 @@ use std::sync::Arc;
 
 use cairn_core::contract::conformance::{CaseStatus, Tier, run_conformance_for_plugin};
 use cairn_core::contract::frontend_adapter::{
-    FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterError, FrontendBackendState,
-    FrontendEdit, FrontendFieldClass, FrontendFieldPolicy, FrontendIdentityContext,
-    FrontendProjection, FrontendProjectionRequest, FrontendReconcileError,
-    FrontendReconcileRequest,
+    CONTRACT_VERSION, FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterError,
+    FrontendBackendState, FrontendEdit, FrontendEventStream, FrontendFieldClass,
+    FrontendFieldPolicy, FrontendIdentityContext, FrontendProjection, FrontendProjectionRequest,
+    FrontendReconcileError, FrontendReconcileRequest,
 };
 use cairn_core::contract::manifest::PluginManifest;
 use cairn_core::contract::memory_store::StoredRecord;
@@ -577,4 +577,341 @@ fn sample_record_with_body(body: &str) -> MemoryRecord {
         extra_frontmatter: std::collections::BTreeMap::new(),
         consent_model: None,
     }
+}
+
+// -----------------------------------------------------------------------------
+// Corner-case coverage for the FrontendAdapter contract surface.
+// -----------------------------------------------------------------------------
+
+#[derive(Default)]
+struct DefaultFrontend;
+
+#[async_trait::async_trait]
+impl FrontendAdapter for DefaultFrontend {
+    fn name(&self) -> &'static str {
+        "default-frontend"
+    }
+
+    fn capabilities(&self) -> &FrontendAdapterCapabilities {
+        static CAPS: FrontendAdapterCapabilities = FrontendAdapterCapabilities {
+            frontmatter: false,
+            sidecar_files: false,
+            live_plugin: false,
+            graph_view: false,
+            max_frontmatter_fields: 0,
+        };
+        &CAPS
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+}
+
+#[test]
+fn contract_version_pinned_to_zero_one_zero() {
+    assert_eq!(CONTRACT_VERSION, ContractVersion::new(0, 1, 0));
+}
+
+#[test]
+fn frontend_field_policy_classifies_every_known_bucket() {
+    assert_eq!(
+        FrontendFieldPolicy::classify("body"),
+        FrontendFieldClass::UserContent
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("tags"),
+        FrontendFieldClass::UserContent
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("wikilinks"),
+        FrontendFieldClass::UserContent
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("last_read_at"),
+        FrontendFieldClass::Metadata
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("local_sort_key"),
+        FrontendFieldClass::Metadata
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("kind"),
+        FrontendFieldClass::Classification
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("confidence"),
+        FrontendFieldClass::Classification
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("evidence_vector"),
+        FrontendFieldClass::Classification
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("actor_chain"),
+        FrontendFieldClass::IdentityProvenance
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("signature"),
+        FrontendFieldClass::IdentityProvenance
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("key_version"),
+        FrontendFieldClass::IdentityProvenance
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("operation_id"),
+        FrontendFieldClass::IdentityProvenance
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("consent_tier"),
+        FrontendFieldClass::VisibilityConsent
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("consent_receipt_ref"),
+        FrontendFieldClass::VisibilityConsent
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("visibility"),
+        FrontendFieldClass::VisibilityConsent
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("share_grants"),
+        FrontendFieldClass::VisibilityConsent
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("version"),
+        FrontendFieldClass::VersionAudit
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("promoted_at"),
+        FrontendFieldClass::VersionAudit
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify("produced_by"),
+        FrontendFieldClass::VersionAudit
+    );
+    assert_eq!(
+        FrontendFieldPolicy::classify(""),
+        FrontendFieldClass::VersionAudit,
+    );
+}
+
+#[test]
+fn frontend_field_policy_rejects_each_immutable_class() {
+    for field in [
+        "kind",
+        "confidence",
+        "evidence_vector",
+        "actor_chain",
+        "signature",
+        "key_version",
+        "operation_id",
+        "consent_tier",
+        "consent_receipt_ref",
+        "visibility",
+        "share_grants",
+        "version",
+        "promoted_at",
+        "produced_by",
+    ] {
+        assert!(
+            !FrontendFieldPolicy::is_mutable_from_frontend(field),
+            "field {field} must be backend-owned and rejected from frontend edits"
+        );
+    }
+}
+
+#[test]
+fn frontend_capabilities_preserve_non_default_max_frontmatter_fields() {
+    let caps = FrontendAdapterCapabilities {
+        frontmatter: true,
+        sidecar_files: true,
+        live_plugin: true,
+        graph_view: true,
+        max_frontmatter_fields: 64,
+    };
+    assert!(caps.frontmatter);
+    assert!(caps.sidecar_files);
+    assert!(caps.live_plugin);
+    assert!(caps.graph_view);
+    assert_eq!(caps.max_frontmatter_fields, 64);
+    let copy = caps;
+    assert_eq!(copy, caps);
+}
+
+#[test]
+fn frontend_reconcile_error_display_covers_every_variant() {
+    let unsigned = FrontendReconcileError::UnsignedIntent.to_string();
+    assert!(unsigned.contains("signed intent"));
+
+    let conflict = FrontendReconcileError::Conflict { current_version: 7 }.to_string();
+    assert!(conflict.contains('7'));
+    assert!(conflict.contains("conflict"));
+
+    let replay = FrontendReconcileError::ReplayDetected.to_string();
+    assert!(replay.contains("replay"));
+
+    let policy = FrontendReconcileError::PolicyDenied {
+        gate: "target_hash".into(),
+        reason: "drift".into(),
+    }
+    .to_string();
+    assert!(policy.contains("target_hash"));
+    assert!(policy.contains("drift"));
+
+    let insufficient = FrontendReconcileError::InsufficientCapability {
+        required: "sidecar_files".into(),
+    }
+    .to_string();
+    assert!(insufficient.contains("sidecar_files"));
+}
+
+#[test]
+fn frontend_adapter_error_display_covers_every_variant() {
+    let not_impl = FrontendAdapterError::NotImplemented {
+        operation: "project",
+    }
+    .to_string();
+    assert!(not_impl.contains("project"));
+
+    let projection = FrontendAdapterError::Projection {
+        message: "missing backend snapshot".into(),
+    }
+    .to_string();
+    assert!(projection.contains("missing backend snapshot"));
+
+    let reconcile: FrontendAdapterError = FrontendReconcileError::UnsignedIntent.into();
+    let rendered = reconcile.to_string();
+    assert!(rendered.contains("signed intent"));
+}
+
+#[test]
+fn frontend_adapter_default_methods_fail_closed_and_return_typed_errors() {
+    let adapter = DefaultFrontend;
+
+    let projection_err = adapter
+        .project(&sample_projection_request())
+        .expect_err("default project must return NotImplemented");
+    assert!(matches!(
+        projection_err,
+        FrontendAdapterError::NotImplemented {
+            operation: "project"
+        }
+    ));
+
+    let reconcile_err = adapter
+        .reconcile(
+            FrontendIdentityContext {
+                principal: Identity::parse("hmn:known-user").expect("valid identity"),
+                agent: None,
+                signed_intent: sample_signed_intent("2026-04-22T14:07:11Z"),
+            },
+            FrontendEdit {
+                target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+                expected_version: 100,
+                target_hash: sample_target_hash(),
+                field_diff: std::collections::BTreeMap::new(),
+            },
+        )
+        .expect_err("default reconcile must return NotImplemented");
+    assert!(matches!(
+        reconcile_err,
+        FrontendAdapterError::NotImplemented {
+            operation: "reconcile"
+        }
+    ));
+
+    assert!(adapter.subscribe(FrontendEventStream).is_none());
+    adapter.shutdown();
+}
+
+fn assert_send_sync<T: Send + Sync + ?Sized>(_: &T) {}
+
+#[test]
+fn frontend_adapter_is_object_safe_and_send_sync() {
+    let adapter: Arc<dyn FrontendAdapter> = Arc::new(DefaultFrontend);
+    assert_send_sync(&*adapter);
+    assert_eq!(adapter.name(), "default-frontend");
+}
+
+#[test]
+fn frontend_reconcile_round_trip_carries_no_agent_when_absent() {
+    let reconcile = ConformanceFrontend
+        .reconcile(
+            FrontendIdentityContext {
+                principal: Identity::parse("hmn:known-user").expect("valid identity"),
+                agent: None,
+                signed_intent: sample_signed_intent("2026-04-22T14:07:11Z"),
+            },
+            FrontendEdit {
+                target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+                expected_version: 100,
+                target_hash: sample_target_hash(),
+                field_diff: std::collections::BTreeMap::from([(
+                    "tags".into(),
+                    serde_json::json!(["pref"]),
+                )]),
+            },
+        )
+        .expect("reconcile must succeed without an agent identity");
+
+    assert!(reconcile.ctx.agent.is_none());
+    assert_eq!(reconcile.field_diff.len(), 1);
+}
+
+#[test]
+fn frontend_reconcile_rejects_first_immutable_field_in_btree_order() {
+    let err = ConformanceFrontend
+        .reconcile(
+            FrontendIdentityContext {
+                principal: Identity::parse("hmn:known-user").expect("valid identity"),
+                agent: None,
+                signed_intent: sample_signed_intent("2026-04-22T14:07:11Z"),
+            },
+            FrontendEdit {
+                target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+                expected_version: 100,
+                target_hash: sample_target_hash(),
+                field_diff: std::collections::BTreeMap::from([
+                    ("body".into(), serde_json::json!("ok")),
+                    ("signature".into(), serde_json::json!("ed25519:...")),
+                    ("operation_id".into(), serde_json::json!("01HQ...")),
+                ]),
+            },
+        )
+        .expect_err("immutable signature/operation_id must reject the whole edit");
+
+    match err {
+        FrontendAdapterError::Reconcile(FrontendReconcileError::ImmutableFieldChanged {
+            field,
+        }) => {
+            assert!(
+                matches!(field.as_str(), "operation_id" | "signature"),
+                "expected an IdentityProvenance field, got {field}"
+            );
+        }
+        other => panic!("expected ImmutableFieldChanged, got {other:?}"),
+    }
+}
+
+#[test]
+fn frontend_projection_request_clones_preserve_payload_equality() {
+    let request = sample_projection_request();
+    let clone = request.clone();
+    assert_eq!(request, clone);
+    assert_eq!(request.expected_version, 100);
+    assert_eq!(request.backend.stored.version, 100);
+}
+
+#[test]
+fn frontend_projection_carries_explicit_sidecars_and_frontmatter() {
+    let projection = FrontendProjection {
+        body: "hello".into(),
+        frontmatter: vec![("k".into(), "v".into()), ("k2".into(), "v2".into())],
+        sidecars: vec![("graph.json".into(), "{}".into())],
+        target_hash: sample_target_hash(),
+    };
+    assert_eq!(projection.frontmatter.len(), 2);
+    assert_eq!(projection.sidecars[0].0, "graph.json");
 }

--- a/crates/cairn-core/tests/frontend_adapter_contract.rs
+++ b/crates/cairn-core/tests/frontend_adapter_contract.rs
@@ -1,0 +1,50 @@
+//! Frontend adapter contract coverage for issue #113.
+//!
+//! These tests are written against the planned frontend contract surface so
+//! they fail red until the production types land.
+#![allow(missing_docs)]
+
+use cairn_core::contract::frontend_adapter::{
+    FrontendAdapterCapabilities, FrontendFieldClass, FrontendFieldPolicy,
+    FrontendReconcileError,
+};
+
+#[test]
+fn frontend_field_policy_allows_user_content_and_metadata_only() {
+    assert!(FrontendFieldPolicy::is_mutable_from_frontend("body"));
+    assert!(FrontendFieldPolicy::is_mutable_from_frontend("tags"));
+    assert!(FrontendFieldPolicy::is_mutable_from_frontend("last_read_at"));
+
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("kind"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("operation_id"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("visibility"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("version"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("unknown_future_field"));
+}
+
+#[test]
+fn frontend_field_policy_classifies_unknown_fields_as_version_audit() {
+    assert_eq!(
+        FrontendFieldPolicy::classify("unknown_future_field"),
+        FrontendFieldClass::VersionAudit
+    );
+}
+
+#[test]
+fn frontend_capabilities_default_to_no_projection_features() {
+    let caps = FrontendAdapterCapabilities::default();
+    assert!(!caps.frontmatter);
+    assert!(!caps.sidecar_files);
+    assert!(!caps.live_plugin);
+    assert!(!caps.graph_view);
+    assert_eq!(caps.max_frontmatter_fields, 0);
+}
+
+#[test]
+fn frontend_reconcile_error_exposes_immutable_field_variant() {
+    let err = FrontendReconcileError::ImmutableFieldChanged {
+        field: "operation_id".into(),
+    };
+    let rendered = err.to_string();
+    assert!(rendered.contains("operation_id"));
+}

--- a/crates/cairn-core/tests/frontend_adapter_contract.rs
+++ b/crates/cairn-core/tests/frontend_adapter_contract.rs
@@ -15,7 +15,11 @@ use cairn_core::contract::frontend_adapter::{
 use cairn_core::contract::manifest::PluginManifest;
 use cairn_core::contract::registry::{PluginName, PluginRegistry};
 use cairn_core::contract::version::{ContractVersion, VersionRange};
-use cairn_core::domain::BodyHash;
+use cairn_core::domain::{
+    ActorChainEntry, CanonicalRecordHash, ChainRole, EvidenceVector, Identity, MemoryClass,
+    MemoryKind, MemoryRecord, MemoryVisibility, Provenance, Rfc3339Timestamp, ScopeTuple,
+    TargetId,
+};
 
 const FRONTEND_MANIFEST: &str = r#"
 name = "stub-frontend-runner"
@@ -129,7 +133,7 @@ impl FrontendAdapter for ConformanceFrontend {
         if edit.target_hash != sample_target_hash() {
             return Err(FrontendReconcileError::PolicyDenied {
                 gate: "target_hash".into(),
-                reason: "projection hash does not match body hash".into(),
+                reason: "projection hash does not match canonical record hash".into(),
             }
             .into());
         }
@@ -206,6 +210,35 @@ fn frontend_adapter_runner_reports_expected_tier2_case_ids() {
 }
 
 #[test]
+fn frontend_adapter_runner_fails_unimplemented_reconcile_cases() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-frontend-runner").expect("valid");
+    let manifest = PluginManifest::parse_toml(FRONTEND_MANIFEST).expect("manifest parses");
+    reg.register_frontend_adapter_with_manifest(name.clone(), manifest, Arc::new(StubFrontend))
+        .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+
+    for id in [
+        "rejects_immutable_field_edits",
+        "rejects_replayed_operation",
+        "rejects_tampered_target_hash",
+        "rejects_unrecognized_principal",
+        "honors_optimistic_version_check",
+    ] {
+        let outcome = outcomes
+            .iter()
+            .find(|outcome| outcome.id == id)
+            .expect("required tier-2 case exists");
+        assert!(
+            matches!(outcome.status, CaseStatus::Failed { .. }),
+            "tier-2 case {id} must fail closed when reconcile is unimplemented, got {:?}",
+            outcome.status
+        );
+    }
+}
+
+#[test]
 fn frontend_adapter_runner_marks_contract_stub_tier2_cases_ok() {
     let mut reg = PluginRegistry::new();
     let name = PluginName::new("stub-frontend-runner").expect("valid");
@@ -238,6 +271,48 @@ fn frontend_adapter_runner_marks_contract_stub_tier2_cases_ok() {
     }
 }
 
-fn sample_target_hash() -> BodyHash {
-    BodyHash::compute("trusted body")
+fn sample_target_hash() -> CanonicalRecordHash {
+    CanonicalRecordHash::compute(&sample_record()).expect("sample record hashes")
+}
+
+fn sample_record() -> MemoryRecord {
+    let user_id = Identity::parse("hmn:known-user").expect("valid identity");
+    MemoryRecord {
+        id: cairn_core::domain::RecordId::parse("01HQZX9F5N0000000000000000")
+            .expect("valid record id"),
+        target_id: TargetId::parse("01HQZX9F5N0000000000000000").expect("valid target id"),
+        kind: MemoryKind::User,
+        class: MemoryClass::Semantic,
+        visibility: MemoryVisibility::Private,
+        scope: ScopeTuple {
+            user: Some("hmn:known-user".to_owned()),
+            ..ScopeTuple::default()
+        },
+        body: "trusted body".to_owned(),
+        provenance: Provenance {
+            source_sensor: Identity::parse("snr:local:hook:cc-session:v1").expect("valid identity"),
+            created_at: Rfc3339Timestamp::parse("2026-04-22T14:02:11Z").expect("valid timestamp"),
+            originating_agent_id: user_id.clone(),
+            source_hash: format!("sha256:{}", "a".repeat(64)),
+            consent_ref: "consent:01HQZ".to_owned(),
+            llm_id_if_any: None,
+        },
+        updated_at: Rfc3339Timestamp::parse("2026-04-22T14:05:11Z").expect("valid timestamp"),
+        evidence: EvidenceVector::default(),
+        salience: 0.5,
+        confidence: 0.7,
+        actor_chain: vec![ActorChainEntry {
+            role: ChainRole::Author,
+            identity: user_id,
+            at: Rfc3339Timestamp::parse("2026-04-22T14:02:11Z").expect("valid timestamp"),
+        }],
+        signature: cairn_core::domain::record::Ed25519Signature::parse(format!(
+            "ed25519:{}",
+            "a".repeat(128)
+        ))
+        .expect("valid signature"),
+        tags: vec!["pref".to_owned()],
+        extra_frontmatter: std::collections::BTreeMap::new(),
+        consent_model: None,
+    }
 }

--- a/docs/superpowers/plans/2026-05-12-issue-113-frontend-adapter-contract.md
+++ b/docs/superpowers/plans/2026-05-12-issue-113-frontend-adapter-contract.md
@@ -1,0 +1,551 @@
+# Issue 113 FrontendAdapter Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `FrontendAdapter` stub in `cairn-core` with a real P1 contract surface, reusable frontend conformance runner, and explicit field-mutability policy that satisfies issue #113 and brief §13.5.c / §13.5.d.
+
+**Architecture:** Keep everything inside `cairn-core` as pure contract and conformance code. Add narrowly scoped frontend request/response/error/policy types to `frontend_adapter.rs`, route `ContractKind::FrontendAdapter` through a new conformance module, and update compile-path / registry tests to the richer trait surface without introducing any concrete frontend adapter crate.
+
+**Tech Stack:** Rust 1.95, `async_trait`, existing `cairn-core` contract/conformance framework, `cargo test`, `cargo check`.
+
+---
+
+## File Map
+
+- Modify: `crates/cairn-core/src/contract/frontend_adapter.rs`
+  - Replace the forward stub with the richer trait, capability struct, reconcile/project types, field-policy helpers, and typed errors.
+- Modify: `crates/cairn-core/src/contract/mod.rs`
+  - Re-export any new public frontend contract types.
+- Modify: `crates/cairn-core/src/contract/conformance/mod.rs`
+  - Add `frontend_adapter` module and route `ContractKind::FrontendAdapter` to it.
+- Create: `crates/cairn-core/src/contract/conformance/frontend_adapter.rs`
+  - Implement tier-1 and tier-2 frontend conformance cases.
+- Modify: `crates/cairn-core/tests/contract_root_exports.rs`
+  - Keep compile-path coverage for newly re-exported frontend types.
+- Modify: `crates/cairn-core/tests/contract_registry.rs`
+  - Update the stub frontend plugin to implement the richer trait methods.
+- Modify: `crates/cairn-core/tests/conformance_tier1.rs`
+  - Add a well-formed frontend stub and assert frontend tier-1 cases pass.
+- Create: `crates/cairn-core/tests/frontend_adapter_contract.rs`
+  - Add field-mutability, reconcile, and frontend tier-2 conformance tests focused on issue #113 behavior.
+- Modify: `docs/design/traceability.md`
+  - Only if implementation meaningfully changes the current coverage note for `#113`.
+
+## Task 1: Add Failing Frontend Contract Tests
+
+**Files:**
+- Create: `crates/cairn-core/tests/frontend_adapter_contract.rs`
+- Modify: `crates/cairn-core/tests/contract_root_exports.rs`
+- Modify: `crates/cairn-core/tests/conformance_tier1.rs`
+
+- [ ] **Step 1: Write the failing field-policy and trait-shape tests**
+
+Add a new integration test file with concrete expectations for mutability defaults and typed frontend errors:
+
+```rust
+use cairn_core::contract::frontend_adapter::{
+    FrontendAdapterCapabilities, FrontendFieldClass, FrontendFieldPolicy,
+    FrontendReconcileError,
+};
+
+#[test]
+fn frontend_field_policy_allows_user_content_and_metadata_only() {
+    assert!(FrontendFieldPolicy::is_mutable_from_frontend("body"));
+    assert!(FrontendFieldPolicy::is_mutable_from_frontend("tags"));
+    assert!(FrontendFieldPolicy::is_mutable_from_frontend("last_read_at"));
+
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("kind"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("operation_id"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("visibility"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("version"));
+    assert!(!FrontendFieldPolicy::is_mutable_from_frontend("unknown_future_field"));
+}
+
+#[test]
+fn frontend_field_policy_classifies_unknown_fields_as_immutable() {
+    assert_eq!(
+        FrontendFieldPolicy::classify("unknown_future_field"),
+        FrontendFieldClass::VersionAudit
+    );
+}
+
+#[test]
+fn frontend_capabilities_default_to_no_projection_features() {
+    let caps = FrontendAdapterCapabilities::default();
+    assert!(!caps.frontmatter);
+    assert!(!caps.sidecar_files);
+    assert!(!caps.live_plugin);
+    assert!(!caps.graph_view);
+    assert_eq!(caps.max_frontmatter_fields, 0);
+}
+
+#[test]
+fn frontend_reconcile_error_exposes_immutable_field_variant() {
+    let err = FrontendReconcileError::ImmutableFieldChanged {
+        field: "operation_id".into(),
+    };
+    let rendered = err.to_string();
+    assert!(rendered.contains("operation_id"));
+}
+```
+
+- [ ] **Step 2: Extend compile-path coverage for the new frontend types**
+
+Add type reachability checks in `crates/cairn-core/tests/contract_root_exports.rs`:
+
+```rust
+use cairn_core::contract::{
+    FrontendAdapterCapabilities, FrontendFieldClass, FrontendFieldPolicy,
+    FrontendReconcileError,
+};
+
+#[test]
+fn frontend_contract_types_are_reachable() {
+    let _: FrontendAdapterCapabilities = FrontendAdapterCapabilities::default();
+    let _: FrontendFieldClass = FrontendFieldClass::UserContent;
+    let _ = FrontendFieldPolicy::is_mutable_from_frontend("body");
+    let _: FrontendReconcileError = FrontendReconcileError::UnsignedIntent;
+}
+```
+
+- [ ] **Step 3: Add a failing frontend tier-1 conformance test**
+
+Append a frontend stub case to `crates/cairn-core/tests/conformance_tier1.rs`:
+
+```rust
+#[test]
+fn tier1_cases_pass_for_well_formed_frontend_adapter() {
+    let mut reg = PluginRegistry::new();
+    let name = PluginName::new("stub-frontend").expect("valid");
+    let manifest = PluginManifest::parse_toml(FRONTEND_MANIFEST).expect("manifest parses");
+    reg.register_frontend_adapter_with_manifest(
+        name.clone(),
+        manifest,
+        Arc::new(StubFrontendAdapter::default()),
+    )
+    .expect("registers");
+
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+    let tier1: Vec<_> = outcomes.iter().filter(|o| o.tier == Tier::One).collect();
+    assert_eq!(tier1.len(), 4, "expect 4 tier-1 cases");
+    for outcome in &tier1 {
+        assert!(matches!(outcome.status, CaseStatus::Ok));
+    }
+}
+```
+
+- [ ] **Step 4: Run the new tests to verify they fail for the right reason**
+
+Run: `cargo test -p cairn-core frontend_adapter_contract -- --nocapture`
+
+Expected: FAIL with unresolved frontend types or missing trait surface members.
+
+Run: `cargo test -p cairn-core conformance_tier1 -- --nocapture`
+
+Expected: FAIL because `FrontendAdapter` has no conformance runner and the new stub cannot implement the richer contract.
+
+- [ ] **Step 5: Commit the red tests**
+
+```bash
+git add crates/cairn-core/tests/frontend_adapter_contract.rs \
+  crates/cairn-core/tests/contract_root_exports.rs \
+  crates/cairn-core/tests/conformance_tier1.rs
+git commit -m "test: add failing frontend adapter contract coverage"
+```
+
+## Task 2: Implement the Rich Frontend Contract Surface
+
+**Files:**
+- Modify: `crates/cairn-core/src/contract/frontend_adapter.rs`
+- Modify: `crates/cairn-core/src/contract/mod.rs`
+
+- [ ] **Step 1: Add the failing registry stub compile case**
+
+Update the existing frontend stub in `crates/cairn-core/tests/contract_registry.rs` to implement the new required methods with `unimplemented!()` placeholders so the build fails on missing core types first:
+
+```rust
+fn project(
+    &self,
+    _request: &FrontendProjectionRequest,
+) -> Result<FrontendProjection, FrontendAdapterError> {
+    unimplemented!("filled after contract types land")
+}
+
+fn reconcile(
+    &self,
+    _ctx: FrontendIdentityContext,
+    _edit: FrontendEdit,
+) -> Result<FrontendReconcileRequest, FrontendAdapterError> {
+    unimplemented!("filled after contract types land")
+}
+```
+
+- [ ] **Step 2: Run the targeted registry test to verify compile failure**
+
+Run: `cargo test -p cairn-core contract_registry -- --nocapture`
+
+Expected: FAIL at compile time because the frontend contract types and methods do not exist yet.
+
+- [ ] **Step 3: Implement the minimal frontend contract types**
+
+In `crates/cairn-core/src/contract/frontend_adapter.rs`, add:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FrontendAdapterCapabilities {
+    pub frontmatter: bool,
+    pub sidecar_files: bool,
+    pub live_plugin: bool,
+    pub graph_view: bool,
+    pub max_frontmatter_fields: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrontendFieldClass {
+    UserContent,
+    Metadata,
+    Classification,
+    IdentityProvenance,
+    VisibilityConsent,
+    VersionAudit,
+}
+
+pub struct FrontendFieldPolicy;
+
+impl FrontendFieldPolicy {
+    pub fn classify(field_name: &str) -> FrontendFieldClass { /* match fields */ }
+    pub fn is_mutable_from_frontend(field_name: &str) -> bool { /* bool match */ }
+}
+```
+
+Also add narrow request/response types:
+
+```rust
+pub struct FrontendProjectionRequest {
+    pub target_id: String,
+    pub expected_version: u64,
+}
+
+pub struct FrontendProjection {
+    pub body: String,
+    pub frontmatter: Vec<(String, String)>,
+    pub sidecars: Vec<(String, String)>,
+    pub target_hash: String,
+}
+
+pub struct FrontendIdentityContext {
+    pub principal: String,
+    pub agent: Option<String>,
+    pub signed_intent_present: bool,
+}
+
+pub struct FrontendEdit {
+    pub target_id: String,
+    pub expected_version: u64,
+    pub target_hash: String,
+    pub changed_fields: Vec<String>,
+}
+
+pub struct FrontendReconcileRequest {
+    pub target_id: String,
+    pub expected_version: u64,
+    pub target_hash: String,
+    pub mutable_fields: Vec<String>,
+    pub ctx: FrontendIdentityContext,
+}
+```
+
+Add typed errors:
+
+```rust
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum FrontendReconcileError {
+    #[error("frontend reconcile conflict at version {current_version}")]
+    Conflict { current_version: u64 },
+    #[error("frontend reconcile requires a signed intent")]
+    UnsignedIntent,
+    #[error("frontend reconcile detected a replayed operation")]
+    ReplayDetected,
+    #[error("frontend reconcile attempted to change immutable field {field}")]
+    ImmutableFieldChanged { field: String },
+    #[error("frontend reconcile policy denied: {gate}: {reason}")]
+    PolicyDenied { gate: String, reason: String },
+    #[error("frontend reconcile requires capability {required}")]
+    InsufficientCapability { required: String },
+}
+```
+
+Wrap projection/reconcile failures:
+
+```rust
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum FrontendAdapterError {
+    #[error(transparent)]
+    Reconcile(#[from] FrontendReconcileError),
+    #[error("frontend projection failed: {message}")]
+    Projection { message: String },
+}
+```
+
+Extend the trait:
+
+```rust
+fn project(
+    &self,
+    request: &FrontendProjectionRequest,
+) -> Result<FrontendProjection, FrontendAdapterError>;
+
+fn reconcile(
+    &self,
+    ctx: FrontendIdentityContext,
+    edit: FrontendEdit,
+) -> Result<FrontendReconcileRequest, FrontendAdapterError>;
+
+fn subscribe(&self, _events: FrontendEventStream) -> Option<FrontendSubscription> {
+    None
+}
+
+fn shutdown(&self) {}
+```
+
+- [ ] **Step 4: Re-export the new frontend types**
+
+In `crates/cairn-core/src/contract/mod.rs`, extend the `pub use frontend_adapter::{ ... }` line so it exports the new types:
+
+```rust
+pub use frontend_adapter::{
+    FrontendAdapter, FrontendAdapterCapabilities, FrontendAdapterError,
+    FrontendAdapterPlugin, FrontendEdit, FrontendFieldClass, FrontendFieldPolicy,
+    FrontendIdentityContext, FrontendProjection, FrontendProjectionRequest,
+    FrontendReconcileError, FrontendReconcileRequest, FrontendSubscription,
+    FrontendEventStream,
+};
+```
+
+- [ ] **Step 5: Run the focused tests to verify they pass**
+
+Run: `cargo test -p cairn-core frontend_adapter_contract -- --nocapture`
+
+Expected: PASS
+
+Run: `cargo test -p cairn-core contract_root_exports -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit the contract surface**
+
+```bash
+git add crates/cairn-core/src/contract/frontend_adapter.rs \
+  crates/cairn-core/src/contract/mod.rs \
+  crates/cairn-core/tests/contract_root_exports.rs \
+  crates/cairn-core/tests/frontend_adapter_contract.rs \
+  crates/cairn-core/tests/contract_registry.rs
+git commit -m "feat: expand frontend adapter contract surface"
+```
+
+## Task 3: Implement the Frontend Conformance Runner
+
+**Files:**
+- Create: `crates/cairn-core/src/contract/conformance/frontend_adapter.rs`
+- Modify: `crates/cairn-core/src/contract/conformance/mod.rs`
+- Modify: `crates/cairn-core/tests/conformance_tier1.rs`
+
+- [ ] **Step 1: Write the failing frontend conformance assertions**
+
+In `crates/cairn-core/tests/frontend_adapter_contract.rs`, add a targeted runner assertion:
+
+```rust
+#[test]
+fn frontend_conformance_runner_reports_tier2_cases() {
+    let mut reg = PluginRegistry::new();
+    let name = register_stub_frontend(&mut reg);
+    let outcomes = run_conformance_for_plugin(&reg, &name);
+
+    let ids: Vec<_> = outcomes.iter().map(|o| o.id).collect();
+    assert!(ids.contains(&"rejects_immutable_field_edits"));
+    assert!(ids.contains(&"rejects_replayed_operation"));
+    assert!(ids.contains(&"rejects_tampered_target_hash"));
+    assert!(ids.contains(&"rejects_unrecognized_principal"));
+    assert!(ids.contains(&"honors_optimistic_version_check"));
+}
+```
+
+- [ ] **Step 2: Run the conformance tests to verify they fail**
+
+Run: `cargo test -p cairn-core frontend_conformance_runner_reports_tier2_cases -- --nocapture`
+
+Expected: FAIL because `ContractKind::FrontendAdapter` still routes to `no_conformance_runner`.
+
+- [ ] **Step 3: Implement the frontend conformance module**
+
+Create `crates/cairn-core/src/contract/conformance/frontend_adapter.rs` with a runner shaped like the existing modules:
+
+```rust
+pub fn run(registry: &PluginRegistry, name: &PluginName) -> Vec<CaseOutcome> {
+    let adapter = match registry.frontend_adapter(name) {
+        Some(adapter) => adapter,
+        None => return Vec::new(),
+    };
+
+    let caps = adapter.capabilities();
+    let mut out = vec![
+        tier1_manifest_matches_host(registry, name, CONTRACT_VERSION),
+        tier1_arc_pointer_stable_frontend(registry, name),
+        tier1_capability_self_consistency_floor_frontend(caps),
+        tier1_manifest_features_match_capabilities(
+            registry,
+            name,
+            &[
+                ("frontmatter", caps.frontmatter),
+                ("sidecar_files", caps.sidecar_files),
+                ("live_plugin", caps.live_plugin),
+                ("graph_view", caps.graph_view),
+            ],
+        ),
+    ];
+
+    out.extend([
+        tier2_rejects_immutable_field_edits(adapter.as_ref()),
+        tier2_rejects_replayed_operation(adapter.as_ref()),
+        tier2_rejects_tampered_target_hash(adapter.as_ref()),
+        tier2_rejects_unrecognized_principal(adapter.as_ref()),
+        tier2_honors_optimistic_version_check(adapter.as_ref()),
+    ]);
+    out
+}
+```
+
+Keep tier-2 cases pure by driving `adapter.reconcile(...)` with synthetic inputs and matching on `FrontendReconcileError`.
+
+- [ ] **Step 4: Route `ContractKind::FrontendAdapter` to the new runner**
+
+In `crates/cairn-core/src/contract/conformance/mod.rs`:
+
+```rust
+pub mod frontend_adapter;
+```
+
+and in `run_conformance_for_plugin(...)`:
+
+```rust
+ContractKind::FrontendAdapter => frontend_adapter::run(registry, name),
+```
+
+Remove `FrontendAdapter` from the fallback `no_conformance_runner` branch.
+
+- [ ] **Step 5: Run focused conformance tests to verify they pass**
+
+Run: `cargo test -p cairn-core conformance_tier1 -- --nocapture`
+
+Expected: PASS
+
+Run: `cargo test -p cairn-core frontend_adapter_contract -- --nocapture`
+
+Expected: PASS, including the frontend tier-2 id checks.
+
+- [ ] **Step 6: Commit the conformance runner**
+
+```bash
+git add crates/cairn-core/src/contract/conformance/mod.rs \
+  crates/cairn-core/src/contract/conformance/frontend_adapter.rs \
+  crates/cairn-core/tests/conformance_tier1.rs \
+  crates/cairn-core/tests/frontend_adapter_contract.rs
+git commit -m "feat: add frontend adapter conformance runner"
+```
+
+## Task 4: Update Registry Stubs and Final Verification
+
+**Files:**
+- Modify: `crates/cairn-core/tests/contract_registry.rs`
+- Modify: `docs/design/traceability.md` (only if needed)
+
+- [ ] **Step 1: Implement the frontend stub plugin minimally**
+
+Replace the temporary `unimplemented!()` calls in `crates/cairn-core/tests/contract_registry.rs` with minimal green implementations:
+
+```rust
+fn project(
+    &self,
+    request: &FrontendProjectionRequest,
+) -> Result<FrontendProjection, FrontendAdapterError> {
+    Ok(FrontendProjection {
+        body: String::new(),
+        frontmatter: Vec::new(),
+        sidecars: Vec::new(),
+        target_hash: request.target_id.clone(),
+    })
+}
+
+fn reconcile(
+    &self,
+    ctx: FrontendIdentityContext,
+    edit: FrontendEdit,
+) -> Result<FrontendReconcileRequest, FrontendAdapterError> {
+    if !ctx.signed_intent_present {
+        return Err(FrontendReconcileError::UnsignedIntent.into());
+    }
+    for field in &edit.changed_fields {
+        if !FrontendFieldPolicy::is_mutable_from_frontend(field) {
+            return Err(FrontendReconcileError::ImmutableFieldChanged {
+                field: field.clone(),
+            }
+            .into());
+        }
+    }
+    Ok(FrontendReconcileRequest {
+        target_id: edit.target_id,
+        expected_version: edit.expected_version,
+        target_hash: edit.target_hash,
+        mutable_fields: edit.changed_fields,
+        ctx,
+    })
+}
+```
+
+- [ ] **Step 2: Run registry and compile-path tests**
+
+Run: `cargo test -p cairn-core contract_registry -- --nocapture`
+
+Expected: PASS
+
+Run: `cargo test -p cairn-core contract_root_exports -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 3: Decide whether traceability needs an update**
+
+Inspect `docs/design/traceability.md`. If the coverage note for §4 / §12 / §13 already accurately says `#113` covers the contract and conformance slice, leave it unchanged. If the implementation adds meaningful specificity, update the note in the same commit.
+
+- [ ] **Step 4: Run final issue verification**
+
+Run:
+
+```bash
+cargo test -p cairn-core frontend_adapter_contract -- --nocapture
+cargo test -p cairn-core conformance_tier1 -- --nocapture
+cargo test -p cairn-core contract_registry -- --nocapture
+cargo test -p cairn-core contract_root_exports -- --nocapture
+cargo check -p cairn-core --locked
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit the final polish**
+
+```bash
+git add crates/cairn-core/tests/contract_registry.rs docs/design/traceability.md
+git commit -m "test: finish frontend adapter contract verification"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - contract surface: Task 2
+  - mutability policy: Tasks 1 and 2
+  - conformance runner: Task 3
+  - registry/compile-path updates: Tasks 2 and 4
+  - verification: Task 4
+- Placeholder scan:
+  - No `TODO` or `TBD` markers remain in the execution steps.
+- Type consistency:
+  - The same frontend type names are used across contract, conformance, and test tasks.

--- a/docs/superpowers/specs/2026-05-12-issue-113-frontend-adapter-contract-design.md
+++ b/docs/superpowers/specs/2026-05-12-issue-113-frontend-adapter-contract-design.md
@@ -1,0 +1,281 @@
+# Issue 113 FrontendAdapter Contract Design
+
+## Summary
+
+Issue [#113](https://github.com/windoliver/cairn/issues/113) implements the
+P1 `FrontendAdapter` contract slice defined by the Cairn design brief in
+§13.5.c and §13.5.d. The goal is to replace the current forward stub with a
+real core contract surface, a reusable conformance runner, and a single
+source of truth for frontend field mutability. This issue does not implement
+any concrete frontend adapter and does not include desktop GUI work.
+
+## Design Sources
+
+- `docs/design/design-brief.md` §4.1 contract conformance rules
+- `docs/design/design-brief.md` §13.5.c backend to frontend bridge
+- `docs/design/design-brief.md` §13.5.d `FrontendAdapter` contract
+- `docs/design/traceability.md` rows for §4, §12, and §13
+
+## Scope
+
+### In Scope
+
+- Expand `cairn-core::contract::frontend_adapter` from a registry stub into a
+  real contract surface.
+- Introduce typed core-only frontend projection and reconcile request types.
+- Encode field-level mutability rules from brief §13.5.c in Rust types and
+  tests.
+- Add a `FrontendAdapter` conformance runner under
+  `cairn-core::contract::conformance`.
+- Add reusable tests for the issue acceptance criteria.
+- Update traceability if the implementation materially changes coverage notes.
+
+### Out of Scope
+
+- Desktop GUI implementation.
+- Obsidian, VS Code, Logseq, raw-markdown, or desktop adapter crates.
+- File-watcher daemon behavior, OS user detection, keychain prompts, or
+  quarantine storage backends.
+- New verbs or CLI subcommands.
+- Full replay-ledger enforcement for nonce reuse beyond the pure contract test
+  model needed by this issue.
+
+## Problem
+
+`FrontendAdapter` currently exists only as a registration placeholder in
+`cairn-core`. The trait advertises name, capabilities, and supported versions,
+but it cannot express the projection or reconcile flow required by the brief.
+The conformance framework also has no `FrontendAdapter` runner, so
+`cairn plugins verify` would fail any manifest that declared the contract.
+
+This leaves three gaps relative to issue #113:
+
+1. There is no typed interface for adapter projection and reverse-edit
+   translation.
+2. There is no reusable conformance suite for safe frontend behavior.
+3. Field mutability rules live only in design prose rather than in a core type
+   that tests and future adapters can share.
+
+## Goals
+
+- Keep the contract pure and harness-agnostic inside `cairn-core`.
+- Express the brief's backend-authoritative reconcile model without pulling
+  storage, daemon, or frontend-specific I/O into core.
+- Reuse existing plugin manifest and tiered conformance patterns.
+- Make the allowed frontend edit surface explicit and testable.
+
+## Non-Goals
+
+- Simulating a full daemon-minted signed-intent flow in this issue.
+- Implementing backend apply logic against SQLite or the WAL.
+- Solving every future adapter-specific projection format detail.
+
+## Proposed Approach
+
+### 1. Expand the Contract Surface
+
+`crates/cairn-core/src/contract/frontend_adapter.rs` will define the contract
+types needed to model the P1 bridge without crossing into adapter I/O:
+
+- `FrontendAdapterCapabilities`
+  - Replace the current three booleans with the brief-aligned capability set:
+    frontmatter projection, sidecar projection, live plugin channel, graph
+    view, and a `max_frontmatter_fields` bound.
+- `FrontendProjection`
+  - Pure output describing what the backend wants surfaced to the frontend:
+    projected frontmatter fields, sidecar documents, optional live-event
+    support flags, and the canonical backend content hash the projection was
+    derived from.
+- `FrontendEdit`
+  - Pure description of an editor-originated change. This carries the target
+    record id, the observed backend version, a file hash or target hash, and a
+    field-level diff broken into mutable and immutable categories.
+- `FrontendIdentityContext`
+  - Minimal identity wrapper for reconcile requests. It will carry the
+    effective principal ids plus a verified signed intent type already present
+    in core, rather than inventing a parallel signature model.
+- `FrontendReconcileRequest`
+  - Pure output of `FrontendAdapter::reconcile`, containing target id,
+    expected version, the validated mutable diff, and the identity context.
+- `FrontendReconcileError`
+  - Typed rejection reasons matching the brief's contract-level outcomes:
+    conflict, unsigned intent, replay detected, immutable field changed,
+    insufficient capability, and policy denied.
+
+The trait shape will follow the brief closely:
+
+- `capabilities()`
+- `project(...) -> Result<FrontendProjection, FrontendAdapterError>`
+- `reconcile(...) -> Result<FrontendReconcileRequest, FrontendAdapterError>`
+- `subscribe(...)` defaulting to `None`
+- `shutdown()` defaulting to no-op
+
+The contract remains in `cairn-core` and remains free of filesystem, daemon,
+SQLite, or frontend SDK dependencies.
+
+### 2. Encode Field Mutability as Core Data
+
+The brief's §13.5.c mutability table will become a first-class core model
+instead of remaining prose only.
+
+Add a small classification enum:
+
+- `FrontendFieldClass::UserContent`
+- `FrontendFieldClass::Metadata`
+- `FrontendFieldClass::Classification`
+- `FrontendFieldClass::IdentityProvenance`
+- `FrontendFieldClass::VisibilityConsent`
+- `FrontendFieldClass::VersionAudit`
+
+Add a helper used by tests and adapters:
+
+- `FrontendFieldPolicy::classify(field_name: &str) -> FrontendFieldClass`
+- `FrontendFieldPolicy::is_mutable_from_frontend(field_name: &str) -> bool`
+
+This policy will encode the issue-required rules:
+
+- mutable: note body, tags, wikilinks, informational metadata
+- immutable: classification, provenance, consent, visibility, version, and
+  audit fields
+
+Unknown fields will fail closed as immutable. That matches the repo's
+capability and privacy stance and avoids silently widening the edit surface.
+
+### 3. Add a Real Conformance Runner
+
+Add `crates/cairn-core/src/contract/conformance/frontend_adapter.rs` and route
+`ContractKind::FrontendAdapter` to it from the conformance entry point.
+
+Tier 1 will mirror the existing contract runners:
+
+- `manifest_matches_host`
+- `arc_pointer_stable`
+- `capability_self_consistency_floor`
+- `manifest_features_match_capabilities`
+
+Tier 2 will encode the brief's frontend-specific invariants as pure cases:
+
+- `rejects_immutable_field_edits`
+- `rejects_replayed_operation`
+- `rejects_tampered_target_hash`
+- `rejects_unrecognized_principal`
+- `honors_optimistic_version_check`
+
+These cases will run against test adapters and synthetic fixtures rather than
+real I/O. The purpose is contract conformance, not backend integration.
+
+### 4. Define the Test Strategy
+
+Tests will be added in layers:
+
+- Unit tests beside `frontend_adapter.rs`
+  - field classification and mutability defaults
+  - typed error mapping for immutable-field and conflict paths
+- Conformance tests in `crates/cairn-core/tests/`
+  - verify a well-formed stub frontend adapter passes tier 1
+  - verify tier 2 frontend cases execute and assert the expected statuses
+- Fixture-style tests
+  - table-driven checks for mutable vs immutable fields named in §13.5.c
+
+This issue will not claim end-to-end daemon or store integration tests because
+those belong to the later adapter and backend implementation issues.
+
+## Data Model Sketch
+
+Implementation may refine helper struct names to match existing core naming,
+but the trait boundary and responsibilities below are the required shape for
+this issue:
+
+```rust
+pub trait FrontendAdapter: Send + Sync {
+    fn name(&self) -> &str;
+    fn capabilities(&self) -> &FrontendAdapterCapabilities;
+    fn supported_contract_versions(&self) -> VersionRange;
+
+    fn project(
+        &self,
+        request: &FrontendProjectionRequest,
+    ) -> Result<FrontendProjection, FrontendAdapterError>;
+
+    fn reconcile(
+        &self,
+        ctx: FrontendIdentityContext,
+        edit: FrontendEdit,
+    ) -> Result<FrontendReconcileRequest, FrontendAdapterError>;
+
+    fn subscribe(&self, _events: FrontendEventStream) -> Option<FrontendSubscription> {
+        None
+    }
+
+    fn shutdown(&self) {}
+}
+```
+
+The request and response types will stay core-native and serializable where
+helpful, but they are not a new IDL surface in this issue.
+
+## Error Handling
+
+This issue will follow repo conventions:
+
+- Use `thiserror`-style typed enums in library code.
+- No `anyhow` in `cairn-core`.
+- No `unwrap()` or `expect()` in production core code.
+
+`FrontendAdapterError` will cover adapter-local projection and reconcile
+failures, while `FrontendReconcileError` will model the contract-level reject
+reasons that conformance cases assert against.
+
+## Compatibility and Migration
+
+- The contract version in `frontend_adapter.rs` will bump because the trait
+  surface materially changes.
+- Existing stub registration tests will be updated to implement the richer
+  trait.
+- There are no bundled frontend plugins yet, so this is a source-compatible
+  move for the repo itself but a semver-significant change for future external
+  adapters.
+
+## Risks and Mitigations
+
+### Risk: Over-modeling future adapter needs
+
+Mitigation:
+Keep the types centered on the issue acceptance criteria and the brief's
+contract sketch. Do not introduce filesystem-specific or GUI-specific payloads.
+
+### Risk: Pulling backend apply semantics into the adapter contract
+
+Mitigation:
+Stop at `FrontendReconcileRequest`. The adapter translates edits; it does not
+apply them. Store and WAL behavior remain outside this issue.
+
+### Risk: Ambiguity around unknown frontend fields
+
+Mitigation:
+Fail closed by classifying unknown fields as immutable until a later brief or
+issue explicitly widens the policy.
+
+## Verification Plan
+
+At minimum, the implementation for #113 should run:
+
+```bash
+cargo test -p cairn-core frontend_adapter
+cargo test -p cairn-core conformance_tier1
+cargo test -p cairn-core contract_registry
+cargo check -p cairn-core --locked
+```
+
+If the implementation touches shared conformance routing or generated manifests,
+expand verification to the workspace checks required by the repo checklist.
+
+## Expected Outcome
+
+After this issue lands:
+
+- `FrontendAdapter` is a real P1 core contract rather than a placeholder.
+- `cairn-core` owns the reusable mutability policy and conformance cases for
+  frontend adapters.
+- Later adapter issues can implement Obsidian, VS Code, Logseq, raw markdown,
+  or desktop-specific behavior without changing the core contract shape again.


### PR DESCRIPTION
## Summary
- Expands the P1 `FrontendAdapter` contract surface in `cairn-core` per design-brief §4 / §8 and issue #113.
- Adds a conformance runner under `contract::conformance::frontend_adapter` that fails closed on capability gaps.
- Hardens contract coverage: registry, root exports, tier-1 conformance, and a dedicated 580-line contract test suite.

## Test plan
- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [ ] `cargo nextest run --workspace --locked --no-fail-fast`
- [ ] `cargo test --doc --workspace --locked`
- [ ] `./scripts/check-core-boundary.sh`

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)