### PR TITLE
test: CLI/MCP verb dispatch smoke coverage (#344)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,22 @@ jobs:
       - name: cargo run -p cairn-core --bin filter_smoke
         run: cargo run -p cairn-core --bin filter_smoke --features smoke --locked --release
 
+  cli-mcp-smoke:
+    name: smoke / cairn cli+mcp verb dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install toolchain (rust-toolchain.toml)
+        run: rustup show active-toolchain || rustup toolchain install
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: cli-mcp-smoke
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: cargo test -p cairn-cli --test status_snapshot --test handshake_tests --test mcp_handshake_e2e
+        run: cargo test -p cairn-cli --locked --test status_snapshot --test handshake_tests --test mcp_handshake_e2e
+
   plugins-verify:
     name: plugins / cairn plugins verify
     runs-on: ubuntu-latest

--- a/crates/cairn-cli/tests/handshake_tests.rs
+++ b/crates/cairn-cli/tests/handshake_tests.rs
@@ -6,6 +6,8 @@
 
 use std::process::Command;
 
+use cairn_core::generated::handshake::HandshakeResponse;
+
 fn cli() -> Command {
     Command::new(env!("CARGO_BIN_EXE_cairn"))
 }
@@ -18,12 +20,14 @@ fn handshake_json_has_challenge_keys() {
         .expect("cairn handshake --json");
     assert!(out.status.success(), "exit: {:?}", out.status);
     let stdout = String::from_utf8(out.stdout).expect("utf-8");
-    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
-    assert_eq!(v["contract"], "cairn.mcp.v1");
-    assert!(v["challenge"]["nonce"].is_string());
-    assert!(v["challenge"]["expires_at"].is_number());
-    let expires: u64 = v["challenge"]["expires_at"].as_u64().expect("u64");
-    assert!(expires > 0, "expires_at must be a positive epoch-ms value");
+    let response: HandshakeResponse =
+        serde_json::from_str(stdout.trim()).expect("handshake must parse as generated type");
+    assert_eq!(response.contract, "cairn.mcp.v1");
+    assert!(!response.challenge.nonce.0.is_empty());
+    assert!(
+        response.challenge.expires_at > 0,
+        "expires_at must be a positive epoch-ms value"
+    );
 }
 
 #[test]
@@ -36,12 +40,12 @@ fn two_handshakes_return_different_nonces() {
         .args(["handshake", "--json"])
         .output()
         .expect("handshake 2");
-    let v1: serde_json::Value =
+    let v1: HandshakeResponse =
         serde_json::from_str(String::from_utf8(out1.stdout).expect("utf-8").trim()).expect("json");
-    let v2: serde_json::Value =
+    let v2: HandshakeResponse =
         serde_json::from_str(String::from_utf8(out2.stdout).expect("utf-8").trim()).expect("json");
     assert_ne!(
-        v1["challenge"]["nonce"], v2["challenge"]["nonce"],
+        v1.challenge.nonce, v2.challenge.nonce,
         "consecutive handshakes must produce distinct nonces (§8.0.a point d)"
     );
 }

--- a/crates/cairn-cli/tests/mcp_handshake_e2e.rs
+++ b/crates/cairn-cli/tests/mcp_handshake_e2e.rs
@@ -34,6 +34,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use cairn_core::generated::envelope::{Response, ResponseStatus, ResponseVerb};
+use cairn_mcp::graph_tools::GRAPH_TOOLS;
 use cairn_mcp::generated::TOOLS;
 use serde_json::Value;
 use tempfile::TempDir;
@@ -122,6 +123,11 @@ fn cairn_mcp_subprocess_advertises_handshake_per_wiring_flag() {
 #[test]
 fn cairn_mcp_subprocess_returns_typed_envelopes_for_core_verb_calls() {
     run_mcp_subprocess("e2e-cli-typed", run_typed_envelope_protocol);
+}
+
+#[test]
+fn cairn_mcp_subprocess_lists_unique_core_verbs_and_expected_graph_tools() {
+    run_mcp_subprocess("e2e-cli-graph", run_graph_tools_protocol);
 }
 
 fn run_mcp_subprocess(tenant: &str, protocol: fn(&mut Child) -> Result<(), String>) {
@@ -322,6 +328,53 @@ fn run_typed_envelope_protocol(child: &mut Child) -> Result<(), String> {
     }
 
     // Drop stdin so the server starts shutting down.
+    client.close_stdin();
+    Ok(())
+}
+
+fn run_graph_tools_protocol(child: &mut Child) -> Result<(), String> {
+    let mut client = ProtocolClient::new(child)?;
+    client.initialize("cli-e2e-graph")?;
+
+    client.send(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#)?;
+    let list_resp = client.recv()?;
+    let names: Vec<&str> = list_resp
+        .pointer("/result/tools")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            format!(
+                "tools/list response missing tools array: {list_resp}\nstderr: {}",
+                client.stderr_so_far()
+            )
+        })?
+        .iter()
+        .filter_map(|t| t.get("name").and_then(Value::as_str))
+        .collect();
+
+    for core in TOOLS.iter().map(|tool| tool.name) {
+        let count = names.iter().filter(|name| **name == core).count();
+        if count != 1 {
+            return Err(format!(
+                "core verb {core} must appear exactly once in tools/list; got count={count} from {names:?}"
+            ));
+        }
+    }
+
+    let mut expected_graph: Vec<&str> = GRAPH_TOOLS.iter().map(|tool| tool.name).collect();
+    expected_graph.sort_unstable();
+    let mut actual_graph: Vec<&str> = names
+        .iter()
+        .copied()
+        .filter(|name| name.starts_with("graph."))
+        .collect();
+    actual_graph.sort_unstable();
+
+    if actual_graph != expected_graph {
+        return Err(format!(
+            "single-tenant stdio tools/list must advertise the expected graph tool set; got {actual_graph:?}, expected {expected_graph:?}"
+        ));
+    }
+
     client.close_stdin();
     Ok(())
 }

--- a/crates/cairn-cli/tests/mcp_handshake_e2e.rs
+++ b/crates/cairn-cli/tests/mcp_handshake_e2e.rs
@@ -34,6 +34,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use cairn_core::generated::envelope::{Response, ResponseStatus, ResponseVerb};
+use cairn_mcp::generated::TOOLS;
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -219,6 +220,17 @@ fn run_tools_list_protocol(child: &mut Child) -> Result<(), String> {
         .iter()
         .filter_map(|t| t.get("name").and_then(Value::as_str))
         .collect();
+    let missing: Vec<&str> = TOOLS
+        .iter()
+        .map(|tool| tool.name)
+        .filter(|name| !names.contains(name))
+        .collect();
+
+    if !missing.is_empty() {
+        return Err(format!(
+            "tools/list over real stdio must include every generated core verb; missing {missing:?} from {names:?}"
+        ));
+    }
 
     if cairn_core::status::wiring::REPLAY_CHALLENGE_WIRED {
         if !names.contains(&"handshake") {

--- a/crates/cairn-cli/tests/mcp_handshake_e2e.rs
+++ b/crates/cairn-cli/tests/mcp_handshake_e2e.rs
@@ -34,8 +34,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use cairn_core::generated::envelope::{Response, ResponseStatus, ResponseVerb};
-use cairn_mcp::graph_tools::GRAPH_TOOLS;
 use cairn_mcp::generated::TOOLS;
+use cairn_mcp::graph_tools::GRAPH_TOOLS;
 use serde_json::Value;
 use tempfile::TempDir;
 

--- a/crates/cairn-cli/tests/status_snapshot.rs
+++ b/crates/cairn-cli/tests/status_snapshot.rs
@@ -3,6 +3,8 @@
 
 use std::process::Command;
 
+use cairn_core::generated::status::StatusResponse;
+
 fn cli() -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_cairn"));
     // Pin CWD to a clean tempdir so the workspace root's transient
@@ -26,14 +28,13 @@ fn status_json_has_required_keys() {
         out.status
     );
     let stdout = String::from_utf8(out.stdout).expect("utf-8");
-    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
-    assert_eq!(v["contract"], "cairn.mcp.v1");
-    assert!(v["server_info"]["version"].is_string());
-    assert!(v["server_info"]["incarnation"].is_string());
-    assert!(v["server_info"]["started_at"].is_string());
-    assert!(v["server_info"]["build"].is_string());
-    assert!(v["capabilities"].is_array());
-    assert!(v["extensions"].is_array());
+    let response: StatusResponse =
+        serde_json::from_str(stdout.trim()).expect("status must parse as generated type");
+    assert_eq!(response.contract, "cairn.mcp.v1");
+    assert!(!response.server_info.version.is_empty());
+    assert!(!response.server_info.incarnation.0.is_empty());
+    assert!(!response.server_info.started_at.is_empty());
+    assert!(!response.server_info.build.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Closes #344.

## Summary
- Add real-process CLI/MCP smoke tests for verb dispatch (handshake, status snapshot, MCP stdio e2e).
- Cover MCP verb dispatch edge cases: malformed args, valid-but-unwired verbs return typed `Response` envelopes (no transport crash).
- Wire matching `cli-mcp-smoke` job in `.github/workflows/ci.yml`.

## Acceptance criteria (issue #344)
- [x] Test spawns real `cairn` binary and `cairn mcp` stdio server (not in-process handlers).
- [x] MCP `tools/list` includes every generated core verb from `cairn_mcp::generated::TOOLS`.
- [x] MCP `tools/call` for an unwired P0 verb (`retrieve`) returns a typed `Aborted/Internal` envelope, not a transport crash.
- [x] CLI `status --json` and `handshake --json` parse as the generated `StatusResponse` / `HandshakeResponse` types.
- [x] CI fails if the binary cannot start or the MCP transport cannot initialize (`cli-mcp-smoke` job gates the three test files).

## Test plan
- [ ] `cargo nextest run -p cairn-cli --locked`
- [ ] `cargo test -p cairn-cli --locked --test status_snapshot --test handshake_tests --test mcp_handshake_e2e`
- [ ] CI `cli-mcp-smoke` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)