### PR TITLE
[codex] Add session tree substrate

### DIFF
--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -31,7 +31,10 @@ use crate::search::ScoreExplain;
 /// while `filter` keeps its narrowing-only role. The companion
 /// `MemoryStoreCapabilities::graph_search` flag and the
 /// `search_graph_neighbors` trait method (default impl returns
-/// `CapabilityUnavailable`) ship in the same bump.
+/// `CapabilityUnavailable`) ship in the same bump. Co-evolved within 0.5 in
+/// #133 when optional session-tree methods landed with default-error
+/// implementations; the public `cairn.sessiontree.v1` capability remains
+/// separately gated.
 pub const CONTRACT_VERSION: ContractVersion = ContractVersion::new(0, 5, 0);
 
 /// Errors raised by `MemoryStore` implementations. Adapters define their
@@ -220,6 +223,65 @@ pub trait MemoryStore: Send + Sync {
             });
         }
         Ok(out)
+    }
+
+    // ── Session trees (#133) ────────────────────────────────────────────────
+
+    /// Load the session tree rooted at `root`.
+    ///
+    /// Adapters that support the v0.3 session-tree metadata substrate should
+    /// synthesize older flat sessions as one-node trees so v0.1/v0.2 session
+    /// retrieval stays compatible after the schema is upgraded. The default
+    /// implementation returns a capability-unavailable error because the
+    /// public `cairn.sessiontree.v1` extension remains opt-in and P2.
+    async fn get_session_tree(&self, root: &SessionId) -> Result<Option<SessionTree>, StoreError> {
+        let _ = root;
+        Err("capability unavailable: session_tree".into())
+    }
+
+    /// Persist copy-on-write fork metadata between two existing sessions.
+    async fn record_session_fork(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+        at_turn_id: &str,
+    ) -> Result<(), StoreError> {
+        let _ = (from, child, at_turn_id);
+        Err("capability unavailable: session_tree".into())
+    }
+
+    /// Persist full-copy clone metadata between two existing sessions.
+    async fn record_session_clone(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+    ) -> Result<(), StoreError> {
+        let _ = (from, child);
+        Err("capability unavailable: session_tree".into())
+    }
+
+    /// Persist metadata for a branch spawned by a tool call.
+    async fn record_session_tool_spawn(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+        at_turn_id: &str,
+        tool_call_id: &str,
+    ) -> Result<(), StoreError> {
+        let _ = (from, child, at_turn_id, tool_call_id);
+        Err("capability unavailable: session_tree".into())
+    }
+
+    /// Persist an explicit, auditable merge between two sessions.
+    async fn record_session_merge(
+        &self,
+        source: &SessionId,
+        destination: &SessionId,
+        strategy: MergeStrategy,
+        applied_at_turn_id: &str,
+    ) -> Result<SessionMerge, StoreError> {
+        let _ = (source, destination, strategy, applied_at_turn_id);
+        Err("capability unavailable: session_tree".into())
     }
 
     // ── Edges (#46) ───────────────────────────────────────────────────────
@@ -520,7 +582,7 @@ pub trait MemoryStorePlugin: MemoryStore + Sized {
 // ── Verb-method support types (#46, #47) ──────────────────────────────────────
 
 use crate::domain::{
-    BodyHash, RecordId, ScopeTuple, TargetId,
+    BodyHash, MergeStrategy, RecordId, ScopeTuple, SessionId, SessionMerge, SessionTree, TargetId,
     filter::ValidatedFilter,
     taxonomy::{MemoryClass, MemoryKind, MemoryVisibility},
 };
@@ -1215,7 +1277,8 @@ mod tests {
 
     /// `CONTRACT_VERSION` for the `MemoryStore` trait is locked to 0.5.0.
     /// #258 bumped 0.3→0.4 (per-row `schema_version`). #191 bumped 0.4→0.5
-    /// (`auth_scope`, `graph_search` capability + trait method).
+    /// (`auth_scope`, `graph_search` capability + trait method). #133
+    /// co-evolved within 0.5 by adding default-error session-tree methods.
     #[test]
     fn contract_version_locked_to_0_5_0() {
         assert_eq!(CONTRACT_VERSION, ContractVersion::new(0, 5, 0));

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -42,6 +42,7 @@ pub mod provenance;
 pub mod record;
 pub mod scope;
 pub mod session;
+pub mod session_tree;
 pub mod source_id;
 pub mod source_ref;
 pub mod target_id;
@@ -83,6 +84,10 @@ pub use scope::ScopeTuple;
 pub use session::{
     DEFAULT_IDLE_WINDOW_SECS, LastActiveSession, Session, SessionDecision, SessionId,
     SessionIdentity, SessionSource, resolve_session,
+};
+pub use session_tree::{
+    BranchKind, MergeStrategy, SessionMerge, SessionParent, SessionTree, SessionTreeError,
+    SessionTreeNode,
 };
 pub use source_id::SourceId;
 pub use source_ref::{SourceRef, validate_source_refs};

--- a/crates/cairn-core/src/domain/session.rs
+++ b/crates/cairn-core/src/domain/session.rs
@@ -21,7 +21,7 @@ use crate::domain::identity::{Identity, IdentityKind};
 /// Opaque session identifier. Typically a ULID minted by the store, but the
 /// type accepts any non-empty `[A-Za-z0-9._:-]+` string so callers may pass
 /// harness-supplied IDs.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct SessionId(String);
 

--- a/crates/cairn-core/src/domain/session_tree.rs
+++ b/crates/cairn-core/src/domain/session_tree.rs
@@ -215,6 +215,15 @@ impl SessionTree {
     /// Constructors maintain these invariants for in-memory writes; this
     /// method protects deserialized snapshots before callers trust lineage.
     pub fn validate(&self) -> Result<(), SessionTreeError> {
+        self.validate_root()?;
+        self.validate_nodes()?;
+        self.validate_all_lineages()?;
+        self.validate_merges()?;
+
+        Ok(())
+    }
+
+    fn validate_root(&self) -> Result<(), SessionTreeError> {
         let root = self
             .nodes
             .get(&self.root)
@@ -233,7 +242,10 @@ impl SessionTree {
                 message: "root node id must match tree root",
             });
         }
+        Ok(())
+    }
 
+    fn validate_nodes(&self) -> Result<(), SessionTreeError> {
         for (id, node) in &self.nodes {
             if &node.session_id != id {
                 return Err(SessionTreeError::MalformedLink {
@@ -241,83 +253,116 @@ impl SessionTree {
                     message: "node key must match session_id",
                 });
             }
-            let mut seen_children = BTreeSet::new();
-            for child in &node.children {
-                if !seen_children.insert(child.clone()) {
-                    return Err(SessionTreeError::MalformedLink {
-                        session_id: id.clone(),
-                        message: "children must not contain duplicates",
-                    });
-                }
-                let child_node =
-                    self.nodes
-                        .get(child)
-                        .ok_or_else(|| SessionTreeError::UnknownSession {
-                            session_id: child.clone(),
-                        })?;
-                let Some(parent) = &child_node.parent else {
-                    return Err(SessionTreeError::MalformedLink {
-                        session_id: child.clone(),
-                        message: "child must point back to parent",
-                    });
-                };
-                if &parent.session_id != id {
-                    return Err(SessionTreeError::MalformedLink {
-                        session_id: child.clone(),
-                        message: "child parent does not match containing node",
-                    });
-                }
-            }
+            self.validate_child_links(id, node)?;
 
             if id == &self.root {
                 continue;
             }
-            let parent = node
-                .parent
-                .as_ref()
-                .ok_or_else(|| SessionTreeError::MalformedLink {
-                    session_id: id.clone(),
-                    message: "non-root node must have a parent",
-                })?;
-            self.require_session(&parent.session_id)?;
-            non_empty(parent.at_turn_id.clone(), "at_turn_id")?;
-            match parent.kind {
-                BranchKind::ToolSpawned => {
-                    let tool_call_id =
-                        parent
-                            .tool_call_id
-                            .clone()
-                            .ok_or(SessionTreeError::EmptyField {
-                                field: "tool_call_id",
-                            })?;
-                    non_empty(tool_call_id, "tool_call_id")?;
-                }
-                BranchKind::Fork | BranchKind::Clone => {
-                    if parent.tool_call_id.is_some() {
-                        return Err(SessionTreeError::MalformedLink {
-                            session_id: id.clone(),
-                            message: "tool_call_id is only valid for tool-spawned branches",
-                        });
-                    }
-                }
-            }
-            let parent_node = self.nodes.get(&parent.session_id).ok_or_else(|| {
-                SessionTreeError::UnknownSession {
-                    session_id: parent.session_id.clone(),
-                }
-            })?;
-            if !parent_node.children.iter().any(|child| child == id) {
+            self.validate_parent_link(id, node)?;
+        }
+        Ok(())
+    }
+
+    fn validate_child_links(
+        &self,
+        id: &SessionId,
+        node: &SessionTreeNode,
+    ) -> Result<(), SessionTreeError> {
+        let mut seen_children = BTreeSet::new();
+        for child in &node.children {
+            if !seen_children.insert(child.clone()) {
                 return Err(SessionTreeError::MalformedLink {
                     session_id: id.clone(),
-                    message: "parent children must include child",
+                    message: "children must not contain duplicates",
+                });
+            }
+            let child_node =
+                self.nodes
+                    .get(child)
+                    .ok_or_else(|| SessionTreeError::UnknownSession {
+                        session_id: child.clone(),
+                    })?;
+            let Some(parent) = &child_node.parent else {
+                return Err(SessionTreeError::MalformedLink {
+                    session_id: child.clone(),
+                    message: "child must point back to parent",
+                });
+            };
+            if &parent.session_id != id {
+                return Err(SessionTreeError::MalformedLink {
+                    session_id: child.clone(),
+                    message: "child parent does not match containing node",
                 });
             }
         }
+        Ok(())
+    }
 
+    fn validate_parent_link(
+        &self,
+        id: &SessionId,
+        node: &SessionTreeNode,
+    ) -> Result<(), SessionTreeError> {
+        let parent = node
+            .parent
+            .as_ref()
+            .ok_or_else(|| SessionTreeError::MalformedLink {
+                session_id: id.clone(),
+                message: "non-root node must have a parent",
+            })?;
+        self.require_session(&parent.session_id)?;
+        non_empty(parent.at_turn_id.clone(), "at_turn_id")?;
+        Self::validate_parent_branch_metadata(id, parent)?;
+        let parent_node =
+            self.nodes
+                .get(&parent.session_id)
+                .ok_or_else(|| SessionTreeError::UnknownSession {
+                    session_id: parent.session_id.clone(),
+                })?;
+        if !parent_node.children.iter().any(|child| child == id) {
+            return Err(SessionTreeError::MalformedLink {
+                session_id: id.clone(),
+                message: "parent children must include child",
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_parent_branch_metadata(
+        id: &SessionId,
+        parent: &SessionParent,
+    ) -> Result<(), SessionTreeError> {
+        match parent.kind {
+            BranchKind::ToolSpawned => {
+                let tool_call_id =
+                    parent
+                        .tool_call_id
+                        .clone()
+                        .ok_or(SessionTreeError::EmptyField {
+                            field: "tool_call_id",
+                        })?;
+                non_empty(tool_call_id, "tool_call_id")?;
+            }
+            BranchKind::Fork | BranchKind::Clone => {
+                if parent.tool_call_id.is_some() {
+                    return Err(SessionTreeError::MalformedLink {
+                        session_id: id.clone(),
+                        message: "tool_call_id is only valid for tool-spawned branches",
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_all_lineages(&self) -> Result<(), SessionTreeError> {
         for id in self.nodes.keys() {
             self.lineage(id)?;
         }
+        Ok(())
+    }
 
+    fn validate_merges(&self) -> Result<(), SessionTreeError> {
         for merge in &self.merges {
             if merge.source == merge.destination {
                 return Err(SessionTreeError::SelfMerge {
@@ -329,14 +374,13 @@ impl SessionTree {
             non_empty(merge.applied_at_turn_id.clone(), "applied_at_turn_id")?;
             validate_merge_strategy(&merge.strategy)?;
         }
-
         Ok(())
     }
 
     /// Create a copy-on-write child session from `from` at `at_turn_id`.
     pub fn fork(
         &mut self,
-        from: SessionId,
+        from: &SessionId,
         child: SessionId,
         at_turn_id: impl Into<String>,
     ) -> Result<(), SessionTreeError> {
@@ -346,7 +390,7 @@ impl SessionTree {
     /// Create a full-copy child session from `from`.
     pub fn clone_session(
         &mut self,
-        from: SessionId,
+        from: &SessionId,
         child: SessionId,
     ) -> Result<(), SessionTreeError> {
         self.add_child(from, child, BranchKind::Clone, "latest", None)
@@ -355,7 +399,7 @@ impl SessionTree {
     /// Create a branch spawned by a tool call from `from` at `at_turn_id`.
     pub fn tool_spawn(
         &mut self,
-        from: SessionId,
+        from: &SessionId,
         child: SessionId,
         at_turn_id: impl Into<String>,
         tool_call_id: impl Into<String>,
@@ -431,13 +475,13 @@ impl SessionTree {
 
     fn add_child(
         &mut self,
-        from: SessionId,
+        from: &SessionId,
         child: SessionId,
         kind: BranchKind,
         at_turn_id: impl Into<String>,
         tool_call_id: Option<String>,
     ) -> Result<(), SessionTreeError> {
-        self.require_session(&from)?;
+        self.require_session(from)?;
         if self.nodes.contains_key(&child) {
             return Err(SessionTreeError::DuplicateSession { session_id: child });
         }
@@ -453,7 +497,12 @@ impl SessionTree {
             children: Vec::new(),
         };
         self.nodes.insert(child.clone(), child_node);
-        let parent = self.nodes.get_mut(&from).expect("parent checked above");
+        let parent = self
+            .nodes
+            .get_mut(from)
+            .ok_or_else(|| SessionTreeError::UnknownSession {
+                session_id: from.clone(),
+            })?;
         parent.children.push(child);
         Ok(())
     }

--- a/crates/cairn-core/src/domain/session_tree.rs
+++ b/crates/cairn-core/src/domain/session_tree.rs
@@ -1,0 +1,492 @@
+//! Pure session-tree model (brief §5.7).
+//!
+//! This module owns the storage-agnostic semantics for v0.3 session trees:
+//! a v0.1 flat session is represented as a one-node tree, forks/clones carry
+//! explicit parentage, and merges are recorded as auditable events. Persistence
+//! and `cairn.sessiontree.v1` dispatch are intentionally out of scope here.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::domain::{RecordId, SessionId};
+
+/// Errors raised by the pure session-tree model before any storage mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum SessionTreeError {
+    /// The requested session id is not present in the tree.
+    #[error("session tree: unknown session `{session_id}`")]
+    UnknownSession {
+        /// Missing session id.
+        session_id: SessionId,
+    },
+    /// A branch tried to insert a session id already present in the tree.
+    #[error("session tree: duplicate session `{session_id}`")]
+    DuplicateSession {
+        /// Duplicate session id.
+        session_id: SessionId,
+    },
+    /// A merge tried to fold a session into itself.
+    #[error("session tree: cannot merge session `{session_id}` into itself")]
+    SelfMerge {
+        /// Reused source/destination session id.
+        session_id: SessionId,
+    },
+    /// Parent/child pointers or node keys are internally inconsistent.
+    #[error("session tree: malformed link for `{session_id}`: {message}")]
+    MalformedLink {
+        /// Session id whose link metadata failed validation.
+        session_id: SessionId,
+        /// Static validation reason.
+        message: &'static str,
+    },
+    /// A branch boundary string was empty.
+    #[error("session tree: `{field}` must not be empty")]
+    EmptyField {
+        /// Empty field name.
+        field: &'static str,
+    },
+}
+
+/// Relationship from a parent session to a child session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum BranchKind {
+    /// Copy-on-write child whose history inherits through a named turn.
+    Fork,
+    /// Full-copy child at the parent's latest turn.
+    Clone,
+    /// Branch spawned by a tool call from a parent turn.
+    ToolSpawned,
+}
+
+/// Merge representation for an auditable session-tree merge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+#[non_exhaustive]
+pub enum MergeStrategy {
+    /// Fold the branch outcome back as a reasoning summary record.
+    ReasoningSummary {
+        /// Record id of the reasoning summary that explains the merge.
+        summary_record_id: RecordId,
+    },
+    /// Splice branch turns into the destination after review.
+    ControlledSplice {
+        /// First source turn included in the splice.
+        first_turn_id: String,
+        /// Last source turn included in the splice.
+        last_turn_id: String,
+    },
+}
+
+/// Parent metadata carried by every non-root session node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionParent {
+    /// Parent session id.
+    pub session_id: SessionId,
+    /// Turn boundary where the branch diverged.
+    ///
+    /// For [`BranchKind::Clone`], this is `"latest"` until the storage layer
+    /// has a concrete latest-turn id to stamp.
+    pub at_turn_id: String,
+    /// Fork or clone relationship.
+    pub kind: BranchKind,
+    /// Tool call that spawned this branch. Present only for
+    /// [`BranchKind::ToolSpawned`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+/// One node in a session tree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionTreeNode {
+    /// This node's session id.
+    pub session_id: SessionId,
+    /// Parent metadata. `None` only for the tree root.
+    pub parent: Option<SessionParent>,
+    /// Direct child sessions in insertion order.
+    pub children: Vec<SessionId>,
+}
+
+/// Explicit merge event between two existing sessions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionMerge {
+    /// Source branch being folded back.
+    pub source: SessionId,
+    /// Destination trunk/session receiving the merge.
+    pub destination: SessionId,
+    /// Explicit merge behavior.
+    pub strategy: MergeStrategy,
+    /// Destination turn where the merge was applied.
+    pub applied_at_turn_id: String,
+}
+
+/// Storage-agnostic session tree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionTree {
+    root: SessionId,
+    nodes: BTreeMap<SessionId, SessionTreeNode>,
+    merges: Vec<SessionMerge>,
+}
+
+impl SessionTree {
+    /// Represent a v0.1 flat session as the simplest one-branch tree.
+    #[must_use]
+    pub fn flat(root: SessionId) -> Self {
+        let mut nodes = BTreeMap::new();
+        nodes.insert(
+            root.clone(),
+            SessionTreeNode {
+                session_id: root.clone(),
+                parent: None,
+                children: Vec::new(),
+            },
+        );
+        Self {
+            root,
+            nodes,
+            merges: Vec::new(),
+        }
+    }
+
+    /// Tree root session id.
+    #[must_use]
+    pub fn root(&self) -> &SessionId {
+        &self.root
+    }
+
+    /// Direct parent metadata for `session_id`, or `None` for the root.
+    pub fn parent(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Option<&SessionParent>, SessionTreeError> {
+        let node = self
+            .nodes
+            .get(session_id)
+            .ok_or_else(|| SessionTreeError::UnknownSession {
+                session_id: session_id.clone(),
+            })?;
+        Ok(node.parent.as_ref())
+    }
+
+    /// Direct children for `session_id`.
+    pub fn children(&self, session_id: &SessionId) -> Result<Vec<SessionId>, SessionTreeError> {
+        let node = self
+            .nodes
+            .get(session_id)
+            .ok_or_else(|| SessionTreeError::UnknownSession {
+                session_id: session_id.clone(),
+            })?;
+        Ok(node.children.clone())
+    }
+
+    /// Return a stable parent-before-children traversal for a subtree.
+    pub fn subtree_preorder(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<Vec<SessionId>, SessionTreeError> {
+        self.require_session(session_id)?;
+        let mut out = Vec::new();
+        let mut stack = vec![session_id.clone()];
+        while let Some(current) = stack.pop() {
+            let node =
+                self.nodes
+                    .get(&current)
+                    .ok_or_else(|| SessionTreeError::UnknownSession {
+                        session_id: current.clone(),
+                    })?;
+            out.push(current);
+            stack.extend(node.children.iter().rev().cloned());
+        }
+        Ok(out)
+    }
+
+    /// Merge events in append order.
+    #[must_use]
+    pub fn merges(&self) -> &[SessionMerge] {
+        &self.merges
+    }
+
+    /// Validate tree invariants after hydration from storage or JSON.
+    ///
+    /// Constructors maintain these invariants for in-memory writes; this
+    /// method protects deserialized snapshots before callers trust lineage.
+    pub fn validate(&self) -> Result<(), SessionTreeError> {
+        let root = self
+            .nodes
+            .get(&self.root)
+            .ok_or_else(|| SessionTreeError::UnknownSession {
+                session_id: self.root.clone(),
+            })?;
+        if root.parent.is_some() {
+            return Err(SessionTreeError::MalformedLink {
+                session_id: self.root.clone(),
+                message: "root must not have a parent",
+            });
+        }
+        if root.session_id != self.root {
+            return Err(SessionTreeError::MalformedLink {
+                session_id: self.root.clone(),
+                message: "root node id must match tree root",
+            });
+        }
+
+        for (id, node) in &self.nodes {
+            if &node.session_id != id {
+                return Err(SessionTreeError::MalformedLink {
+                    session_id: id.clone(),
+                    message: "node key must match session_id",
+                });
+            }
+            let mut seen_children = BTreeSet::new();
+            for child in &node.children {
+                if !seen_children.insert(child.clone()) {
+                    return Err(SessionTreeError::MalformedLink {
+                        session_id: id.clone(),
+                        message: "children must not contain duplicates",
+                    });
+                }
+                let child_node =
+                    self.nodes
+                        .get(child)
+                        .ok_or_else(|| SessionTreeError::UnknownSession {
+                            session_id: child.clone(),
+                        })?;
+                let Some(parent) = &child_node.parent else {
+                    return Err(SessionTreeError::MalformedLink {
+                        session_id: child.clone(),
+                        message: "child must point back to parent",
+                    });
+                };
+                if &parent.session_id != id {
+                    return Err(SessionTreeError::MalformedLink {
+                        session_id: child.clone(),
+                        message: "child parent does not match containing node",
+                    });
+                }
+            }
+
+            if id == &self.root {
+                continue;
+            }
+            let parent = node
+                .parent
+                .as_ref()
+                .ok_or_else(|| SessionTreeError::MalformedLink {
+                    session_id: id.clone(),
+                    message: "non-root node must have a parent",
+                })?;
+            self.require_session(&parent.session_id)?;
+            non_empty(parent.at_turn_id.clone(), "at_turn_id")?;
+            match parent.kind {
+                BranchKind::ToolSpawned => {
+                    let tool_call_id =
+                        parent
+                            .tool_call_id
+                            .clone()
+                            .ok_or(SessionTreeError::EmptyField {
+                                field: "tool_call_id",
+                            })?;
+                    non_empty(tool_call_id, "tool_call_id")?;
+                }
+                BranchKind::Fork | BranchKind::Clone => {
+                    if parent.tool_call_id.is_some() {
+                        return Err(SessionTreeError::MalformedLink {
+                            session_id: id.clone(),
+                            message: "tool_call_id is only valid for tool-spawned branches",
+                        });
+                    }
+                }
+            }
+            let parent_node = self.nodes.get(&parent.session_id).ok_or_else(|| {
+                SessionTreeError::UnknownSession {
+                    session_id: parent.session_id.clone(),
+                }
+            })?;
+            if !parent_node.children.iter().any(|child| child == id) {
+                return Err(SessionTreeError::MalformedLink {
+                    session_id: id.clone(),
+                    message: "parent children must include child",
+                });
+            }
+        }
+
+        for id in self.nodes.keys() {
+            self.lineage(id)?;
+        }
+
+        for merge in &self.merges {
+            if merge.source == merge.destination {
+                return Err(SessionTreeError::SelfMerge {
+                    session_id: merge.source.clone(),
+                });
+            }
+            self.require_session(&merge.source)?;
+            self.require_session(&merge.destination)?;
+            non_empty(merge.applied_at_turn_id.clone(), "applied_at_turn_id")?;
+            validate_merge_strategy(&merge.strategy)?;
+        }
+
+        Ok(())
+    }
+
+    /// Create a copy-on-write child session from `from` at `at_turn_id`.
+    pub fn fork(
+        &mut self,
+        from: SessionId,
+        child: SessionId,
+        at_turn_id: impl Into<String>,
+    ) -> Result<(), SessionTreeError> {
+        self.add_child(from, child, BranchKind::Fork, at_turn_id, None)
+    }
+
+    /// Create a full-copy child session from `from`.
+    pub fn clone_session(
+        &mut self,
+        from: SessionId,
+        child: SessionId,
+    ) -> Result<(), SessionTreeError> {
+        self.add_child(from, child, BranchKind::Clone, "latest", None)
+    }
+
+    /// Create a branch spawned by a tool call from `from` at `at_turn_id`.
+    pub fn tool_spawn(
+        &mut self,
+        from: SessionId,
+        child: SessionId,
+        at_turn_id: impl Into<String>,
+        tool_call_id: impl Into<String>,
+    ) -> Result<(), SessionTreeError> {
+        let tool_call_id = non_empty(tool_call_id.into(), "tool_call_id")?;
+        self.add_child(
+            from,
+            child,
+            BranchKind::ToolSpawned,
+            at_turn_id,
+            Some(tool_call_id),
+        )
+    }
+
+    /// Return the root-to-session lineage, inclusive.
+    pub fn lineage(&self, session_id: &SessionId) -> Result<Vec<SessionId>, SessionTreeError> {
+        let mut lineage = Vec::new();
+        let mut current = session_id.clone();
+        let mut seen = BTreeSet::new();
+        loop {
+            if !seen.insert(current.clone()) {
+                return Err(SessionTreeError::MalformedLink {
+                    session_id: session_id.clone(),
+                    message: "lineage must not contain cycles",
+                });
+            }
+            let node =
+                self.nodes
+                    .get(&current)
+                    .ok_or_else(|| SessionTreeError::UnknownSession {
+                        session_id: current.clone(),
+                    })?;
+            lineage.push(node.session_id.clone());
+            let Some(parent) = &node.parent else {
+                break;
+            };
+            current = parent.session_id.clone();
+        }
+        lineage.reverse();
+        if lineage.first() != Some(&self.root) {
+            return Err(SessionTreeError::MalformedLink {
+                session_id: session_id.clone(),
+                message: "lineage must reach root",
+            });
+        }
+        Ok(lineage)
+    }
+
+    /// Append an explicit merge event between two existing sessions.
+    pub fn record_merge(
+        &mut self,
+        source: SessionId,
+        destination: SessionId,
+        strategy: MergeStrategy,
+        applied_at_turn_id: impl Into<String>,
+    ) -> Result<SessionMerge, SessionTreeError> {
+        if source == destination {
+            return Err(SessionTreeError::SelfMerge { session_id: source });
+        }
+        self.require_session(&source)?;
+        self.require_session(&destination)?;
+        validate_merge_strategy(&strategy)?;
+        let applied_at_turn_id = non_empty(applied_at_turn_id.into(), "applied_at_turn_id")?;
+        let merge = SessionMerge {
+            source,
+            destination,
+            strategy,
+            applied_at_turn_id,
+        };
+        self.merges.push(merge.clone());
+        Ok(merge)
+    }
+
+    fn add_child(
+        &mut self,
+        from: SessionId,
+        child: SessionId,
+        kind: BranchKind,
+        at_turn_id: impl Into<String>,
+        tool_call_id: Option<String>,
+    ) -> Result<(), SessionTreeError> {
+        self.require_session(&from)?;
+        if self.nodes.contains_key(&child) {
+            return Err(SessionTreeError::DuplicateSession { session_id: child });
+        }
+        let at_turn_id = non_empty(at_turn_id.into(), "at_turn_id")?;
+        let child_node = SessionTreeNode {
+            session_id: child.clone(),
+            parent: Some(SessionParent {
+                session_id: from.clone(),
+                at_turn_id,
+                kind,
+                tool_call_id,
+            }),
+            children: Vec::new(),
+        };
+        self.nodes.insert(child.clone(), child_node);
+        let parent = self.nodes.get_mut(&from).expect("parent checked above");
+        parent.children.push(child);
+        Ok(())
+    }
+
+    fn require_session(&self, session_id: &SessionId) -> Result<(), SessionTreeError> {
+        if self.nodes.contains_key(session_id) {
+            Ok(())
+        } else {
+            Err(SessionTreeError::UnknownSession {
+                session_id: session_id.clone(),
+            })
+        }
+    }
+}
+
+fn non_empty(value: String, field: &'static str) -> Result<String, SessionTreeError> {
+    if value.is_empty() {
+        Err(SessionTreeError::EmptyField { field })
+    } else {
+        Ok(value)
+    }
+}
+
+fn validate_merge_strategy(strategy: &MergeStrategy) -> Result<(), SessionTreeError> {
+    match strategy {
+        MergeStrategy::ReasoningSummary { .. } => Ok(()),
+        MergeStrategy::ControlledSplice {
+            first_turn_id,
+            last_turn_id,
+        } => {
+            non_empty(first_turn_id.clone(), "first_turn_id")?;
+            non_empty(last_turn_id.clone(), "last_turn_id")?;
+            Ok(())
+        }
+    }
+}

--- a/crates/cairn-core/tests/session_tree.rs
+++ b/crates/cairn-core/tests/session_tree.rs
@@ -1,0 +1,431 @@
+#![allow(missing_docs)]
+
+use cairn_core::domain::session_tree::{BranchKind, MergeStrategy, SessionTree, SessionTreeError};
+use cairn_core::domain::{RecordId, SessionId};
+
+fn sid(raw: &str) -> SessionId {
+    SessionId::parse(raw).expect("valid session id")
+}
+
+fn rid(raw: &str) -> RecordId {
+    RecordId::parse(raw).expect("valid record id")
+}
+
+#[test]
+fn flat_session_is_one_branch_tree() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let tree = SessionTree::flat(root.clone());
+
+    assert_eq!(tree.root(), &root);
+    assert_eq!(
+        tree.lineage(&root).expect("root lineage"),
+        vec![root.clone()]
+    );
+    assert_eq!(tree.parent(&root).expect("root parent"), None);
+    assert!(tree.children(&root).expect("root children").is_empty());
+    assert!(tree.merges().is_empty());
+}
+
+#[test]
+fn flat_session_tree_round_trips_as_v0_1_compatible_snapshot() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let tree = SessionTree::flat(root.clone());
+
+    let value = serde_json::to_value(&tree).expect("serialize flat tree");
+    assert_eq!(value["root"], root.as_str());
+    assert_eq!(
+        value["nodes"][root.as_str()]["session_id"],
+        root.as_str(),
+        "flat compatibility snapshot keeps the original session id"
+    );
+    assert_eq!(
+        value["nodes"][root.as_str()]["parent"],
+        serde_json::Value::Null
+    );
+    assert_eq!(
+        value["nodes"][root.as_str()]["children"],
+        serde_json::json!([])
+    );
+    assert_eq!(value["merges"], serde_json::json!([]));
+
+    let restored: SessionTree = serde_json::from_value(value).expect("restore flat tree");
+    restored.validate().expect("restored flat tree validates");
+    assert_eq!(
+        restored.lineage(&root).expect("restored lineage"),
+        vec![root]
+    );
+}
+
+#[test]
+fn fork_preserves_parent_child_lineage() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let child = sid("01JTS6R4J70000000000000001");
+    let grandchild = sid("01JTS6R4J70000000000000002");
+    let mut tree = SessionTree::flat(root.clone());
+
+    tree.fork(root.clone(), child.clone(), "turn-4")
+        .expect("fork child");
+    tree.clone_session(child.clone(), grandchild.clone())
+        .expect("clone grandchild");
+
+    assert_eq!(
+        tree.lineage(&grandchild).expect("grandchild lineage"),
+        vec![root.clone(), child.clone(), grandchild.clone()]
+    );
+    assert_eq!(
+        tree.children(&root).expect("root children"),
+        vec![child.clone()]
+    );
+    assert_eq!(
+        tree.parent(&child)
+            .expect("child parent")
+            .expect("child parent")
+            .kind,
+        BranchKind::Fork
+    );
+    assert_eq!(
+        tree.parent(&grandchild)
+            .expect("grandchild parent")
+            .expect("grandchild parent")
+            .kind,
+        BranchKind::Clone
+    );
+}
+
+#[test]
+fn subtree_preorder_returns_parent_before_children_in_insertion_order() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let first = sid("01JTS6R4J70000000000000001");
+    let second = sid("01JTS6R4J70000000000000002");
+    let grandchild = sid("01JTS6R4J70000000000000003");
+    let mut tree = SessionTree::flat(root.clone());
+
+    tree.fork(root.clone(), first.clone(), "turn-4")
+        .expect("fork first child");
+    tree.fork(root.clone(), second.clone(), "turn-5")
+        .expect("fork second child");
+    tree.tool_spawn(first.clone(), grandchild.clone(), "turn-6", "call-review")
+        .expect("tool branch");
+
+    assert_eq!(
+        tree.subtree_preorder(&root).expect("root subtree"),
+        vec![root.clone(), first.clone(), grandchild.clone(), second]
+    );
+    assert_eq!(
+        tree.subtree_preorder(&first).expect("child subtree"),
+        vec![first, grandchild]
+    );
+}
+
+#[test]
+fn tool_spawned_branch_preserves_tool_call_metadata() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let child = sid("01JTS6R4J70000000000000001");
+    let mut tree = SessionTree::flat(root.clone());
+
+    tree.tool_spawn(root.clone(), child.clone(), "turn-4", "call-search")
+        .expect("tool spawned branch");
+
+    let parent = tree
+        .parent(&child)
+        .expect("child parent")
+        .expect("child parent");
+    assert_eq!(parent.kind, BranchKind::ToolSpawned);
+    assert_eq!(parent.at_turn_id, "turn-4");
+    assert_eq!(parent.tool_call_id.as_deref(), Some("call-search"));
+    assert_eq!(
+        tree.lineage(&child).expect("child lineage"),
+        vec![root, child]
+    );
+}
+
+#[test]
+fn branch_insertion_rejects_missing_parent_and_duplicate_child() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let child = sid("01JTS6R4J70000000000000001");
+    let missing = sid("01JTS6R4J70000000000000002");
+    let mut tree = SessionTree::flat(root.clone());
+
+    let err = tree
+        .fork(missing.clone(), child.clone(), "turn-4")
+        .expect_err("missing parent rejected");
+    assert_eq!(
+        err,
+        SessionTreeError::UnknownSession {
+            session_id: missing.clone()
+        }
+    );
+
+    tree.fork(root.clone(), child.clone(), "turn-4")
+        .expect("first fork");
+    let err = tree
+        .clone_session(root.clone(), child.clone())
+        .expect_err("duplicate child rejected");
+    assert_eq!(
+        err,
+        SessionTreeError::DuplicateSession {
+            session_id: child.clone()
+        }
+    );
+
+    let err = tree
+        .subtree_preorder(&missing)
+        .expect_err("missing subtree root rejected");
+    assert_eq!(
+        err,
+        SessionTreeError::UnknownSession {
+            session_id: missing
+        }
+    );
+}
+
+#[test]
+fn merges_are_explicit_and_auditable() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let branch = sid("01JTS6R4J70000000000000001");
+    let summary = rid("01JTS6R4J70000000000000002");
+    let mut tree = SessionTree::flat(root.clone());
+    tree.fork(root.clone(), branch.clone(), "turn-4")
+        .expect("fork branch");
+
+    let merge = tree
+        .record_merge(
+            branch.clone(),
+            root.clone(),
+            MergeStrategy::ReasoningSummary {
+                summary_record_id: summary.clone(),
+            },
+            "turn-8",
+        )
+        .expect("merge branch");
+
+    assert_eq!(merge.source, branch);
+    assert_eq!(merge.destination, root);
+    assert_eq!(merge.applied_at_turn_id.as_str(), "turn-8");
+    assert_eq!(
+        merge.strategy,
+        MergeStrategy::ReasoningSummary {
+            summary_record_id: summary
+        }
+    );
+    assert_eq!(tree.merges(), &[merge]);
+}
+
+#[test]
+fn controlled_splice_merge_records_source_turn_range() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let branch = sid("01JTS6R4J70000000000000001");
+    let mut tree = SessionTree::flat(root.clone());
+    tree.fork(root.clone(), branch.clone(), "turn-4")
+        .expect("fork branch");
+
+    let merge = tree
+        .record_merge(
+            branch.clone(),
+            root.clone(),
+            MergeStrategy::ControlledSplice {
+                first_turn_id: "turn-5".to_owned(),
+                last_turn_id: "turn-7".to_owned(),
+            },
+            "turn-8",
+        )
+        .expect("controlled splice");
+
+    assert_eq!(merge.source, branch);
+    assert_eq!(merge.destination, root);
+    assert_eq!(
+        merge.strategy,
+        MergeStrategy::ControlledSplice {
+            first_turn_id: "turn-5".to_owned(),
+            last_turn_id: "turn-7".to_owned(),
+        }
+    );
+    tree.validate().expect("controlled splice validates");
+}
+
+#[test]
+fn controlled_splice_merge_rejects_empty_source_turn_range() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let branch = sid("01JTS6R4J70000000000000001");
+    let mut tree = SessionTree::flat(root.clone());
+    tree.fork(root.clone(), branch.clone(), "turn-4")
+        .expect("fork branch");
+
+    let err = tree
+        .record_merge(
+            branch,
+            root,
+            MergeStrategy::ControlledSplice {
+                first_turn_id: String::new(),
+                last_turn_id: "turn-7".to_owned(),
+            },
+            "turn-8",
+        )
+        .expect_err("empty splice range rejected");
+
+    assert_eq!(
+        err,
+        SessionTreeError::EmptyField {
+            field: "first_turn_id"
+        }
+    );
+}
+
+#[test]
+fn merge_rejects_unknown_endpoints_and_self_merge() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let missing = sid("01JTS6R4J70000000000000001");
+    let summary = rid("01JTS6R4J70000000000000002");
+    let mut tree = SessionTree::flat(root.clone());
+
+    let err = tree
+        .record_merge(
+            missing.clone(),
+            root.clone(),
+            MergeStrategy::ReasoningSummary {
+                summary_record_id: summary.clone(),
+            },
+            "turn-8",
+        )
+        .expect_err("missing source rejected");
+    assert_eq!(
+        err,
+        SessionTreeError::UnknownSession {
+            session_id: missing
+        }
+    );
+
+    let err = tree
+        .record_merge(
+            root.clone(),
+            root.clone(),
+            MergeStrategy::ReasoningSummary {
+                summary_record_id: summary,
+            },
+            "turn-8",
+        )
+        .expect_err("self merge rejected");
+    assert_eq!(err, SessionTreeError::SelfMerge { session_id: root });
+}
+
+#[test]
+fn validate_accepts_consistent_tree_snapshot() {
+    let root = sid("01JTS6R4J70000000000000000");
+    let branch = sid("01JTS6R4J70000000000000001");
+    let summary = rid("01JTS6R4J70000000000000002");
+    let mut tree = SessionTree::flat(root.clone());
+
+    tree.tool_spawn(root.clone(), branch.clone(), "turn-4", "call-search")
+        .expect("tool branch");
+    tree.record_merge(
+        branch,
+        root,
+        MergeStrategy::ReasoningSummary {
+            summary_record_id: summary,
+        },
+        "turn-8",
+    )
+    .expect("merge");
+
+    tree.validate().expect("consistent tree validates");
+}
+
+#[test]
+fn validate_rejects_hydrated_tool_branch_without_tool_call_id() {
+    let raw = serde_json::json!({
+        "root": "01JTS6R4J70000000000000000",
+        "nodes": {
+            "01JTS6R4J70000000000000000": {
+                "session_id": "01JTS6R4J70000000000000000",
+                "parent": null,
+                "children": ["01JTS6R4J70000000000000001"]
+            },
+            "01JTS6R4J70000000000000001": {
+                "session_id": "01JTS6R4J70000000000000001",
+                "parent": {
+                    "session_id": "01JTS6R4J70000000000000000",
+                    "at_turn_id": "turn-4",
+                    "kind": "tool_spawned"
+                },
+                "children": []
+            }
+        },
+        "merges": []
+    });
+    let tree: SessionTree = serde_json::from_value(raw).expect("deserialize malformed tree");
+
+    let err = tree
+        .validate()
+        .expect_err("tool-spawned branch requires tool call id");
+    assert_eq!(
+        err,
+        SessionTreeError::EmptyField {
+            field: "tool_call_id"
+        }
+    );
+}
+
+#[test]
+fn validate_rejects_hydrated_parent_cycle_disconnected_from_root() {
+    let tree = disconnected_cycle_tree();
+
+    let err = tree
+        .validate()
+        .expect_err("cyclic lineage must be rejected");
+    assert_eq!(
+        err,
+        SessionTreeError::MalformedLink {
+            session_id: sid("01JTS6R4J70000000000000001"),
+            message: "lineage must not contain cycles",
+        }
+    );
+}
+
+#[test]
+fn lineage_rejects_hydrated_parent_cycle() {
+    let tree = disconnected_cycle_tree();
+
+    let err = tree
+        .lineage(&sid("01JTS6R4J70000000000000001"))
+        .expect_err("cyclic lineage must be rejected");
+    assert_eq!(
+        err,
+        SessionTreeError::MalformedLink {
+            session_id: sid("01JTS6R4J70000000000000001"),
+            message: "lineage must not contain cycles",
+        }
+    );
+}
+
+fn disconnected_cycle_tree() -> SessionTree {
+    let raw = serde_json::json!({
+        "root": "01JTS6R4J70000000000000000",
+        "nodes": {
+            "01JTS6R4J70000000000000000": {
+                "session_id": "01JTS6R4J70000000000000000",
+                "parent": null,
+                "children": []
+            },
+            "01JTS6R4J70000000000000001": {
+                "session_id": "01JTS6R4J70000000000000001",
+                "parent": {
+                    "session_id": "01JTS6R4J70000000000000002",
+                    "at_turn_id": "turn-4",
+                    "kind": "fork"
+                },
+                "children": ["01JTS6R4J70000000000000002"]
+            },
+            "01JTS6R4J70000000000000002": {
+                "session_id": "01JTS6R4J70000000000000002",
+                "parent": {
+                    "session_id": "01JTS6R4J70000000000000001",
+                    "at_turn_id": "turn-5",
+                    "kind": "fork"
+                },
+                "children": ["01JTS6R4J70000000000000001"]
+            }
+        },
+        "merges": []
+    });
+    serde_json::from_value(raw).expect("deserialize cyclic tree")
+}

--- a/crates/cairn-core/tests/session_tree.rs
+++ b/crates/cairn-core/tests/session_tree.rs
@@ -63,9 +63,9 @@ fn fork_preserves_parent_child_lineage() {
     let grandchild = sid("01JTS6R4J70000000000000002");
     let mut tree = SessionTree::flat(root.clone());
 
-    tree.fork(root.clone(), child.clone(), "turn-4")
+    tree.fork(&root, child.clone(), "turn-4")
         .expect("fork child");
-    tree.clone_session(child.clone(), grandchild.clone())
+    tree.clone_session(&child, grandchild.clone())
         .expect("clone grandchild");
 
     assert_eq!(
@@ -100,11 +100,11 @@ fn subtree_preorder_returns_parent_before_children_in_insertion_order() {
     let grandchild = sid("01JTS6R4J70000000000000003");
     let mut tree = SessionTree::flat(root.clone());
 
-    tree.fork(root.clone(), first.clone(), "turn-4")
+    tree.fork(&root, first.clone(), "turn-4")
         .expect("fork first child");
-    tree.fork(root.clone(), second.clone(), "turn-5")
+    tree.fork(&root, second.clone(), "turn-5")
         .expect("fork second child");
-    tree.tool_spawn(first.clone(), grandchild.clone(), "turn-6", "call-review")
+    tree.tool_spawn(&first, grandchild.clone(), "turn-6", "call-review")
         .expect("tool branch");
 
     assert_eq!(
@@ -123,7 +123,7 @@ fn tool_spawned_branch_preserves_tool_call_metadata() {
     let child = sid("01JTS6R4J70000000000000001");
     let mut tree = SessionTree::flat(root.clone());
 
-    tree.tool_spawn(root.clone(), child.clone(), "turn-4", "call-search")
+    tree.tool_spawn(&root, child.clone(), "turn-4", "call-search")
         .expect("tool spawned branch");
 
     let parent = tree
@@ -147,7 +147,7 @@ fn branch_insertion_rejects_missing_parent_and_duplicate_child() {
     let mut tree = SessionTree::flat(root.clone());
 
     let err = tree
-        .fork(missing.clone(), child.clone(), "turn-4")
+        .fork(&missing, child.clone(), "turn-4")
         .expect_err("missing parent rejected");
     assert_eq!(
         err,
@@ -156,10 +156,10 @@ fn branch_insertion_rejects_missing_parent_and_duplicate_child() {
         }
     );
 
-    tree.fork(root.clone(), child.clone(), "turn-4")
+    tree.fork(&root, child.clone(), "turn-4")
         .expect("first fork");
     let err = tree
-        .clone_session(root.clone(), child.clone())
+        .clone_session(&root, child.clone())
         .expect_err("duplicate child rejected");
     assert_eq!(
         err,
@@ -185,7 +185,7 @@ fn merges_are_explicit_and_auditable() {
     let branch = sid("01JTS6R4J70000000000000001");
     let summary = rid("01JTS6R4J70000000000000002");
     let mut tree = SessionTree::flat(root.clone());
-    tree.fork(root.clone(), branch.clone(), "turn-4")
+    tree.fork(&root, branch.clone(), "turn-4")
         .expect("fork branch");
 
     let merge = tree
@@ -216,7 +216,7 @@ fn controlled_splice_merge_records_source_turn_range() {
     let root = sid("01JTS6R4J70000000000000000");
     let branch = sid("01JTS6R4J70000000000000001");
     let mut tree = SessionTree::flat(root.clone());
-    tree.fork(root.clone(), branch.clone(), "turn-4")
+    tree.fork(&root, branch.clone(), "turn-4")
         .expect("fork branch");
 
     let merge = tree
@@ -248,7 +248,7 @@ fn controlled_splice_merge_rejects_empty_source_turn_range() {
     let root = sid("01JTS6R4J70000000000000000");
     let branch = sid("01JTS6R4J70000000000000001");
     let mut tree = SessionTree::flat(root.clone());
-    tree.fork(root.clone(), branch.clone(), "turn-4")
+    tree.fork(&root, branch.clone(), "turn-4")
         .expect("fork branch");
 
     let err = tree
@@ -315,7 +315,7 @@ fn validate_accepts_consistent_tree_snapshot() {
     let summary = rid("01JTS6R4J70000000000000002");
     let mut tree = SessionTree::flat(root.clone());
 
-    tree.tool_spawn(root.clone(), branch.clone(), "turn-4", "call-search")
+    tree.tool_spawn(&root, branch.clone(), "turn-4", "call-search")
         .expect("tool branch");
     tree.record_merge(
         branch,

--- a/crates/cairn-store-sqlite/src/error.rs
+++ b/crates/cairn-store-sqlite/src/error.rs
@@ -86,6 +86,10 @@ pub enum StoreError {
     #[error("invalid record: {0}")]
     InvalidRecord(#[from] cairn_core::domain::DomainError),
 
+    /// Session-tree branch or merge metadata failed pure domain validation.
+    #[error("invalid session tree: {0}")]
+    InvalidSessionTree(#[from] cairn_core::domain::SessionTreeError),
+
     /// Record id was looked up but not present (or only present as a
     /// tombstoned row that callers must not see via `get`).
     #[error("record not found: {id}")]

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -120,6 +120,9 @@ const M0059_SESSION_METADATA_AUDIT_SEQ: &str =
 const M0060_CONSENT_SCOPE_UPPERCASE: &str = include_str!("sql/0060_consent_scope_uppercase.sql");
 // Issue #313 — salience access tracking and decay guardrails.
 const M0061_SALIENCE_ACCESS: &str = include_str!("sql/0061_salience_access.sql");
+// Issue #133 — storage substrate for session tree branch/merge metadata.
+// Renumbered from 0061 during rebase because #313 landed 0061 first.
+const M0062_SESSION_TREE: &str = include_str!("sql/0062_session_tree.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -299,6 +302,7 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
         M0060_CONSENT_SCOPE_UPPERCASE,
     ),
     (61, "0061_salience_access", M0061_SALIENCE_ACCESS),
+    (62, "0062_session_tree", M0062_SESSION_TREE),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -361,5 +365,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0059_SESSION_METADATA_AUDIT_SEQ),
         M::up(M0060_CONSENT_SCOPE_UPPERCASE),
         M::up(M0061_SALIENCE_ACCESS),
+        M::up(M0062_SESSION_TREE),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/sql/0062_session_tree.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0062_session_tree.sql
@@ -1,0 +1,72 @@
+-- Migration 0062: storage substrate for v0.3 session trees.
+-- Issue #133 / brief §5.7.
+--
+-- This adds branch/merge metadata without advertising the blocked
+-- cairn.sessiontree.v1 extension. Existing v0.1 session rows remain valid:
+-- read paths synthesize a one-node tree when no row exists here.
+
+CREATE TABLE session_tree_nodes (
+  session_id         TEXT PRIMARY KEY
+                     REFERENCES sessions(session_id) ON DELETE CASCADE,
+  parent_session_id  TEXT
+                     REFERENCES sessions(session_id) ON DELETE RESTRICT,
+  at_turn_id         TEXT,
+  branch_kind        TEXT CHECK (branch_kind IN ('fork', 'clone', 'tool_spawned')),
+  tool_call_id       TEXT,
+  created_at         INTEGER NOT NULL,
+
+  CHECK (session_id != parent_session_id),
+  CHECK (
+    (parent_session_id IS NULL AND at_turn_id IS NULL AND branch_kind IS NULL AND tool_call_id IS NULL)
+    OR
+    (parent_session_id IS NOT NULL AND at_turn_id IS NOT NULL AND branch_kind IS NOT NULL)
+  ),
+  CHECK (
+    branch_kind IS NULL
+    OR (branch_kind = 'tool_spawned' AND tool_call_id IS NOT NULL AND length(tool_call_id) > 0)
+    OR (branch_kind IN ('fork', 'clone') AND tool_call_id IS NULL)
+  )
+);
+
+CREATE INDEX session_tree_nodes_parent_idx
+  ON session_tree_nodes(parent_session_id, created_at, session_id)
+  WHERE parent_session_id IS NOT NULL;
+
+CREATE TABLE session_tree_merges (
+  merge_id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_session_id    TEXT NOT NULL
+                       REFERENCES sessions(session_id) ON DELETE RESTRICT,
+  destination_session_id TEXT NOT NULL
+                       REFERENCES sessions(session_id) ON DELETE RESTRICT,
+  strategy_kind        TEXT NOT NULL CHECK (strategy_kind IN ('reasoning_summary', 'controlled_splice')),
+  summary_record_id    TEXT,
+  first_turn_id        TEXT,
+  last_turn_id         TEXT,
+  applied_at_turn_id   TEXT NOT NULL,
+  created_at           INTEGER NOT NULL,
+
+  CHECK (source_session_id != destination_session_id),
+  CHECK (
+    (strategy_kind = 'reasoning_summary'
+      AND summary_record_id IS NOT NULL
+      AND first_turn_id IS NULL
+      AND last_turn_id IS NULL)
+    OR
+    (strategy_kind = 'controlled_splice'
+      AND summary_record_id IS NULL
+      AND first_turn_id IS NOT NULL
+      AND length(first_turn_id) > 0
+      AND last_turn_id IS NOT NULL
+      AND length(last_turn_id) > 0)
+  ),
+  CHECK (length(applied_at_turn_id) > 0)
+);
+
+CREATE INDEX session_tree_merges_source_idx
+  ON session_tree_merges(source_session_id, created_at, merge_id);
+
+CREATE INDEX session_tree_merges_destination_idx
+  ON session_tree_merges(destination_session_id, created_at, merge_id);
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (62, '0062_session_tree', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/store/sessions.rs
+++ b/crates/cairn-store-sqlite/src/store/sessions.rs
@@ -649,10 +649,10 @@ impl SqliteMemoryStore {
     ) -> Result<(), StoreError> {
         let mut check = SessionTree::flat(from.clone());
         match kind {
-            BranchKind::Fork => check.fork(from.clone(), child.clone(), at_turn_id.clone())?,
-            BranchKind::Clone => check.clone_session(from.clone(), child.clone())?,
+            BranchKind::Fork => check.fork(from, child.clone(), at_turn_id.clone())?,
+            BranchKind::Clone => check.clone_session(from, child.clone())?,
             BranchKind::ToolSpawned => check.tool_spawn(
-                from.clone(),
+                from,
                 child.clone(),
                 at_turn_id.clone(),
                 tool_call_id.clone().ok_or(SessionTreeError::EmptyField {
@@ -1321,10 +1321,10 @@ fn load_session_tree_sync(
             field: "at_turn_id",
         })?;
         match parse_branch_kind(branch_kind.as_deref(), &session_id)? {
-            BranchKind::Fork => tree.fork(parent, session_id, at_turn_id)?,
-            BranchKind::Clone => tree.clone_session(parent, session_id)?,
+            BranchKind::Fork => tree.fork(&parent, session_id, at_turn_id)?,
+            BranchKind::Clone => tree.clone_session(&parent, session_id)?,
             BranchKind::ToolSpawned => tree.tool_spawn(
-                parent,
+                &parent,
                 session_id,
                 at_turn_id,
                 tool_call_id.ok_or(SessionTreeError::EmptyField {

--- a/crates/cairn-store-sqlite/src/store/sessions.rs
+++ b/crates/cairn-store-sqlite/src/store/sessions.rs
@@ -4,15 +4,20 @@
 //! is the persistence half: locating the most recent active session for an
 //! identity, minting new ones, bumping `last_activity_at`, and ending them.
 //!
-//! Methods are inherent on [`SqliteMemoryStore`] rather than on the
-//! [`MemoryStore`] trait: P0 deliberately keeps session storage out of the
-//! trait surface so future stores (fixture, remote) don't have to implement
-//! it. The verb dispatcher reaches into the concrete store, the same way
-//! [`SqliteMemoryStore::with_tx`] is reached.
+//! Session lifecycle methods remain inherent on [`SqliteMemoryStore`].
+//! Session-tree metadata is also exposed through the optional
+//! [`MemoryStore`] trait methods added for the v0.3 substrate; adapters that
+//! do not implement those methods keep the default capability-unavailable
+//! behavior.
 //!
 //! [`MemoryStore`]: cairn_core::contract::memory_store::MemoryStore
 
+use std::collections::BTreeSet;
+
 use cairn_core::domain::session::{LastActiveSession, Session, SessionId, SessionIdentity};
+use cairn_core::domain::{
+    BranchKind, MergeStrategy, RecordId, SessionMerge, SessionTree, SessionTreeError,
+};
 use rusqlite::{OptionalExtension, params};
 use tracing::instrument;
 use ulid::Ulid;
@@ -563,6 +568,184 @@ impl SqliteMemoryStore {
         Ok(row.filter(|s| s.identity == *expected))
     }
 
+    /// Load session-tree metadata rooted at `root`.
+    ///
+    /// Existing v0.1 sessions have no `session_tree_nodes` row; those are
+    /// synthesized as a one-node flat tree so old sessions keep retrieving
+    /// normally after the v0.3 schema lands.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Sqlite`] / [`StoreError::Worker`] for storage failures,
+    /// and [`StoreError::InvalidSessionTree`] when persisted metadata violates
+    /// the pure session-tree invariants.
+    #[instrument(
+        skip(self),
+        err,
+        fields(verb = "get_session_tree", session_id = %root.as_str()),
+    )]
+    #[allow(
+        tail_expr_drop_order,
+        reason = "drop order of the cloned tokio_rusqlite handle relative to the await temporary is benign — both are channel-backed clones with no observable side effects beyond worker shutdown, which the runtime handles regardless of order"
+    )]
+    pub async fn get_session_tree(
+        &self,
+        root: &SessionId,
+    ) -> Result<Option<SessionTree>, StoreError> {
+        let conn = self.require_conn("get_session_tree")?.clone();
+        let root_key = root.as_str().to_owned();
+        conn.call(move |c| Ok::<_, tokio_rusqlite::Error>(load_session_tree_sync(c, &root_key)))
+            .await
+            .map_err(StoreError::from)?
+    }
+
+    /// Persist copy-on-write branch metadata between two existing sessions.
+    pub async fn record_session_fork(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+        at_turn_id: impl Into<String>,
+    ) -> Result<(), StoreError> {
+        self.record_session_branch(from, child, BranchKind::Fork, at_turn_id.into(), None)
+            .await
+    }
+
+    /// Persist full-copy branch metadata between two existing sessions.
+    pub async fn record_session_clone(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+    ) -> Result<(), StoreError> {
+        self.record_session_branch(from, child, BranchKind::Clone, "latest".to_owned(), None)
+            .await
+    }
+
+    /// Persist tool-spawned branch metadata between two existing sessions.
+    pub async fn record_session_tool_spawn(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+        at_turn_id: impl Into<String>,
+        tool_call_id: impl Into<String>,
+    ) -> Result<(), StoreError> {
+        self.record_session_branch(
+            from,
+            child,
+            BranchKind::ToolSpawned,
+            at_turn_id.into(),
+            Some(tool_call_id.into()),
+        )
+        .await
+    }
+
+    async fn record_session_branch(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+        kind: BranchKind,
+        at_turn_id: String,
+        tool_call_id: Option<String>,
+    ) -> Result<(), StoreError> {
+        let mut check = SessionTree::flat(from.clone());
+        match kind {
+            BranchKind::Fork => check.fork(from.clone(), child.clone(), at_turn_id.clone())?,
+            BranchKind::Clone => check.clone_session(from.clone(), child.clone())?,
+            BranchKind::ToolSpawned => check.tool_spawn(
+                from.clone(),
+                child.clone(),
+                at_turn_id.clone(),
+                tool_call_id.clone().ok_or(SessionTreeError::EmptyField {
+                    field: "tool_call_id",
+                })?,
+            )?,
+            _ => {
+                return Err(StoreError::Invariant {
+                    what: "unknown future BranchKind cannot be persisted by this store".to_owned(),
+                });
+            }
+        }
+
+        let conn = self.require_conn("record_session_branch")?.clone();
+        let from_key = from.as_str().to_owned();
+        let child_key = child.as_str().to_owned();
+        let kind_wire = branch_kind_wire(kind).to_owned();
+        conn.call(move |c| {
+            let now_ms = current_unix_ms();
+            c.execute(
+                "INSERT OR IGNORE INTO session_tree_nodes \
+                   (session_id, parent_session_id, at_turn_id, branch_kind, tool_call_id, created_at) \
+                 VALUES (?1, NULL, NULL, NULL, NULL, ?2)",
+                params![from_key, now_ms],
+            )?;
+            c.execute(
+                "INSERT INTO session_tree_nodes \
+                   (session_id, parent_session_id, at_turn_id, branch_kind, tool_call_id, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![child_key, from_key, at_turn_id, kind_wire, tool_call_id, now_ms],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Persist an explicit, auditable session-tree merge between sessions.
+    pub async fn record_session_merge(
+        &self,
+        source: &SessionId,
+        destination: &SessionId,
+        strategy: MergeStrategy,
+        applied_at_turn_id: impl Into<String>,
+    ) -> Result<SessionMerge, StoreError> {
+        let applied_at_turn_id = applied_at_turn_id.into();
+        if source == destination {
+            return Err(SessionTreeError::SelfMerge {
+                session_id: source.clone(),
+            }
+            .into());
+        }
+        let tree = self.get_session_tree(source).await?.ok_or_else(|| {
+            SessionTreeError::UnknownSession {
+                session_id: source.clone(),
+            }
+        })?;
+        tree.lineage(destination)?;
+        let mut check = tree.clone();
+        let merge = check.record_merge(
+            source.clone(),
+            destination.clone(),
+            strategy.clone(),
+            applied_at_turn_id.clone(),
+        )?;
+
+        let conn = self.require_conn("record_session_merge")?.clone();
+        let source_key = source.as_str().to_owned();
+        let destination_key = destination.as_str().to_owned();
+        let encoded = EncodedMergeStrategy::from_strategy(&strategy);
+        conn.call(move |c| {
+            c.execute(
+                "INSERT INTO session_tree_merges \
+                   (source_session_id, destination_session_id, strategy_kind, \
+                    summary_record_id, first_turn_id, last_turn_id, applied_at_turn_id, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    source_key,
+                    destination_key,
+                    encoded.kind,
+                    encoded.summary_record_id,
+                    encoded.first_turn_id,
+                    encoded.last_turn_id,
+                    applied_at_turn_id,
+                    current_unix_ms(),
+                ],
+            )?;
+            Ok::<_, tokio_rusqlite::Error>(())
+        })
+        .await?;
+        Ok(merge)
+    }
+
     /// Test-only accessor that bypasses the identity guard
     /// [`SqliteMemoryStore::get_session`] enforces.
     ///
@@ -1044,6 +1227,293 @@ impl From<rusqlite::Error> for InTxError {
             }
         }
         Self::Sqlite(e)
+    }
+}
+
+type SessionTreeNodeRow = (
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+type SessionTreeMergeRow = (
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    String,
+);
+
+struct EncodedMergeStrategy {
+    kind: &'static str,
+    summary_record_id: Option<String>,
+    first_turn_id: Option<String>,
+    last_turn_id: Option<String>,
+}
+
+impl EncodedMergeStrategy {
+    fn from_strategy(strategy: &MergeStrategy) -> Self {
+        match strategy {
+            MergeStrategy::ReasoningSummary { summary_record_id } => Self {
+                kind: "reasoning_summary",
+                summary_record_id: Some(summary_record_id.as_str().to_owned()),
+                first_turn_id: None,
+                last_turn_id: None,
+            },
+            MergeStrategy::ControlledSplice {
+                first_turn_id,
+                last_turn_id,
+            } => Self {
+                kind: "controlled_splice",
+                summary_record_id: None,
+                first_turn_id: Some(first_turn_id.clone()),
+                last_turn_id: Some(last_turn_id.clone()),
+            },
+            _ => Self {
+                kind: "unknown",
+                summary_record_id: None,
+                first_turn_id: None,
+                last_turn_id: None,
+            },
+        }
+    }
+}
+
+fn load_session_tree_sync(
+    conn: &rusqlite::Connection,
+    root_key: &str,
+) -> Result<Option<SessionTree>, StoreError> {
+    let root_exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) = 1 FROM sessions WHERE session_id = ?1",
+            params![root_key],
+            |r| r.get::<_, i64>(0).map(|v| v == 1),
+        )
+        .map_err(StoreError::Sqlite)?;
+    if !root_exists {
+        return Ok(None);
+    }
+
+    let root_key = resolve_session_tree_root_key(conn, root_key)?;
+    let root = parse_session_id(&root_key)?;
+    let mut tree = SessionTree::flat(root.clone());
+    let mut subtree_ids = BTreeSet::from([root.clone()]);
+    let rows = load_session_tree_node_rows(conn, &root_key)?;
+
+    for (session_id, parent_session_id, at_turn_id, branch_kind, tool_call_id) in rows {
+        let session_id = parse_session_id(&session_id)?;
+        subtree_ids.insert(session_id.clone());
+        if session_id == root {
+            continue;
+        }
+        let parent = parent_session_id.ok_or_else(|| {
+            StoreError::InvalidSessionTree(SessionTreeError::MalformedLink {
+                session_id: session_id.clone(),
+                message: "non-root node must have a parent",
+            })
+        })?;
+        let parent = parse_session_id(&parent)?;
+        let at_turn_id = at_turn_id.ok_or(SessionTreeError::EmptyField {
+            field: "at_turn_id",
+        })?;
+        match parse_branch_kind(branch_kind.as_deref(), &session_id)? {
+            BranchKind::Fork => tree.fork(parent, session_id, at_turn_id)?,
+            BranchKind::Clone => tree.clone_session(parent, session_id)?,
+            BranchKind::ToolSpawned => tree.tool_spawn(
+                parent,
+                session_id,
+                at_turn_id,
+                tool_call_id.ok_or(SessionTreeError::EmptyField {
+                    field: "tool_call_id",
+                })?,
+            )?,
+            _ => unreachable!("BranchKind is non_exhaustive for forward compatibility"),
+        }
+    }
+
+    for row in load_session_tree_merge_rows(conn)? {
+        let (source, destination, strategy_kind, summary, first, last, applied_at) = row;
+        let source = parse_session_id(&source)?;
+        let destination = parse_session_id(&destination)?;
+        if !(subtree_ids.contains(&source) && subtree_ids.contains(&destination)) {
+            continue;
+        }
+        tree.record_merge(
+            source,
+            destination,
+            parse_merge_strategy(&strategy_kind, summary, first, last)?,
+            applied_at,
+        )?;
+    }
+    tree.validate()?;
+    Ok(Some(tree))
+}
+
+fn resolve_session_tree_root_key(
+    conn: &rusqlite::Connection,
+    session_key: &str,
+) -> Result<String, StoreError> {
+    let mut stmt = conn.prepare(
+        "WITH RECURSIVE ancestors(session_id, parent_session_id) AS ( \
+           SELECT session_id, parent_session_id \
+             FROM session_tree_nodes \
+            WHERE session_id = ?1 \
+           UNION \
+           SELECT n.session_id, n.parent_session_id \
+             FROM session_tree_nodes n \
+             JOIN ancestors ON ancestors.parent_session_id = n.session_id \
+         ) \
+         SELECT session_id \
+           FROM ancestors \
+          WHERE parent_session_id IS NULL \
+          LIMIT 1",
+    )?;
+    let resolved = stmt
+        .query_row(params![session_key], |r| r.get::<_, String>(0))
+        .optional()
+        .map_err(StoreError::Sqlite)?;
+    if let Some(root_key) = resolved {
+        return Ok(root_key);
+    }
+
+    let has_metadata: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM session_tree_nodes WHERE session_id = ?1",
+            params![session_key],
+            |r| r.get::<_, i64>(0).map(|v| v > 0),
+        )
+        .map_err(StoreError::Sqlite)?;
+    if !has_metadata {
+        return Ok(session_key.to_owned());
+    }
+
+    let session_id = parse_session_id(session_key)?;
+    Err(StoreError::InvalidSessionTree(
+        SessionTreeError::MalformedLink {
+            session_id,
+            message: "session tree ancestry does not reach a root",
+        },
+    ))
+}
+
+fn load_session_tree_node_rows(
+    conn: &rusqlite::Connection,
+    root_key: &str,
+) -> Result<Vec<SessionTreeNodeRow>, StoreError> {
+    let mut stmt = conn.prepare(
+        "WITH RECURSIVE subtree(session_id, depth) AS ( \
+           SELECT ?1, 0 \
+           UNION ALL \
+           SELECT n.session_id, subtree.depth + 1 \
+             FROM session_tree_nodes n \
+             JOIN subtree ON n.parent_session_id = subtree.session_id \
+         ) \
+         SELECT n.session_id, n.parent_session_id, n.at_turn_id, n.branch_kind, n.tool_call_id \
+           FROM session_tree_nodes n \
+           JOIN subtree ON subtree.session_id = n.session_id \
+          ORDER BY subtree.depth, n.created_at, n.session_id",
+    )?;
+    let rows = stmt.query_map(params![root_key], |r| {
+        Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?))
+    })?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(StoreError::Sqlite)
+}
+
+fn load_session_tree_merge_rows(
+    conn: &rusqlite::Connection,
+) -> Result<Vec<SessionTreeMergeRow>, StoreError> {
+    let mut stmt = conn.prepare(
+        "SELECT source_session_id, destination_session_id, strategy_kind, \
+                summary_record_id, first_turn_id, last_turn_id, applied_at_turn_id \
+           FROM session_tree_merges \
+          ORDER BY created_at, merge_id",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get(0)?,
+            r.get(1)?,
+            r.get(2)?,
+            r.get(3)?,
+            r.get(4)?,
+            r.get(5)?,
+            r.get(6)?,
+        ))
+    })?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(StoreError::Sqlite)
+}
+
+fn parse_session_id(raw: &str) -> Result<SessionId, StoreError> {
+    SessionId::parse(raw).map_err(|e| StoreError::Invariant {
+        what: format!("session_tree session_id round-trip failed: {e}"),
+    })
+}
+
+fn parse_record_id(raw: &str) -> Result<RecordId, StoreError> {
+    RecordId::parse(raw).map_err(|e| StoreError::Invariant {
+        what: format!("session_tree record_id round-trip failed: {e}"),
+    })
+}
+
+fn parse_branch_kind(raw: Option<&str>, session_id: &SessionId) -> Result<BranchKind, StoreError> {
+    match raw {
+        Some("fork") => Ok(BranchKind::Fork),
+        Some("clone") => Ok(BranchKind::Clone),
+        Some("tool_spawned") => Ok(BranchKind::ToolSpawned),
+        Some(_) => Err(StoreError::InvalidSessionTree(
+            SessionTreeError::MalformedLink {
+                session_id: session_id.clone(),
+                message: "unknown branch kind",
+            },
+        )),
+        None => Err(StoreError::InvalidSessionTree(
+            SessionTreeError::MalformedLink {
+                session_id: session_id.clone(),
+                message: "non-root node must have a branch kind",
+            },
+        )),
+    }
+}
+
+fn branch_kind_wire(kind: BranchKind) -> &'static str {
+    match kind {
+        BranchKind::Fork => "fork",
+        BranchKind::Clone => "clone",
+        BranchKind::ToolSpawned => "tool_spawned",
+        _ => unreachable!("BranchKind is non_exhaustive for forward compatibility"),
+    }
+}
+
+fn parse_merge_strategy(
+    kind: &str,
+    summary_record_id: Option<String>,
+    first_turn_id: Option<String>,
+    last_turn_id: Option<String>,
+) -> Result<MergeStrategy, StoreError> {
+    match kind {
+        "reasoning_summary" => Ok(MergeStrategy::ReasoningSummary {
+            summary_record_id: parse_record_id(&summary_record_id.ok_or(
+                SessionTreeError::EmptyField {
+                    field: "summary_record_id",
+                },
+            )?)?,
+        }),
+        "controlled_splice" => Ok(MergeStrategy::ControlledSplice {
+            first_turn_id: first_turn_id.ok_or(SessionTreeError::EmptyField {
+                field: "first_turn_id",
+            })?,
+            last_turn_id: last_turn_id.ok_or(SessionTreeError::EmptyField {
+                field: "last_turn_id",
+            })?,
+        }),
+        _ => Err(StoreError::Invariant {
+            what: "session_tree merge strategy kind is unknown".to_owned(),
+        }),
     }
 }
 

--- a/crates/cairn-store-sqlite/src/store/trait_impl.rs
+++ b/crates/cairn-store-sqlite/src/store/trait_impl.rs
@@ -15,7 +15,9 @@ use cairn_core::contract::memory_store::{
 };
 use cairn_core::contract::version::VersionRange;
 use cairn_core::domain::consent_timeline::ConsentModel;
-use cairn_core::domain::{MemoryRecord, RecordId, TargetId};
+use cairn_core::domain::{
+    MemoryRecord, MergeStrategy, RecordId, SessionId, SessionMerge, SessionTree, TargetId,
+};
 use cairn_core::search::GraphCandidate;
 
 use crate::error::StoreError as ConcreteError;
@@ -73,6 +75,78 @@ impl MemoryStore for SqliteMemoryStore {
             return not_initialized("versions");
         }
         self.do_versions(target).await.map_err(Into::into)
+    }
+
+    async fn get_session_tree(&self, root: &SessionId) -> Result<Option<SessionTree>, StoreError> {
+        if self.conn.is_none() {
+            return not_initialized("get_session_tree");
+        }
+        SqliteMemoryStore::get_session_tree(self, root)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn record_session_fork(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+        at_turn_id: &str,
+    ) -> Result<(), StoreError> {
+        if self.conn.is_none() {
+            return not_initialized("record_session_fork");
+        }
+        SqliteMemoryStore::record_session_fork(self, from, child, at_turn_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn record_session_clone(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+    ) -> Result<(), StoreError> {
+        if self.conn.is_none() {
+            return not_initialized("record_session_clone");
+        }
+        SqliteMemoryStore::record_session_clone(self, from, child)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn record_session_tool_spawn(
+        &self,
+        from: &SessionId,
+        child: &SessionId,
+        at_turn_id: &str,
+        tool_call_id: &str,
+    ) -> Result<(), StoreError> {
+        if self.conn.is_none() {
+            return not_initialized("record_session_tool_spawn");
+        }
+        SqliteMemoryStore::record_session_tool_spawn(self, from, child, at_turn_id, tool_call_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn record_session_merge(
+        &self,
+        source: &SessionId,
+        destination: &SessionId,
+        strategy: MergeStrategy,
+        applied_at_turn_id: &str,
+    ) -> Result<SessionMerge, StoreError> {
+        if self.conn.is_none() {
+            return not_initialized("record_session_merge");
+        }
+        SqliteMemoryStore::record_session_merge(
+            self,
+            source,
+            destination,
+            strategy,
+            applied_at_turn_id,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn put_edge(&self, edge: &Edge) -> Result<(), StoreError> {

--- a/crates/cairn-store-sqlite/src/verify.rs
+++ b/crates/cairn-store-sqlite/src/verify.rs
@@ -267,6 +267,12 @@ const EXPECTED_OBJECTS: &[(&str, &str)] = &[
     // watermarks for assemble_hot cache invalidation.
     ("table", "hot_source_watermarks"),
     ("table", "hot_prefix_cache"),
+    // 0062_session_tree (issue #133): v0.3 branch/merge metadata substrate.
+    ("table", "session_tree_nodes"),
+    ("index", "session_tree_nodes_parent_idx"),
+    ("table", "session_tree_merges"),
+    ("index", "session_tree_merges_source_idx"),
+    ("index", "session_tree_merges_destination_idx"),
 ];
 
 /// Identity registry objects share `cairn.db` but are owned by

--- a/crates/cairn-store-sqlite/tests/migrations.rs
+++ b/crates/cairn-store-sqlite/tests/migrations.rs
@@ -15,7 +15,7 @@ fn fresh_in_memory_opens_to_head() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 61);
+    assert_eq!(head, 62);
 }
 
 #[test]
@@ -31,7 +31,116 @@ fn fresh_vault_opens_and_reopens_idempotent() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 61);
+    assert_eq!(head, 62);
+}
+
+#[test]
+fn migration_0062_creates_session_tree_tables() {
+    let conn = open_in_memory().expect("open");
+
+    for table in ["session_tree_nodes", "session_tree_merges"] {
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) = 1 FROM sqlite_schema WHERE type = 'table' AND name = ?1",
+                [table],
+                |r| r.get::<_, i64>(0).map(|v| v == 1),
+            )
+            .expect("query table");
+        assert!(exists, "{table} must exist");
+    }
+
+    for index in [
+        "session_tree_nodes_parent_idx",
+        "session_tree_merges_source_idx",
+        "session_tree_merges_destination_idx",
+    ] {
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) = 1 FROM sqlite_schema WHERE type = 'index' AND name = ?1",
+                [index],
+                |r| r.get::<_, i64>(0).map(|v| v == 1),
+            )
+            .expect("query index");
+        assert!(exists, "{index} must exist");
+    }
+}
+
+#[test]
+fn migration_0062_enforces_session_tree_shape_constraints() {
+    let conn = open_in_memory().expect("open");
+    let sessions = [
+        ("01JTS6R4J7000000000000000D", "/tree-root"),
+        ("01JTS6R4J7000000000000000E", "/tree-child"),
+        ("01JTS6R4J7000000000000000F", "/tree-tool"),
+    ];
+    for (session_id, project_root) in sessions {
+        conn.execute(
+            "INSERT INTO sessions \
+               (session_id, user_id, agent_id, project_root, title, \
+                created_at, last_activity_at, ended_at) \
+             VALUES (?1, 'hmn:alice', 'agt:claude-code:opus-4-7:main:v1', ?2, '', 0, 0, NULL)",
+            params![session_id, project_root],
+        )
+        .expect("seed session");
+    }
+
+    conn.execute(
+        "INSERT INTO session_tree_nodes \
+           (session_id, parent_session_id, at_turn_id, branch_kind, tool_call_id, created_at) \
+         VALUES ('01JTS6R4J7000000000000000D', NULL, NULL, NULL, NULL, 0)",
+        [],
+    )
+    .expect("valid root node");
+    conn.execute(
+        "INSERT INTO session_tree_nodes \
+           (session_id, parent_session_id, at_turn_id, branch_kind, tool_call_id, created_at) \
+         VALUES ('01JTS6R4J7000000000000000E', '01JTS6R4J7000000000000000D', 'turn-2', 'fork', NULL, 0)",
+        [],
+    )
+    .expect("valid fork node");
+
+    let err = conn
+        .execute(
+            "INSERT INTO session_tree_nodes \
+               (session_id, parent_session_id, at_turn_id, branch_kind, tool_call_id, created_at) \
+             VALUES ('01JTS6R4J7000000000000000F', '01JTS6R4J7000000000000000D', 'turn-3', 'tool_spawned', NULL, 0)",
+            [],
+        )
+        .expect_err("tool-spawned node must carry tool_call_id");
+    assert!(
+        format!("{err}").contains("CHECK constraint failed"),
+        "unexpected error: {err}"
+    );
+
+    let err = conn
+        .execute(
+            "INSERT INTO session_tree_merges \
+               (source_session_id, destination_session_id, strategy_kind, summary_record_id, \
+                first_turn_id, last_turn_id, applied_at_turn_id, created_at) \
+             VALUES ('01JTS6R4J7000000000000000E', '01JTS6R4J7000000000000000D', \
+                     'controlled_splice', NULL, 'turn-2', NULL, 'turn-4', 0)",
+            [],
+        )
+        .expect_err("controlled splice must carry both turn bounds");
+    assert!(
+        format!("{err}").contains("CHECK constraint failed"),
+        "unexpected error: {err}"
+    );
+
+    let err = conn
+        .execute(
+            "INSERT INTO session_tree_merges \
+               (source_session_id, destination_session_id, strategy_kind, summary_record_id, \
+                first_turn_id, last_turn_id, applied_at_turn_id, created_at) \
+             VALUES ('01JTS6R4J7000000000000000E', '01JTS6R4J7000000000000000E', \
+                     'reasoning_summary', '01JTS6R4J7000000000000000A', NULL, NULL, 'turn-4', 0)",
+            [],
+        )
+        .expect_err("self-merge must be rejected");
+    assert!(
+        format!("{err}").contains("CHECK constraint failed"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]

--- a/crates/cairn-store-sqlite/tests/sessions.rs
+++ b/crates/cairn-store-sqlite/tests/sessions.rs
@@ -6,10 +6,13 @@
 
 #![allow(missing_docs)]
 
+use cairn_core::contract::memory_store::MemoryStore;
 use cairn_core::domain::Identity;
 use cairn_core::domain::session::{
     DEFAULT_IDLE_WINDOW_SECS, SessionDecision, SessionIdentity, resolve_session,
 };
+use cairn_core::domain::session_tree::{BranchKind, MergeStrategy};
+use cairn_core::domain::{RecordId, SessionId};
 use cairn_store_sqlite::{NewSessionMetadata, ResolveOutcome, open, open_in_memory};
 
 fn user() -> Identity {
@@ -22,6 +25,10 @@ fn agent() -> Identity {
 
 fn identity(project: Option<&str>) -> SessionIdentity {
     SessionIdentity::new(user(), agent(), project.map(str::to_owned)).expect("valid")
+}
+
+fn record_id(raw: &str) -> RecordId {
+    RecordId::parse(raw).expect("valid record id")
 }
 
 #[tokio::test]
@@ -51,6 +58,251 @@ async fn create_then_find_returns_same_id() {
     assert_eq!(found.id, session.id);
     // Idle is well within the 24 h window for a freshly-minted row.
     assert!(found.idle_secs < DEFAULT_IDLE_WINDOW_SECS);
+}
+
+#[tokio::test]
+async fn legacy_session_retrieves_as_flat_session_tree() {
+    let store = open_in_memory().await.expect("open");
+    let id_a = identity(Some("/repo"));
+    let session = store
+        .create_session(&id_a, NewSessionMetadata::default())
+        .await
+        .expect("create");
+
+    let tree = store
+        .get_session_tree(&session.id)
+        .await
+        .expect("load tree")
+        .expect("session exists");
+
+    tree.validate().expect("flat tree validates");
+    assert_eq!(tree.root(), &session.id);
+    assert_eq!(
+        tree.lineage(&session.id).expect("flat lineage"),
+        vec![session.id.clone()]
+    );
+    assert!(tree.merges().is_empty());
+}
+
+#[tokio::test]
+async fn session_tree_metadata_is_available_through_store_contract() {
+    let store = open_in_memory().await.expect("open");
+    let root = store
+        .create_session(&identity(Some("/repo-root")), NewSessionMetadata::default())
+        .await
+        .expect("create root");
+    let child = store
+        .create_session(
+            &identity(Some("/repo-child")),
+            NewSessionMetadata::default(),
+        )
+        .await
+        .expect("create child");
+
+    let contract: &dyn MemoryStore = &store;
+    contract
+        .record_session_fork(&root.id, &child.id, "turn-2")
+        .await
+        .expect("record fork through trait");
+
+    let tree = contract
+        .get_session_tree(&root.id)
+        .await
+        .expect("load tree through trait")
+        .expect("tree exists");
+
+    assert_eq!(
+        tree.lineage(&child.id).expect("child lineage"),
+        vec![root.id, child.id]
+    );
+}
+
+#[tokio::test]
+async fn session_tree_branch_and_merge_metadata_round_trips() {
+    let store = open_in_memory().await.expect("open");
+    let root = store
+        .create_session(&identity(Some("/repo-root")), NewSessionMetadata::default())
+        .await
+        .expect("create root");
+    let branch = store
+        .create_session(
+            &identity(Some("/repo-branch")),
+            NewSessionMetadata::default(),
+        )
+        .await
+        .expect("create branch");
+    let tool_branch = store
+        .create_session(&identity(Some("/repo-tool")), NewSessionMetadata::default())
+        .await
+        .expect("create tool branch");
+
+    store
+        .record_session_fork(&root.id, &branch.id, "turn-4")
+        .await
+        .expect("record fork");
+    store
+        .record_session_tool_spawn(&branch.id, &tool_branch.id, "turn-5", "call-review")
+        .await
+        .expect("record tool branch");
+    let summary = record_id("01JTS6R4J70000000000000009");
+    store
+        .record_session_merge(
+            &tool_branch.id,
+            &root.id,
+            MergeStrategy::ReasoningSummary {
+                summary_record_id: summary.clone(),
+            },
+            "turn-8",
+        )
+        .await
+        .expect("record merge");
+
+    let tree = store
+        .get_session_tree(&root.id)
+        .await
+        .expect("load tree")
+        .expect("root exists");
+
+    tree.validate().expect("tree validates");
+    assert_eq!(
+        tree.lineage(&tool_branch.id).expect("tool branch lineage"),
+        vec![root.id.clone(), branch.id.clone(), tool_branch.id.clone()]
+    );
+    let parent = tree
+        .parent(&tool_branch.id)
+        .expect("parent lookup")
+        .expect("tool branch parent");
+    assert_eq!(parent.kind, BranchKind::ToolSpawned);
+    assert_eq!(parent.tool_call_id.as_deref(), Some("call-review"));
+    assert_eq!(
+        tree.subtree_preorder(&root.id).expect("preorder"),
+        vec![root.id.clone(), branch.id.clone(), tool_branch.id.clone()]
+    );
+    assert_eq!(tree.merges().len(), 1);
+    assert_eq!(tree.merges()[0].source, tool_branch.id);
+    assert_eq!(tree.merges()[0].destination, root.id);
+    assert_eq!(
+        tree.merges()[0].strategy,
+        MergeStrategy::ReasoningSummary {
+            summary_record_id: summary
+        }
+    );
+
+    let branch_tree = store
+        .get_session_tree(&tool_branch.id)
+        .await
+        .expect("load tree from branch")
+        .expect("branch exists");
+    assert_eq!(branch_tree.root(), tree.root());
+    assert_eq!(
+        branch_tree
+            .lineage(&tool_branch.id)
+            .expect("branch lineage from branch lookup"),
+        vec![root.id.clone(), branch.id.clone(), tool_branch.id.clone()]
+    );
+    assert_eq!(branch_tree.merges(), tree.merges());
+}
+
+#[tokio::test]
+async fn session_tree_merge_rejects_unrelated_sessions() {
+    let store = open_in_memory().await.expect("open");
+    let source = store
+        .create_session(
+            &identity(Some("/repo-source")),
+            NewSessionMetadata::default(),
+        )
+        .await
+        .expect("create source");
+    let destination = store
+        .create_session(
+            &identity(Some("/repo-destination")),
+            NewSessionMetadata::default(),
+        )
+        .await
+        .expect("create destination");
+    let summary = record_id("01JTS6R4J7000000000000000A");
+
+    let err = store
+        .record_session_merge(
+            &source.id,
+            &destination.id,
+            MergeStrategy::ReasoningSummary {
+                summary_record_id: summary,
+            },
+            "turn-9",
+        )
+        .await
+        .expect_err("unrelated sessions cannot be merged");
+
+    assert!(
+        err.to_string().contains("unknown session"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn session_tree_branch_lookup_rejects_parent_cycle_without_hanging() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("sessions.db");
+    {
+        let conn = cairn_store_sqlite::open_sync(&db_path).expect("open sync");
+        let session_a = "01JTS6R4J7000000000000000B";
+        let session_b = "01JTS6R4J7000000000000000C";
+        for (session_id, project_root) in [(session_a, "/cycle-a"), (session_b, "/cycle-b")] {
+            conn.execute(
+                "INSERT INTO sessions \
+                   (session_id, user_id, agent_id, project_root, title, \
+                    created_at, last_activity_at, ended_at) \
+                 VALUES (?1, 'hmn:alice', 'agt:claude-code:opus-4-7:main:v1', ?2, '', 0, 0, NULL)",
+                rusqlite::params![session_id, project_root],
+            )
+            .expect("insert session");
+        }
+        conn.execute(
+            "INSERT INTO session_tree_nodes \
+               (session_id, parent_session_id, at_turn_id, branch_kind, tool_call_id, created_at) \
+             VALUES (?1, ?2, 'turn-a', 'fork', NULL, 0)",
+            rusqlite::params![session_a, session_b],
+        )
+        .expect("insert cycle a");
+        conn.execute(
+            "INSERT INTO session_tree_nodes \
+               (session_id, parent_session_id, at_turn_id, branch_kind, tool_call_id, created_at) \
+             VALUES (?1, ?2, 'turn-b', 'fork', NULL, 0)",
+            rusqlite::params![session_b, session_a],
+        )
+        .expect("insert cycle b");
+    }
+
+    let store = open(&db_path).await.expect("open async");
+    let session_a = SessionId::parse("01JTS6R4J7000000000000000B").expect("valid session id");
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        store.get_session_tree(&session_a),
+    )
+    .await
+    .expect("cycle detection should not hang");
+    let err = result.expect_err("cycle without a root is invalid");
+
+    assert!(
+        err.to_string()
+            .contains("session tree ancestry does not reach a root"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn missing_session_tree_returns_none() {
+    let store = open_in_memory().await.expect("open");
+    let missing = SessionId::parse("01JTS6R4J70000000000000000").expect("valid session id");
+
+    assert!(
+        store
+            .get_session_tree(&missing)
+            .await
+            .expect("load missing tree")
+            .is_none()
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add a pure session-tree model for flat compatibility, forks, clones, tool-spawned branches, lineage, and auditable merges.
- Add SQLite migration 0061 plus store APIs and MemoryStore default-method wiring for session-tree metadata.
- Preserve v0.1 flat-session retrieval by synthesizing one-node trees, and keep the public sessiontree extension unadvertised while the issue remains blocked.

## Validation

- cargo test -p cairn-core --test session_tree
- cargo test -p cairn-store-sqlite --test sessions
- cargo test -p cairn-store-sqlite --test migrations
- cargo test -p cairn-store-sqlite --test capabilities_unchanged
- cargo fmt --check
- git diff --check

Closes #133