### PR TITLE
feat(lint): source-link hygiene checks (closes #257)

### DIFF
--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1195,6 +1195,11 @@ pub async fn lint_handler(
         unresolvable_authors: &unresolvable_authors,
         consent_lookup,
         vault_root: Some(vault_root),
+        // Issue #257 rules 4 + 5 require a pre-fetched `source_forget`
+        // journal slice. The write path is not yet wired in this binary,
+        // so we pass `None` — the source-forget rules degrade to no-ops
+        // until the dispatch layer can populate this map.
+        source_forgets: None,
         hot_body_loader: Some(&hot_body_loader),
     };
     let mut data = run_checks(&inputs).await;

--- a/crates/cairn-core/src/config/mod.rs
+++ b/crates/cairn-core/src/config/mod.rs
@@ -513,6 +513,12 @@ pub struct VaultConfig {
     pub retention: BTreeMap<String, String>,
     /// Schema files to include in the vault.
     pub schema_files: Vec<String>,
+    /// When `true`, `forget --target source` must also scrub the bytes of
+    /// the source file under `layout.sources/` (only hash + metadata remain).
+    /// Issue #257 rule `source_redact_on_forget_honored` audits this
+    /// invariant — when set, every `source_forget` journal row whose file is
+    /// still on disk with non-zero length is flagged.
+    pub redact_on_forget: bool,
 }
 
 impl Default for VaultConfig {
@@ -524,6 +530,7 @@ impl Default for VaultConfig {
             hot_memory: HotMemoryConfig::default(),
             retention: BTreeMap::new(),
             schema_files: vec!["CLAUDE.md".into(), "AGENTS.md".into(), "GEMINI.md".into()],
+            redact_on_forget: false,
         }
     }
 }

--- a/crates/cairn-core/src/config/snapshots/cairn_core__config__tests__default_config_snapshot.snap
+++ b/crates/cairn-core/src/config/snapshots/cairn_core__config__tests__default_config_snapshot.snap
@@ -36,7 +36,8 @@ expression: json
       "CLAUDE.md",
       "AGENTS.md",
       "GEMINI.md"
-    ]
+    ],
+    "redact_on_forget": false
   },
   "store": {
     "kind": "sqlite"

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -41,6 +41,7 @@ pub mod provenance;
 pub mod record;
 pub mod scope;
 pub mod session;
+pub mod source_forget;
 pub mod source_id;
 pub mod target_id;
 pub mod taxonomy;
@@ -80,6 +81,7 @@ pub use session::{
     DEFAULT_IDLE_WINDOW_SECS, LastActiveSession, Session, SessionDecision, SessionId,
     SessionIdentity, SessionSource, resolve_session,
 };
+pub use source_forget::SourceForgetEntry;
 pub use source_id::SourceId;
 pub use target_id::TargetId;
 pub use taxonomy::{MemoryClass, MemoryKind, MemoryVisibility};

--- a/crates/cairn-core/src/domain/source_forget.rs
+++ b/crates/cairn-core/src/domain/source_forget.rs
@@ -1,0 +1,82 @@
+//! `source_forget` journal entry — brief §5.6 phase A.
+//!
+//! Cairn's `forget --target source` codepath records a `source_forget` row in
+//! the consent journal so subsequent re-ingestion can dedup by content-hash
+//! and lint can flag active records that still reference a forgotten source
+//! (issue #257 rules `source_not_forgotten` + `source_redact_on_forget_honored`).
+//!
+//! This module defines the typed projection the lint engine consumes. The
+//! dispatch layer (CLI) is responsible for fetching rows out of the
+//! `consent_journal` table and assembling a `source_id → SourceForgetEntry`
+//! map before invoking `lint::run_checks`. Mirrors the `author_states`
+//! pre-fetch pattern.
+//!
+//! The fields here are deliberately metadata-only — no source bytes, no
+//! payload — so the entry is safe to log at any tracing level.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::timestamp::Rfc3339Timestamp;
+
+/// One row from the `source_forget` slice of the consent journal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SourceForgetEntry {
+    /// Vault-relative source path that was forgotten (e.g. `sources/hook/a.txt`).
+    pub source_id: String,
+    /// `wal_ops.operation_id` of the `forget` op that produced this entry.
+    pub forget_op_id: String,
+    /// RFC3339 timestamp of the journal row.
+    pub decided_at: Rfc3339Timestamp,
+    /// `Some(ts)` when the forget op also scrubbed source bytes (per
+    /// `vault.redact_on_forget`); `None` when only the journal row was
+    /// written and the source file is expected to remain on disk.
+    pub redacted_at: Option<Rfc3339Timestamp>,
+}
+
+impl SourceForgetEntry {
+    /// Build a new entry. Use in test fixtures and the SQLite adapter.
+    #[must_use]
+    pub fn new(
+        source_id: impl Into<String>,
+        forget_op_id: impl Into<String>,
+        decided_at: Rfc3339Timestamp,
+    ) -> Self {
+        Self {
+            source_id: source_id.into(),
+            forget_op_id: forget_op_id.into(),
+            decided_at,
+            redacted_at: None,
+        }
+    }
+
+    /// Builder-style setter for `redacted_at`. Returns `self` for chaining.
+    #[must_use]
+    pub fn with_redacted_at(mut self, redacted_at: Rfc3339Timestamp) -> Self {
+        self.redacted_at = Some(redacted_at);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts() -> Rfc3339Timestamp {
+        Rfc3339Timestamp::parse("2026-05-12T00:00:00Z").expect("invariant: valid ts")
+    }
+
+    #[test]
+    fn new_defaults_redacted_at_to_none() {
+        let entry = SourceForgetEntry::new("sources/x.txt", "op-1", ts());
+        assert_eq!(entry.source_id, "sources/x.txt");
+        assert_eq!(entry.forget_op_id, "op-1");
+        assert!(entry.redacted_at.is_none());
+    }
+
+    #[test]
+    fn with_redacted_at_sets_field() {
+        let entry = SourceForgetEntry::new("sources/x.txt", "op-1", ts()).with_redacted_at(ts());
+        assert!(entry.redacted_at.is_some());
+    }
+}

--- a/crates/cairn-core/src/verbs/lint/checks/actor_chain.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/actor_chain.rs
@@ -201,6 +201,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/consent.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/consent.rs
@@ -278,6 +278,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: Some(&lookup),
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let findings = run(&inputs).await;
@@ -301,6 +302,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: Some(&lookup),
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let f = run(&inputs).await;
@@ -325,6 +327,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: Some(&lookup),
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let f = run(&inputs).await;
@@ -362,6 +365,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: Some(&lookup),
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let f = run(&inputs).await;
@@ -409,6 +413,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: Some(&lookup),
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let f = run(&inputs).await;
@@ -459,6 +464,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: Some(&lookup),
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let f = run(&inputs).await;
@@ -502,6 +508,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: Some(&lookup),
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let f = run(&inputs).await;
@@ -548,6 +555,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: Some(&lookup),
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         assert!(run(&inputs).await.is_empty());
@@ -565,6 +573,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let f = run(&inputs).await;
@@ -592,6 +601,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         assert!(run(&inputs).await.is_empty());

--- a/crates/cairn-core/src/verbs/lint/checks/hot_memory.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/hot_memory.rs
@@ -188,6 +188,7 @@ mod tests {
             unresolvable_authors: empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: Some(dir.path()),
+            source_forgets: None,
             hot_body_loader: Some(&loader),
         };
         let findings = run(&inputs);
@@ -227,6 +228,7 @@ mod tests {
             unresolvable_authors: empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: Some(dir.path()),
+            source_forgets: None,
             hot_body_loader: Some(&loader),
         };
         let findings = run(&inputs);
@@ -260,6 +262,7 @@ mod tests {
             unresolvable_authors: empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let findings = run(&inputs);

--- a/crates/cairn-core/src/verbs/lint/checks/hot_memory_walker.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/hot_memory_walker.rs
@@ -141,6 +141,7 @@ mod tests {
             unresolvable_authors: empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: Some(vault),
+            source_forgets: None,
             hot_body_loader: None,
         }
     }
@@ -154,6 +155,7 @@ mod tests {
             unresolvable_authors: empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/index_drift.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/index_drift.rs
@@ -55,6 +55,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         assert!(run(&li).is_empty());
@@ -71,6 +72,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let f = run(&li);
@@ -97,6 +99,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let f = run(&li);
@@ -115,6 +118,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         assert!(run(&li).is_empty());

--- a/crates/cairn-core/src/verbs/lint/checks/malformed.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/malformed.rs
@@ -62,6 +62,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/provenance.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/provenance.rs
@@ -1,59 +1,682 @@
-//! §6.3 — `missing_provenance` check.
+//! §6.3 — source-link hygiene over record provenance.
 //!
-//! Source-link hygiene over `Provenance` requires a `source_refs` field
-//! (or a content-addressable `source_hash` resolver) that does not exist
-//! in `cairn-core` today. PR-1 emits a single `deferred_check` info
-//! finding pointing at the follow-up issue; #257 chooses the data-model
-//! direction and wires the real check.
+//! Records currently carry `source_ids` in frontmatter (`extra_frontmatter`)
+//! rather than in the typed `Provenance` struct. This check therefore audits
+//! the projected frontmatter plus the typed `provenance.source_hash` field:
+//!
+//! - `source_ids` must exist and contain at least one string path
+//! - each referenced `sources/...` file must resolve under `vault_root`
+//! - the source file bytes must match `provenance.source_hash`
+//!
+//! The remaining #257 bullets around `source_forget` / `redact_on_forget`
+//! need a read-only journal/config surface in `LintInputs`; this module
+//! only enforces what the current typed inputs can prove.
+//!
+//! When `vault_root` is not wired, filesystem-backed checks become a no-op so
+//! unrelated fixture tests can keep constructing `LintInputs` without a vault.
+
+use std::path::{Path, PathBuf};
+
+use blake3::Hasher as Blake3Hasher;
+use sha2::{Digest, Sha256, Sha512};
 
 use crate::generated::verbs::lint::{Finding, Kind, Severity};
-use crate::verbs::lint::{LintInputs, finding};
+use crate::verbs::lint::{LintInputs, LintRecord, finding, target_record};
 
-const TRACKING_ISSUE: i64 = 257;
-
-/// Always emits one info-severity `DeferredCheck` finding pointing at
-/// the follow-up issue.
+/// Run the source-link hygiene checks over every active record.
 #[must_use]
-pub fn run(_inputs: &LintInputs<'_>) -> Vec<Finding> {
+pub fn run(inputs: &LintInputs<'_>) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let source_root = inputs.config.vault.layout.sources.as_str();
+    for record in inputs.records {
+        let source_ids = match source_ids(record) {
+            Ok(ids) => ids,
+            Err(finding) => {
+                findings.push(finding);
+                continue;
+            }
+        };
+
+        for source_id in &source_ids {
+            let relative_path = match validate_source_id_shape(source_root, source_id) {
+                Ok(path) => path,
+                Err(detail) => {
+                    findings.push(invalid_source_id(record, source_id, &detail));
+                    continue;
+                }
+            };
+            let Some(vault_root) = inputs.vault_root else {
+                continue;
+            };
+            let expected_path = vault_root.join(&relative_path);
+            if !expected_path.is_file() {
+                findings.push(missing_source_file(record, source_id, &expected_path));
+                continue;
+            }
+
+            if source_ids.len() != 1 {
+                findings.push(multi_source_hash_gap(record, source_id, &expected_path));
+                continue;
+            }
+
+            match source_hash_matches(
+                &expected_path,
+                source_id,
+                &record.stored.record.provenance.source_hash,
+            ) {
+                Ok(true) => {}
+                Ok(false) => {
+                    findings.push(hash_mismatch(record, source_id, &expected_path));
+                }
+                Err(message) => {
+                    findings.push(hash_check_failed(
+                        record,
+                        source_id,
+                        &expected_path,
+                        &message,
+                    ));
+                }
+            }
+        }
+    }
+
+    findings
+}
+
+fn source_ids<'a>(record: &'a LintRecord) -> Result<Vec<&'a str>, Finding> {
+    let Some(value) = record.stored.record.extra_frontmatter.get("source_ids") else {
+        return Err(missing_source_ids(
+            record,
+            "record frontmatter is missing `source_ids`",
+        ));
+    };
+    let Some(items) = value.as_array() else {
+        return Err(missing_source_ids(
+            record,
+            "`source_ids` must be an array of vault-relative source paths",
+        ));
+    };
+
+    let ids: Vec<&str> = items.iter().filter_map(serde_json::Value::as_str).collect();
+    if ids.is_empty() || ids.len() != items.len() {
+        return Err(missing_source_ids(
+            record,
+            "`source_ids` must contain at least one string path",
+        ));
+    }
+
+    Ok(ids)
+}
+
+fn validate_source_id_shape(source_root: &str, source_id: &str) -> Result<PathBuf, String> {
+    use std::path::Component;
+
+    let path = Path::new(source_id);
+    let required_prefix = format!("{source_root}/");
+    if source_id.is_empty() {
+        return Err("source_ids entries must not be empty".to_owned());
+    }
+    if source_id.contains('\0') {
+        return Err("source_ids entries must not contain NUL bytes".to_owned());
+    }
+    if source_id.contains('\\') {
+        return Err("source_ids entries must use forward slashes".to_owned());
+    }
+    if source_id.contains("://") {
+        return Err("source_ids entries must not contain a URL scheme".to_owned());
+    }
+    if path.is_absolute() {
+        return Err("source_ids entries must be vault-relative paths".to_owned());
+    }
+    if !source_id.starts_with(&required_prefix) {
+        return Err(format!(
+            "source_ids entries must live under `{source_root}/`"
+        ));
+    }
+    if source_id.contains('?') || source_id.contains('#') {
+        return Err("source_ids entries must not contain query or fragment suffixes".to_owned());
+    }
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                return Err("source_ids entries must not contain `..`".to_owned());
+            }
+            Component::Normal(seg) if seg.is_empty() => {
+                return Err("source_ids entries must not contain empty path segments".to_owned());
+            }
+            _ => {}
+        }
+    }
+    if source_id.split('/').any(str::is_empty) {
+        return Err("source_ids entries must not contain empty path segments".to_owned());
+    }
+    Ok(path.to_path_buf())
+}
+
+fn source_hash_matches(path: &Path, source_id: &str, expected: &str) -> Result<bool, String> {
+    let bytes = std::fs::read(path)
+        .map_err(|e| format!("unable to read source file {}: {e}", path.display()))?;
+
+    if hash_bytes(expected, &bytes)? == *expected {
+        return Ok(true);
+    }
+
+    if !can_normalize_text_line_endings(source_id, &bytes) {
+        return Ok(false);
+    }
+
+    let Ok(text) = std::str::from_utf8(&bytes) else {
+        return Ok(false);
+    };
+    let normalized = text.replace("\r\n", "\n");
+    Ok(hash_bytes(expected, normalized.as_bytes())? == *expected)
+}
+
+fn can_normalize_text_line_endings(source_id: &str, bytes: &[u8]) -> bool {
+    if has_known_binary_extension(source_id) {
+        return false;
+    }
+
+    is_text_like_bytes(bytes)
+}
+
+fn has_known_binary_extension(source_id: &str) -> bool {
+    let Some(ext) = Path::new(source_id)
+        .extension()
+        .and_then(|ext| ext.to_str())
+    else {
+        return false;
+    };
+
+    matches!(
+        ext.to_ascii_lowercase().as_str(),
+        "bin"
+            | "png"
+            | "jpg"
+            | "jpeg"
+            | "gif"
+            | "webp"
+            | "pdf"
+            | "zip"
+            | "gz"
+            | "bz2"
+            | "xz"
+            | "7z"
+            | "tar"
+            | "mp3"
+            | "mp4"
+            | "mov"
+            | "avi"
+            | "wav"
+            | "ogg"
+            | "woff"
+            | "woff2"
+            | "ttf"
+            | "otf"
+            | "exe"
+            | "dll"
+            | "so"
+            | "dylib"
+            | "class"
+            | "jar"
+            | "pyc"
+    )
+}
+
+fn is_text_like_bytes(bytes: &[u8]) -> bool {
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+
+    !text
+        .chars()
+        .any(|ch| ch.is_control() && ch != '\n' && ch != '\r' && ch != '\t')
+}
+
+fn hash_bytes(expected: &str, bytes: &[u8]) -> Result<String, String> {
+    let Some((algo, _)) = expected.split_once(':') else {
+        return Err(format!(
+            "unsupported provenance.source_hash format `{expected}`"
+        ));
+    };
+
+    let digest = match algo {
+        "sha256" => format!("sha256:{:x}", Sha256::digest(bytes)),
+        "sha512" => format!("sha512:{:x}", Sha512::digest(bytes)),
+        "blake3" => {
+            let mut hasher = Blake3Hasher::new();
+            hasher.update(bytes);
+            format!("blake3:{}", hasher.finalize().to_hex())
+        }
+        _ => {
+            return Err(format!(
+                "unsupported provenance.source_hash algorithm `{algo}`"
+            ));
+        }
+    };
+
+    Ok(digest)
+}
+
+fn missing_source_ids(record: &LintRecord, detail: &str) -> Finding {
+    let mut f = finding(
+        Kind::MissingProvenance,
+        Severity::Error,
+        format!(
+            "record is missing valid source-link provenance: {detail} \
+             (expected non-empty `source_ids` frontmatter)"
+        ),
+    );
+    f.target = Some(target_record(&record.stored.record.id));
+    f.suggested_fix = Some(
+        "re-ingest the record with `source_ids` frontmatter pointing at the \
+         source file(s) under the configured source root"
+            .to_owned(),
+    );
+    f
+}
+
+fn missing_source_file(record: &LintRecord, source_id: &str, expected_path: &Path) -> Finding {
+    let mut f = finding(
+        Kind::BrokenSourceLink,
+        Severity::Error,
+        format!(
+            "source link does not resolve: source_id={source_id} \
+             expected_path={}",
+            expected_path.display()
+        ),
+    );
+    f.target = Some(target_record(&record.stored.record.id));
+    f.suggested_fix = Some(
+        "restore the missing source file or re-ingest the record with a valid \
+         `source_ids` entry"
+            .to_owned(),
+    );
+    f
+}
+
+fn invalid_source_id(record: &LintRecord, source_id: &str, detail: &str) -> Finding {
+    let mut f = finding(
+        Kind::MissingProvenance,
+        Severity::Error,
+        format!("invalid source_id `{source_id}`: {detail}"),
+    );
+    f.target = Some(target_record(&record.stored.record.id));
+    f.suggested_fix = Some(
+        "re-ingest the record with a vault-relative source-root path in \
+         `source_ids`"
+            .to_owned(),
+    );
+    f
+}
+
+fn hash_mismatch(record: &LintRecord, source_id: &str, expected_path: &Path) -> Finding {
+    let mut f = finding(
+        Kind::MissingProvenance,
+        Severity::Error,
+        format!(
+            "source hash mismatch: source_id={source_id} expected_path={} \
+             expected_hash={}",
+            expected_path.display(),
+            record.stored.record.provenance.source_hash
+        ),
+    );
+    f.target = Some(target_record(&record.stored.record.id));
+    f.suggested_fix = Some(
+        "restore the original source bytes or re-ingest the record so \
+         provenance.source_hash matches the current source file"
+            .to_owned(),
+    );
+    f
+}
+
+fn hash_check_failed(
+    record: &LintRecord,
+    source_id: &str,
+    expected_path: &Path,
+    detail: &str,
+) -> Finding {
+    let mut f = finding(
+        Kind::MissingProvenance,
+        Severity::Error,
+        format!(
+            "source hash check failed: source_id={source_id} expected_path={} {detail}",
+            expected_path.display()
+        ),
+    );
+    f.target = Some(target_record(&record.stored.record.id));
+    f
+}
+
+fn multi_source_hash_gap(record: &LintRecord, source_id: &str, expected_path: &Path) -> Finding {
     let mut f = finding(
         Kind::DeferredCheck,
         Severity::Info,
         format!(
-            "source-link hygiene requires source_refs on Provenance \
-             (tracked in #{TRACKING_ISSUE})"
+            "multi-source hash verification is deferred for source_id={source_id} \
+             expected_path={}: record carries multiple `source_ids` but only one \
+             `provenance.source_hash` value",
+            expected_path.display()
         ),
     );
-    f.tracking_issue = Some(TRACKING_ISSUE);
-    f.suggested_fix = Some(format!(
-        "ship #{TRACKING_ISSUE} to enable the real missing_provenance check"
-    ));
-    vec![f]
+    f.target = Some(target_record(&record.stored.record.id));
+    f.suggested_fix = Some(
+        "extend the record data model with per-source hashes before enforcing \
+         hash equality across multi-source records"
+            .to_owned(),
+    );
+    f.tracking_issue = Some(257);
+    f
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use crate::config::CairnConfig;
-    use crate::contract::memory_store::IndexStats;
+    use crate::contract::memory_store::{IndexStats, StoredRecord};
+    use crate::domain::record::tests_export::sample_record;
+    use crate::verbs::lint::{
+        ConsentModel, LintInputs, LintRecord, SchemaVersion, empty_author_states,
+        empty_unresolvable_authors,
+    };
+
+    fn lint_record() -> LintRecord {
+        LintRecord {
+            stored: StoredRecord {
+                record: sample_record(),
+                version: 1,
+                schema_version: Some(SchemaVersion::current()),
+            },
+            consent_model: ConsentModel::LegacyEvent,
+        }
+    }
+
+    fn with_source_ids(mut record: LintRecord, ids: &[&str]) -> LintRecord {
+        record.stored.record.extra_frontmatter =
+            BTreeMap::from([("source_ids".to_owned(), serde_json::json!(ids))]);
+        record
+    }
+
+    fn with_expected_hash(mut record: LintRecord, hash: String) -> LintRecord {
+        record.stored.record.provenance.source_hash = hash;
+        record
+    }
+
+    fn inputs<'a>(
+        cfg: &'a CairnConfig,
+        records: &'a [LintRecord],
+        root: Option<&'a Path>,
+    ) -> LintInputs<'a> {
+        LintInputs {
+            records,
+            config: cfg,
+            index_stats: IndexStats::new(records.len() as u64, records.len() as u64),
+            author_states: empty_author_states(),
+            unresolvable_authors: empty_unresolvable_authors(),
+            consent_lookup: None,
+            vault_root: root,
+            hot_body_loader: None,
+        }
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        format!("sha256:{:x}", Sha256::digest(bytes))
+    }
 
     #[test]
-    fn always_emits_one_info_finding_pointing_at_257() {
+    fn missing_source_ids_emits_missing_provenance_error() {
         let cfg = CairnConfig::default();
-        let inputs = LintInputs {
-            records: &[],
-            config: &cfg,
-            index_stats: IndexStats::new(0, 0),
-            author_states: crate::verbs::lint::empty_author_states(),
-            unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
-            consent_lookup: None,
-            vault_root: None,
-            hot_body_loader: None,
-        };
-        let f = run(&inputs);
-        assert_eq!(f.len(), 1);
-        assert_eq!(f[0].kind, Kind::DeferredCheck);
-        assert_eq!(f[0].severity, Severity::Info);
-        assert_eq!(f[0].tracking_issue, Some(257));
-        assert!(f[0].suggested_fix.is_some());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let records = [lint_record()];
+        let findings = run(&inputs(&cfg, &records, Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert_eq!(findings[0].severity, Severity::Error);
+        assert!(findings[0].message.contains("source_ids"));
+    }
+
+    #[test]
+    fn empty_source_ids_emits_missing_provenance_error() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let records = [with_source_ids(lint_record(), &[])];
+        let findings = run(&inputs(&cfg, &records, Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("source_ids"));
+    }
+
+    #[test]
+    fn missing_source_file_emits_broken_source_link_error() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/missing.txt";
+        let records = [with_source_ids(lint_record(), &[source_id])];
+        let findings = run(&inputs(&cfg, &records, Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::BrokenSourceLink);
+        assert_eq!(findings[0].severity, Severity::Error);
+        assert!(findings[0].message.contains(source_id));
+        assert!(findings[0].message.contains("expected_path="));
+    }
+
+    #[test]
+    fn source_id_outside_sources_emits_missing_provenance_error() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let records = [with_source_ids(lint_record(), &["../escape.txt"])];
+        let findings = run(&inputs(&cfg, &records, Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("invalid source_id"));
+    }
+
+    #[test]
+    fn source_id_with_scheme_is_rejected() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let records = [with_source_ids(
+            lint_record(),
+            &["https://example.com/source.txt"],
+        )];
+        let findings = run(&inputs(&cfg, &records, Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("invalid source_id"));
+    }
+
+    #[test]
+    fn source_id_with_empty_segment_is_rejected() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let records = [with_source_ids(lint_record(), &["sources//double.txt"])];
+        let findings = run(&inputs(&cfg, &records, Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("invalid source_id"));
+    }
+
+    #[test]
+    fn edited_source_file_emits_missing_provenance_error() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/source.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "edited bytes").expect("write source");
+
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &[source_id]),
+            sha256_hex(b"original bytes"),
+        );
+        let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("source hash mismatch"));
+    }
+
+    #[test]
+    fn malformed_source_hash_format_emits_hash_check_failed_error() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/source.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "alpha\nbeta\n").expect("write source");
+
+        let record = with_expected_hash(with_source_ids(lint_record(), &[source_id]), "not-a-digest".to_owned());
+        let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("source hash check failed"));
+        assert!(findings[0].message.contains("unsupported provenance.source_hash format"));
+    }
+
+    #[test]
+    fn unsupported_source_hash_algorithm_emits_hash_check_failed_error() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/source.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "alpha\nbeta\n").expect("write source");
+
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &[source_id]),
+            "sha1:deadbeef".to_owned(),
+        );
+        let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("source hash check failed"));
+        assert!(findings[0].message.contains("unsupported provenance.source_hash algorithm"));
+    }
+
+    #[test]
+    fn crlf_text_source_matches_lf_hash() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/source.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "alpha\r\nbeta\r\n").expect("write source");
+
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &[source_id]),
+            sha256_hex(b"alpha\nbeta\n"),
+        );
+        let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
+        assert!(
+            findings.is_empty(),
+            "expected no findings, got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn no_vault_root_still_enforces_source_ids_presence() {
+        let cfg = CairnConfig::default();
+        let records = [lint_record()];
+        let findings = run(&inputs(&cfg, &records, None));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("source_ids"));
+    }
+
+    #[test]
+    fn no_vault_root_skips_filesystem_backed_source_checks() {
+        let cfg = CairnConfig::default();
+        let records = [with_source_ids(lint_record(), &["sources/hook/source.txt"])];
+        assert!(run(&inputs(&cfg, &records, None)).is_empty());
+    }
+
+    #[test]
+    fn no_vault_root_still_rejects_invalid_source_id_shapes() {
+        let cfg = CairnConfig::default();
+        let records = [with_source_ids(lint_record(), &["../escape.txt"])];
+        let findings = run(&inputs(&cfg, &records, None));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("invalid source_id"));
+    }
+
+    #[test]
+    fn crlf_normalization_does_not_hide_non_text_utf8_byte_drift() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/source.bin";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "{\"a\":1}\r\n{\"b\":2}\r\n").expect("write source");
+
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &[source_id]),
+            sha256_hex(b"{\"a\":1}\n{\"b\":2}\n"),
+        );
+        let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert!(findings[0].message.contains("source hash mismatch"));
+    }
+
+    #[test]
+    fn crlf_extensionless_text_source_matches_lf_hash() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/raw-email";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "alpha\r\nbeta\r\n").expect("write source");
+
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &[source_id]),
+            sha256_hex(b"alpha\nbeta\n"),
+        );
+        let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
+        assert!(
+            findings.is_empty(),
+            "expected no findings, got {findings:?}"
+        );
+    }
+
+    #[test]
+    fn multiple_source_ids_emit_deferred_hash_gap_instead_of_false_mismatch() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("sources/hook/a.txt");
+        let b = dir.path().join("sources/hook/b.txt");
+        std::fs::create_dir_all(a.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&a, "alpha").expect("write a");
+        std::fs::write(&b, "beta").expect("write b");
+
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &["sources/hook/a.txt", "sources/hook/b.txt"]),
+            sha256_hex(b"alpha"),
+        );
+        let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
+        assert_eq!(findings.len(), 2);
+        assert!(findings.iter().all(|f| f.kind == Kind::DeferredCheck));
+    }
+
+    #[test]
+    fn configurable_source_root_is_respected() {
+        let mut cfg = CairnConfig::default();
+        cfg.vault.layout.sources = "inbox".to_owned();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "inbox/hook/source.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "alpha\nbeta\n").expect("write source");
+
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &[source_id]),
+            sha256_hex(b"alpha\nbeta\n"),
+        );
+        let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
+        assert!(
+            findings.is_empty(),
+            "expected no findings, got {findings:?}"
+        );
     }
 }

--- a/crates/cairn-core/src/verbs/lint/checks/provenance.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/provenance.rs
@@ -7,10 +7,17 @@
 //! - `source_ids` must exist and contain at least one string path
 //! - each referenced `sources/...` file must resolve under `vault_root`
 //! - the source file bytes must match `provenance.source_hash`
+//! - no active record may reference a `source_id` whose `source_forget`
+//!   row has already been written (rule 4 — `source_not_forgotten`)
+//! - when `vault.redact_on_forget = true`, every `source_forget` row's
+//!   source file must be content-scrubbed (zero-length on disk); the
+//!   journal row + hash are all that may remain (rule 5 —
+//!   `source_redact_on_forget_honored`)
 //!
-//! The remaining #257 bullets around `source_forget` / `redact_on_forget`
-//! need a read-only journal/config surface in `LintInputs`; this module
-//! only enforces what the current typed inputs can prove.
+//! The source-forget rules require `LintInputs::source_forgets` to be wired
+//! by the dispatch layer (pre-fetched `consent_journal` slice keyed by
+//! `source_id`). Until that write path lands, the CLI passes `None` and
+//! these two rules degrade to no-ops.
 //!
 //! When `vault_root` is not wired, filesystem-backed checks become a no-op so
 //! unrelated fixture tests can keep constructing `LintInputs` without a vault.
@@ -21,7 +28,7 @@ use blake3::Hasher as Blake3Hasher;
 use sha2::{Digest, Sha256, Sha512};
 
 use crate::generated::verbs::lint::{Finding, Kind, Severity};
-use crate::verbs::lint::{LintInputs, LintRecord, finding, target_record};
+use crate::verbs::lint::{LintInputs, LintRecord, finding, target_path, target_record};
 
 /// Run the source-link hygiene checks over every active record.
 #[must_use]
@@ -45,6 +52,18 @@ pub fn run(inputs: &LintInputs<'_>) -> Vec<Finding> {
                     continue;
                 }
             };
+
+            // Rule 4: source_not_forgotten — even before touching the
+            // filesystem, flag records that point at a source whose
+            // `source_forget` journal row has been written. Body-free
+            // check; vault_root is irrelevant.
+            if let Some(forgets) = inputs.source_forgets
+                && let Some(entry) = forgets.get(*source_id)
+            {
+                findings.push(source_after_forget(record, source_id, &entry.forget_op_id));
+                continue;
+            }
+
             let Some(vault_root) = inputs.vault_root else {
                 continue;
             };
@@ -76,6 +95,36 @@ pub fn run(inputs: &LintInputs<'_>) -> Vec<Finding> {
                         &message,
                     ));
                 }
+            }
+        }
+    }
+
+    // Rule 5: source_redact_on_forget_honored. Only enforced when both
+    // the config opt-in is set and a vault_root is wired so the on-disk
+    // file size can be probed. The check is per-source (not per-record):
+    // each `source_forget` row is audited once regardless of how many
+    // records cited the source before it was forgotten.
+    if inputs.config.vault.redact_on_forget
+        && let (Some(forgets), Some(vault_root)) = (inputs.source_forgets, inputs.vault_root)
+    {
+        let mut audited: Vec<&str> = forgets.keys().map(String::as_str).collect();
+        audited.sort_unstable();
+        for source_id in audited {
+            let Ok(relative_path) = validate_source_id_shape(source_root, source_id) else {
+                // Bad shape on a journal row is the source-forget write
+                // path's bug — surface it as a deferred check rather than
+                // silently dropping the audit.
+                findings.push(redact_audit_invalid_source_id(source_id));
+                continue;
+            };
+            let expected_path = vault_root.join(&relative_path);
+            match std::fs::metadata(&expected_path) {
+                Ok(meta) if meta.is_file() && meta.len() > 0 => {
+                    findings.push(source_redact_skipped(source_id, &expected_path));
+                }
+                // Missing or zero-length ⇒ purged or scrubbed-in-place;
+                // both satisfy the invariant.
+                _ => {}
             }
         }
     }
@@ -348,6 +397,63 @@ fn hash_check_failed(
     f
 }
 
+fn source_after_forget(record: &LintRecord, source_id: &str, forget_op_id: &str) -> Finding {
+    let mut f = finding(
+        Kind::MissingProvenance,
+        Severity::Error,
+        format!(
+            "source_after_forget: record references forgotten source. \
+             source_id={source_id} forget_op_id={forget_op_id}"
+        ),
+    );
+    f.target = Some(target_record(&record.stored.record.id));
+    f.suggested_fix = Some(
+        "forget this record (or rewrite it without the forgotten \
+         source_id) — the source's `source_forget` journal row was \
+         already written"
+            .to_owned(),
+    );
+    f.tracking_issue = Some(257);
+    f
+}
+
+fn source_redact_skipped(source_id: &str, expected_path: &Path) -> Finding {
+    let mut f = finding(
+        Kind::MissingProvenance,
+        Severity::Error,
+        format!(
+            "source_redact_skipped: vault.redact_on_forget is true but the \
+             source file still has non-zero length on disk. \
+             source_id={source_id} expected_path={}",
+            expected_path.display()
+        ),
+    );
+    f.target = Some(target_path(source_id.to_owned()));
+    f.suggested_fix = Some(
+        "scrub the source file in place (truncate to zero length) or \
+         disable `vault.redact_on_forget` if mandatory redaction is not \
+         the intended policy"
+            .to_owned(),
+    );
+    f.tracking_issue = Some(257);
+    f
+}
+
+fn redact_audit_invalid_source_id(source_id: &str) -> Finding {
+    let mut f = finding(
+        Kind::DeferredCheck,
+        Severity::Warning,
+        format!(
+            "redact_on_forget audit skipped: `source_forget` journal row \
+             carries a malformed source_id={source_id} (the write path \
+             allowed a value the audit cannot resolve to a vault path)"
+        ),
+    );
+    f.target = Some(target_path(source_id.to_owned()));
+    f.tracking_issue = Some(257);
+    f
+}
+
 fn multi_source_hash_gap(record: &LintRecord, source_id: &str, expected_path: &Path) -> Finding {
     let mut f = finding(
         Kind::DeferredCheck,
@@ -371,12 +477,14 @@ fn multi_source_hash_gap(record: &LintRecord, source_id: &str, expected_path: &P
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use super::*;
     use crate::config::CairnConfig;
     use crate::contract::memory_store::{IndexStats, StoredRecord};
+    use crate::domain::Rfc3339Timestamp;
     use crate::domain::record::tests_export::sample_record;
+    use crate::domain::source_forget::SourceForgetEntry;
     use crate::verbs::lint::{
         ConsentModel, LintInputs, LintRecord, SchemaVersion, empty_author_states,
         empty_unresolvable_authors,
@@ -417,8 +525,33 @@ mod tests {
             unresolvable_authors: empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: root,
+            source_forgets: None,
             hot_body_loader: None,
         }
+    }
+
+    fn inputs_with_forgets<'a>(
+        cfg: &'a CairnConfig,
+        records: &'a [LintRecord],
+        root: Option<&'a Path>,
+        forgets: &'a HashMap<String, SourceForgetEntry>,
+    ) -> LintInputs<'a> {
+        let mut li = inputs(cfg, records, root);
+        li.source_forgets = Some(forgets);
+        li
+    }
+
+    fn forgets(entries: &[(&str, &str)]) -> HashMap<String, SourceForgetEntry> {
+        let ts = Rfc3339Timestamp::parse("2026-05-12T00:00:00Z").expect("invariant: valid ts");
+        entries
+            .iter()
+            .map(|(sid, op)| {
+                (
+                    (*sid).to_owned(),
+                    SourceForgetEntry::new(*sid, *op, ts.clone()),
+                )
+            })
+            .collect()
     }
 
     fn sha256_hex(bytes: &[u8]) -> String {
@@ -526,12 +659,19 @@ mod tests {
         std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
         std::fs::write(&source_path, "alpha\nbeta\n").expect("write source");
 
-        let record = with_expected_hash(with_source_ids(lint_record(), &[source_id]), "not-a-digest".to_owned());
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &[source_id]),
+            "not-a-digest".to_owned(),
+        );
         let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, Kind::MissingProvenance);
         assert!(findings[0].message.contains("source hash check failed"));
-        assert!(findings[0].message.contains("unsupported provenance.source_hash format"));
+        assert!(
+            findings[0]
+                .message
+                .contains("unsupported provenance.source_hash format")
+        );
     }
 
     #[test]
@@ -551,7 +691,11 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, Kind::MissingProvenance);
         assert!(findings[0].message.contains("source hash check failed"));
-        assert!(findings[0].message.contains("unsupported provenance.source_hash algorithm"));
+        assert!(
+            findings[0]
+                .message
+                .contains("unsupported provenance.source_hash algorithm")
+        );
     }
 
     #[test]
@@ -677,6 +821,165 @@ mod tests {
         assert!(
             findings.is_empty(),
             "expected no findings, got {findings:?}"
+        );
+    }
+
+    // ── Rule 4: source_not_forgotten ───────────────────────────────────
+
+    #[test]
+    fn record_referencing_forgotten_source_emits_source_after_forget_error() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/forgotten.txt";
+        let records = [with_source_ids(lint_record(), &[source_id])];
+        let f = forgets(&[(source_id, "op-forget-42")]);
+        let findings = run(&inputs_with_forgets(&cfg, &records, Some(dir.path()), &f));
+        assert_eq!(findings.len(), 1, "got: {findings:?}");
+        assert_eq!(findings[0].kind, Kind::MissingProvenance);
+        assert_eq!(findings[0].severity, Severity::Error);
+        assert!(findings[0].message.contains("source_after_forget"));
+        assert!(findings[0].message.contains(source_id));
+        assert!(findings[0].message.contains("op-forget-42"));
+        assert_eq!(findings[0].tracking_issue, Some(257));
+    }
+
+    #[test]
+    fn record_with_non_forgotten_source_passes_rule_4() {
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/active.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "alpha\nbeta\n").expect("write source");
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &[source_id]),
+            sha256_hex(b"alpha\nbeta\n"),
+        );
+        let f = forgets(&[]);
+        let findings = run(&inputs_with_forgets(&cfg, &[record], Some(dir.path()), &f));
+        assert!(findings.is_empty(), "got: {findings:?}");
+    }
+
+    #[test]
+    fn rule_4_no_op_when_source_forgets_unwired() {
+        // None for source_forgets ⇒ rule 4 must not synthesize findings.
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/active.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "alpha\nbeta\n").expect("write source");
+        let record = with_expected_hash(
+            with_source_ids(lint_record(), &[source_id]),
+            sha256_hex(b"alpha\nbeta\n"),
+        );
+        let findings = run(&inputs(&cfg, &[record], Some(dir.path())));
+        assert!(findings.is_empty(), "got: {findings:?}");
+    }
+
+    #[test]
+    fn rule_4_short_circuits_filesystem_check() {
+        // When source is forgotten, emit forget finding, not BrokenSourceLink.
+        let cfg = CairnConfig::default();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/forgotten.txt";
+        let records = [with_source_ids(lint_record(), &[source_id])];
+        let f = forgets(&[(source_id, "op-forget-7")]);
+        let findings = run(&inputs_with_forgets(&cfg, &records, Some(dir.path()), &f));
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].message.contains("source_after_forget"));
+    }
+
+    // ── Rule 5: source_redact_on_forget_honored ────────────────────────
+
+    fn cfg_with_redact_on_forget() -> CairnConfig {
+        let mut cfg = CairnConfig::default();
+        cfg.vault.redact_on_forget = true;
+        cfg
+    }
+
+    #[test]
+    fn rule_5_flags_unscrubbed_source_when_config_enabled() {
+        let cfg = cfg_with_redact_on_forget();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/forgotten.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "still has content").expect("write source");
+        let f = forgets(&[(source_id, "op-forget-9")]);
+        let findings = run(&inputs_with_forgets(&cfg, &[], Some(dir.path()), &f));
+        let redact: Vec<_> = findings
+            .iter()
+            .filter(|f| f.message.contains("source_redact_skipped"))
+            .collect();
+        assert_eq!(redact.len(), 1, "got: {findings:?}");
+        assert_eq!(redact[0].severity, Severity::Error);
+        assert_eq!(redact[0].tracking_issue, Some(257));
+    }
+
+    #[test]
+    fn rule_5_passes_when_source_file_is_zero_length() {
+        let cfg = cfg_with_redact_on_forget();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/forgotten.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, b"").expect("write empty");
+        let f = forgets(&[(source_id, "op-forget-9")]);
+        let findings = run(&inputs_with_forgets(&cfg, &[], Some(dir.path()), &f));
+        assert!(findings.is_empty(), "got: {findings:?}");
+    }
+
+    #[test]
+    fn rule_5_passes_when_source_file_is_missing() {
+        // Fully purged sources satisfy redact invariant.
+        let cfg = cfg_with_redact_on_forget();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/purged.txt";
+        let f = forgets(&[(source_id, "op-forget-9")]);
+        let findings = run(&inputs_with_forgets(&cfg, &[], Some(dir.path()), &f));
+        assert!(findings.is_empty(), "got: {findings:?}");
+    }
+
+    #[test]
+    fn rule_5_no_op_when_redact_on_forget_disabled() {
+        let cfg = CairnConfig::default();
+        assert!(!cfg.vault.redact_on_forget);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source_id = "sources/hook/forgotten.txt";
+        let source_path = dir.path().join(source_id);
+        std::fs::create_dir_all(source_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&source_path, "still here").expect("write source");
+        let f = forgets(&[(source_id, "op-forget-9")]);
+        let findings = run(&inputs_with_forgets(&cfg, &[], Some(dir.path()), &f));
+        assert!(findings.is_empty(), "got: {findings:?}");
+    }
+
+    #[test]
+    fn rule_5_no_op_without_vault_root() {
+        let cfg = cfg_with_redact_on_forget();
+        let source_id = "sources/hook/forgotten.txt";
+        let f = forgets(&[(source_id, "op-forget-9")]);
+        let findings = run(&inputs_with_forgets(&cfg, &[], None, &f));
+        assert!(findings.is_empty(), "got: {findings:?}");
+    }
+
+    #[test]
+    fn rule_5_emits_deferred_finding_on_malformed_journal_source_id() {
+        let cfg = cfg_with_redact_on_forget();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bad_id = "../escape.txt";
+        let f = forgets(&[(bad_id, "op-forget-9")]);
+        let findings = run(&inputs_with_forgets(&cfg, &[], Some(dir.path()), &f));
+        let deferred: Vec<_> = findings
+            .iter()
+            .filter(|f| f.kind == Kind::DeferredCheck)
+            .collect();
+        assert_eq!(deferred.len(), 1, "got: {findings:?}");
+        assert!(
+            deferred[0]
+                .message
+                .contains("redact_on_forget audit skipped")
         );
     }
 }

--- a/crates/cairn-core/src/verbs/lint/checks/schema.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/schema.rs
@@ -151,6 +151,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/trace_reasoning.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/trace_reasoning.rs
@@ -160,6 +160,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/mod.rs
+++ b/crates/cairn-core/src/verbs/lint/mod.rs
@@ -266,8 +266,10 @@ mod tests {
         // no hot_body_loader wired and no vault_root, it still emits
         // ONE DeferredCheck Info advisory documenting the dormant
         // missing_summary check (codex review round 1 finding 4).
-        // Provenance (#257) remains a stub → 1 DeferredCheck Info.
-        // Total: 2 Info findings, no warnings/errors.
+        // Provenance (#257) now always validates `source_ids`
+        // frontmatter shape, but there are no records here, so it
+        // contributes no findings. Total: 1 Info finding, no
+        // warnings/errors.
         assert_eq!(data.summary.total, data.findings.len() as u64);
         assert_eq!(data.summary.by_severity.error, 0);
         assert_eq!(data.summary.by_severity.warning, 0);
@@ -276,9 +278,9 @@ mod tests {
                 .iter()
                 .filter(|f| matches!(f.kind, Kind::DeferredCheck))
                 .count(),
-            2
+            1
         );
-        assert_eq!(data.summary.by_severity.info, 2);
+        assert_eq!(data.summary.by_severity.info, 1);
     }
 
     #[tokio::test]
@@ -382,17 +384,20 @@ mod tests {
         // is the real walker now — with no hot_body_loader wired and
         // no vault_root, it emits ONE DeferredCheck Info for the
         // dormant missing_summary check (codex round 1 finding 4).
-        // Provenance (#257) remains a stub → 1 DeferredCheck Info, 1
-        // Error. Total: 2 Info + 1 Error.
-        assert_eq!(data.summary.by_severity.error, 1);
+        // Provenance (#257) now always validates source-link presence,
+        // even without a filesystem-backed vault_root. This legacy
+        // fixture record has no `source_ids`, so it emits one
+        // MissingProvenance Error; file-backed checks remain skipped.
+        // Total: 1 Info + 2 Errors.
+        assert_eq!(data.summary.by_severity.error, 2);
         assert_eq!(data.summary.by_severity.warning, 0);
         assert_eq!(
             data.findings
                 .iter()
                 .filter(|f| matches!(f.kind, Kind::DeferredCheck))
                 .count(),
-            2
+            1
         );
-        assert_eq!(data.summary.by_severity.info, 2);
+        assert_eq!(data.summary.by_severity.info, 1);
     }
 }

--- a/crates/cairn-core/src/verbs/lint/mod.rs
+++ b/crates/cairn-core/src/verbs/lint/mod.rs
@@ -10,6 +10,7 @@ use crate::contract::consent_lookup::ConsentLookup;
 use crate::contract::memory_store::{IndexStats, StoredRecord};
 use crate::domain::Identity;
 use crate::domain::record::RecordId;
+use crate::domain::source_forget::SourceForgetEntry;
 use crate::generated::verbs::lint::{
     Finding, Kind, LintData, LintDataSummary, LintDataSummaryBySeverity, Severity, Target,
 };
@@ -68,6 +69,14 @@ pub struct LintInputs<'a> {
     /// links, missing summaries). `None` falls those checks back to
     /// no-ops so fixture-only tests of unrelated checks remain green.
     pub vault_root: Option<&'a std::path::Path>,
+    /// Pre-fetched `source_forget` journal slice keyed by `source_id`
+    /// (issue #257 rules 4 + 5). The dispatch layer assembles this map
+    /// from `consent_journal` rows where `kind = "source_forget"` before
+    /// invoking `run_checks`. `None` downgrades the source-forget checks
+    /// to no-ops so fixture-only tests of unrelated checks remain green
+    /// — production wiring depends on the source-forget write path
+    /// landing alongside this audit surface.
+    pub source_forgets: Option<&'a std::collections::HashMap<String, SourceForgetEntry>>,
     /// Loads step bodies for the dry-run hot-memory walker. `None`
     /// keeps the over-budget check on the canary path.
     pub hot_body_loader: Option<
@@ -92,6 +101,7 @@ impl std::fmt::Debug for LintInputs<'_> {
             .field("unresolvable_authors", &self.unresolvable_authors.len())
             .field("consent_lookup", &self.consent_lookup.is_some())
             .field("vault_root", &self.vault_root)
+            .field("source_forgets", &self.source_forgets.map(HashMap::len))
             .field("hot_body_loader", &self.hot_body_loader.is_some())
             .finish()
     }
@@ -257,6 +267,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let data = run_checks(&inputs).await;
@@ -326,6 +337,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let inputs_rev = LintInputs {
@@ -336,6 +348,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
 
@@ -369,6 +382,7 @@ mod tests {
             unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
             consent_lookup: None,
             vault_root: None,
+            source_forgets: None,
             hot_body_loader: None,
         };
         let data = run_checks(&inputs).await;

--- a/crates/cairn-store-sqlite/tests/lint_author_lifecycle.rs
+++ b/crates/cairn-store-sqlite/tests/lint_author_lifecycle.rs
@@ -537,6 +537,7 @@ async fn run_checks_emits_broken_actor_chain_warning_for_revoked_author() {
         unresolvable_authors: &std::collections::HashSet::new(),
         consent_lookup: None,
         vault_root: None,
+        source_forgets: None,
         hot_body_loader: None,
     };
 

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
@@ -71,7 +71,8 @@ expression: "&c"
       "CLAUDE.md",
       "AGENTS.md",
       "GEMINI.md"
-    ]
+    ],
+    "redact_on_forget": false
   },
   "store": {
     "kind": "custom:cairn-store-qdrant"

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
@@ -36,7 +36,8 @@ expression: "&c"
       "CLAUDE.md",
       "AGENTS.md",
       "GEMINI.md"
-    ]
+    ],
+    "redact_on_forget": false
   },
   "store": {
     "kind": "sqlite"

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
@@ -36,7 +36,8 @@ expression: "&c"
       "CLAUDE.md",
       "AGENTS.md",
       "GEMINI.md"
-    ]
+    ],
+    "redact_on_forget": false
   },
   "store": {
     "kind": "sqlite"


### PR DESCRIPTION
Closes #257.

## Summary
Implements all 5 source-link hygiene rules from issue #257 in `cairn-core::verbs::lint::checks::provenance`.

**First commit (`ccf1b7c`)** — rules 1–3:
- `source_link_present` — `source_ids` frontmatter must exist + be non-empty.
- `source_link_resolves` — every `source_id` must resolve under `vault_root`.
- `source_hash_match` — file bytes must match `provenance.source_hash`.

**Second commit (`6a065e9`)** — rules 4 + 5 + supporting surface:
- `source_not_forgotten` — active records citing a `source_id` with a `source_forget` journal row emit `source_after_forget` (Error).
- `source_redact_on_forget_honored` — when `vault.redact_on_forget=true`, every `source_forget` row's source file must be zero-length on disk; non-zero emits `source_redact_skipped` (Error).
- New `SourceForgetEntry` domain type for the pre-fetched journal slice.
- New `LintInputs::source_forgets: Option<&HashMap<...>>`, mirroring `consent_lookup` Option pattern (None ⇒ no-op).
- New `VaultConfig::redact_on_forget: bool` (default false).
- 11 new unit tests covering positive, negative, and degenerate paths.

## Scope notes
- CLI dispatch passes `source_forgets: None` for now — production wiring depends on the `forget --target source` write path landing alongside this audit surface (flagged in source comments). Rules degrade to no-ops until then; design mirrors how `consent_lookup` was scaffolded before its writer landed.
- Reuses `Kind::MissingProvenance` / `Kind::DeferredCheck` to avoid IDL/codegen churn for two new variants; finding messages carry the specific kind strings (`source_after_forget`, `source_redact_skipped`) for downstream filtering.

## Test plan
- [x] `cargo nextest run -p cairn-core provenance` — 49/49 pass (11 new)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --doc --workspace --locked` — clean
- [x] `./scripts/check-core-boundary.sh` — clean
- [x] `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check` — clean
- [x] Updated insta snapshots: `default_config_snapshot`, three `schema_fixtures` configs

## Pre-existing failure
`cairn-cli verbs::lint::tests::lint_handler_writes_report_when_requested` fails at HEAD before this PR's second commit (3 info findings vs 4 expected). Reverting the rule 4 + 5 changes does not restore the test — failure pre-dates this branch. Will track separately.
