### PR TITLE
[codex] Add workflow flush plan drainer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ dependencies = [
  "cairn-test-fixtures",
  "chrono",
  "fs4",
+ "proptest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "cairn-core",
  "cairn-store-sqlite",
  "cairn-test-fixtures",
+ "chrono",
  "fs4",
  "rusqlite",
  "serde",

--- a/crates/cairn-cli/src/verbs/status.rs
+++ b/crates/cairn-cli/src/verbs/status.rs
@@ -227,6 +227,7 @@ pub fn run_with_context(
         // makes the two sides un-divergeable.
         pipeline_dispatch: Some(pipeline_dispatch_advertisement(&DefaultRegistry)),
         mcp_graph_tools: mcp_graph_tools_field,
+        workflows: None,
     };
 
     if json {

--- a/crates/cairn-core/src/generated/schemas/prelude/status.json
+++ b/crates/cairn-core/src/generated/schemas/prelude/status.json
@@ -497,6 +497,46 @@
         "incarnation"
       ],
       "type": "object"
+    },
+    "workflows": {
+      "description": "Runtime workflow-drainer progress for `cairn.admin.v1` status (issue #291). Each entry reports one workflow class; entries are sorted by workflow name for byte-stable status responses.",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "drained_plans": {
+            "description": "Plans drained successfully, including idempotent already-applied plans.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "last_applied_at": {
+            "description": "Most recent successful plan-drain timestamp for this workflow.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "pending_plans": {
+            "description": "Plans produced but not yet drained, usually because cancellation stopped between plans.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "workflow": {
+            "description": "Stable workflow class name.",
+            "enum": [
+              "consolidate",
+              "promote",
+              "expire"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "workflow",
+          "drained_plans",
+          "pending_plans"
+        ],
+        "type": "object"
+      },
+      "type": "array",
+      "uniqueItems": true
     }
   },
   "required": [

--- a/crates/cairn-core/src/generated/status.rs
+++ b/crates/cairn-core/src/generated/status.rs
@@ -180,6 +180,29 @@ pub struct StatusResponseServerInfo {
     pub version: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum StatusResponseWorkflowsWorkflow {
+    Consolidate,
+    Promote,
+    Expire,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatusResponseWorkflows {
+    /// Plans drained successfully, including idempotent already-applied plans.
+    pub drained_plans: u64,
+    /// Most recent successful plan-drain timestamp for this workflow.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_applied_at: Option<String>,
+    /// Plans produced but not yet drained, usually because cancellation stopped between plans.
+    pub pending_plans: u64,
+    /// Stable workflow class name.
+    pub workflow: StatusResponseWorkflowsWorkflow,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StatusResponse {
@@ -193,6 +216,9 @@ pub struct StatusResponse {
     pub pipeline_dispatch: Option<Vec<StatusResponsePipelineDispatch>>,
     pub sensors: StatusResponseSensors,
     pub server_info: StatusResponseServerInfo,
+    /// Runtime workflow-drainer progress for `cairn.admin.v1` status (issue #291). Each entry reports one workflow class; entries are sorted by workflow name for byte-stable status responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflows: Option<Vec<StatusResponseWorkflows>>,
 }
 
 pub const SCHEMA: &[u8] = include_bytes!("schemas/prelude/status.json");

--- a/crates/cairn-idl/schema/prelude/status.json
+++ b/crates/cairn-idl/schema/prelude/status.json
@@ -101,6 +101,38 @@
         }
       }
     },
+    "workflows": {
+      "type": "array",
+      "uniqueItems": true,
+      "description": "Runtime workflow-drainer progress for `cairn.admin.v1` status (issue #291). Each entry reports one workflow class; entries are sorted by workflow name for byte-stable status responses.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["workflow", "drained_plans", "pending_plans"],
+        "properties": {
+          "workflow": {
+            "type": "string",
+            "enum": ["consolidate", "promote", "expire"],
+            "description": "Stable workflow class name."
+          },
+          "drained_plans": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Plans drained successfully, including idempotent already-applied plans."
+          },
+          "pending_plans": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Plans produced but not yet drained, usually because cancellation stopped between plans."
+          },
+          "last_applied_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Most recent successful plan-drain timestamp for this workflow."
+          }
+        }
+      }
+    },
     "pipeline_dispatch": {
       "type": "array",
       "uniqueItems": true,

--- a/crates/cairn-mcp/src/generated/schemas/prelude/status.json
+++ b/crates/cairn-mcp/src/generated/schemas/prelude/status.json
@@ -497,6 +497,46 @@
         "incarnation"
       ],
       "type": "object"
+    },
+    "workflows": {
+      "description": "Runtime workflow-drainer progress for `cairn.admin.v1` status (issue #291). Each entry reports one workflow class; entries are sorted by workflow name for byte-stable status responses.",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "drained_plans": {
+            "description": "Plans drained successfully, including idempotent already-applied plans.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "last_applied_at": {
+            "description": "Most recent successful plan-drain timestamp for this workflow.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "pending_plans": {
+            "description": "Plans produced but not yet drained, usually because cancellation stopped between plans.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "workflow": {
+            "description": "Stable workflow class name.",
+            "enum": [
+              "consolidate",
+              "promote",
+              "expire"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "workflow",
+          "drained_plans",
+          "pending_plans"
+        ],
+        "type": "object"
+      },
+      "type": "array",
+      "uniqueItems": true
     }
   },
   "required": [

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -443,6 +443,7 @@ impl CairnMcpHandler {
                     cairn_core::generated::status::StatusResponseMcpGraphToolsProbeBasis::ConfigOnly,
                 error: None,
             }),
+            workflows: None,
         }
     }
 }

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -204,6 +204,7 @@ impl<T: Transport> Sdk<T> {
                 probe_basis: StatusResponseMcpGraphToolsProbeBasis::ConfigOnly,
                 error: None,
             }),
+            workflows: None,
         }
     }
 

--- a/crates/cairn-workflows/Cargo.toml
+++ b/crates/cairn-workflows/Cargo.toml
@@ -34,6 +34,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 cairn-store-sqlite = { workspace = true, features = ["test-helpers"] }
 cairn-test-fixtures = { workspace = true }
+proptest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "test-util"] }
 tokio-util = { workspace = true }

--- a/crates/cairn-workflows/Cargo.toml
+++ b/crates/cairn-workflows/Cargo.toml
@@ -19,6 +19,7 @@ cairn-core = { workspace = true }
 # when packaged for publish.
 cairn-store-sqlite = { workspace = true }
 async-trait = { workspace = true }
+chrono = { workspace = true }
 fs4 = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -35,6 +36,7 @@ cairn-store-sqlite = { workspace = true, features = ["test-helpers"] }
 cairn-test-fixtures = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time", "test-util"] }
+tokio-util = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/cairn-workflows/src/drainer.rs
+++ b/crates/cairn-workflows/src/drainer.rs
@@ -237,11 +237,11 @@ impl WorkflowCheckpointStore for FileWorkflowCheckpointStore {
     ) -> Result<(), WorkflowError> {
         let key = (workflow.to_owned(), plan_id.0.clone());
         {
-            let mut applied = self.applied.lock().map_err(|_| WorkflowError::Internal {
+            let applied = self.applied.lock().map_err(|_| WorkflowError::Internal {
                 workflow,
                 message: "workflow checkpoint lock poisoned".to_owned(),
             })?;
-            if !applied.insert(key) {
+            if applied.contains(&key) {
                 return Ok(());
             }
         }
@@ -265,7 +265,14 @@ impl WorkflowCheckpointStore for FileWorkflowCheckpointStore {
         file.flush().map_err(|source| WorkflowError::Internal {
             workflow,
             message: format!("flush workflow checkpoint record failed: {source}"),
-        })
+        })?;
+
+        let mut applied = self.applied.lock().map_err(|_| WorkflowError::Internal {
+            workflow,
+            message: "workflow checkpoint lock poisoned".to_owned(),
+        })?;
+        applied.insert(key);
+        Ok(())
     }
 }
 

--- a/crates/cairn-workflows/src/drainer.rs
+++ b/crates/cairn-workflows/src/drainer.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{File, OpenOptions};
-use std::io::{Read as _, Write as _};
+use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -233,6 +233,25 @@ impl FileWorkflowCheckpointStore {
                 .map_err(|source| WorkflowError::Internal {
                     workflow: "checkpoint",
                     message: format!("truncate torn workflow checkpoint record failed: {source}"),
+                })?;
+        } else if valid_len > 0 && !contents.ends_with('\n') {
+            read_file
+                .seek(SeekFrom::End(0))
+                .map_err(|source| WorkflowError::Internal {
+                    workflow: "checkpoint",
+                    message: format!("seek workflow checkpoint file failed: {source}"),
+                })?;
+            read_file
+                .write_all(b"\n")
+                .map_err(|source| WorkflowError::Internal {
+                    workflow: "checkpoint",
+                    message: format!("terminate workflow checkpoint record failed: {source}"),
+                })?;
+            read_file
+                .flush()
+                .map_err(|source| WorkflowError::Internal {
+                    workflow: "checkpoint",
+                    message: format!("flush workflow checkpoint terminator failed: {source}"),
                 })?;
         }
         let file = OpenOptions::new()

--- a/crates/cairn-workflows/src/drainer.rs
+++ b/crates/cairn-workflows/src/drainer.rs
@@ -1,0 +1,298 @@
+//! FlushPlan-producing workflow boundary and shared drainer.
+//!
+//! Issue #291 starts by making background workflows pure plan producers.
+//! This module owns the common apply loop so cancellation, idempotency, and
+//! telemetry live in one place before concrete workflow planners are wired.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use cairn_core::domain::FlushPlan;
+use cairn_core::generated::status::{StatusResponseWorkflows, StatusResponseWorkflowsWorkflow};
+use chrono::SecondsFormat;
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument as _;
+
+/// Shared inputs available to workflow planners and the drainer.
+#[derive(Debug, Clone)]
+pub struct WorkflowContext {
+    /// Cooperative cancellation token owned by the drainer.
+    pub cancel: CancellationToken,
+}
+
+impl Default for WorkflowContext {
+    fn default() -> Self {
+        Self {
+            cancel: CancellationToken::new(),
+        }
+    }
+}
+
+/// Errors raised while planning or applying workflow-produced flush plans.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkflowError {
+    /// The workflow failed before producing a complete plan batch.
+    #[error("workflow {workflow} planning failed: {source}")]
+    Planning {
+        /// Workflow name.
+        workflow: &'static str,
+        /// Error source.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// Applying one plan failed.
+    #[error("workflow {workflow} apply failed for plan {operation_id}: {source}")]
+    Apply {
+        /// Workflow name.
+        workflow: &'static str,
+        /// Plan operation id.
+        operation_id: String,
+        /// Error source.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// Generic internal error used by adapters that do not expose a typed
+    /// lower-level error.
+    #[error("workflow {workflow} internal error: {message}")]
+    Internal {
+        /// Workflow name.
+        workflow: &'static str,
+        /// Human-readable error detail.
+        message: String,
+    },
+}
+
+impl WorkflowError {
+    /// Build an apply error while preserving the lower-level source.
+    pub fn apply<E>(workflow: &'static str, plan: &FlushPlan, source: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::Apply {
+            workflow,
+            operation_id: plan.operation_id.0.clone(),
+            source: Box::new(source),
+        }
+    }
+}
+
+/// Pure background workflow: inspect context and return plans, but do not
+/// apply mutations directly.
+#[async_trait::async_trait]
+pub trait Workflow: Send + Sync {
+    /// Stable workflow class name, e.g. `consolidate`, `promote`, or `expire`.
+    fn name(&self) -> &'static str;
+
+    /// Produce a batch of plans for this run.
+    async fn plan(&self, ctx: &WorkflowContext) -> Result<Vec<FlushPlan>, WorkflowError>;
+}
+
+/// Outcome of applying a single workflow plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlushPlanApplyOutcome {
+    /// Mutations were applied by this invocation.
+    Applied,
+    /// The plan's operation id was already terminal; this is a successful
+    /// idempotent no-op.
+    AlreadyApplied,
+}
+
+/// Shared apply path used by [`WorkflowDrainer`].
+#[async_trait::async_trait]
+pub trait FlushPlanApply: Send + Sync {
+    /// Apply one plan for `workflow`.
+    async fn apply(
+        &self,
+        workflow: &'static str,
+        plan: FlushPlan,
+    ) -> Result<FlushPlanApplyOutcome, WorkflowError>;
+}
+
+/// Summary of one drain run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DrainStats {
+    /// Workflow name.
+    pub workflow: &'static str,
+    /// Plans produced by the workflow.
+    pub planned: usize,
+    /// Plans applied by this run.
+    pub applied: usize,
+    /// Plans that were already terminal before this run tried to apply them.
+    pub already_applied: usize,
+    /// Whether cancellation stopped the drain before all planned plans were
+    /// considered.
+    pub cancelled: bool,
+}
+
+/// Status projection for `cairn.admin.v1` workflow reporting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowStatusSnapshot {
+    /// Workflow name.
+    pub workflow: &'static str,
+    /// Plans drained successfully, including idempotent already-applied plans.
+    pub drained_plans: usize,
+    /// Plans left undrained by cancellation.
+    pub pending_plans: usize,
+    /// RFC 3339 timestamp for the most recent successful plan drain.
+    pub last_applied_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct WorkflowStatusState {
+    drained_plans: usize,
+    pending_plans: usize,
+    last_applied_at: Option<String>,
+}
+
+/// Single apply loop for workflow-produced [`FlushPlan`] batches.
+pub struct WorkflowDrainer {
+    ctx: WorkflowContext,
+    apply: Arc<dyn FlushPlanApply>,
+    status: Arc<Mutex<BTreeMap<&'static str, WorkflowStatusState>>>,
+}
+
+impl WorkflowDrainer {
+    /// Create a drainer around shared context and a concrete apply adapter.
+    #[must_use]
+    pub fn new(ctx: WorkflowContext, apply: Arc<dyn FlushPlanApply>) -> Self {
+        Self {
+            ctx,
+            apply,
+            status: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    /// Return byte-stable workflow status snapshots ordered by workflow name.
+    #[must_use]
+    pub fn status(&self) -> Vec<WorkflowStatusSnapshot> {
+        let Ok(status) = self.status.lock() else {
+            return Vec::new();
+        };
+        status
+            .iter()
+            .map(|(workflow, state)| WorkflowStatusSnapshot {
+                workflow,
+                drained_plans: state.drained_plans,
+                pending_plans: state.pending_plans,
+                last_applied_at: state.last_applied_at.clone(),
+            })
+            .collect()
+    }
+
+    /// Convert drainer snapshots into the generated `status.workflows[]`
+    /// wire shape.
+    #[must_use]
+    pub fn status_to_wire(snapshots: &[WorkflowStatusSnapshot]) -> Vec<StatusResponseWorkflows> {
+        snapshots
+            .iter()
+            .filter_map(|snapshot| {
+                let workflow = workflow_to_wire(snapshot.workflow)?;
+                Some(StatusResponseWorkflows {
+                    workflow,
+                    drained_plans: u64::try_from(snapshot.drained_plans).unwrap_or(u64::MAX),
+                    pending_plans: u64::try_from(snapshot.pending_plans).unwrap_or(u64::MAX),
+                    last_applied_at: snapshot.last_applied_at.clone(),
+                })
+            })
+            .collect()
+    }
+
+    /// Plan and apply one workflow batch.
+    ///
+    /// Cancellation is checked between plans. A plan that has started applying
+    /// is allowed to finish so the WAL boundary remains atomic.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first planning or apply error.
+    pub async fn run(&self, workflow: Arc<dyn Workflow>) -> Result<DrainStats, WorkflowError> {
+        let name = workflow.name();
+        if !is_known_workflow(name) {
+            return Err(WorkflowError::Internal {
+                workflow: name,
+                message: format!("unknown workflow `{name}`"),
+            });
+        }
+        let plans = workflow.plan(&self.ctx).await?;
+        let planned = plans.len();
+        let mut applied = 0;
+        let mut already_applied = 0;
+        let mut cancelled = self.ctx.cancel.is_cancelled();
+        self.record_run_started(name, planned);
+
+        for plan in plans {
+            if self.ctx.cancel.is_cancelled() {
+                cancelled = true;
+                break;
+            }
+
+            match self.apply_one(name, plan).await? {
+                FlushPlanApplyOutcome::Applied => applied += 1,
+                FlushPlanApplyOutcome::AlreadyApplied => already_applied += 1,
+            }
+            self.record_plan_drained(name);
+        }
+
+        if self.ctx.cancel.is_cancelled() && applied + already_applied < planned {
+            cancelled = true;
+        }
+
+        Ok(DrainStats {
+            workflow: name,
+            planned,
+            applied,
+            already_applied,
+            cancelled,
+        })
+    }
+
+    fn record_run_started(&self, workflow: &'static str, planned: usize) {
+        let Ok(mut status) = self.status.lock() else {
+            return;
+        };
+        let state = status.entry(workflow).or_default();
+        state.pending_plans = planned;
+    }
+
+    fn record_plan_drained(&self, workflow: &'static str) {
+        let Ok(mut status) = self.status.lock() else {
+            return;
+        };
+        let state = status.entry(workflow).or_default();
+        state.drained_plans = state.drained_plans.saturating_add(1);
+        state.pending_plans = state.pending_plans.saturating_sub(1);
+        state.last_applied_at = Some(now_rfc3339());
+    }
+
+    async fn apply_one(
+        &self,
+        workflow: &'static str,
+        plan: FlushPlan,
+    ) -> Result<FlushPlanApplyOutcome, WorkflowError> {
+        let span = tracing::info_span!(
+            "workflow.apply_one",
+            workflow,
+            plan_id = %plan.operation_id.0,
+            mutation_count = plan.mutations.len(),
+        );
+        self.apply.apply(workflow, plan).instrument(span).await
+    }
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn is_known_workflow(workflow: &str) -> bool {
+    workflow_to_wire(workflow).is_some()
+}
+
+fn workflow_to_wire(workflow: &str) -> Option<StatusResponseWorkflowsWorkflow> {
+    match workflow {
+        "consolidate" => Some(StatusResponseWorkflowsWorkflow::Consolidate),
+        "promote" => Some(StatusResponseWorkflowsWorkflow::Promote),
+        "expire" => Some(StatusResponseWorkflowsWorkflow::Expire),
+        _ => None,
+    }
+}

--- a/crates/cairn-workflows/src/drainer.rs
+++ b/crates/cairn-workflows/src/drainer.rs
@@ -192,16 +192,19 @@ impl FileWorkflowCheckpointStore {
                 workflow: "checkpoint",
                 message: format!("read workflow checkpoint file failed: {source}"),
             })?;
-        let lines: Vec<&str> = contents.lines().collect();
-        let ended_cleanly = contents.is_empty() || contents.ends_with('\n');
         let mut applied = BTreeSet::new();
-        for (index, line) in lines.iter().enumerate() {
+        let mut valid_len = 0;
+        for line in contents.split_inclusive('\n') {
+            let line_ended = line.ends_with('\n');
+            let record_len = line.len();
+            let line = line.trim_end_matches('\n');
             if line.trim().is_empty() {
+                valid_len += record_len;
                 continue;
             }
             let record: FileCheckpointRecord = match serde_json::from_str(line) {
                 Ok(record) => record,
-                Err(_) if index + 1 == lines.len() && !ended_cleanly => break,
+                Err(_) if !line_ended => break,
                 Err(source) => {
                     return Err(WorkflowError::Internal {
                         workflow: "checkpoint",
@@ -216,6 +219,21 @@ impl FileWorkflowCheckpointStore {
                 });
             }
             applied.insert((record.workflow, record.operation_id));
+            valid_len += record_len;
+        }
+        if valid_len < contents.len() {
+            read_file
+                .set_len(
+                    u64::try_from(valid_len).map_err(|_| WorkflowError::Internal {
+                        workflow: "checkpoint",
+                        message: "workflow checkpoint valid prefix length overflowed u64"
+                            .to_owned(),
+                    })?,
+                )
+                .map_err(|source| WorkflowError::Internal {
+                    workflow: "checkpoint",
+                    message: format!("truncate torn workflow checkpoint record failed: {source}"),
+                })?;
         }
         let file = OpenOptions::new()
             .append(true)

--- a/crates/cairn-workflows/src/drainer.rs
+++ b/crates/cairn-workflows/src/drainer.rs
@@ -4,12 +4,17 @@
 //! This module owns the common apply loop so cancellation, idempotency, and
 //! telemetry live in one place before concrete workflow planners are wired.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead as _, BufReader, Write as _};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use cairn_core::domain::FlushPlan;
+use cairn_core::generated::common::Ulid;
 use cairn_core::generated::status::{StatusResponseWorkflows, StatusResponseWorkflowsWorkflow};
 use chrono::SecondsFormat;
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument as _;
 
@@ -109,6 +114,161 @@ pub trait FlushPlanApply: Send + Sync {
     ) -> Result<FlushPlanApplyOutcome, WorkflowError>;
 }
 
+/// Durable checkpoint for workflow plan ids that have drained successfully.
+#[async_trait::async_trait]
+pub trait WorkflowCheckpointStore: Send + Sync {
+    /// Return true when `plan_id` has already drained for `workflow`.
+    async fn is_applied(
+        &self,
+        workflow: &'static str,
+        plan_id: &Ulid,
+    ) -> Result<bool, WorkflowError>;
+
+    /// Mark `plan_id` as drained for `workflow`.
+    async fn mark_applied(
+        &self,
+        workflow: &'static str,
+        plan_id: &Ulid,
+    ) -> Result<(), WorkflowError>;
+}
+
+#[derive(Default)]
+struct NoopWorkflowCheckpointStore;
+
+#[async_trait::async_trait]
+impl WorkflowCheckpointStore for NoopWorkflowCheckpointStore {
+    async fn is_applied(
+        &self,
+        _workflow: &'static str,
+        _plan_id: &Ulid,
+    ) -> Result<bool, WorkflowError> {
+        Ok(false)
+    }
+
+    async fn mark_applied(
+        &self,
+        _workflow: &'static str,
+        _plan_id: &Ulid,
+    ) -> Result<(), WorkflowError> {
+        Ok(())
+    }
+}
+
+/// Append-only JSONL checkpoint store for workflow plan ids.
+pub struct FileWorkflowCheckpointStore {
+    applied: Mutex<BTreeSet<(String, String)>>,
+    file: Mutex<File>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct FileCheckpointRecord {
+    workflow: String,
+    operation_id: String,
+}
+
+impl FileWorkflowCheckpointStore {
+    /// Open or create a workflow checkpoint file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkflowError::Internal`] when the file cannot be opened,
+    /// read, or parsed.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, WorkflowError> {
+        let path = path.as_ref();
+        let read_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .map_err(|source| WorkflowError::Internal {
+                workflow: "checkpoint",
+                message: format!("open workflow checkpoint file failed: {source}"),
+            })?;
+        let mut applied = BTreeSet::new();
+        for line in BufReader::new(read_file).lines() {
+            let line = line.map_err(|source| WorkflowError::Internal {
+                workflow: "checkpoint",
+                message: format!("read workflow checkpoint file failed: {source}"),
+            })?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let record: FileCheckpointRecord =
+                serde_json::from_str(&line).map_err(|source| WorkflowError::Internal {
+                    workflow: "checkpoint",
+                    message: format!("parse workflow checkpoint record failed: {source}"),
+                })?;
+            applied.insert((record.workflow, record.operation_id));
+        }
+        let file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(path)
+            .map_err(|source| WorkflowError::Internal {
+                workflow: "checkpoint",
+                message: format!("append workflow checkpoint file failed: {source}"),
+            })?;
+        Ok(Self {
+            applied: Mutex::new(applied),
+            file: Mutex::new(file),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowCheckpointStore for FileWorkflowCheckpointStore {
+    async fn is_applied(
+        &self,
+        workflow: &'static str,
+        plan_id: &Ulid,
+    ) -> Result<bool, WorkflowError> {
+        let applied = self.applied.lock().map_err(|_| WorkflowError::Internal {
+            workflow,
+            message: "workflow checkpoint lock poisoned".to_owned(),
+        })?;
+        Ok(applied.contains(&(workflow.to_owned(), plan_id.0.clone())))
+    }
+
+    async fn mark_applied(
+        &self,
+        workflow: &'static str,
+        plan_id: &Ulid,
+    ) -> Result<(), WorkflowError> {
+        let key = (workflow.to_owned(), plan_id.0.clone());
+        {
+            let mut applied = self.applied.lock().map_err(|_| WorkflowError::Internal {
+                workflow,
+                message: "workflow checkpoint lock poisoned".to_owned(),
+            })?;
+            if !applied.insert(key) {
+                return Ok(());
+            }
+        }
+
+        let record = FileCheckpointRecord {
+            workflow: workflow.to_owned(),
+            operation_id: plan_id.0.clone(),
+        };
+        let line = serde_json::to_string(&record).map_err(|source| WorkflowError::Internal {
+            workflow,
+            message: format!("encode workflow checkpoint record failed: {source}"),
+        })?;
+        let mut file = self.file.lock().map_err(|_| WorkflowError::Internal {
+            workflow,
+            message: "workflow checkpoint file lock poisoned".to_owned(),
+        })?;
+        writeln!(file, "{line}").map_err(|source| WorkflowError::Internal {
+            workflow,
+            message: format!("write workflow checkpoint record failed: {source}"),
+        })?;
+        file.flush().map_err(|source| WorkflowError::Internal {
+            workflow,
+            message: format!("flush workflow checkpoint record failed: {source}"),
+        })
+    }
+}
+
 /// Summary of one drain run.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DrainStats {
@@ -149,6 +309,7 @@ struct WorkflowStatusState {
 pub struct WorkflowDrainer {
     ctx: WorkflowContext,
     apply: Arc<dyn FlushPlanApply>,
+    checkpoint: Arc<dyn WorkflowCheckpointStore>,
     status: Arc<Mutex<BTreeMap<&'static str, WorkflowStatusState>>>,
 }
 
@@ -156,9 +317,20 @@ impl WorkflowDrainer {
     /// Create a drainer around shared context and a concrete apply adapter.
     #[must_use]
     pub fn new(ctx: WorkflowContext, apply: Arc<dyn FlushPlanApply>) -> Self {
+        Self::new_with_checkpoint(ctx, apply, Arc::new(NoopWorkflowCheckpointStore))
+    }
+
+    /// Create a drainer with a durable plan checkpoint store.
+    #[must_use]
+    pub fn new_with_checkpoint(
+        ctx: WorkflowContext,
+        apply: Arc<dyn FlushPlanApply>,
+        checkpoint: Arc<dyn WorkflowCheckpointStore>,
+    ) -> Self {
         Self {
             ctx,
             apply,
+            checkpoint,
             status: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
@@ -227,10 +399,18 @@ impl WorkflowDrainer {
                 break;
             }
 
+            if self.checkpoint.is_applied(name, &plan.operation_id).await? {
+                already_applied += 1;
+                self.record_plan_drained(name);
+                continue;
+            }
+
+            let operation_id = plan.operation_id.clone();
             match self.apply_one(name, plan).await? {
                 FlushPlanApplyOutcome::Applied => applied += 1,
                 FlushPlanApplyOutcome::AlreadyApplied => already_applied += 1,
             }
+            self.checkpoint.mark_applied(name, &operation_id).await?;
             self.record_plan_drained(name);
         }
 

--- a/crates/cairn-workflows/src/drainer.rs
+++ b/crates/cairn-workflows/src/drainer.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{File, OpenOptions};
-use std::io::{BufRead as _, BufReader, Write as _};
+use std::io::{Read as _, Write as _};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -175,7 +175,7 @@ impl FileWorkflowCheckpointStore {
     /// read, or parsed.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, WorkflowError> {
         let path = path.as_ref();
-        let read_file = OpenOptions::new()
+        let mut read_file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
@@ -185,20 +185,36 @@ impl FileWorkflowCheckpointStore {
                 workflow: "checkpoint",
                 message: format!("open workflow checkpoint file failed: {source}"),
             })?;
-        let mut applied = BTreeSet::new();
-        for line in BufReader::new(read_file).lines() {
-            let line = line.map_err(|source| WorkflowError::Internal {
+        let mut contents = String::new();
+        read_file
+            .read_to_string(&mut contents)
+            .map_err(|source| WorkflowError::Internal {
                 workflow: "checkpoint",
                 message: format!("read workflow checkpoint file failed: {source}"),
             })?;
+        let lines: Vec<&str> = contents.lines().collect();
+        let ended_cleanly = contents.is_empty() || contents.ends_with('\n');
+        let mut applied = BTreeSet::new();
+        for (index, line) in lines.iter().enumerate() {
             if line.trim().is_empty() {
                 continue;
             }
-            let record: FileCheckpointRecord =
-                serde_json::from_str(&line).map_err(|source| WorkflowError::Internal {
+            let record: FileCheckpointRecord = match serde_json::from_str(line) {
+                Ok(record) => record,
+                Err(_) if index + 1 == lines.len() && !ended_cleanly => break,
+                Err(source) => {
+                    return Err(WorkflowError::Internal {
+                        workflow: "checkpoint",
+                        message: format!("parse workflow checkpoint record failed: {source}"),
+                    });
+                }
+            };
+            if record.workflow.is_empty() || record.operation_id.is_empty() {
+                return Err(WorkflowError::Internal {
                     workflow: "checkpoint",
-                    message: format!("parse workflow checkpoint record failed: {source}"),
-                })?;
+                    message: "parse workflow checkpoint record failed: empty field".to_owned(),
+                });
+            }
             applied.insert((record.workflow, record.operation_id));
         }
         let file = OpenOptions::new()

--- a/crates/cairn-workflows/src/lib.rs
+++ b/crates/cairn-workflows/src/lib.rs
@@ -23,10 +23,11 @@ pub use consolidation::{
     ConsolidationPayload, FORGET_CLEANUP_KIND, ForgetCleanupPayload,
 };
 pub use drainer::{
-    DrainStats, FlushPlanApply, FlushPlanApplyOutcome, Workflow, WorkflowContext, WorkflowDrainer,
-    WorkflowError, WorkflowStatusSnapshot,
+    DrainStats, FileWorkflowCheckpointStore, FlushPlanApply, FlushPlanApplyOutcome, Workflow,
+    WorkflowCheckpointStore, WorkflowContext, WorkflowDrainer, WorkflowError,
+    WorkflowStatusSnapshot,
 };
-pub use planners::ExpirePlanSource;
+pub use planners::{ConsolidatePlanSource, ExpirePlanSource, PromotePlanSource};
 pub use scheduler::{Clock, MockClock, Scheduler, SchedulerConfig, SystemClock};
 pub use sqlite_apply::SqliteFlushPlanApply;
 pub use sqlite_store::{SqliteJobStore, SqliteJobStoreInitError};

--- a/crates/cairn-workflows/src/lib.rs
+++ b/crates/cairn-workflows/src/lib.rs
@@ -10,16 +10,27 @@
 
 pub mod consent_mirror;
 pub mod consolidation;
+pub mod drainer;
+pub mod planners;
 pub mod scheduler;
+pub mod sqlite_apply;
 pub mod sqlite_store;
+pub mod workflows;
 
 pub use consent_mirror::{ConsentLogMaterializer, MirrorError};
 pub use consolidation::{
     CONSOLIDATION_KIND, ConsolidationForgetCleanupHandler, ConsolidationHandler,
     ConsolidationPayload, FORGET_CLEANUP_KIND, ForgetCleanupPayload,
 };
+pub use drainer::{
+    DrainStats, FlushPlanApply, FlushPlanApplyOutcome, Workflow, WorkflowContext, WorkflowDrainer,
+    WorkflowError, WorkflowStatusSnapshot,
+};
+pub use planners::ExpirePlanSource;
 pub use scheduler::{Clock, MockClock, Scheduler, SchedulerConfig, SystemClock};
+pub use sqlite_apply::SqliteFlushPlanApply;
 pub use sqlite_store::{SqliteJobStore, SqliteJobStoreInitError};
+pub use workflows::{ConsolidateWorkflow, ExpireWorkflow, PromoteWorkflow, WorkflowPlanSource};
 
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::contract::workflow_orchestrator::{

--- a/crates/cairn-workflows/src/planners.rs
+++ b/crates/cairn-workflows/src/planners.rs
@@ -1,12 +1,14 @@
 //! Store-backed workflow plan sources.
 
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use cairn_core::contract::memory_store::{ListArgs, ListCursor, MemoryStore};
 use cairn_core::domain::flush_plan::{
     ExpirationReason, FlushMode, FlushPlan, PlanReason, PlannedMutation,
 };
-use cairn_core::domain::{Identity, MemoryRecord};
+use cairn_core::domain::{Identity, MemoryKind, MemoryRecord};
 use cairn_core::generated::common::Ulid;
 use chrono::{Duration, SecondsFormat};
 
@@ -19,6 +21,73 @@ pub struct ExpirePlanSource {
     issuer: Identity,
     salience_threshold: f32,
     page_limit: usize,
+}
+
+/// Store-backed promotion planner.
+pub struct PromotePlanSource {
+    store: Arc<dyn MemoryStore>,
+    issuer: Identity,
+    to_kind: MemoryKind,
+    confidence_threshold: f32,
+    page_limit: usize,
+}
+
+impl PromotePlanSource {
+    const DEFAULT_PAGE_LIMIT: usize = 1000;
+
+    /// Create a promotion planner for active records with confidence greater
+    /// than or equal to `confidence_threshold`.
+    #[must_use]
+    pub fn new(
+        store: Arc<dyn MemoryStore>,
+        issuer: Identity,
+        to_kind: MemoryKind,
+        confidence_threshold: f32,
+    ) -> Self {
+        Self {
+            store,
+            issuer,
+            to_kind,
+            confidence_threshold,
+            page_limit: Self::DEFAULT_PAGE_LIMIT,
+        }
+    }
+
+    /// Override the planner's store page size.
+    #[must_use]
+    pub fn with_page_limit(mut self, page_limit: usize) -> Self {
+        self.page_limit = page_limit.max(1);
+        self
+    }
+}
+
+/// Store-backed consolidation planner.
+pub struct ConsolidatePlanSource {
+    store: Arc<dyn MemoryStore>,
+    issuer: Identity,
+    page_limit: usize,
+}
+
+impl ConsolidatePlanSource {
+    const DEFAULT_PAGE_LIMIT: usize = 1000;
+
+    /// Create a consolidation planner that expires exact duplicate active
+    /// bodies, keeping the highest-confidence/highest-salience candidate.
+    #[must_use]
+    pub fn new(store: Arc<dyn MemoryStore>, issuer: Identity) -> Self {
+        Self {
+            store,
+            issuer,
+            page_limit: Self::DEFAULT_PAGE_LIMIT,
+        }
+    }
+
+    /// Override the planner's store page size.
+    #[must_use]
+    pub fn with_page_limit(mut self, page_limit: usize) -> Self {
+        self.page_limit = page_limit.max(1);
+        self
+    }
 }
 
 impl ExpirePlanSource {
@@ -88,6 +157,59 @@ impl WorkflowPlanSource for ExpirePlanSource {
     }
 }
 
+#[async_trait::async_trait]
+impl WorkflowPlanSource for PromotePlanSource {
+    async fn plan(
+        &self,
+        workflow: &'static str,
+        _ctx: &WorkflowContext,
+    ) -> Result<Vec<FlushPlan>, WorkflowError> {
+        if workflow != "promote" {
+            return Ok(Vec::new());
+        }
+
+        let mut plans = Vec::new();
+        for record in list_active_records(&self.store, workflow, self.page_limit).await? {
+            if record.kind == self.to_kind || record.confidence < self.confidence_threshold {
+                continue;
+            }
+            plans.push(self.plan_for_record(&record));
+        }
+        Ok(plans)
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowPlanSource for ConsolidatePlanSource {
+    async fn plan(
+        &self,
+        workflow: &'static str,
+        _ctx: &WorkflowContext,
+    ) -> Result<Vec<FlushPlan>, WorkflowError> {
+        if workflow != "consolidate" {
+            return Ok(Vec::new());
+        }
+
+        let mut by_body: BTreeMap<String, Vec<MemoryRecord>> = BTreeMap::new();
+        for record in list_active_records(&self.store, workflow, self.page_limit).await? {
+            by_body.entry(record.body.clone()).or_default().push(record);
+        }
+
+        let mut plans = Vec::new();
+        for mut records in by_body.into_values() {
+            if records.len() < 2 {
+                continue;
+            }
+            records.sort_by(compare_consolidation_candidate);
+            let keeper = records.remove(0);
+            for duplicate in records {
+                plans.push(self.plan_for_duplicate(&duplicate, &keeper));
+            }
+        }
+        Ok(plans)
+    }
+}
+
 impl ExpirePlanSource {
     fn plan_for_record(&self, record: &MemoryRecord) -> FlushPlan {
         let issued_at = now_rfc3339();
@@ -114,6 +236,101 @@ impl ExpirePlanSource {
             placeholder: false,
         }
     }
+}
+
+impl PromotePlanSource {
+    fn plan_for_record(&self, record: &MemoryRecord) -> FlushPlan {
+        let issued_at = now_rfc3339();
+        let expires_at = expires_at_rfc3339();
+        FlushPlan {
+            operation_id: new_ulid(),
+            issued_at,
+            issuer: self.issuer.clone(),
+            principal: None,
+            scope: record.scope.clone(),
+            mode: FlushMode::Autonomous,
+            mutations: vec![PlannedMutation::Promote {
+                from: record.target_id.clone(),
+                to_kind: self.to_kind,
+                evidence: Vec::new(),
+            }],
+            reason: PlanReason::Promote {
+                confidence: record.confidence,
+                evidence_count: 0,
+            },
+            source_events: Vec::new(),
+            target_hashes: std::collections::BTreeMap::new(),
+            dependencies: Vec::new(),
+            expires_at,
+            placeholder: false,
+        }
+    }
+}
+
+impl ConsolidatePlanSource {
+    fn plan_for_duplicate(&self, duplicate: &MemoryRecord, _keeper: &MemoryRecord) -> FlushPlan {
+        let issued_at = now_rfc3339();
+        let expires_at = expires_at_rfc3339();
+        FlushPlan {
+            operation_id: new_ulid(),
+            issued_at,
+            issuer: self.issuer.clone(),
+            principal: None,
+            scope: duplicate.scope.clone(),
+            mode: FlushMode::Autonomous,
+            mutations: vec![PlannedMutation::Expire {
+                target: duplicate.target_id.clone(),
+                reason: ExpirationReason::SupersededByCanonical,
+            }],
+            reason: PlanReason::Expire {
+                ttl_expired: false,
+                salience_below: None,
+            },
+            source_events: Vec::new(),
+            target_hashes: std::collections::BTreeMap::new(),
+            dependencies: Vec::new(),
+            expires_at,
+            placeholder: false,
+        }
+    }
+}
+
+async fn list_active_records(
+    store: &Arc<dyn MemoryStore>,
+    workflow: &'static str,
+    page_limit: usize,
+) -> Result<Vec<MemoryRecord>, WorkflowError> {
+    let mut records = Vec::new();
+    let mut cursor: Option<ListCursor> = None;
+    loop {
+        let page = store
+            .list(&ListArgs {
+                limit: page_limit,
+                cursor: cursor.clone(),
+                ..ListArgs::default()
+            })
+            .await
+            .map_err(|e| WorkflowError::Internal {
+                workflow,
+                message: format!("{workflow} planner list failed: {e}"),
+            })?;
+
+        records.extend(page.records);
+
+        let Some(next_cursor) = page.next_cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+    Ok(records)
+}
+
+fn compare_consolidation_candidate(left: &MemoryRecord, right: &MemoryRecord) -> Ordering {
+    right
+        .confidence
+        .total_cmp(&left.confidence)
+        .then_with(|| right.salience.total_cmp(&left.salience))
+        .then_with(|| left.target_id.as_str().cmp(right.target_id.as_str()))
 }
 
 fn new_ulid() -> Ulid {

--- a/crates/cairn-workflows/src/planners.rs
+++ b/crates/cairn-workflows/src/planners.rs
@@ -11,6 +11,7 @@ use cairn_core::domain::flush_plan::{
 use cairn_core::domain::{Identity, MemoryKind, MemoryRecord};
 use cairn_core::generated::common::Ulid;
 use chrono::{Duration, SecondsFormat};
+use sha2::{Digest, Sha256};
 
 use crate::drainer::{WorkflowContext, WorkflowError};
 use crate::workflows::WorkflowPlanSource;
@@ -215,7 +216,13 @@ impl ExpirePlanSource {
         let issued_at = now_rfc3339();
         let expires_at = expires_at_rfc3339();
         FlushPlan {
-            operation_id: new_ulid(),
+            operation_id: stable_plan_ulid(&[
+                "expire",
+                record.target_id.as_str(),
+                record.id.as_str(),
+                &record.salience.to_bits().to_string(),
+                &self.salience_threshold.to_bits().to_string(),
+            ]),
             issued_at,
             issuer: self.issuer.clone(),
             principal: None,
@@ -243,7 +250,15 @@ impl PromotePlanSource {
         let issued_at = now_rfc3339();
         let expires_at = expires_at_rfc3339();
         FlushPlan {
-            operation_id: new_ulid(),
+            operation_id: stable_plan_ulid(&[
+                "promote",
+                record.target_id.as_str(),
+                record.id.as_str(),
+                record.kind.as_str(),
+                self.to_kind.as_str(),
+                &record.confidence.to_bits().to_string(),
+                &self.confidence_threshold.to_bits().to_string(),
+            ]),
             issued_at,
             issuer: self.issuer.clone(),
             principal: None,
@@ -268,11 +283,19 @@ impl PromotePlanSource {
 }
 
 impl ConsolidatePlanSource {
-    fn plan_for_duplicate(&self, duplicate: &MemoryRecord, _keeper: &MemoryRecord) -> FlushPlan {
+    fn plan_for_duplicate(&self, duplicate: &MemoryRecord, keeper: &MemoryRecord) -> FlushPlan {
         let issued_at = now_rfc3339();
         let expires_at = expires_at_rfc3339();
         FlushPlan {
-            operation_id: new_ulid(),
+            operation_id: stable_plan_ulid(&[
+                "consolidate",
+                duplicate.target_id.as_str(),
+                duplicate.id.as_str(),
+                keeper.target_id.as_str(),
+                keeper.id.as_str(),
+                &duplicate.confidence.to_bits().to_string(),
+                &duplicate.salience.to_bits().to_string(),
+            ]),
             issued_at,
             issuer: self.issuer.clone(),
             principal: None,
@@ -333,8 +356,16 @@ fn compare_consolidation_candidate(left: &MemoryRecord, right: &MemoryRecord) ->
         .then_with(|| left.target_id.as_str().cmp(right.target_id.as_str()))
 }
 
-fn new_ulid() -> Ulid {
-    Ulid(ulid::Ulid::new().to_string())
+fn stable_plan_ulid(parts: &[&str]) -> Ulid {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update((part.len() as u64).to_be_bytes());
+        hasher.update(part.as_bytes());
+    }
+    let digest = hasher.finalize();
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    Ulid(ulid::Ulid::from_bytes(bytes).to_string())
 }
 
 fn now_rfc3339() -> String {

--- a/crates/cairn-workflows/src/planners.rs
+++ b/crates/cairn-workflows/src/planners.rs
@@ -1,0 +1,129 @@
+//! Store-backed workflow plan sources.
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::{ListArgs, ListCursor, MemoryStore};
+use cairn_core::domain::flush_plan::{
+    ExpirationReason, FlushMode, FlushPlan, PlanReason, PlannedMutation,
+};
+use cairn_core::domain::{Identity, MemoryRecord};
+use cairn_core::generated::common::Ulid;
+use chrono::{Duration, SecondsFormat};
+
+use crate::drainer::{WorkflowContext, WorkflowError};
+use crate::workflows::WorkflowPlanSource;
+
+/// Store-backed expiration planner.
+pub struct ExpirePlanSource {
+    store: Arc<dyn MemoryStore>,
+    issuer: Identity,
+    salience_threshold: f32,
+    page_limit: usize,
+}
+
+impl ExpirePlanSource {
+    const DEFAULT_PAGE_LIMIT: usize = 1000;
+
+    /// Create an expiration planner that expires active records whose salience
+    /// is less than or equal to `salience_threshold`.
+    #[must_use]
+    pub fn new(store: Arc<dyn MemoryStore>, issuer: Identity, salience_threshold: f32) -> Self {
+        Self {
+            store,
+            issuer,
+            salience_threshold,
+            page_limit: Self::DEFAULT_PAGE_LIMIT,
+        }
+    }
+
+    /// Override the planner's store page size.
+    #[must_use]
+    pub fn with_page_limit(mut self, page_limit: usize) -> Self {
+        self.page_limit = page_limit.max(1);
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkflowPlanSource for ExpirePlanSource {
+    async fn plan(
+        &self,
+        workflow: &'static str,
+        _ctx: &WorkflowContext,
+    ) -> Result<Vec<FlushPlan>, WorkflowError> {
+        if workflow != "expire" {
+            return Ok(Vec::new());
+        }
+
+        let mut plans = Vec::new();
+        let mut cursor: Option<ListCursor> = None;
+        loop {
+            let page = self
+                .store
+                .list(&ListArgs {
+                    limit: self.page_limit,
+                    cursor: cursor.clone(),
+                    ..ListArgs::default()
+                })
+                .await
+                .map_err(|e| WorkflowError::Internal {
+                    workflow,
+                    message: format!("expiration planner list failed: {e}"),
+                })?;
+
+            plans.extend(
+                page.records
+                    .iter()
+                    .filter(|record| record.salience <= self.salience_threshold)
+                    .map(|record| self.plan_for_record(record)),
+            );
+
+            let Some(next_cursor) = page.next_cursor else {
+                break;
+            };
+            cursor = Some(next_cursor);
+        }
+
+        Ok(plans)
+    }
+}
+
+impl ExpirePlanSource {
+    fn plan_for_record(&self, record: &MemoryRecord) -> FlushPlan {
+        let issued_at = now_rfc3339();
+        let expires_at = expires_at_rfc3339();
+        FlushPlan {
+            operation_id: new_ulid(),
+            issued_at,
+            issuer: self.issuer.clone(),
+            principal: None,
+            scope: record.scope.clone(),
+            mode: FlushMode::Autonomous,
+            mutations: vec![PlannedMutation::Expire {
+                target: record.target_id.clone(),
+                reason: ExpirationReason::SalienceBelowThreshold,
+            }],
+            reason: PlanReason::Expire {
+                ttl_expired: false,
+                salience_below: Some(self.salience_threshold),
+            },
+            source_events: Vec::new(),
+            target_hashes: std::collections::BTreeMap::new(),
+            dependencies: Vec::new(),
+            expires_at,
+            placeholder: false,
+        }
+    }
+}
+
+fn new_ulid() -> Ulid {
+    Ulid(ulid::Ulid::new().to_string())
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn expires_at_rfc3339() -> String {
+    (chrono::Utc::now() + Duration::minutes(5)).to_rfc3339_opts(SecondsFormat::Secs, true)
+}

--- a/crates/cairn-workflows/src/planners.rs
+++ b/crates/cairn-workflows/src/planners.rs
@@ -227,7 +227,7 @@ impl ExpirePlanSource {
             }],
             reason: PlanReason::Expire {
                 ttl_expired: false,
-                salience_below: Some(self.salience_threshold),
+                salience_below: Some(record.salience),
             },
             source_events: Vec::new(),
             target_hashes: std::collections::BTreeMap::new(),

--- a/crates/cairn-workflows/src/sqlite_apply.rs
+++ b/crates/cairn-workflows/src/sqlite_apply.rs
@@ -70,7 +70,13 @@ async fn preflight(
                 record,
                 prior_version,
             } => {
+                record
+                    .validate()
+                    .map_err(|source| WorkflowError::apply(workflow, plan, source))?;
                 ensure_upsert_version(store, workflow, plan, record, *prior_version).await?;
+            }
+            PlannedMutation::Promote { from, to_kind, .. } => {
+                ensure_promote_valid(store, workflow, plan, from, *to_kind).await?;
             }
             PlannedMutation::Delete {
                 target,
@@ -314,6 +320,30 @@ async fn ensure_upsert_version(
             },
         )),
     }
+}
+
+async fn ensure_promote_valid(
+    store: &SqliteMemoryStore,
+    workflow: &'static str,
+    plan: &FlushPlan,
+    target: &TargetId,
+    to_kind: cairn_core::domain::MemoryKind,
+) -> Result<(), WorkflowError> {
+    let Some(active) = store
+        .get_active_by_target(target)
+        .await
+        .map_err(|source| apply_boxed_error(workflow, plan, source))?
+    else {
+        return Ok(());
+    };
+    if active.record.kind == to_kind {
+        return Ok(());
+    }
+    let mut promoted = active.record;
+    promoted.kind = to_kind;
+    promoted
+        .validate()
+        .map_err(|source| WorkflowError::apply(workflow, plan, source))
 }
 
 fn check_delete_version(

--- a/crates/cairn-workflows/src/sqlite_apply.rs
+++ b/crates/cairn-workflows/src/sqlite_apply.rs
@@ -88,6 +88,7 @@ fn mutation_target(mutation: &PlannedMutation) -> Option<&str> {
     match mutation {
         PlannedMutation::Upsert { record, .. } => Some(record.target_id.as_str()),
         PlannedMutation::Delete { target, .. }
+        | PlannedMutation::Promote { from: target, .. }
         | PlannedMutation::Expire { target, .. }
         | PlannedMutation::ForgetRecord { target } => Some(target.as_str()),
         _ => None,
@@ -121,6 +122,9 @@ async fn apply_one(
         PlannedMutation::Expire { target, .. } => {
             expire_active_target(store, workflow, plan, target).await
         }
+        PlannedMutation::Promote { from, to_kind, .. } => {
+            promote_active_target(store, workflow, plan, from, *to_kind).await
+        }
         PlannedMutation::ForgetRecord { target } => {
             forget_active_target(store, workflow, plan, target).await
         }
@@ -137,6 +141,7 @@ fn is_supported(mutation: &PlannedMutation) -> bool {
         mutation,
         PlannedMutation::Upsert { .. }
             | PlannedMutation::Expire { .. }
+            | PlannedMutation::Promote { .. }
             | PlannedMutation::ForgetRecord { .. }
             | PlannedMutation::Delete { .. }
     )
@@ -220,6 +225,33 @@ async fn expire_active_target(
         .await
         .map(|()| FlushPlanApplyOutcome::Applied)
         .map_err(|e| WorkflowError::apply(workflow, plan, e))
+}
+
+async fn promote_active_target(
+    store: &SqliteMemoryStore,
+    workflow: &'static str,
+    plan: &FlushPlan,
+    target: &TargetId,
+    to_kind: cairn_core::domain::MemoryKind,
+) -> Result<FlushPlanApplyOutcome, WorkflowError> {
+    let Some(active) = store
+        .get_active_by_target(target)
+        .await
+        .map_err(|source| apply_boxed_error(workflow, plan, source))?
+    else {
+        return Ok(FlushPlanApplyOutcome::AlreadyApplied);
+    };
+    if active.record.kind == to_kind {
+        return Ok(FlushPlanApplyOutcome::AlreadyApplied);
+    }
+
+    let mut promoted = active.record;
+    promoted.kind = to_kind;
+    store
+        .upsert(&promoted)
+        .await
+        .map(|_| FlushPlanApplyOutcome::Applied)
+        .map_err(|source| apply_boxed_error(workflow, plan, source))
 }
 
 async fn ensure_delete_version(

--- a/crates/cairn-workflows/src/sqlite_apply.rs
+++ b/crates/cairn-workflows/src/sqlite_apply.rs
@@ -1,0 +1,360 @@
+//! SQLite-backed [`FlushPlanApply`] implementation.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::MemoryStore as _;
+use cairn_core::domain::flush_plan::{FlushPlan, PlannedMutation};
+use cairn_core::domain::{MemoryRecord, TargetId};
+use cairn_store_sqlite::{SqliteMemoryStore, StoreError as SqliteStoreError};
+
+use crate::drainer::{FlushPlanApply, FlushPlanApplyOutcome, WorkflowError};
+
+/// Apply workflow-produced [`FlushPlan`]s through the `SQLite` store.
+pub struct SqliteFlushPlanApply {
+    store: Arc<SqliteMemoryStore>,
+}
+
+impl SqliteFlushPlanApply {
+    /// Create an apply adapter backed by `store`.
+    #[must_use]
+    pub fn new(store: Arc<SqliteMemoryStore>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait::async_trait]
+impl FlushPlanApply for SqliteFlushPlanApply {
+    async fn apply(
+        &self,
+        workflow: &'static str,
+        plan: FlushPlan,
+    ) -> Result<FlushPlanApplyOutcome, WorkflowError> {
+        if plan.mutations.is_empty() {
+            return Ok(FlushPlanApplyOutcome::AlreadyApplied);
+        }
+        preflight(&self.store, workflow, &plan).await?;
+
+        let mut applied_any = false;
+        for mutation in &plan.mutations {
+            match apply_one(&self.store, workflow, &plan, mutation).await? {
+                FlushPlanApplyOutcome::Applied => applied_any = true,
+                FlushPlanApplyOutcome::AlreadyApplied => {}
+            }
+        }
+        if applied_any {
+            Ok(FlushPlanApplyOutcome::Applied)
+        } else {
+            Ok(FlushPlanApplyOutcome::AlreadyApplied)
+        }
+    }
+}
+
+async fn preflight(
+    store: &SqliteMemoryStore,
+    workflow: &'static str,
+    plan: &FlushPlan,
+) -> Result<(), WorkflowError> {
+    let mut seen_targets = BTreeSet::new();
+    for mutation in &plan.mutations {
+        if !is_supported(mutation) {
+            return Err(unsupported_error(workflow, mutation));
+        }
+        if let Some(target) = mutation_target(mutation)
+            && !seen_targets.insert(target.to_owned())
+        {
+            return Err(duplicate_target_error(workflow, target));
+        }
+        match mutation {
+            PlannedMutation::Upsert {
+                record,
+                prior_version,
+            } => {
+                ensure_upsert_version(store, workflow, plan, record, *prior_version).await?;
+            }
+            PlannedMutation::Delete {
+                target,
+                prior_version,
+            } => {
+                ensure_delete_version(store, workflow, plan, target, *prior_version).await?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn mutation_target(mutation: &PlannedMutation) -> Option<&str> {
+    match mutation {
+        PlannedMutation::Upsert { record, .. } => Some(record.target_id.as_str()),
+        PlannedMutation::Delete { target, .. }
+        | PlannedMutation::Expire { target, .. }
+        | PlannedMutation::ForgetRecord { target } => Some(target.as_str()),
+        _ => None,
+    }
+}
+
+async fn apply_one(
+    store: &SqliteMemoryStore,
+    workflow: &'static str,
+    plan: &FlushPlan,
+    mutation: &PlannedMutation,
+) -> Result<FlushPlanApplyOutcome, WorkflowError> {
+    match mutation {
+        PlannedMutation::Upsert {
+            record,
+            prior_version,
+        } => {
+            ensure_upsert_version(store, workflow, plan, record, *prior_version).await?;
+            store
+                .upsert(record)
+                .await
+                .map(|outcome| {
+                    if outcome.content_changed {
+                        FlushPlanApplyOutcome::Applied
+                    } else {
+                        FlushPlanApplyOutcome::AlreadyApplied
+                    }
+                })
+                .map_err(|source| apply_boxed_error(workflow, plan, source))
+        }
+        PlannedMutation::Expire { target, .. } => {
+            expire_active_target(store, workflow, plan, target).await
+        }
+        PlannedMutation::ForgetRecord { target } => {
+            forget_active_target(store, workflow, plan, target).await
+        }
+        PlannedMutation::Delete {
+            target,
+            prior_version,
+        } => delete_active_target(store, workflow, plan, target, *prior_version).await,
+        other => Err(unsupported_error(workflow, other)),
+    }
+}
+
+fn is_supported(mutation: &PlannedMutation) -> bool {
+    matches!(
+        mutation,
+        PlannedMutation::Upsert { .. }
+            | PlannedMutation::Expire { .. }
+            | PlannedMutation::ForgetRecord { .. }
+            | PlannedMutation::Delete { .. }
+    )
+}
+
+fn unsupported_error(workflow: &'static str, mutation: &PlannedMutation) -> WorkflowError {
+    WorkflowError::Internal {
+        workflow,
+        message: format!(
+            "unsupported mutation kind `{}` in workflow FlushPlan apply",
+            mutation_kind(mutation),
+        ),
+    }
+}
+
+fn duplicate_target_error(workflow: &'static str, target: &str) -> WorkflowError {
+    WorkflowError::Internal {
+        workflow,
+        message: format!("duplicate mutation target `{target}` in workflow FlushPlan apply"),
+    }
+}
+
+async fn forget_active_target(
+    store: &SqliteMemoryStore,
+    workflow: &'static str,
+    plan: &FlushPlan,
+    target: &TargetId,
+) -> Result<FlushPlanApplyOutcome, WorkflowError> {
+    let Some(active) = store
+        .get_active_by_target(target)
+        .await
+        .map_err(|source| apply_boxed_error(workflow, plan, source))?
+    else {
+        return Ok(FlushPlanApplyOutcome::AlreadyApplied);
+    };
+    store
+        .forget_record(&active.record.id)
+        .await
+        .map(|_| FlushPlanApplyOutcome::Applied)
+        .map_err(|e| WorkflowError::apply(workflow, plan, e))
+}
+
+async fn delete_active_target(
+    store: &SqliteMemoryStore,
+    workflow: &'static str,
+    plan: &FlushPlan,
+    target: &TargetId,
+    prior_version: u32,
+) -> Result<FlushPlanApplyOutcome, WorkflowError> {
+    let Some(active) = store
+        .get_active_by_target(target)
+        .await
+        .map_err(|source| apply_boxed_error(workflow, plan, source))?
+    else {
+        return Ok(FlushPlanApplyOutcome::AlreadyApplied);
+    };
+    check_delete_version(workflow, plan, target, prior_version, active.version)?;
+    store
+        .forget_record(&active.record.id)
+        .await
+        .map(|_| FlushPlanApplyOutcome::Applied)
+        .map_err(|e| WorkflowError::apply(workflow, plan, e))
+}
+
+async fn expire_active_target(
+    store: &SqliteMemoryStore,
+    workflow: &'static str,
+    plan: &FlushPlan,
+    target: &TargetId,
+) -> Result<FlushPlanApplyOutcome, WorkflowError> {
+    if store
+        .get_active_by_target(target)
+        .await
+        .map_err(|source| apply_boxed_error(workflow, plan, source))?
+        .is_none()
+    {
+        return Ok(FlushPlanApplyOutcome::AlreadyApplied);
+    }
+    store
+        .expire(target)
+        .await
+        .map(|()| FlushPlanApplyOutcome::Applied)
+        .map_err(|e| WorkflowError::apply(workflow, plan, e))
+}
+
+async fn ensure_delete_version(
+    store: &SqliteMemoryStore,
+    workflow: &'static str,
+    plan: &FlushPlan,
+    target: &TargetId,
+    prior_version: u32,
+) -> Result<(), WorkflowError> {
+    let Some(active) = store
+        .get_active_by_target(target)
+        .await
+        .map_err(|source| apply_boxed_error(workflow, plan, source))?
+    else {
+        return Ok(());
+    };
+    check_delete_version(workflow, plan, target, prior_version, active.version)
+}
+
+async fn ensure_upsert_version(
+    store: &SqliteMemoryStore,
+    workflow: &'static str,
+    plan: &FlushPlan,
+    record: &MemoryRecord,
+    prior_version: Option<u32>,
+) -> Result<(), WorkflowError> {
+    let active = store
+        .get_active_by_target(&record.target_id)
+        .await
+        .map_err(|source| apply_boxed_error(workflow, plan, source))?;
+    match (active, prior_version) {
+        (None, None) => Ok(()),
+        (Some(active), Some(prior_version)) => check_upsert_version(
+            workflow,
+            plan,
+            &record.target_id,
+            prior_version,
+            active.version,
+        ),
+        (Some(active), None) => Err(WorkflowError::apply(
+            workflow,
+            plan,
+            SqliteStoreError::Invariant {
+                what: format!(
+                    "upsert expected new target `{}` but live version {} exists",
+                    record.target_id.as_str(),
+                    active.version,
+                ),
+            },
+        )),
+        (None, Some(prior_version)) => Err(WorkflowError::apply(
+            workflow,
+            plan,
+            SqliteStoreError::Invariant {
+                what: format!(
+                    "upsert prior_version mismatch for missing target `{}`: plan={}",
+                    record.target_id.as_str(),
+                    prior_version,
+                ),
+            },
+        )),
+    }
+}
+
+fn check_delete_version(
+    workflow: &'static str,
+    plan: &FlushPlan,
+    target: &TargetId,
+    prior_version: u32,
+    active_version: u32,
+) -> Result<(), WorkflowError> {
+    if active_version == prior_version {
+        return Ok(());
+    }
+    Err(WorkflowError::apply(
+        workflow,
+        plan,
+        SqliteStoreError::Invariant {
+            what: format!(
+                "delete prior_version mismatch for target `{}`: plan={}, live={}",
+                target.as_str(),
+                prior_version,
+                active_version,
+            ),
+        },
+    ))
+}
+
+fn check_upsert_version(
+    workflow: &'static str,
+    plan: &FlushPlan,
+    target: &TargetId,
+    prior_version: u32,
+    active_version: u32,
+) -> Result<(), WorkflowError> {
+    if active_version == prior_version {
+        return Ok(());
+    }
+    Err(WorkflowError::apply(
+        workflow,
+        plan,
+        SqliteStoreError::Invariant {
+            what: format!(
+                "upsert prior_version mismatch for target `{}`: plan={}, live={}",
+                target.as_str(),
+                prior_version,
+                active_version,
+            ),
+        },
+    ))
+}
+
+fn apply_boxed_error(
+    workflow: &'static str,
+    plan: &FlushPlan,
+    source: Box<dyn std::error::Error + Send + Sync>,
+) -> WorkflowError {
+    WorkflowError::Apply {
+        workflow,
+        operation_id: plan.operation_id.0.clone(),
+        source,
+    }
+}
+
+fn mutation_kind(mutation: &PlannedMutation) -> &'static str {
+    match mutation {
+        PlannedMutation::Upsert { .. } => "upsert",
+        PlannedMutation::Delete { .. } => "delete",
+        PlannedMutation::Patch { .. } => "patch",
+        PlannedMutation::Rename { .. } => "rename",
+        PlannedMutation::Promote { .. } => "promote",
+        PlannedMutation::Expire { .. } => "expire",
+        PlannedMutation::ForgetSession { .. } => "forget_session",
+        PlannedMutation::ForgetRecord { .. } => "forget_record",
+        PlannedMutation::Evolve { .. } => "evolve",
+        _ => "unknown",
+    }
+}

--- a/crates/cairn-workflows/src/workflows.rs
+++ b/crates/cairn-workflows/src/workflows.rs
@@ -1,0 +1,67 @@
+//! Concrete workflow class wrappers.
+//!
+//! The planning logic for consolidate/promote/expire is intentionally injected
+//! through [`WorkflowPlanSource`]. That keeps these workflow types pure
+//! `FlushPlan` producers while the store-specific candidate selection lands in
+//! narrower follow-up modules.
+
+use std::sync::Arc;
+
+use cairn_core::domain::FlushPlan;
+
+use crate::drainer::{Workflow, WorkflowContext, WorkflowError};
+
+/// Planner backing a concrete workflow class.
+#[async_trait::async_trait]
+pub trait WorkflowPlanSource: Send + Sync {
+    /// Produce plans for `workflow`.
+    async fn plan(
+        &self,
+        workflow: &'static str,
+        ctx: &WorkflowContext,
+    ) -> Result<Vec<FlushPlan>, WorkflowError>;
+}
+
+macro_rules! workflow_type {
+    ($ty:ident, $name:literal, $doc:literal) => {
+        #[doc = $doc]
+        pub struct $ty {
+            source: Arc<dyn WorkflowPlanSource>,
+        }
+
+        impl $ty {
+            /// Create a workflow backed by `source`.
+            #[must_use]
+            pub fn new(source: Arc<dyn WorkflowPlanSource>) -> Self {
+                Self { source }
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl Workflow for $ty {
+            fn name(&self) -> &'static str {
+                $name
+            }
+
+            async fn plan(&self, ctx: &WorkflowContext) -> Result<Vec<FlushPlan>, WorkflowError> {
+                self.source.plan($name, ctx).await
+            }
+        }
+    };
+}
+
+workflow_type!(
+    ConsolidateWorkflow,
+    "consolidate",
+    "Consolidation workflow class: emits `FlushPlan` batches for canonicalization and summary updates."
+);
+workflow_type!(
+    PromoteWorkflow,
+    "promote",
+    "Promotion workflow class: emits `FlushPlan` batches for tier-boundary promotion candidates."
+);
+workflow_type!(
+    ExpireWorkflow,
+    "expire",
+    "Expiration workflow class: emits `FlushPlan` batches for TTL and salience expiration candidates."
+);

--- a/crates/cairn-workflows/tests/expire_plan_source.rs
+++ b/crates/cairn-workflows/tests/expire_plan_source.rs
@@ -4,9 +4,13 @@
 use std::sync::Arc;
 
 use cairn_core::contract::memory_store::MemoryStore as _;
-use cairn_core::domain::{ExpirationReason, FlushMode, Identity, PlannedMutation};
+use cairn_core::domain::{
+    ExpirationReason, FlushMode, Identity, MemoryKind, PlanReason, PlannedMutation,
+};
 use cairn_test_fixtures::{FixtureStore, memstore, sample_record};
-use cairn_workflows::{ExpirePlanSource, WorkflowContext, WorkflowPlanSource};
+use cairn_workflows::{
+    ConsolidatePlanSource, ExpirePlanSource, PromotePlanSource, WorkflowContext, WorkflowPlanSource,
+};
 
 #[tokio::test]
 async fn expire_plan_source_emits_expire_plan_for_low_salience_records() {
@@ -88,5 +92,90 @@ async fn expire_plan_source_paginates_past_first_store_page() {
     assert!(matches!(
         &plans[0].mutations[0],
         PlannedMutation::Expire { target, .. } if *target == low.target_id
+    ));
+}
+
+#[tokio::test]
+async fn promote_plan_source_emits_promote_plan_for_confident_non_target_kind() {
+    let store = Arc::new(memstore().await);
+    let mut candidate = sample_record(4);
+    candidate.kind = MemoryKind::Reference;
+    candidate.confidence = 0.95;
+    let mut already_promoted = sample_record(5);
+    already_promoted.kind = MemoryKind::Fact;
+    already_promoted.confidence = 0.99;
+    store.upsert(&candidate).await.expect("seed candidate");
+    store
+        .upsert(&already_promoted)
+        .await
+        .expect("seed promoted");
+
+    let source = PromotePlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:promote:v1").expect("valid issuer"),
+        MemoryKind::Fact,
+        0.9,
+    );
+
+    let plans = source
+        .plan("promote", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].mode, FlushMode::Autonomous);
+    assert!(matches!(
+        &plans[0].mutations[0],
+        PlannedMutation::Promote {
+            from,
+            to_kind: MemoryKind::Fact,
+            evidence,
+        } if from == &candidate.target_id && evidence.is_empty()
+    ));
+    assert!(matches!(
+        plans[0].reason,
+        PlanReason::Promote {
+            confidence,
+            evidence_count: 0,
+        } if (confidence - 0.95).abs() < f32::EPSILON
+    ));
+}
+
+#[tokio::test]
+async fn consolidate_plan_source_expires_duplicate_bodies_but_keeps_best_record() {
+    let store = Arc::new(memstore().await);
+    let mut keeper = sample_record(6);
+    keeper.body = "shared body".to_owned();
+    keeper.confidence = 0.9;
+    keeper.salience = 0.8;
+    let mut duplicate = sample_record(7);
+    duplicate.body = "shared body".to_owned();
+    duplicate.confidence = 0.6;
+    duplicate.salience = 0.4;
+    let mut unique = sample_record(8);
+    unique.body = "unique body".to_owned();
+    unique.confidence = 0.1;
+    store.upsert(&keeper).await.expect("seed keeper");
+    store.upsert(&duplicate).await.expect("seed duplicate");
+    store.upsert(&unique).await.expect("seed unique");
+
+    let source = ConsolidatePlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:consolidate:v1").expect("valid issuer"),
+    );
+
+    let plans = source
+        .plan("consolidate", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].mode, FlushMode::Autonomous);
+    assert!(matches!(
+        &plans[0].mutations[0],
+        PlannedMutation::Expire {
+            target,
+            reason: ExpirationReason::SupersededByCanonical,
+        } if target == &duplicate.target_id
     ));
 }

--- a/crates/cairn-workflows/tests/expire_plan_source.rs
+++ b/crates/cairn-workflows/tests/expire_plan_source.rs
@@ -44,6 +44,13 @@ async fn expire_plan_source_emits_expire_plan_for_low_salience_records() {
             reason: ExpirationReason::SalienceBelowThreshold,
         } if *target == low.target_id
     ));
+    assert!(matches!(
+        plans[0].reason,
+        PlanReason::Expire {
+            ttl_expired: false,
+            salience_below: Some(salience),
+        } if (salience - low.salience).abs() < f32::EPSILON
+    ));
 }
 
 #[tokio::test]

--- a/crates/cairn-workflows/tests/expire_plan_source.rs
+++ b/crates/cairn-workflows/tests/expire_plan_source.rs
@@ -1,0 +1,92 @@
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::MemoryStore as _;
+use cairn_core::domain::{ExpirationReason, FlushMode, Identity, PlannedMutation};
+use cairn_test_fixtures::{FixtureStore, memstore, sample_record};
+use cairn_workflows::{ExpirePlanSource, WorkflowContext, WorkflowPlanSource};
+
+#[tokio::test]
+async fn expire_plan_source_emits_expire_plan_for_low_salience_records() {
+    let store = Arc::new(FixtureStore::new());
+    let mut low = sample_record(1);
+    low.salience = 0.1;
+    let mut high = sample_record(2);
+    high.salience = 0.9;
+    store.upsert(&low).await.expect("seed low salience");
+    store.upsert(&high).await.expect("seed high salience");
+
+    let source = ExpirePlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:expire:v1").expect("valid issuer"),
+        0.2,
+    );
+
+    let plans = source
+        .plan("expire", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].mode, FlushMode::Autonomous);
+    assert_eq!(plans[0].scope, low.scope);
+    assert_eq!(plans[0].mutations.len(), 1);
+    assert!(matches!(
+        &plans[0].mutations[0],
+        PlannedMutation::Expire {
+            target,
+            reason: ExpirationReason::SalienceBelowThreshold,
+        } if *target == low.target_id
+    ));
+}
+
+#[tokio::test]
+async fn expire_plan_source_returns_empty_for_other_workflow_names() {
+    let store = Arc::new(FixtureStore::new());
+    let source = ExpirePlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:expire:v1").expect("valid issuer"),
+        0.2,
+    );
+
+    let plans = source
+        .plan("promote", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert!(plans.is_empty());
+}
+
+#[tokio::test]
+async fn expire_plan_source_paginates_past_first_store_page() {
+    let store = Arc::new(memstore().await);
+    let mut low = sample_record(1);
+    low.salience = 0.1;
+    store.upsert(&low).await.expect("seed low salience");
+
+    for seed in 2..=3 {
+        let mut high = sample_record(seed);
+        high.salience = 0.9;
+        store.upsert(&high).await.expect("seed high salience");
+    }
+
+    let source = ExpirePlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:expire:v1").expect("valid issuer"),
+        0.2,
+    )
+    .with_page_limit(2);
+
+    let plans = source
+        .plan("expire", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert_eq!(plans.len(), 1);
+    assert!(matches!(
+        &plans[0].mutations[0],
+        PlannedMutation::Expire { target, .. } if *target == low.target_id
+    ));
+}

--- a/crates/cairn-workflows/tests/expire_plan_source.rs
+++ b/crates/cairn-workflows/tests/expire_plan_source.rs
@@ -103,6 +103,33 @@ async fn expire_plan_source_paginates_past_first_store_page() {
 }
 
 #[tokio::test]
+async fn expire_plan_source_reuses_operation_ids_for_same_candidates() {
+    let store = Arc::new(FixtureStore::new());
+    let mut low = sample_record(9);
+    low.salience = 0.1;
+    store.upsert(&low).await.expect("seed low salience");
+
+    let source = ExpirePlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:expire:v1").expect("valid issuer"),
+        0.2,
+    );
+
+    let first = source
+        .plan("expire", &WorkflowContext::default())
+        .await
+        .expect("first plan");
+    let second = source
+        .plan("expire", &WorkflowContext::default())
+        .await
+        .expect("second plan");
+
+    assert_eq!(first.len(), 1);
+    assert_eq!(second.len(), 1);
+    assert_eq!(first[0].operation_id, second[0].operation_id);
+}
+
+#[tokio::test]
 async fn promote_plan_source_emits_promote_plan_for_confident_non_target_kind() {
     let store = Arc::new(memstore().await);
     let mut candidate = sample_record(4);
@@ -149,6 +176,35 @@ async fn promote_plan_source_emits_promote_plan_for_confident_non_target_kind() 
 }
 
 #[tokio::test]
+async fn promote_plan_source_reuses_operation_ids_for_same_candidates() {
+    let store = Arc::new(memstore().await);
+    let mut candidate = sample_record(10);
+    candidate.kind = MemoryKind::Reference;
+    candidate.confidence = 0.95;
+    store.upsert(&candidate).await.expect("seed candidate");
+
+    let source = PromotePlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:promote:v1").expect("valid issuer"),
+        MemoryKind::Fact,
+        0.9,
+    );
+
+    let first = source
+        .plan("promote", &WorkflowContext::default())
+        .await
+        .expect("first plan");
+    let second = source
+        .plan("promote", &WorkflowContext::default())
+        .await
+        .expect("second plan");
+
+    assert_eq!(first.len(), 1);
+    assert_eq!(second.len(), 1);
+    assert_eq!(first[0].operation_id, second[0].operation_id);
+}
+
+#[tokio::test]
 async fn consolidate_plan_source_expires_duplicate_bodies_but_keeps_best_record() {
     let store = Arc::new(memstore().await);
     let mut keeper = sample_record(6);
@@ -185,4 +241,37 @@ async fn consolidate_plan_source_expires_duplicate_bodies_but_keeps_best_record(
             reason: ExpirationReason::SupersededByCanonical,
         } if target == &duplicate.target_id
     ));
+}
+
+#[tokio::test]
+async fn consolidate_plan_source_reuses_operation_ids_for_same_duplicates() {
+    let store = Arc::new(memstore().await);
+    let mut keeper = sample_record(11);
+    keeper.body = "shared body".to_owned();
+    keeper.confidence = 0.9;
+    keeper.salience = 0.8;
+    let mut duplicate = sample_record(12);
+    duplicate.body = "shared body".to_owned();
+    duplicate.confidence = 0.6;
+    duplicate.salience = 0.4;
+    store.upsert(&keeper).await.expect("seed keeper");
+    store.upsert(&duplicate).await.expect("seed duplicate");
+
+    let source = ConsolidatePlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:consolidate:v1").expect("valid issuer"),
+    );
+
+    let first = source
+        .plan("consolidate", &WorkflowContext::default())
+        .await
+        .expect("first plan");
+    let second = source
+        .plan("consolidate", &WorkflowContext::default())
+        .await
+        .expect("second plan");
+
+    assert_eq!(first.len(), 1);
+    assert_eq!(second.len(), 1);
+    assert_eq!(first[0].operation_id, second[0].operation_id);
 }

--- a/crates/cairn-workflows/tests/flush_drainer.rs
+++ b/crates/cairn-workflows/tests/flush_drainer.rs
@@ -8,9 +8,10 @@ use cairn_core::generated::common::Ulid;
 use cairn_core::generated::status::StatusResponseWorkflowsWorkflow;
 use cairn_test_fixtures::flush_plan::sample_plan;
 use cairn_workflows::{
-    DrainStats, FlushPlanApply, FlushPlanApplyOutcome, Workflow, WorkflowContext, WorkflowDrainer,
-    WorkflowError,
+    DrainStats, FileWorkflowCheckpointStore, FlushPlanApply, FlushPlanApplyOutcome, Workflow,
+    WorkflowCheckpointStore, WorkflowContext, WorkflowDrainer, WorkflowError,
 };
+use proptest::prelude::*;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Clone)]
@@ -287,6 +288,103 @@ async fn drainer_rejects_unknown_workflow_names_before_status_recording() {
 
 fn plan(id: &str) -> FlushPlan {
     sample_plan(id, cairn_core::domain::FlushMode::Autonomous)
+}
+
+#[tokio::test]
+async fn drainer_skips_checkpointed_plan_ids_after_restart() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("workflow-checkpoints.jsonl");
+    let checkpoint = Arc::new(FileWorkflowCheckpointStore::open(&path).expect("open checkpoint"));
+    checkpoint
+        .mark_applied("expire", &ulid("01HQZK000000000000000000R1"))
+        .await
+        .expect("seed checkpoint");
+    let apply = Arc::new(RecordingApply::default());
+    let drainer =
+        WorkflowDrainer::new_with_checkpoint(WorkflowContext::default(), apply.clone(), checkpoint);
+
+    let stats = drainer
+        .run(Arc::new(StaticWorkflow {
+            name: "expire",
+            plans: vec![
+                plan("01HQZK000000000000000000R1"),
+                plan("01HQZK000000000000000000R2"),
+            ],
+        }))
+        .await
+        .expect("drain succeeds");
+
+    assert_eq!(stats.planned, 2);
+    assert_eq!(stats.applied, 1);
+    assert_eq!(stats.already_applied, 1);
+    assert_eq!(
+        *apply.applied.lock().expect("poisoned"),
+        vec![ulid("01HQZK000000000000000000R2")]
+    );
+
+    let reopened = FileWorkflowCheckpointStore::open(&path).expect("reopen checkpoint");
+    assert!(
+        reopened
+            .is_applied("expire", &ulid("01HQZK000000000000000000R1"))
+            .await
+            .expect("read first")
+    );
+    assert!(
+        reopened
+            .is_applied("expire", &ulid("01HQZK000000000000000000R2"))
+            .await
+            .expect("read second")
+    );
+}
+
+proptest! {
+    #[test]
+    fn drainer_resume_checkpoint_property((total, drained_before_restart) in (1usize..8).prop_flat_map(|total| (Just(total), 0usize..=total))) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        runtime.block_on(async move {
+            let dir = tempfile::tempdir().expect("temp dir");
+            let path = dir.path().join("workflow-checkpoints.jsonl");
+            let checkpoint = Arc::new(FileWorkflowCheckpointStore::open(&path).expect("open checkpoint"));
+            let plans: Vec<_> = (0..total)
+                .map(|index| plan(&format!("01HQZK000000000000000P{index:02}")))
+                .collect();
+            for plan in plans.iter().take(drained_before_restart) {
+                checkpoint
+                    .mark_applied("expire", &plan.operation_id)
+                    .await
+                    .expect("seed checkpoint");
+            }
+            let apply = Arc::new(RecordingApply::default());
+            let drainer = WorkflowDrainer::new_with_checkpoint(
+                WorkflowContext::default(),
+                apply.clone(),
+                Arc::new(FileWorkflowCheckpointStore::open(&path).expect("reopen checkpoint")),
+            );
+
+            let stats = drainer
+                .run(Arc::new(StaticWorkflow {
+                    name: "expire",
+                    plans: plans.clone(),
+                }))
+                .await
+                .expect("drain succeeds");
+
+            prop_assert_eq!(stats.planned, total);
+            prop_assert_eq!(stats.already_applied, drained_before_restart);
+            prop_assert_eq!(stats.applied, total - drained_before_restart);
+            let applied = apply.applied.lock().expect("poisoned").clone();
+            let expected: Vec<_> = plans
+                .iter()
+                .skip(drained_before_restart)
+                .map(|plan| plan.operation_id.clone())
+                .collect();
+            prop_assert_eq!(applied, expected);
+            Ok(())
+        })?;
+    }
 }
 
 fn ulid(id: &str) -> Ulid {

--- a/crates/cairn-workflows/tests/flush_drainer.rs
+++ b/crates/cairn-workflows/tests/flush_drainer.rs
@@ -367,6 +367,41 @@ async fn file_checkpoint_open_skips_torn_final_record_after_crash() {
 }
 
 #[tokio::test]
+async fn file_checkpoint_open_truncates_torn_final_record_before_append() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("workflow-checkpoints.jsonl");
+    std::fs::write(
+        &path,
+        concat!(
+            "{\"workflow\":\"expire\",\"operation_id\":\"01HQZK000000000000000000R1\"}\n",
+            "{\"workflow\":\"expire\",\"operation_id\":\"01HQZK000000000000000"
+        ),
+    )
+    .expect("write checkpoint");
+
+    let checkpoint = FileWorkflowCheckpointStore::open(&path).expect("open checkpoint");
+    checkpoint
+        .mark_applied("expire", &ulid("01HQZK000000000000000000R2"))
+        .await
+        .expect("append after recovery");
+
+    let reopened = FileWorkflowCheckpointStore::open(&path).expect("reopen checkpoint");
+
+    assert!(
+        reopened
+            .is_applied("expire", &ulid("01HQZK000000000000000000R1"))
+            .await
+            .expect("read first complete record")
+    );
+    assert!(
+        reopened
+            .is_applied("expire", &ulid("01HQZK000000000000000000R2"))
+            .await
+            .expect("read appended record")
+    );
+}
+
+#[tokio::test]
 async fn file_checkpoint_open_rejects_corrupt_complete_record() {
     let dir = tempfile::tempdir().expect("temp dir");
     let path = dir.path().join("workflow-checkpoints.jsonl");

--- a/crates/cairn-workflows/tests/flush_drainer.rs
+++ b/crates/cairn-workflows/tests/flush_drainer.rs
@@ -337,6 +337,58 @@ async fn drainer_skips_checkpointed_plan_ids_after_restart() {
     );
 }
 
+#[tokio::test]
+async fn file_checkpoint_open_skips_torn_final_record_after_crash() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("workflow-checkpoints.jsonl");
+    std::fs::write(
+        &path,
+        concat!(
+            "{\"workflow\":\"expire\",\"operation_id\":\"01HQZK000000000000000000R1\"}\n",
+            "{\"workflow\":\"expire\",\"operation_id\":\"01HQZK000000000000000"
+        ),
+    )
+    .expect("write checkpoint");
+
+    let checkpoint = FileWorkflowCheckpointStore::open(&path).expect("open checkpoint");
+
+    assert!(
+        checkpoint
+            .is_applied("expire", &ulid("01HQZK000000000000000000R1"))
+            .await
+            .expect("read complete record")
+    );
+    assert!(
+        !checkpoint
+            .is_applied("expire", &ulid("01HQZK000000000000000000R2"))
+            .await
+            .expect("read missing record")
+    );
+}
+
+#[tokio::test]
+async fn file_checkpoint_open_rejects_corrupt_complete_record() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("workflow-checkpoints.jsonl");
+    std::fs::write(
+        &path,
+        concat!(
+            "{\"workflow\":\"expire\",\"operation_id\":\"01HQZK000000000000000000R1\"}\n",
+            "{\"workflow\":\"expire\",\"operation_id\":}\n"
+        ),
+    )
+    .expect("write checkpoint");
+
+    let Err(err) = FileWorkflowCheckpointStore::open(&path) else {
+        panic!("complete corrupt checkpoint line should fail");
+    };
+
+    assert!(
+        err.to_string()
+            .contains("parse workflow checkpoint record failed")
+    );
+}
+
 proptest! {
     #[test]
     fn drainer_resume_checkpoint_property((total, drained_before_restart) in (1usize..8).prop_flat_map(|total| (Just(total), 0usize..=total))) {

--- a/crates/cairn-workflows/tests/flush_drainer.rs
+++ b/crates/cairn-workflows/tests/flush_drainer.rs
@@ -402,6 +402,38 @@ async fn file_checkpoint_open_truncates_torn_final_record_before_append() {
 }
 
 #[tokio::test]
+async fn file_checkpoint_open_terminates_valid_final_record_before_append() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("workflow-checkpoints.jsonl");
+    std::fs::write(
+        &path,
+        "{\"workflow\":\"expire\",\"operation_id\":\"01HQZK000000000000000000R1\"}",
+    )
+    .expect("write checkpoint");
+
+    let checkpoint = FileWorkflowCheckpointStore::open(&path).expect("open checkpoint");
+    checkpoint
+        .mark_applied("expire", &ulid("01HQZK000000000000000000R2"))
+        .await
+        .expect("append after newline recovery");
+
+    let reopened = FileWorkflowCheckpointStore::open(&path).expect("reopen checkpoint");
+
+    assert!(
+        reopened
+            .is_applied("expire", &ulid("01HQZK000000000000000000R1"))
+            .await
+            .expect("read original record")
+    );
+    assert!(
+        reopened
+            .is_applied("expire", &ulid("01HQZK000000000000000000R2"))
+            .await
+            .expect("read appended record")
+    );
+}
+
+#[tokio::test]
 async fn file_checkpoint_open_rejects_corrupt_complete_record() {
     let dir = tempfile::tempdir().expect("temp dir");
     let path = dir.path().join("workflow-checkpoints.jsonl");

--- a/crates/cairn-workflows/tests/flush_drainer.rs
+++ b/crates/cairn-workflows/tests/flush_drainer.rs
@@ -1,0 +1,294 @@
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use std::sync::{Arc, Mutex};
+
+use cairn_core::domain::FlushPlan;
+use cairn_core::generated::common::Ulid;
+use cairn_core::generated::status::StatusResponseWorkflowsWorkflow;
+use cairn_test_fixtures::flush_plan::sample_plan;
+use cairn_workflows::{
+    DrainStats, FlushPlanApply, FlushPlanApplyOutcome, Workflow, WorkflowContext, WorkflowDrainer,
+    WorkflowError,
+};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+struct StaticWorkflow {
+    name: &'static str,
+    plans: Vec<FlushPlan>,
+}
+
+#[async_trait::async_trait]
+impl Workflow for StaticWorkflow {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    async fn plan(&self, _ctx: &WorkflowContext) -> Result<Vec<FlushPlan>, WorkflowError> {
+        Ok(self.plans.clone())
+    }
+}
+
+#[derive(Default)]
+struct RecordingApply {
+    applied: Mutex<Vec<Ulid>>,
+    already_applied: Mutex<Vec<Ulid>>,
+}
+
+#[async_trait::async_trait]
+impl FlushPlanApply for RecordingApply {
+    async fn apply(
+        &self,
+        workflow: &'static str,
+        plan: FlushPlan,
+    ) -> Result<FlushPlanApplyOutcome, WorkflowError> {
+        assert_eq!(workflow, "expire");
+        let id = plan.operation_id.clone();
+        if self.already_applied.lock().expect("poisoned").contains(&id) {
+            return Ok(FlushPlanApplyOutcome::AlreadyApplied);
+        }
+        self.applied.lock().expect("poisoned").push(id);
+        Ok(FlushPlanApplyOutcome::Applied)
+    }
+}
+
+struct CancellingApply {
+    applied: Mutex<Vec<Ulid>>,
+    cancel: CancellationToken,
+}
+
+#[async_trait::async_trait]
+impl FlushPlanApply for CancellingApply {
+    async fn apply(
+        &self,
+        _workflow: &'static str,
+        plan: FlushPlan,
+    ) -> Result<FlushPlanApplyOutcome, WorkflowError> {
+        self.applied
+            .lock()
+            .expect("poisoned")
+            .push(plan.operation_id.clone());
+        self.cancel.cancel();
+        Ok(FlushPlanApplyOutcome::Applied)
+    }
+}
+
+#[tokio::test]
+async fn drainer_applies_plans_in_order_and_reports_stats() {
+    let plans = vec![
+        plan("01HQZK000000000000000000V1"),
+        plan("01HQZK000000000000000000V2"),
+    ];
+    let apply = Arc::new(RecordingApply::default());
+    let drainer = WorkflowDrainer::new(WorkflowContext::default(), apply.clone());
+
+    let stats = drainer
+        .run(Arc::new(StaticWorkflow {
+            name: "expire",
+            plans,
+        }))
+        .await
+        .expect("drain succeeds");
+
+    assert_eq!(
+        stats,
+        DrainStats {
+            workflow: "expire",
+            planned: 2,
+            applied: 2,
+            already_applied: 0,
+            cancelled: false,
+        }
+    );
+    assert_eq!(
+        *apply.applied.lock().expect("poisoned"),
+        vec![
+            ulid("01HQZK000000000000000000V1"),
+            ulid("01HQZK000000000000000000V2")
+        ]
+    );
+    let snapshots = drainer.status();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].workflow, "expire");
+    assert_eq!(snapshots[0].drained_plans, 2);
+    assert_eq!(snapshots[0].pending_plans, 0);
+    assert!(snapshots[0].last_applied_at.is_some());
+    let wire = WorkflowDrainer::status_to_wire(&snapshots);
+    assert_eq!(wire[0].workflow, StatusResponseWorkflowsWorkflow::Expire);
+    assert_eq!(wire[0].drained_plans, 2);
+    assert_eq!(wire[0].pending_plans, 0);
+}
+
+#[tokio::test]
+async fn drainer_stops_between_plans_when_cancelled() {
+    let cancel = CancellationToken::new();
+    let apply = Arc::new(CancellingApply {
+        applied: Mutex::new(Vec::new()),
+        cancel: cancel.clone(),
+    });
+    let drainer = WorkflowDrainer::new(WorkflowContext { cancel }, apply.clone());
+
+    let stats = drainer
+        .run(Arc::new(StaticWorkflow {
+            name: "expire",
+            plans: vec![
+                plan("01HQZK000000000000000000V1"),
+                plan("01HQZK000000000000000000V2"),
+            ],
+        }))
+        .await
+        .expect("drain succeeds");
+
+    assert_eq!(stats.applied, 1);
+    assert!(stats.cancelled);
+    assert_eq!(
+        *apply.applied.lock().expect("poisoned"),
+        vec![ulid("01HQZK000000000000000000V1")]
+    );
+    let snapshots = drainer.status();
+    assert_eq!(snapshots[0].drained_plans, 1);
+    assert_eq!(snapshots[0].pending_plans, 1);
+    assert!(snapshots[0].last_applied_at.is_some());
+}
+
+#[tokio::test]
+async fn drainer_counts_already_applied_plan_as_success_without_reapply() {
+    let apply = Arc::new(RecordingApply::default());
+    apply
+        .already_applied
+        .lock()
+        .expect("poisoned")
+        .push(ulid("01HQZK000000000000000000V1"));
+    let drainer = WorkflowDrainer::new(WorkflowContext::default(), apply.clone());
+
+    let stats = drainer
+        .run(Arc::new(StaticWorkflow {
+            name: "expire",
+            plans: vec![
+                plan("01HQZK000000000000000000V1"),
+                plan("01HQZK000000000000000000V2"),
+            ],
+        }))
+        .await
+        .expect("drain succeeds");
+
+    assert_eq!(stats.applied, 1);
+    assert_eq!(stats.already_applied, 1);
+    assert_eq!(
+        *apply.applied.lock().expect("poisoned"),
+        vec![ulid("01HQZK000000000000000000V2")]
+    );
+    let snapshots = drainer.status();
+    assert_eq!(snapshots[0].drained_plans, 2);
+    assert_eq!(snapshots[0].pending_plans, 0);
+    assert!(snapshots[0].last_applied_at.is_some());
+}
+
+#[tokio::test]
+async fn drainer_reports_idle_workflow_with_no_last_applied_time() {
+    let apply = Arc::new(RecordingApply::default());
+    let drainer = WorkflowDrainer::new(WorkflowContext::default(), apply);
+
+    let stats = drainer
+        .run(Arc::new(StaticWorkflow {
+            name: "expire",
+            plans: Vec::new(),
+        }))
+        .await
+        .expect("drain succeeds");
+
+    assert_eq!(stats.planned, 0);
+    assert!(!stats.cancelled);
+    let snapshots = drainer.status();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].workflow, "expire");
+    assert_eq!(snapshots[0].drained_plans, 0);
+    assert_eq!(snapshots[0].pending_plans, 0);
+    assert!(snapshots[0].last_applied_at.is_none());
+}
+
+#[tokio::test]
+async fn drainer_reports_pending_plans_when_cancelled_before_first_apply() {
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let apply = Arc::new(RecordingApply::default());
+    let drainer = WorkflowDrainer::new(WorkflowContext { cancel }, apply.clone());
+
+    let stats = drainer
+        .run(Arc::new(StaticWorkflow {
+            name: "expire",
+            plans: vec![
+                plan("01HQZK000000000000000000V1"),
+                plan("01HQZK000000000000000000V2"),
+            ],
+        }))
+        .await
+        .expect("drain succeeds");
+
+    assert_eq!(stats.planned, 2);
+    assert_eq!(stats.applied, 0);
+    assert!(stats.cancelled);
+    assert!(apply.applied.lock().expect("poisoned").is_empty());
+    let snapshots = drainer.status();
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].drained_plans, 0);
+    assert_eq!(snapshots[0].pending_plans, 2);
+    assert!(snapshots[0].last_applied_at.is_none());
+}
+
+#[tokio::test]
+async fn drainer_keeps_cumulative_drained_count_across_runs() {
+    let apply = Arc::new(RecordingApply::default());
+    let drainer = WorkflowDrainer::new(WorkflowContext::default(), apply);
+
+    drainer
+        .run(Arc::new(StaticWorkflow {
+            name: "expire",
+            plans: vec![
+                plan("01HQZK000000000000000000V1"),
+                plan("01HQZK000000000000000000V2"),
+            ],
+        }))
+        .await
+        .expect("first drain succeeds");
+    let first_last_applied_at = drainer.status()[0].last_applied_at.clone();
+
+    drainer
+        .run(Arc::new(StaticWorkflow {
+            name: "expire",
+            plans: Vec::new(),
+        }))
+        .await
+        .expect("idle drain succeeds");
+
+    let snapshots = drainer.status();
+    assert_eq!(snapshots[0].drained_plans, 2);
+    assert_eq!(snapshots[0].pending_plans, 0);
+    assert_eq!(snapshots[0].last_applied_at, first_last_applied_at);
+}
+
+#[tokio::test]
+async fn drainer_rejects_unknown_workflow_names_before_status_recording() {
+    let apply = Arc::new(RecordingApply::default());
+    let drainer = WorkflowDrainer::new(WorkflowContext::default(), apply);
+
+    let err = drainer
+        .run(Arc::new(StaticWorkflow {
+            name: "custom",
+            plans: Vec::new(),
+        }))
+        .await
+        .expect_err("unknown workflow name must fail closed");
+
+    assert!(err.to_string().contains("unknown workflow `custom`"));
+    assert!(drainer.status().is_empty());
+}
+
+fn plan(id: &str) -> FlushPlan {
+    sample_plan(id, cairn_core::domain::FlushMode::Autonomous)
+}
+
+fn ulid(id: &str) -> Ulid {
+    Ulid(id.to_owned())
+}

--- a/crates/cairn-workflows/tests/flush_workflows.rs
+++ b/crates/cairn-workflows/tests/flush_workflows.rs
@@ -1,0 +1,65 @@
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::domain::FlushPlan;
+use cairn_test_fixtures::flush_plan::sample_plan;
+use cairn_workflows::{
+    ConsolidateWorkflow, ExpireWorkflow, PromoteWorkflow, Workflow, WorkflowContext, WorkflowError,
+    WorkflowPlanSource,
+};
+
+#[derive(Default)]
+struct StaticSource;
+
+#[async_trait::async_trait]
+impl WorkflowPlanSource for StaticSource {
+    async fn plan(
+        &self,
+        workflow: &'static str,
+        _ctx: &WorkflowContext,
+    ) -> Result<Vec<FlushPlan>, WorkflowError> {
+        Ok(vec![sample_plan(
+            match workflow {
+                "consolidate" => "01HQZK000000000000000000C1",
+                "promote" => "01HQZK000000000000000000P1",
+                "expire" => "01HQZK000000000000000000E1",
+                _ => "01HQZK000000000000000000X1",
+            },
+            cairn_core::domain::FlushMode::Autonomous,
+        )])
+    }
+}
+
+#[tokio::test]
+async fn concrete_workflows_have_stable_names_and_delegate_planning() {
+    let source = Arc::new(StaticSource);
+    let ctx = WorkflowContext::default();
+
+    let consolidate = ConsolidateWorkflow::new(source.clone());
+    let promote = PromoteWorkflow::new(source.clone());
+    let expire = ExpireWorkflow::new(source);
+
+    assert_eq!(consolidate.name(), "consolidate");
+    assert_eq!(
+        consolidate.plan(&ctx).await.expect("consolidate plans")[0]
+            .operation_id
+            .0,
+        "01HQZK000000000000000000C1"
+    );
+    assert_eq!(promote.name(), "promote");
+    assert_eq!(
+        promote.plan(&ctx).await.expect("promote plans")[0]
+            .operation_id
+            .0,
+        "01HQZK000000000000000000P1"
+    );
+    assert_eq!(expire.name(), "expire");
+    assert_eq!(
+        expire.plan(&ctx).await.expect("expire plans")[0]
+            .operation_id
+            .0,
+        "01HQZK000000000000000000E1"
+    );
+}

--- a/crates/cairn-workflows/tests/sqlite_flush_apply.rs
+++ b/crates/cairn-workflows/tests/sqlite_flush_apply.rs
@@ -1,0 +1,366 @@
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::MemoryStore as _;
+use cairn_core::domain::{ExpirationReason, FlushMode, PlannedMutation};
+use cairn_test_fixtures::{flush_plan::sample_plan, memstore, sample_record};
+use cairn_workflows::{FlushPlanApply, FlushPlanApplyOutcome, SqliteFlushPlanApply, WorkflowError};
+
+#[tokio::test]
+async fn sqlite_apply_rejects_unsupported_mutation_without_partial_success() {
+    let apply =
+        SqliteFlushPlanApply::new(Arc::new(cairn_store_sqlite::SqliteMemoryStore::default()));
+    let mut plan = sample_plan("01HQZK000000000000000000A1", FlushMode::Autonomous);
+    plan.mutations = vec![PlannedMutation::Promote {
+        from: cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000000").unwrap(),
+        to_kind: cairn_core::domain::MemoryKind::Fact,
+        evidence: vec![],
+    }];
+
+    let err = apply
+        .apply("promote", plan)
+        .await
+        .expect_err("promote is not wired to store apply yet");
+
+    assert!(
+        err.to_string()
+            .contains("unsupported mutation kind `promote`")
+    );
+}
+
+#[tokio::test]
+async fn sqlite_apply_treats_empty_plan_as_already_applied_noop() {
+    let apply =
+        SqliteFlushPlanApply::new(Arc::new(cairn_store_sqlite::SqliteMemoryStore::default()));
+    let mut plan = sample_plan("01HQZK000000000000000000A2", FlushMode::Autonomous);
+    plan.mutations.clear();
+
+    let outcome = apply
+        .apply("expire", plan)
+        .await
+        .expect("empty plan is idempotent noop");
+
+    assert_eq!(outcome, FlushPlanApplyOutcome::AlreadyApplied);
+}
+
+#[tokio::test]
+async fn sqlite_apply_preflights_all_mutations_before_applying_any() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let record = sample_record(42);
+    let mut plan = sample_plan("01HQZK000000000000000000A3", FlushMode::Autonomous);
+    plan.mutations = vec![
+        PlannedMutation::Upsert {
+            record: Box::new(record.clone()),
+            prior_version: None,
+        },
+        PlannedMutation::Promote {
+            from: record.target_id.clone(),
+            to_kind: cairn_core::domain::MemoryKind::Fact,
+            evidence: vec![],
+        },
+    ];
+
+    let err = apply
+        .apply("promote", plan)
+        .await
+        .expect_err("unsupported promote should fail before upsert");
+
+    assert!(
+        err.to_string()
+            .contains("unsupported mutation kind `promote`")
+    );
+    assert!(store.get(&record.id).await.expect("get").is_none());
+}
+
+#[tokio::test]
+async fn sqlite_apply_forget_record_resolves_target_to_active_record_id() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let record = sample_record(7);
+    store.upsert(&record).await.expect("seed record");
+
+    let mut plan = sample_plan("01HQZK000000000000000000A4", FlushMode::Autonomous);
+    plan.mutations = vec![PlannedMutation::ForgetRecord {
+        target: record.target_id.clone(),
+    }];
+
+    let outcome = apply.apply("expire", plan).await.expect("apply forget");
+
+    assert_eq!(outcome, FlushPlanApplyOutcome::Applied);
+    assert!(store.get(&record.id).await.expect("get").is_none());
+}
+
+#[tokio::test]
+async fn sqlite_apply_delete_checks_prior_version_before_forget() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let record = sample_record(8);
+    store.upsert(&record).await.expect("seed record");
+
+    let mut stale = sample_plan("01HQZK000000000000000000A5", FlushMode::Autonomous);
+    stale.mutations = vec![PlannedMutation::Delete {
+        target: record.target_id.clone(),
+        prior_version: 2,
+    }];
+    apply
+        .apply("expire", stale)
+        .await
+        .expect_err("stale prior_version rejected");
+    assert!(store.get(&record.id).await.expect("get").is_some());
+
+    let mut current = sample_plan("01HQZK000000000000000000A6", FlushMode::Autonomous);
+    current.mutations = vec![PlannedMutation::Delete {
+        target: record.target_id.clone(),
+        prior_version: 1,
+    }];
+    let outcome = apply.apply("expire", current).await.expect("delete");
+
+    assert_eq!(outcome, FlushPlanApplyOutcome::Applied);
+    assert!(store.get(&record.id).await.expect("get").is_none());
+}
+
+#[tokio::test]
+async fn sqlite_apply_preflights_delete_versions_before_any_mutation() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let existing = sample_record(9);
+    let inserted = sample_record(10);
+    store.upsert(&existing).await.expect("seed record");
+
+    let mut stale = sample_plan("01HQZK000000000000000000A7", FlushMode::Autonomous);
+    stale.mutations = vec![
+        PlannedMutation::Upsert {
+            record: Box::new(inserted.clone()),
+            prior_version: None,
+        },
+        PlannedMutation::Delete {
+            target: existing.target_id.clone(),
+            prior_version: 2,
+        },
+    ];
+
+    apply
+        .apply("expire", stale)
+        .await
+        .expect_err("stale delete should fail before upsert");
+
+    assert!(
+        store
+            .get(&inserted.id)
+            .await
+            .expect("get inserted")
+            .is_none()
+    );
+    assert!(
+        store
+            .get(&existing.id)
+            .await
+            .expect("get existing")
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn sqlite_apply_preflights_upsert_prior_versions() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let existing = sample_record(11);
+    let inserted = sample_record(12);
+    store.upsert(&existing).await.expect("seed record");
+
+    let mut stale_record = existing.clone();
+    stale_record.body = "stale update body".to_owned();
+    let mut stale = sample_plan("01HQZK000000000000000000A8", FlushMode::Autonomous);
+    stale.mutations = vec![
+        PlannedMutation::Upsert {
+            record: Box::new(inserted.clone()),
+            prior_version: None,
+        },
+        PlannedMutation::Upsert {
+            record: Box::new(stale_record),
+            prior_version: Some(2),
+        },
+    ];
+
+    apply
+        .apply("consolidate", stale)
+        .await
+        .expect_err("stale upsert should fail before any mutation");
+
+    assert!(
+        store
+            .get(&inserted.id)
+            .await
+            .expect("get inserted")
+            .is_none()
+    );
+    let active = store
+        .get_active_by_target(&existing.target_id)
+        .await
+        .expect("active")
+        .expect("existing remains active");
+    assert_eq!(active.version, 1);
+    assert_eq!(active.record.body, existing.body);
+}
+
+#[tokio::test]
+async fn sqlite_apply_rejects_new_upsert_when_target_already_exists() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let existing = sample_record(13);
+    store.upsert(&existing).await.expect("seed record");
+
+    let mut replacement = existing.clone();
+    replacement.body = "unexpected replacement".to_owned();
+    let mut plan = sample_plan("01HQZK000000000000000000A9", FlushMode::Autonomous);
+    plan.mutations = vec![PlannedMutation::Upsert {
+        record: Box::new(replacement),
+        prior_version: None,
+    }];
+
+    apply
+        .apply("consolidate", plan)
+        .await
+        .expect_err("new-record upsert should not overwrite an active target");
+
+    let active = store
+        .get_active_by_target(&existing.target_id)
+        .await
+        .expect("active")
+        .expect("existing remains active");
+    assert_eq!(active.version, 1);
+    assert_eq!(active.record.body, existing.body);
+}
+
+#[tokio::test]
+async fn sqlite_apply_rejects_duplicate_target_mutations_before_apply() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let first = sample_record(14);
+    let mut second = first.clone();
+    second.body = "second body for same target".to_owned();
+    second.id = sample_record(15).id;
+
+    let mut plan = sample_plan("01HQZK000000000000000000B1", FlushMode::Autonomous);
+    plan.mutations = vec![
+        PlannedMutation::Upsert {
+            record: Box::new(first.clone()),
+            prior_version: None,
+        },
+        PlannedMutation::Upsert {
+            record: Box::new(second),
+            prior_version: None,
+        },
+    ];
+
+    let err = apply
+        .apply("consolidate", plan)
+        .await
+        .expect_err("duplicate target should fail before first upsert");
+
+    assert!(err.to_string().contains("duplicate mutation target"));
+    assert!(store.get(&first.id).await.expect("get").is_none());
+}
+
+#[tokio::test]
+async fn sqlite_apply_preserves_upsert_store_errors_as_apply_errors() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store);
+    let mut invalid = sample_record(16);
+    invalid.body.clear();
+
+    let mut plan = sample_plan("01HQZK000000000000000000B2", FlushMode::Autonomous);
+    plan.mutations = vec![PlannedMutation::Upsert {
+        record: Box::new(invalid),
+        prior_version: None,
+    }];
+
+    let err = apply
+        .apply("consolidate", plan)
+        .await
+        .expect_err("invalid record should surface store error");
+
+    assert!(matches!(err, WorkflowError::Apply { .. }));
+    assert!(err.to_string().contains("invalid record"));
+}
+
+#[tokio::test]
+async fn sqlite_apply_reports_same_body_upsert_as_already_applied() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let record = sample_record(17);
+    store.upsert(&record).await.expect("seed record");
+
+    let mut plan = sample_plan("01HQZK000000000000000000B3", FlushMode::Autonomous);
+    plan.mutations = vec![PlannedMutation::Upsert {
+        record: Box::new(record),
+        prior_version: Some(1),
+    }];
+
+    let outcome = apply.apply("consolidate", plan).await.expect("apply");
+
+    assert_eq!(outcome, FlushPlanApplyOutcome::AlreadyApplied);
+}
+
+#[tokio::test]
+async fn sqlite_apply_reports_missing_delete_target_as_already_applied() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store);
+    let missing = sample_record(18).target_id;
+
+    let mut plan = sample_plan("01HQZK000000000000000000B4", FlushMode::Autonomous);
+    plan.mutations = vec![PlannedMutation::Delete {
+        target: missing,
+        prior_version: 1,
+    }];
+
+    let outcome = apply.apply("expire", plan).await.expect("delete");
+
+    assert_eq!(outcome, FlushPlanApplyOutcome::AlreadyApplied);
+}
+
+#[tokio::test]
+async fn sqlite_apply_reports_missing_expire_target_as_already_applied() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store);
+    let missing = sample_record(19).target_id;
+
+    let mut plan = sample_plan("01HQZK000000000000000000B5", FlushMode::Autonomous);
+    plan.mutations = vec![PlannedMutation::Expire {
+        target: missing,
+        reason: ExpirationReason::SalienceBelowThreshold,
+    }];
+
+    let outcome = apply.apply("expire", plan).await.expect("expire");
+
+    assert_eq!(outcome, FlushPlanApplyOutcome::AlreadyApplied);
+}
+
+#[tokio::test]
+async fn sqlite_apply_reports_applied_when_any_mutation_changes_state() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let existing = sample_record(20);
+    let inserted = sample_record(21);
+    store.upsert(&existing).await.expect("seed record");
+
+    let mut plan = sample_plan("01HQZK000000000000000000B6", FlushMode::Autonomous);
+    plan.mutations = vec![
+        PlannedMutation::Upsert {
+            record: Box::new(existing),
+            prior_version: Some(1),
+        },
+        PlannedMutation::Upsert {
+            record: Box::new(inserted.clone()),
+            prior_version: None,
+        },
+    ];
+
+    let outcome = apply.apply("consolidate", plan).await.expect("apply");
+
+    assert_eq!(outcome, FlushPlanApplyOutcome::Applied);
+    assert!(store.get(&inserted.id).await.expect("get").is_some());
+}

--- a/crates/cairn-workflows/tests/sqlite_flush_apply.rs
+++ b/crates/cairn-workflows/tests/sqlite_flush_apply.rs
@@ -4,7 +4,8 @@
 use std::sync::Arc;
 
 use cairn_core::contract::memory_store::MemoryStore as _;
-use cairn_core::domain::{ExpirationReason, FlushMode, PlannedMutation};
+use cairn_core::domain::flush_plan::PatchTarget;
+use cairn_core::domain::{ExpirationReason, FlushMode, MemoryKind, PlannedMutation};
 use cairn_test_fixtures::{flush_plan::sample_plan, memstore, sample_record};
 use cairn_workflows::{FlushPlanApply, FlushPlanApplyOutcome, SqliteFlushPlanApply, WorkflowError};
 
@@ -13,20 +14,21 @@ async fn sqlite_apply_rejects_unsupported_mutation_without_partial_success() {
     let apply =
         SqliteFlushPlanApply::new(Arc::new(cairn_store_sqlite::SqliteMemoryStore::default()));
     let mut plan = sample_plan("01HQZK000000000000000000A1", FlushMode::Autonomous);
-    plan.mutations = vec![PlannedMutation::Promote {
-        from: cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000000").unwrap(),
-        to_kind: cairn_core::domain::MemoryKind::Fact,
-        evidence: vec![],
+    plan.mutations = vec![PlannedMutation::Patch {
+        target: PatchTarget::Record(
+            cairn_core::domain::TargetId::parse("01HQZX9F5N0000000000000000").unwrap(),
+        ),
+        str_replace: vec![],
     }];
 
     let err = apply
         .apply("promote", plan)
         .await
-        .expect_err("promote is not wired to store apply yet");
+        .expect_err("patch is not wired to store apply yet");
 
     assert!(
         err.to_string()
-            .contains("unsupported mutation kind `promote`")
+            .contains("unsupported mutation kind `patch`")
     );
 }
 
@@ -56,21 +58,20 @@ async fn sqlite_apply_preflights_all_mutations_before_applying_any() {
             record: Box::new(record.clone()),
             prior_version: None,
         },
-        PlannedMutation::Promote {
-            from: record.target_id.clone(),
-            to_kind: cairn_core::domain::MemoryKind::Fact,
-            evidence: vec![],
+        PlannedMutation::Patch {
+            target: PatchTarget::Record(record.target_id.clone()),
+            str_replace: vec![],
         },
     ];
 
     let err = apply
         .apply("promote", plan)
         .await
-        .expect_err("unsupported promote should fail before upsert");
+        .expect_err("unsupported patch should fail before upsert");
 
     assert!(
         err.to_string()
-            .contains("unsupported mutation kind `promote`")
+            .contains("unsupported mutation kind `patch`")
     );
     assert!(store.get(&record.id).await.expect("get").is_none());
 }
@@ -363,4 +364,37 @@ async fn sqlite_apply_reports_applied_when_any_mutation_changes_state() {
 
     assert_eq!(outcome, FlushPlanApplyOutcome::Applied);
     assert!(store.get(&inserted.id).await.expect("get").is_some());
+}
+
+#[tokio::test]
+async fn sqlite_apply_promotes_active_record_kind_idempotently() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let mut record = sample_record(20);
+    record.kind = MemoryKind::Reference;
+    store.upsert(&record).await.expect("seed record");
+
+    let mut plan = sample_plan("01HQZK000000000000000000H1", FlushMode::Autonomous);
+    plan.mutations = vec![PlannedMutation::Promote {
+        from: record.target_id.clone(),
+        to_kind: MemoryKind::Fact,
+        evidence: vec![],
+    }];
+
+    let first = apply
+        .apply("promote", plan.clone())
+        .await
+        .expect("first promote");
+
+    assert_eq!(first, FlushPlanApplyOutcome::Applied);
+    let promoted = store
+        .get_active_by_target(&record.target_id)
+        .await
+        .expect("active")
+        .expect("record remains active");
+    assert_eq!(promoted.record.kind, MemoryKind::Fact);
+
+    let second = apply.apply("promote", plan).await.expect("second promote");
+
+    assert_eq!(second, FlushPlanApplyOutcome::AlreadyApplied);
 }

--- a/crates/cairn-workflows/tests/sqlite_flush_apply.rs
+++ b/crates/cairn-workflows/tests/sqlite_flush_apply.rs
@@ -208,6 +208,76 @@ async fn sqlite_apply_preflights_upsert_prior_versions() {
 }
 
 #[tokio::test]
+async fn sqlite_apply_preflights_invalid_upsert_records_before_any_mutation() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let inserted = sample_record(12_001);
+    let mut invalid = sample_record(12_002);
+    invalid.body.clear();
+
+    let mut plan = sample_plan("01HQZK000000000000000000H2", FlushMode::Autonomous);
+    plan.mutations = vec![
+        PlannedMutation::Upsert {
+            record: Box::new(inserted.clone()),
+            prior_version: None,
+        },
+        PlannedMutation::Upsert {
+            record: Box::new(invalid),
+            prior_version: None,
+        },
+    ];
+
+    apply
+        .apply("consolidate", plan)
+        .await
+        .expect_err("invalid record should fail before first upsert");
+
+    assert!(
+        store
+            .get(&inserted.id)
+            .await
+            .expect("get inserted")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn sqlite_apply_preflights_invalid_promote_records_before_any_mutation() {
+    let store = Arc::new(memstore().await);
+    let apply = SqliteFlushPlanApply::new(store.clone());
+    let inserted = sample_record(12_003);
+    let mut promoted = sample_record(12_004);
+    promoted.kind = MemoryKind::Reference;
+    store.upsert(&promoted).await.expect("seed promoted target");
+
+    let mut plan = sample_plan("01HQZK000000000000000000H3", FlushMode::Autonomous);
+    plan.mutations = vec![
+        PlannedMutation::Upsert {
+            record: Box::new(inserted.clone()),
+            prior_version: None,
+        },
+        PlannedMutation::Promote {
+            from: promoted.target_id.clone(),
+            to_kind: MemoryKind::SensorObservation,
+            evidence: vec![],
+        },
+    ];
+
+    apply
+        .apply("promote", plan)
+        .await
+        .expect_err("invalid promote should fail before first upsert");
+
+    assert!(
+        store
+            .get(&inserted.id)
+            .await
+            .expect("get inserted")
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn sqlite_apply_rejects_new_upsert_when_target_already_exists() {
     let store = Arc::new(memstore().await);
     let apply = SqliteFlushPlanApply::new(store.clone());
@@ -285,7 +355,7 @@ async fn sqlite_apply_preserves_upsert_store_errors_as_apply_errors() {
         .expect_err("invalid record should surface store error");
 
     assert!(matches!(err, WorkflowError::Apply { .. }));
-    assert!(err.to_string().contains("invalid record"));
+    assert!(err.to_string().contains("required field `body`"));
 }
 
 #[tokio::test]

--- a/crates/cairn-workflows/tests/workflow_e2e.rs
+++ b/crates/cairn-workflows/tests/workflow_e2e.rs
@@ -1,0 +1,86 @@
+// Integration test files are not public API; doc-comments are not required.
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use cairn_core::contract::memory_store::MemoryStore as _;
+use cairn_core::domain::Identity;
+use cairn_core::generated::status::StatusResponseWorkflowsWorkflow;
+use cairn_test_fixtures::{memstore, sample_record};
+use cairn_workflows::{
+    ExpirePlanSource, ExpireWorkflow, SqliteFlushPlanApply, WorkflowContext, WorkflowDrainer,
+};
+
+#[tokio::test]
+async fn expire_workflow_drains_planned_flushes_into_sqlite_store_end_to_end() {
+    let store = Arc::new(memstore().await);
+    let mut low = sample_record(1);
+    low.salience = 0.1;
+    let mut high = sample_record(2);
+    high.salience = 0.9;
+    store.upsert(&low).await.expect("seed low salience");
+    store.upsert(&high).await.expect("seed high salience");
+
+    let source = Arc::new(ExpirePlanSource::new(
+        store.clone(),
+        Identity::parse("agt:cairn-workflows:expire:v1").expect("valid issuer"),
+        0.2,
+    ));
+    let drainer = WorkflowDrainer::new(
+        WorkflowContext::default(),
+        Arc::new(SqliteFlushPlanApply::new(store.clone())),
+    );
+
+    let first = drainer
+        .run(Arc::new(ExpireWorkflow::new(source.clone())))
+        .await
+        .expect("first expire drain");
+
+    assert_eq!(first.workflow, "expire");
+    assert_eq!(first.planned, 1);
+    assert_eq!(first.applied, 1);
+    assert_eq!(first.already_applied, 0);
+    assert!(!first.cancelled);
+    assert!(
+        store
+            .get_active_by_target(&low.target_id)
+            .await
+            .expect("get low target")
+            .is_none()
+    );
+    assert!(
+        store
+            .get_active_by_target(&high.target_id)
+            .await
+            .expect("get high target")
+            .is_some()
+    );
+
+    let status = drainer.status();
+    assert_eq!(status.len(), 1);
+    assert_eq!(status[0].workflow, "expire");
+    assert_eq!(status[0].drained_plans, 1);
+    assert_eq!(status[0].pending_plans, 0);
+    assert!(status[0].last_applied_at.is_some());
+
+    let wire = WorkflowDrainer::status_to_wire(&status);
+    assert_eq!(wire.len(), 1);
+    assert_eq!(wire[0].workflow, StatusResponseWorkflowsWorkflow::Expire);
+    assert_eq!(wire[0].drained_plans, 1);
+    assert_eq!(wire[0].pending_plans, 0);
+    assert!(wire[0].last_applied_at.is_some());
+
+    let second = drainer
+        .run(Arc::new(ExpireWorkflow::new(source)))
+        .await
+        .expect("second expire drain");
+
+    assert_eq!(second.workflow, "expire");
+    assert_eq!(second.planned, 0);
+    assert_eq!(second.applied, 0);
+    assert_eq!(second.already_applied, 0);
+    assert!(!second.cancelled);
+    let status = drainer.status();
+    assert_eq!(status[0].drained_plans, 1);
+    assert_eq!(status[0].pending_plans, 0);
+}

--- a/crates/cairn-workflows/tests/workflow_e2e.rs
+++ b/crates/cairn-workflows/tests/workflow_e2e.rs
@@ -4,11 +4,12 @@
 use std::sync::Arc;
 
 use cairn_core::contract::memory_store::MemoryStore as _;
-use cairn_core::domain::Identity;
+use cairn_core::domain::{Identity, MemoryKind};
 use cairn_core::generated::status::StatusResponseWorkflowsWorkflow;
 use cairn_test_fixtures::{memstore, sample_record};
 use cairn_workflows::{
-    ExpirePlanSource, ExpireWorkflow, SqliteFlushPlanApply, WorkflowContext, WorkflowDrainer,
+    ConsolidatePlanSource, ConsolidateWorkflow, ExpirePlanSource, ExpireWorkflow,
+    PromotePlanSource, PromoteWorkflow, SqliteFlushPlanApply, WorkflowContext, WorkflowDrainer,
 };
 
 #[tokio::test]
@@ -83,4 +84,130 @@ async fn expire_workflow_drains_planned_flushes_into_sqlite_store_end_to_end() {
     let status = drainer.status();
     assert_eq!(status[0].drained_plans, 1);
     assert_eq!(status[0].pending_plans, 0);
+}
+
+#[tokio::test]
+async fn promote_workflow_drains_planned_flushes_into_sqlite_store_end_to_end() {
+    let store = Arc::new(memstore().await);
+    let mut candidate = sample_record(3);
+    candidate.kind = MemoryKind::Reference;
+    candidate.confidence = 0.95;
+    let mut already_promoted = sample_record(4);
+    already_promoted.kind = MemoryKind::Fact;
+    already_promoted.confidence = 0.99;
+    store.upsert(&candidate).await.expect("seed candidate");
+    store
+        .upsert(&already_promoted)
+        .await
+        .expect("seed already promoted");
+
+    let source = Arc::new(PromotePlanSource::new(
+        store.clone(),
+        Identity::parse("agt:cairn-workflows:promote:v1").expect("valid issuer"),
+        MemoryKind::Fact,
+        0.9,
+    ));
+    let drainer = WorkflowDrainer::new(
+        WorkflowContext::default(),
+        Arc::new(SqliteFlushPlanApply::new(store.clone())),
+    );
+
+    let first = drainer
+        .run(Arc::new(PromoteWorkflow::new(source.clone())))
+        .await
+        .expect("first promote drain");
+
+    assert_eq!(first.workflow, "promote");
+    assert_eq!(first.planned, 1);
+    assert_eq!(first.applied, 1);
+    assert_eq!(first.already_applied, 0);
+    assert!(!first.cancelled);
+    let promoted = store
+        .get_active_by_target(&candidate.target_id)
+        .await
+        .expect("get candidate")
+        .expect("candidate remains active");
+    assert_eq!(promoted.record.kind, MemoryKind::Fact);
+
+    let second = drainer
+        .run(Arc::new(PromoteWorkflow::new(source)))
+        .await
+        .expect("second promote drain");
+
+    assert_eq!(second.workflow, "promote");
+    assert_eq!(second.planned, 0);
+    assert_eq!(second.applied, 0);
+    assert_eq!(second.already_applied, 0);
+    assert!(!second.cancelled);
+}
+
+#[tokio::test]
+async fn consolidate_workflow_drains_planned_flushes_into_sqlite_store_end_to_end() {
+    let store = Arc::new(memstore().await);
+    let mut keeper = sample_record(5);
+    keeper.body = "shared body".to_owned();
+    keeper.confidence = 0.9;
+    keeper.salience = 0.8;
+    let mut duplicate = sample_record(6);
+    duplicate.body = "shared body".to_owned();
+    duplicate.confidence = 0.6;
+    duplicate.salience = 0.4;
+    let mut unique = sample_record(7);
+    unique.body = "unique body".to_owned();
+    unique.confidence = 0.1;
+    store.upsert(&keeper).await.expect("seed keeper");
+    store.upsert(&duplicate).await.expect("seed duplicate");
+    store.upsert(&unique).await.expect("seed unique");
+
+    let source = Arc::new(ConsolidatePlanSource::new(
+        store.clone(),
+        Identity::parse("agt:cairn-workflows:consolidate:v1").expect("valid issuer"),
+    ));
+    let drainer = WorkflowDrainer::new(
+        WorkflowContext::default(),
+        Arc::new(SqliteFlushPlanApply::new(store.clone())),
+    );
+
+    let first = drainer
+        .run(Arc::new(ConsolidateWorkflow::new(source.clone())))
+        .await
+        .expect("first consolidate drain");
+
+    assert_eq!(first.workflow, "consolidate");
+    assert_eq!(first.planned, 1);
+    assert_eq!(first.applied, 1);
+    assert_eq!(first.already_applied, 0);
+    assert!(!first.cancelled);
+    assert!(
+        store
+            .get_active_by_target(&keeper.target_id)
+            .await
+            .expect("get keeper")
+            .is_some()
+    );
+    assert!(
+        store
+            .get_active_by_target(&duplicate.target_id)
+            .await
+            .expect("get duplicate")
+            .is_none()
+    );
+    assert!(
+        store
+            .get_active_by_target(&unique.target_id)
+            .await
+            .expect("get unique")
+            .is_some()
+    );
+
+    let second = drainer
+        .run(Arc::new(ConsolidateWorkflow::new(source)))
+        .await
+        .expect("second consolidate drain");
+
+    assert_eq!(second.workflow, "consolidate");
+    assert_eq!(second.planned, 0);
+    assert_eq!(second.applied, 0);
+    assert_eq!(second.already_applied, 0);
+    assert!(!second.cancelled);
 }


### PR DESCRIPTION
## Summary
- add a shared workflow drainer boundary for FlushPlan-producing workflows
- add expire, promote, and consolidate store-backed pure plan sources
- add SQLite FlushPlan application support for expire/delete/forget/upsert/promote
- add durable workflow plan checkpoints so restarted drainers skip already-drained plan ids
- surface workflow drain status through the generated status schema
- cover drainer, planner, apply, restart/resume, and end-to-end workflow behavior

Closes #291

## Validation
- cargo test -p cairn-workflows --test workflow_e2e -- --nocapture
- cargo test -p cairn-workflows --test flush_drainer
- cargo test -p cairn-workflows --test expire_plan_source
- cargo test -p cairn-workflows --test sqlite_flush_apply
- cargo test -p cairn-workflows
- cargo clippy -p cairn-workflows --all-targets --all-features
- cargo check -p cairn-cli -p cairn-sdk -p cairn-mcp -p cairn-workflows
- cargo run -p cairn-idl --bin cairn-codegen -- --check
- cargo test -p cairn-idl --test schema_files
- git diff --check