### PR TITLE
[codex] Add local sensor consent gating

### DIFF
--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -319,7 +319,13 @@ fn main() -> ExitCode {
             Err(code) => code,
         },
         Some(("sensor", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
-            Ok((vault_root, _source, config)) => verbs::sensor::run(sub, &vault_root, config),
+            Ok((vault_root, _source, config)) => {
+                if let Some(code) = enforce_vault_binding("sensor", &vault_root) {
+                    code
+                } else {
+                    verbs::sensor::run(sub, &vault_root, config)
+                }
+            }
             Err(code) => code,
         },
         Some(("handshake", sub)) => run_handshake(sub, explicit_vault.as_deref()),

--- a/crates/cairn-cli/tests/sensor_cli.rs
+++ b/crates/cairn-cli/tests/sensor_cli.rs
@@ -129,3 +129,63 @@ fn status_json_reports_sensor_consent_state() {
     assert_eq!(recording["consent"], "enabled");
     assert_eq!(recording["gate"], "allowed");
 }
+
+#[test]
+fn sensor_status_rejects_unbound_explicit_vault() {
+    let vault = tempfile::tempdir().expect("tempdir");
+
+    let out = cli()
+        .args(["--vault"])
+        .arg(vault.path())
+        .args(["sensor", "status", "--json"])
+        .output()
+        .expect("cairn sensor status");
+
+    assert_eq!(
+        out.status.code(),
+        Some(78),
+        "status should reject unbound vault; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("no Cairn vault"),
+        "stderr should explain missing vault binding: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn sensor_enable_rejects_unbound_explicit_vault_without_creating_state() {
+    let vault = tempfile::tempdir().expect("tempdir");
+
+    let out = cli()
+        .args(["--vault"])
+        .arg(vault.path())
+        .args([
+            "sensor",
+            "enable",
+            "terminal",
+            "--reason",
+            "operator_on",
+            "--json",
+        ])
+        .output()
+        .expect("cairn sensor enable");
+
+    assert_eq!(
+        out.status.code(),
+        Some(78),
+        "enable should reject unbound vault; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("no Cairn vault"),
+        "stderr should explain missing vault binding: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(!vault.path().join(".cairn/config.yaml").exists());
+    assert!(!vault.path().join(".cairn/cairn.db").exists());
+    assert!(!vault.path().join(".cairn/consent.log").exists());
+}


### PR DESCRIPTION
## Summary
- rebuild the PR branch on latest `main`, which already carries the broader sensor consent implementation
- keep the remaining issue-88 hardening by enforcing vault binding before `cairn sensor` subcommands run
- add regression coverage for explicit unbootstrapped `--vault` paths so status/enable fail without creating config, DB, or consent state

## Test Plan
- `cargo fmt --check`
- `cargo test -p cairn-cli --test sensor_cli -- --nocapture`
- `cargo test -p cairn-cli sensor -- --nocapture`
- `cargo run -p cairn-cli --bin cairn-docgen --locked -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`

## Notes
- Closes #88.
- Branch was force-pushed after rebasing/rebuilding on `origin/main` to remove superseded conflicting sensor-command history.
