### PR TITLE
[codex] Add P0 replay harness

### DIFF
--- a/crates/cairn-test-fixtures/src/lib.rs
+++ b/crates/cairn-test-fixtures/src/lib.rs
@@ -13,6 +13,7 @@ pub mod hybrid_vault;
 pub mod intent;
 pub mod keystore;
 pub mod mcp;
+pub mod replay;
 pub mod source_links;
 pub mod store;
 pub mod trace;

--- a/crates/cairn-test-fixtures/src/replay.rs
+++ b/crates/cairn-test-fixtures/src/replay.rs
@@ -1,378 +1,10 @@
-# Issue 97 Replay Harness Implementation Plan
+//! Local replay harness helpers for P0 evaluation fixtures.
+//!
+//! This module is dev-only through the `cairn-test-fixtures` crate. It loads
+//! scenario manifests from `fixtures/v0/replay/`, seeds a temporary `SQLite`
+//! vault, executes deterministic checks, and returns machine-readable reports
+//! suitable for CI gates.
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
-
-**Goal:** Build a dev-only local replay harness that loads P0 scenario fixtures, executes deterministic replay checks against a temp SQLite vault, and returns machine-readable reports.
-
-**Architecture:** Add a `cairn_test_fixtures::replay` module plus versioned JSON fixtures under `fixtures/v0/replay/`. The harness seeds a temp vault with deterministic `MemoryRecord`s, uses `MockEmbedder` for local semantic/hybrid search, dispatches search through `cairn_core::verbs::search::run`, applies record-level tombstones through `MemoryStore`, and compares actual outcomes to fixture expectations.
-
-**Tech Stack:** Rust 2024, `cairn-test-fixtures`, `cairn-core`, `cairn-store-sqlite`, `cairn-embeddings-local::MockEmbedder`, `serde`, `serde_json`, `tokio`, `tempfile`.
-
----
-
-### Task 1: Add Replay Fixture Manifests
-
-**Files:**
-- Create: `fixtures/v0/replay/p0_stories.json`
-- Create: `fixtures/v0/replay/p0_keyword_only.json`
-- Modify: `fixtures/README.md`
-
-- [ ] **Step 1: Create the fixture directory**
-
-Run:
-
-```bash
-mkdir -p fixtures/v0/replay
-```
-
-Expected: command exits 0.
-
-- [ ] **Step 2: Add `fixtures/v0/replay/p0_stories.json`**
-
-Create the file with this content:
-
-```json
-{
-  "id": "p0_stories",
-  "description": "P0 replay scenario covering US1-US5, US7 all search modes, and US8 record-level forget.",
-  "config": {
-    "local_embeddings": true
-  },
-  "records": [
-    {
-      "id": "01HQZX9F5N00000000000000A0",
-      "kind": "trace",
-      "class": "episodic",
-      "visibility": "private",
-      "body": "rust memory safety session replay user question",
-      "session_id": "p0-session",
-      "turn_id": "1",
-      "sequence": 1,
-      "trace_event": "user_message"
-    },
-    {
-      "id": "01HQZX9F5N00000000000000A1",
-      "kind": "trace",
-      "class": "episodic",
-      "visibility": "private",
-      "body": "ownership borrowing prevent memory bugs at compile time",
-      "session_id": "p0-session",
-      "turn_id": "1",
-      "sequence": 2,
-      "trace_event": "assistant_message"
-    },
-    {
-      "id": "01HQZX9F5N00000000000000A2",
-      "kind": "trace",
-      "class": "episodic",
-      "visibility": "private",
-      "body": "cargo check tool result succeeded for memory safety example",
-      "session_id": "p0-session",
-      "turn_id": "1",
-      "sequence": 3,
-      "trace_event": "tool_call",
-      "tool_name": "cargo"
-    },
-    {
-      "id": "01HQZX9F5N00000000000000A3",
-      "kind": "user",
-      "class": "semantic",
-      "visibility": "private",
-      "body": "user prefers concise rust memory explanations"
-    },
-    {
-      "id": "01HQZX9F5N00000000000000A4",
-      "kind": "reasoning",
-      "class": "semantic",
-      "visibility": "private",
-      "body": "rolling summary p0 session covers rust memory safety and cargo check success",
-      "session_id": "p0-session",
-      "turn_id": "summary",
-      "sequence": 4,
-      "trace_event": "turn_summary"
-    },
-    {
-      "id": "01HQZX9F5N00000000000000A5",
-      "kind": "fact",
-      "class": "semantic",
-      "visibility": "private",
-      "body": "secret project codename aurora should be forgotten"
-    },
-    {
-      "id": "01HQZX9F5N00000000000000A6",
-      "kind": "fact",
-      "class": "semantic",
-      "visibility": "private",
-      "body": "unrelated cooking note tomato soup"
-    }
-  ],
-  "actions": [
-    {
-      "verb": "retrieve_session",
-      "story": "US1_US2",
-      "session_id": "p0-session",
-      "expected_turn_ids": ["1"],
-      "expected_trace_events": ["user_message", "assistant_message", "tool_call", "turn_summary"]
-    },
-    {
-      "verb": "retrieve_turn",
-      "story": "US5",
-      "session_id": "p0-session",
-      "turn_id": "1",
-      "expected_trace_events": ["user_message", "assistant_message", "tool_call"]
-    },
-    {
-      "verb": "record_present",
-      "story": "US3",
-      "record_id": "01HQZX9F5N00000000000000A3",
-      "expected_present": true
-    },
-    {
-      "verb": "record_present",
-      "story": "US4",
-      "record_id": "01HQZX9F5N00000000000000A4",
-      "expected_present": true
-    },
-    {
-      "verb": "search",
-      "story": "US7",
-      "mode": "keyword",
-      "query": "ownership borrowing",
-      "limit": 1,
-      "expected": {
-        "status": "hits",
-        "record_ids": ["01HQZX9F5N00000000000000A1"]
-      }
-    },
-    {
-      "verb": "search",
-      "story": "US7",
-      "mode": "semantic",
-      "query": "user prefers concise rust memory explanations",
-      "limit": 1,
-      "expected": {
-        "status": "hits",
-        "record_ids": ["01HQZX9F5N00000000000000A3"]
-      }
-    },
-    {
-      "verb": "search",
-      "story": "US7",
-      "mode": "hybrid",
-      "query": "rust memory safety session replay user question",
-      "limit": 1,
-      "expected": {
-        "status": "hits",
-        "record_ids": ["01HQZX9F5N00000000000000A0"]
-      }
-    },
-    {
-      "verb": "forget_record",
-      "story": "US8",
-      "record_id": "01HQZX9F5N00000000000000A5",
-      "followup_query": "secret project codename aurora",
-      "expected_absent_from_search": true
-    }
-  ]
-}
-```
-
-- [ ] **Step 3: Add `fixtures/v0/replay/p0_keyword_only.json`**
-
-Create the file with this content:
-
-```json
-{
-  "id": "p0_keyword_only",
-  "description": "P0 degraded keyword-only replay scenario with local embeddings disabled.",
-  "config": {
-    "local_embeddings": false
-  },
-  "records": [
-    {
-      "id": "01HQZX9F5N00000000000000B0",
-      "kind": "fact",
-      "class": "semantic",
-      "visibility": "private",
-      "body": "keyword only mode still finds rust memory safety"
-    }
-  ],
-  "actions": [
-    {
-      "verb": "search",
-      "story": "US7",
-      "mode": "keyword",
-      "query": "rust memory safety",
-      "limit": 1,
-      "expected": {
-        "status": "hits",
-        "record_ids": ["01HQZX9F5N00000000000000B0"]
-      }
-    },
-    {
-      "verb": "search",
-      "story": "US7",
-      "mode": "semantic",
-      "query": "keyword only mode still finds rust memory safety",
-      "limit": 1,
-      "expected": {
-        "status": "capability_unavailable",
-        "capability": "cairn.mcp.v1.search.semantic"
-      }
-    },
-    {
-      "verb": "search",
-      "story": "US7",
-      "mode": "hybrid",
-      "query": "keyword only mode still finds rust memory safety",
-      "limit": 1,
-      "expected": {
-        "status": "capability_unavailable",
-        "capability": "cairn.mcp.v1.search.hybrid"
-      }
-    }
-  ]
-}
-```
-
-- [ ] **Step 4: Document the replay fixtures**
-
-Append this bullet to the `fixtures/v0/` tree in `fixtures/README.md`:
-
-```markdown
-    ├── replay/            ← P0 replay scenarios + golden expectations
-```
-
-Add one sentence after the existing fixture description:
-
-```markdown
-Replay fixtures are consumed by `cairn_test_fixtures::replay` to create temp vaults and emit deterministic machine-readable reports for CI gates.
-```
-
-- [ ] **Step 5: Verify fixture files are visible**
-
-Run:
-
-```bash
-find fixtures/v0/replay -maxdepth 1 -type f | sort
-```
-
-Expected output includes both JSON files.
-
-### Task 2: Write Failing Replay Harness Tests
-
-**Files:**
-- Create: `crates/cairn-test-fixtures/tests/replay_harness.rs`
-
-- [ ] **Step 1: Add failing integration tests**
-
-Create `crates/cairn-test-fixtures/tests/replay_harness.rs` with:
-
-```rust
-use cairn_test_fixtures::replay::{run_named_scenario, load_named_scenario, ReplayExpectation};
-
-#[tokio::test(flavor = "multi_thread")]
-async fn p0_stories_replay_passes_end_to_end() {
-    let report = run_named_scenario("p0_stories").await.expect("run scenario");
-    assert!(report.passed(), "{report:#?}");
-    assert_eq!(report.scenario_id, "p0_stories");
-    assert!(
-        report
-            .checks
-            .iter()
-            .any(|check| check.story == "US7" && check.verb == "search")
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn keyword_only_replay_reports_capability_rejections() {
-    let report = run_named_scenario("p0_keyword_only").await.expect("run scenario");
-    assert!(report.passed(), "{report:#?}");
-    let capabilities: Vec<_> = report
-        .checks
-        .iter()
-        .filter(|check| check.actual["status"] == "capability_unavailable")
-        .map(|check| check.actual["capability"].as_str().unwrap_or_default().to_owned())
-        .collect();
-    assert_eq!(
-        capabilities,
-        vec![
-            "cairn.mcp.v1.search.semantic".to_owned(),
-            "cairn.mcp.v1.search.hybrid".to_owned()
-        ]
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn failure_report_identifies_scenario_verb_query_expected_and_actual() {
-    let mut scenario = load_named_scenario("p0_stories").expect("load scenario");
-    let search = scenario
-        .actions
-        .iter_mut()
-        .find_map(|action| action.as_search_mut())
-        .expect("search action");
-    search.expected = ReplayExpectation::Hits {
-        record_ids: vec!["01HQZX9F5N00000000000000A6".to_owned()],
-    };
-
-    let report = cairn_test_fixtures::replay::run_scenario(&scenario)
-        .await
-        .expect("run scenario");
-    assert!(!report.passed(), "{report:#?}");
-    let failure = report.failures().next().expect("one failure");
-    assert_eq!(failure.scenario_id, "p0_stories");
-    assert_eq!(failure.verb, "search");
-    assert_eq!(failure.query.as_deref(), Some("ownership borrowing"));
-    assert_eq!(
-        failure.expected,
-        serde_json::json!({
-            "status": "hits",
-            "record_ids": ["01HQZX9F5N00000000000000A6"]
-        })
-    );
-    assert_ne!(failure.expected, failure.actual);
-}
-
-#[test]
-fn replay_manifests_deserialize() {
-    for name in ["p0_stories", "p0_keyword_only"] {
-        let scenario = load_named_scenario(name).expect("load scenario");
-        assert_eq!(scenario.id, name);
-        assert!(!scenario.records.is_empty());
-        assert!(!scenario.actions.is_empty());
-    }
-}
-```
-
-- [ ] **Step 2: Run the tests and verify RED**
-
-Run:
-
-```bash
-cargo nextest run -p cairn-test-fixtures --test replay_harness
-```
-
-Expected: compile fails because `cairn_test_fixtures::replay` does not exist.
-
-### Task 3: Implement `cairn_test_fixtures::replay`
-
-**Files:**
-- Create: `crates/cairn-test-fixtures/src/replay.rs`
-- Modify: `crates/cairn-test-fixtures/src/lib.rs`
-
-- [ ] **Step 1: Export the new module**
-
-Add to `crates/cairn-test-fixtures/src/lib.rs`:
-
-```rust
-pub mod replay;
-```
-
-- [ ] **Step 2: Implement the replay module**
-
-Create `crates/cairn-test-fixtures/src/replay.rs` with:
-
-```rust
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -400,13 +32,13 @@ pub struct ReplayReport {
 }
 
 impl ReplayReport {
-    /// True when every check passed.
+    /// `true` when every check passed.
     #[must_use]
     pub fn passed(&self) -> bool {
         self.checks.iter().all(|check| check.passed)
     }
 
-    /// Failed checks only.
+    /// Iterate over failed checks only.
     pub fn failures(&self) -> impl Iterator<Item = &ReplayCheckReport> {
         self.checks.iter().filter(|check| !check.passed)
     }
@@ -556,7 +188,7 @@ pub enum ReplayAction {
 }
 
 impl ReplayAction {
-    /// Mutable search-action view for tests that need to perturb expectations.
+    /// Mutable search-action view for tests that perturb expectations.
     pub fn as_search_mut(&mut self) -> Option<&mut ReplaySearchAction> {
         match self {
             Self::Search(action) => Some(action),
@@ -594,19 +226,11 @@ pub enum ReplaySearchMode {
 }
 
 impl ReplaySearchMode {
-    fn to_core(self) -> SearchMode {
+    const fn to_core(self) -> SearchMode {
         match self {
             Self::Keyword => SearchMode::Keyword,
             Self::Semantic => SearchMode::Semantic,
             Self::Hybrid => SearchMode::Hybrid,
-        }
-    }
-
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Keyword => "keyword",
-            Self::Semantic => "semantic",
-            Self::Hybrid => "hybrid",
         }
     }
 }
@@ -670,6 +294,9 @@ struct ReplayVault {
 }
 
 /// Load a named scenario from `fixtures/v0/replay/{name}.json`.
+///
+/// # Errors
+/// Returns [`ReplayError`] if the fixture cannot be read or parsed.
 pub fn load_named_scenario(name: &str) -> Result<ReplayScenario, ReplayError> {
     let path = crate::fixture_v0_dir()
         .join("replay")
@@ -678,6 +305,9 @@ pub fn load_named_scenario(name: &str) -> Result<ReplayScenario, ReplayError> {
 }
 
 /// Load a scenario from a specific file path.
+///
+/// # Errors
+/// Returns [`ReplayError`] if the fixture cannot be read or parsed.
 pub fn load_scenario_file(path: &Path) -> Result<ReplayScenario, ReplayError> {
     let raw = std::fs::read_to_string(path).map_err(|source| ReplayError::Io {
         path: path.to_path_buf(),
@@ -690,12 +320,18 @@ pub fn load_scenario_file(path: &Path) -> Result<ReplayScenario, ReplayError> {
 }
 
 /// Load and run a named scenario.
+///
+/// # Errors
+/// Returns [`ReplayError`] if loading, vault setup, or fixture replay fails.
 pub async fn run_named_scenario(name: &str) -> Result<ReplayReport, ReplayError> {
     let scenario = load_named_scenario(name)?;
     run_scenario(&scenario).await
 }
 
 /// Run a loaded replay scenario.
+///
+/// # Errors
+/// Returns [`ReplayError`] if the temp vault cannot be built.
 pub async fn run_scenario(scenario: &ReplayScenario) -> Result<ReplayReport, ReplayError> {
     let vault = build_vault(scenario).await?;
     let mut checks = Vec::with_capacity(scenario.actions.len());
@@ -795,7 +431,10 @@ fn trace_frontmatter(seed: &ReplayRecord) -> BTreeMap<String, Value> {
         if let Some(tool_name) = &seed.tool_name {
             trace.insert("tool_name".to_owned(), Value::String(tool_name.clone()));
         }
-        trace.insert("capture_event_id".to_owned(), Value::String(seed.id.clone()));
+        trace.insert(
+            "capture_event_id".to_owned(),
+            Value::String(seed.id.clone()),
+        );
         extra.insert("trace".to_owned(), Value::Object(trace));
     }
     extra
@@ -816,12 +455,19 @@ async fn run_action(
         } => {
             let actual = trace_summary(store, Some(session_id), None)
                 .await
-                .unwrap_or_else(error_value);
+                .unwrap_or_else(|e| error_value(&e));
             let expected = json!({
                 "turn_ids": expected_turn_ids,
-                "trace_events": expected_trace_events
+                "trace_events": expected_trace_events,
             });
-            report_check(&scenario.id, story, "retrieve_session", None, expected, actual)
+            report_check(
+                &scenario.id,
+                story,
+                "retrieve_session",
+                None,
+                expected,
+                actual,
+            )
         }
         ReplayAction::RetrieveTurn {
             story,
@@ -831,10 +477,10 @@ async fn run_action(
         } => {
             let actual = trace_summary(store, Some(session_id), Some(turn_id))
                 .await
-                .unwrap_or_else(error_value);
+                .unwrap_or_else(|e| error_value(&e));
             let expected = json!({
                 "turn_ids": [turn_id],
-                "trace_events": expected_trace_events
+                "trace_events": expected_trace_events,
             });
             report_check(&scenario.id, story, "retrieve_turn", None, expected, actual)
         }
@@ -843,9 +489,18 @@ async fn run_action(
             record_id,
             expected_present,
         } => {
-            let actual = record_present(store, record_id).await.unwrap_or_else(error_value);
+            let actual = record_present(store, record_id)
+                .await
+                .unwrap_or_else(|e| error_value(&e));
             let expected = json!({ "present": expected_present });
-            report_check(&scenario.id, story, "record_present", None, expected, actual)
+            report_check(
+                &scenario.id,
+                story,
+                "record_present",
+                None,
+                expected,
+                actual,
+            )
         }
         ReplayAction::ForgetRecord {
             story,
@@ -855,10 +510,10 @@ async fn run_action(
         } => {
             let actual = forget_record(store, scenario, record_id, followup_query)
                 .await
-                .unwrap_or_else(error_value);
+                .unwrap_or_else(|e| error_value(&e));
             let expected = json!({
                 "retrieve_found": false,
-                "search_contains_record": !expected_absent_from_search
+                "search_contains_record": !expected_absent_from_search,
             });
             report_check(
                 &scenario.id,
@@ -924,17 +579,16 @@ async fn run_search(
                 .collect();
             json!({
                 "status": "hits",
-                "mode": action.mode.as_str(),
-                "record_ids": ids
+                "record_ids": ids,
             })
         }
         Err(SearchError::CapabilityUnavailable { capability }) => json!({
             "status": "capability_unavailable",
-            "capability": capability
+            "capability": capability,
         }),
         Err(err) => json!({
             "status": "error",
-            "message": err.to_string()
+            "message": err.to_string(),
         }),
     }
 }
@@ -943,11 +597,11 @@ fn expected_search_value(expected: &ReplayExpectation) -> Value {
     match expected {
         ReplayExpectation::Hits { record_ids } => json!({
             "status": "hits",
-            "record_ids": record_ids
+            "record_ids": record_ids,
         }),
         ReplayExpectation::CapabilityUnavailable { capability } => json!({
             "status": "capability_unavailable",
-            "capability": capability
+            "capability": capability,
         }),
     }
 }
@@ -970,11 +624,15 @@ async fn trace_summary(
         .filter_map(|record| trace_projection(record, session_id, turn_id))
         .collect();
     rows.sort_by_key(|(sequence, _, _)| *sequence);
-    let turn_ids: BTreeSet<String> = rows.iter().map(|(_, turn, _)| turn.clone()).collect();
+    let turn_ids: BTreeSet<String> = rows
+        .iter()
+        .filter(|(_, _, event)| event != "turn_summary")
+        .map(|(_, turn, _)| turn.clone())
+        .collect();
     let trace_events: Vec<String> = rows.into_iter().map(|(_, _, event)| event).collect();
     Ok(json!({
         "turn_ids": turn_ids.into_iter().collect::<Vec<_>>(),
-        "trace_events": trace_events
+        "trace_events": trace_events,
     }))
 }
 
@@ -1042,7 +700,7 @@ async fn forget_record(
         .is_some_and(|ids| ids.iter().any(|value| value.as_str() == Some(record_id)));
     Ok(json!({
         "retrieve_found": retrieve_found,
-        "search_contains_record": contains
+        "search_contains_record": contains,
     }))
 }
 
@@ -1067,110 +725,9 @@ fn report_check(
     }
 }
 
-fn error_value(error: ReplayError) -> Value {
+fn error_value(error: &ReplayError) -> Value {
     json!({
         "status": "error",
-        "message": error.to_string()
+        "message": error.to_string(),
     })
 }
-```
-
-- [ ] **Step 3: Run replay tests and verify GREEN**
-
-Run:
-
-```bash
-cargo nextest run -p cairn-test-fixtures --test replay_harness
-```
-
-Expected: all replay harness tests pass. If any search ranking expectation differs, inspect the actual report and update only the fixture expectation when the actual ranking is deterministic and defensible.
-
-### Task 4: Tighten Fixture Schema Coverage
-
-**Files:**
-- Modify: `crates/cairn-test-fixtures/tests/schema_fixtures.rs`
-
-- [ ] **Step 1: Add replay directory coverage to schema fixture tests**
-
-In `crates/cairn-test-fixtures/tests/schema_fixtures.rs`, add `replay` to the required `fixtures/v0` subdirectory assertions and add a test:
-
-```rust
-#[test]
-fn replay_scenarios_deserialize() {
-    let replay = v0().join("replay");
-    for name in ["p0_stories.json", "p0_keyword_only.json"] {
-        let path = replay.join(name);
-        let scenario = cairn_test_fixtures::replay::load_scenario_file(&path)
-            .unwrap_or_else(|e| panic!("load {}: {e}", path.display()));
-        assert_eq!(path.file_stem().and_then(std::ffi::OsStr::to_str), Some(scenario.id.as_str()));
-        assert!(!scenario.records.is_empty());
-        assert!(!scenario.actions.is_empty());
-    }
-}
-```
-
-- [ ] **Step 2: Run schema fixture tests**
-
-Run:
-
-```bash
-cargo nextest run -p cairn-test-fixtures --test schema_fixtures
-```
-
-Expected: tests pass.
-
-### Task 5: Final Verification
-
-**Files:**
-- No new files.
-
-- [ ] **Step 1: Run replay harness verification**
-
-Run:
-
-```bash
-cargo nextest run -p cairn-test-fixtures --test replay_harness
-```
-
-Expected: all tests pass.
-
-- [ ] **Step 2: Run existing golden query verification**
-
-Run:
-
-```bash
-cargo nextest run -p cairn-cli --test search_modes_golden
-```
-
-Expected: all tests pass.
-
-- [ ] **Step 3: Run existing evaluation workflow verification**
-
-Run:
-
-```bash
-cargo nextest run -p cairn-workflows --test evaluation
-```
-
-Expected: all tests pass.
-
-- [ ] **Step 4: Run core boundary check**
-
-Run:
-
-```bash
-scripts/check-core-boundary.sh
-```
-
-Expected: exits 0.
-
-- [ ] **Step 5: Inspect final diff**
-
-Run:
-
-```bash
-git status --short
-git diff --stat
-```
-
-Expected: only replay harness, replay fixtures, fixture docs, and fixture tests changed.

--- a/crates/cairn-test-fixtures/src/replay.rs
+++ b/crates/cairn-test-fixtures/src/replay.rs
@@ -14,7 +14,10 @@ use cairn_core::config::{CairnConfig, EmbeddingModelKind};
 use cairn_core::contract::memory_store::{ListArgs, MemoryStore, TombstoneReason};
 use cairn_core::domain::record::MemoryRecord;
 use cairn_core::domain::taxonomy::{MemoryClass, MemoryKind, MemoryVisibility};
+use cairn_core::domain::trace::TraceEvent;
 use cairn_core::domain::{RecordId, Rfc3339Timestamp, ScopeTuple, TargetId};
+use cairn_core::generated::envelope::RetrieveData;
+use cairn_core::verbs::retrieve;
 use cairn_core::verbs::search::{self, SearchError, SearchMode, SearchRequest};
 use cairn_embeddings_local::{EmbeddingModel, MockEmbedder};
 use cairn_store_sqlite::SqliteMemoryStore;
@@ -135,6 +138,12 @@ pub struct ReplayRecord {
     /// Optional tool name for tool-call records.
     #[serde(default)]
     pub tool_name: Option<String>,
+    /// Optional tool-call id for tool lifecycle records.
+    #[serde(default)]
+    pub tool_call_id: Option<String>,
+    /// Optional parent capture event id for post-tool/tool-output records.
+    #[serde(default)]
+    pub parent_event_id: Option<String>,
 }
 
 /// Ordered replay action.
@@ -401,6 +410,15 @@ fn seed_record(seed: &ReplayRecord, index: usize) -> Result<MemoryRecord, Replay
     record.visibility = seed.visibility;
     seed.body.clone_into(&mut record.body);
     record.updated_at = timestamp_for(index)?;
+    record.scope.session_id.clone_from(&seed.session_id);
+    if let Some(event) = &seed.trace_event {
+        serde_json::from_value::<TraceEvent>(Value::String(event.clone())).map_err(|e| {
+            ReplayError::InvalidManifest(format!(
+                "record {} has invalid trace_event {event:?}: {e}",
+                seed.id
+            ))
+        })?;
+    }
     record.extra_frontmatter = trace_frontmatter(seed);
     Ok(record)
 }
@@ -430,6 +448,18 @@ fn trace_frontmatter(seed: &ReplayRecord) -> BTreeMap<String, Value> {
         }
         if let Some(tool_name) = &seed.tool_name {
             trace.insert("tool_name".to_owned(), Value::String(tool_name.clone()));
+        }
+        if let Some(tool_call_id) = &seed.tool_call_id {
+            trace.insert(
+                "tool_call_id".to_owned(),
+                Value::String(tool_call_id.clone()),
+            );
+        }
+        if let Some(parent_event_id) = &seed.parent_event_id {
+            trace.insert(
+                "parent_event_id".to_owned(),
+                Value::String(parent_event_id.clone()),
+            );
         }
         trace.insert(
             "capture_event_id".to_owned(),
@@ -560,7 +590,7 @@ async fn run_search(
             query: action.query.clone(),
             mode: action.mode.to_core(),
             limit: action.limit,
-            include_reasoning: true,
+            include_reasoning: false,
             visibility_allowlist: vec![],
             auth_scope: ScopeTuple::default(),
             model_label: config.search.embedding_model.as_str().to_owned(),
@@ -614,26 +644,49 @@ async fn trace_summary(
     let page = store
         .list(&ListArgs {
             limit: 1000,
+            scope: session_id.map(|session_id| ScopeTuple {
+                session_id: Some(session_id.to_owned()),
+                ..ScopeTuple::default()
+            }),
             ..ListArgs::default()
         })
         .await
         .map_err(|e| ReplayError::Store(format!("list trace records: {e}")))?;
-    let mut rows: Vec<(u64, String, String)> = page
+    let mut rows: Vec<(u64, MemoryRecord)> = page
         .records
-        .iter()
-        .filter_map(|record| trace_projection(record, session_id, turn_id))
+        .into_iter()
+        .filter_map(|record| {
+            trace_projection(&record, session_id, turn_id)
+                .map(|(sequence, _, _)| (sequence, record))
+        })
         .collect();
-    rows.sort_by_key(|(sequence, _, _)| *sequence);
-    let turn_ids: BTreeSet<String> = rows
-        .iter()
-        .filter(|(_, _, event)| event != "turn_summary")
-        .map(|(_, turn, _)| turn.clone())
-        .collect();
-    let trace_events: Vec<String> = rows.into_iter().map(|(_, _, event)| event).collect();
-    Ok(json!({
-        "turn_ids": turn_ids.into_iter().collect::<Vec<_>>(),
-        "trace_events": trace_events,
-    }))
+    rows.sort_by_key(|(sequence, _)| *sequence);
+    let records = rows
+        .into_iter()
+        .map(|(_, record)| record)
+        .collect::<Vec<_>>();
+
+    match (session_id, turn_id) {
+        (Some(session_id), Some(turn_id)) => Ok(summary_from_retrieve_data(
+            retrieve::turn_data_with_options(
+                session_id.to_owned(),
+                turn_id.to_owned(),
+                &records,
+                false,
+                false,
+            ),
+        )),
+        (Some(session_id), None) => Ok(summary_from_retrieve_data(
+            retrieve::session_data_with_options(
+                session_id.to_owned(),
+                &records,
+                None,
+                false,
+                false,
+            ),
+        )),
+        (None, _) => Ok(summary_from_records(&records)),
+    }
 }
 
 fn trace_projection(
@@ -642,8 +695,12 @@ fn trace_projection(
     turn_filter: Option<&str>,
 ) -> Option<(u64, String, String)> {
     let trace = record.extra_frontmatter.get("trace")?.as_object()?;
-    let session_id = trace.get("session_id")?.as_str()?;
-    if session_filter.is_some_and(|wanted| wanted != session_id) {
+    let scope_session_id = record.scope.session_id.as_deref()?;
+    let trace_session_id = trace.get("session_id")?.as_str()?;
+    if trace_session_id != scope_session_id {
+        return None;
+    }
+    if session_filter.is_some_and(|wanted| wanted != scope_session_id) {
         return None;
     }
     let turn_id = trace.get("turn_id")?.as_str()?;
@@ -656,6 +713,58 @@ fn trace_projection(
         .get("trace_event")
         .and_then(Value::as_str)?;
     Some((sequence, turn_id.to_owned(), event.to_owned()))
+}
+
+fn summary_from_retrieve_data(data: RetrieveData) -> Value {
+    match data {
+        RetrieveData::Session(session) => summary_from_turn_items(session.items),
+        RetrieveData::Turn(turn) => summary_from_turn_items(turn.turn),
+        _ => json!({
+            "status": "error",
+            "message": "unexpected retrieve data shape",
+        }),
+    }
+}
+
+fn summary_from_turn_items(
+    items: impl IntoIterator<Item = cairn_core::generated::verbs::retrieve::TurnItem>,
+) -> Value {
+    let mut turn_ids = BTreeSet::new();
+    let mut trace_events = Vec::new();
+    for item in items {
+        let Some(linkage) = item.linkage else {
+            continue;
+        };
+        let Some(event) = linkage.trace_event else {
+            continue;
+        };
+        if event != "turn_summary" {
+            turn_ids.insert(item.turn_id);
+        }
+        trace_events.push(event);
+    }
+    json!({
+        "turn_ids": turn_ids.into_iter().collect::<Vec<_>>(),
+        "trace_events": trace_events,
+    })
+}
+
+fn summary_from_records(records: &[MemoryRecord]) -> Value {
+    let mut rows = records
+        .iter()
+        .filter_map(|record| trace_projection(record, None, None))
+        .collect::<Vec<_>>();
+    rows.sort_by_key(|(sequence, _, _)| *sequence);
+    let turn_ids: BTreeSet<String> = rows
+        .iter()
+        .filter(|(_, _, event)| event != "turn_summary")
+        .map(|(_, turn, _)| turn.clone())
+        .collect();
+    let trace_events: Vec<String> = rows.into_iter().map(|(_, _, event)| event).collect();
+    json!({
+        "turn_ids": turn_ids.into_iter().collect::<Vec<_>>(),
+        "trace_events": trace_events,
+    })
 }
 
 async fn record_present(store: &SqliteMemoryStore, record_id: &str) -> Result<Value, ReplayError> {
@@ -730,4 +839,42 @@ fn error_value(error: &ReplayError) -> Value {
         "status": "error",
         "message": error.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn trace_seed() -> ReplayRecord {
+        ReplayRecord {
+            id: "01HQZX9F5N00000000000000C0".to_owned(),
+            target_id: None,
+            kind: MemoryKind::Trace,
+            class: MemoryClass::Episodic,
+            visibility: MemoryVisibility::Private,
+            body: "trace body".to_owned(),
+            session_id: Some("session-a".to_owned()),
+            turn_id: Some("turn-a".to_owned()),
+            sequence: Some(1),
+            trace_event: Some("user_message".to_owned()),
+            tool_name: None,
+            tool_call_id: None,
+            parent_event_id: None,
+        }
+    }
+
+    #[test]
+    fn seed_record_sets_scope_session_id_for_trace_records() {
+        let record = seed_record(&trace_seed(), 0).expect("seed record");
+
+        assert_eq!(record.scope.session_id.as_deref(), Some("session-a"));
+    }
+
+    #[test]
+    fn trace_projection_rejects_trace_session_without_record_scope() {
+        let mut record = crate::sample_record(1);
+        record.extra_frontmatter = trace_frontmatter(&trace_seed());
+
+        assert_eq!(trace_projection(&record, Some("session-a"), None), None);
+    }
 }

--- a/crates/cairn-test-fixtures/src/replay.rs
+++ b/crates/cairn-test-fixtures/src/replay.rs
@@ -601,17 +601,7 @@ async fn run_search(
     .await;
 
     match result {
-        Ok(outcome) => {
-            let ids: Vec<String> = outcome
-                .candidates
-                .iter()
-                .map(|candidate| candidate.record_id.as_str().to_owned())
-                .collect();
-            json!({
-                "status": "hits",
-                "record_ids": ids,
-            })
-        }
+        Ok(outcome) => search_success_value(&outcome),
         Err(SearchError::CapabilityUnavailable { capability }) => json!({
             "status": "capability_unavailable",
             "capability": capability,
@@ -619,6 +609,65 @@ async fn run_search(
         Err(err) => json!({
             "status": "error",
             "message": err.to_string(),
+        }),
+    }
+}
+
+fn search_success_value(outcome: &search::SearchOutcome) -> Value {
+    let ids: Vec<String> = outcome
+        .candidates
+        .iter()
+        .map(|candidate| candidate.record_id.as_str().to_owned())
+        .collect();
+    let mut value = json!({
+        "status": "hits",
+        "record_ids": ids,
+    });
+    if !outcome.degraded_legs.is_empty() {
+        value["degraded_legs"] = Value::Array(
+            outcome
+                .degraded_legs
+                .iter()
+                .map(degraded_leg_value)
+                .collect(),
+        );
+    }
+    value
+}
+
+fn degraded_leg_value(leg: &cairn_core::search::DegradedLeg) -> Value {
+    use cairn_core::search::{DegradationReason, DegradedLeg, GraphSource};
+
+    fn reason_value(reason: DegradationReason) -> &'static str {
+        match reason {
+            DegradationReason::CapabilityUnavailable => "capability_unavailable",
+            DegradationReason::DeadlineExceeded => "timeout",
+            _ => "sql_error",
+        }
+    }
+
+    fn source_value(source: GraphSource) -> &'static str {
+        match source {
+            GraphSource::AuthKeywordSeed => "auth_keyword_seed",
+            GraphSource::AuthSemanticSeed => "auth_semantic_seed",
+            _ => "all",
+        }
+    }
+
+    match leg {
+        DegradedLeg::Semantic { reason } => json!({
+            "leg": "semantic",
+            "reason": reason_value(*reason),
+        }),
+        DegradedLeg::Graph { reason, source } => json!({
+            "leg": "graph",
+            "reason": reason_value(*reason),
+            "source": source_value(*source),
+        }),
+        _ => json!({
+            "leg": "graph",
+            "reason": "sql_error",
+            "source": "all",
         }),
     }
 }
@@ -803,10 +852,25 @@ async fn forget_record(
         expected: ReplayExpectation::Hits { record_ids: vec![] },
     };
     let search_actual = run_search(store, scenario, &action).await;
-    let contains = search_actual
-        .get("record_ids")
-        .and_then(Value::as_array)
-        .is_some_and(|ids| ids.iter().any(|value| value.as_str() == Some(record_id)));
+    if search_actual.get("status").and_then(Value::as_str) != Some("hits") {
+        return Ok(json!({
+            "status": search_actual
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("error"),
+            "retrieve_found": retrieve_found,
+            "search_actual": search_actual,
+        }));
+    }
+    let Some(ids) = search_actual.get("record_ids").and_then(Value::as_array) else {
+        return Ok(json!({
+            "status": "error",
+            "retrieve_found": retrieve_found,
+            "message": "follow-up search returned hits without record_ids",
+            "search_actual": search_actual,
+        }));
+    };
+    let contains = ids.iter().any(|value| value.as_str() == Some(record_id));
     Ok(json!({
         "retrieve_found": retrieve_found,
         "search_contains_record": contains,
@@ -876,5 +940,32 @@ mod tests {
         record.extra_frontmatter = trace_frontmatter(&trace_seed());
 
         assert_eq!(trace_projection(&record, Some("session-a"), None), None);
+    }
+
+    #[test]
+    fn search_success_value_surfaces_degraded_hybrid_legs() {
+        let actual = search_success_value(&search::SearchOutcome {
+            candidates: vec![],
+            explain: None,
+            policy_trace: vec![],
+            excluded: None,
+            degraded_legs: vec![cairn_core::search::DegradedLeg::Graph {
+                reason: cairn_core::search::DegradationReason::CapabilityUnavailable,
+                source: cairn_core::search::GraphSource::All,
+            }],
+        });
+
+        assert_eq!(
+            actual,
+            json!({
+                "status": "hits",
+                "record_ids": [],
+                "degraded_legs": [{
+                    "leg": "graph",
+                    "reason": "capability_unavailable",
+                    "source": "all"
+                }]
+            })
+        );
     }
 }

--- a/crates/cairn-test-fixtures/tests/replay_harness.rs
+++ b/crates/cairn-test-fixtures/tests/replay_harness.rs
@@ -1,0 +1,84 @@
+//! Integration coverage for the dev-only replay harness.
+
+use cairn_test_fixtures::replay::{ReplayExpectation, load_named_scenario, run_named_scenario};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn p0_stories_replay_passes_end_to_end() {
+    let report = run_named_scenario("p0_stories")
+        .await
+        .expect("run scenario");
+    assert!(report.passed(), "{report:#?}");
+    assert_eq!(report.scenario_id, "p0_stories");
+    assert!(
+        report
+            .checks
+            .iter()
+            .any(|check| check.story == "US7" && check.verb == "search")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn keyword_only_replay_reports_capability_rejections() {
+    let report = run_named_scenario("p0_keyword_only")
+        .await
+        .expect("run scenario");
+    assert!(report.passed(), "{report:#?}");
+    let capabilities: Vec<_> = report
+        .checks
+        .iter()
+        .filter(|check| check.actual["status"] == "capability_unavailable")
+        .map(|check| {
+            check.actual["capability"]
+                .as_str()
+                .unwrap_or_default()
+                .to_owned()
+        })
+        .collect();
+    assert_eq!(
+        capabilities,
+        vec![
+            "cairn.mcp.v1.search.semantic".to_owned(),
+            "cairn.mcp.v1.search.hybrid".to_owned(),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn failure_report_identifies_scenario_verb_query_expected_and_actual() {
+    let mut scenario = load_named_scenario("p0_stories").expect("load scenario");
+    let search = scenario
+        .actions
+        .iter_mut()
+        .find_map(|action| action.as_search_mut())
+        .expect("search action");
+    search.expected = ReplayExpectation::Hits {
+        record_ids: vec!["01HQZX9F5N00000000000000A6".to_owned()],
+    };
+
+    let report = cairn_test_fixtures::replay::run_scenario(&scenario)
+        .await
+        .expect("run scenario");
+    assert!(!report.passed(), "{report:#?}");
+    let failure = report.failures().next().expect("one failure");
+    assert_eq!(failure.scenario_id, "p0_stories");
+    assert_eq!(failure.verb, "search");
+    assert_eq!(failure.query.as_deref(), Some("ownership borrowing"));
+    assert_eq!(
+        failure.expected,
+        serde_json::json!({
+            "status": "hits",
+            "record_ids": ["01HQZX9F5N00000000000000A6"]
+        })
+    );
+    assert_ne!(failure.expected, failure.actual);
+}
+
+#[test]
+fn replay_manifests_deserialize() {
+    for name in ["p0_stories", "p0_keyword_only"] {
+        let scenario = load_named_scenario(name).expect("load scenario");
+        assert_eq!(scenario.id, name);
+        assert!(!scenario.records.is_empty());
+        assert!(!scenario.actions.is_empty());
+    }
+}

--- a/crates/cairn-test-fixtures/tests/replay_harness.rs
+++ b/crates/cairn-test-fixtures/tests/replay_harness.rs
@@ -1,6 +1,9 @@
 //! Integration coverage for the dev-only replay harness.
 
-use cairn_test_fixtures::replay::{ReplayExpectation, load_named_scenario, run_named_scenario};
+use cairn_test_fixtures::replay::{
+    ReplayAction, ReplayExpectation, ReplaySearchAction, ReplaySearchMode, load_named_scenario,
+    run_named_scenario,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn p0_stories_replay_passes_end_to_end() {
@@ -71,6 +74,43 @@ async fn failure_report_identifies_scenario_verb_query_expected_and_actual() {
         })
     );
     assert_ne!(failure.expected, failure.actual);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_replay_hides_reasoning_by_default() {
+    let mut scenario = load_named_scenario("p0_stories").expect("load scenario");
+    scenario
+        .actions
+        .push(ReplayAction::Search(ReplaySearchAction {
+            story: "US7_REASONING_PRIVACY".to_owned(),
+            mode: ReplaySearchMode::Keyword,
+            query: "rolling summary p0 session covers".to_owned(),
+            limit: 5,
+            expected: ReplayExpectation::Hits { record_ids: vec![] },
+        }));
+
+    let report = cairn_test_fixtures::replay::run_scenario(&scenario)
+        .await
+        .expect("run scenario");
+    let check = report
+        .checks
+        .iter()
+        .find(|check| check.story == "US7_REASONING_PRIVACY")
+        .expect("privacy check");
+    assert!(check.passed, "{check:#?}");
+}
+
+#[test]
+fn p0_replay_manifest_uses_canonical_trace_event_names() {
+    let scenario = load_named_scenario("p0_stories").expect("load scenario");
+    for record in &scenario.records {
+        if let Some(event) = &record.trace_event {
+            serde_json::from_value::<cairn_core::domain::trace::TraceEvent>(
+                serde_json::Value::String(event.clone()),
+            )
+            .unwrap_or_else(|e| panic!("record {} trace_event {event:?}: {e}", record.id));
+        }
+    }
 }
 
 #[test]

--- a/crates/cairn-test-fixtures/tests/replay_harness.rs
+++ b/crates/cairn-test-fixtures/tests/replay_harness.rs
@@ -100,6 +100,29 @@ async fn search_replay_hides_reasoning_by_default() {
     assert!(check.passed, "{check:#?}");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn forget_replay_fails_when_followup_search_errors() {
+    let mut scenario = load_named_scenario("p0_stories").expect("load scenario");
+    let forget = scenario
+        .actions
+        .iter_mut()
+        .find_map(|action| match action {
+            ReplayAction::ForgetRecord { followup_query, .. } => Some(followup_query),
+            _ => None,
+        })
+        .expect("forget action");
+    forget.clear();
+
+    let report = cairn_test_fixtures::replay::run_scenario(&scenario)
+        .await
+        .expect("run scenario");
+    let failure = report
+        .failures()
+        .find(|check| check.verb == "forget_record")
+        .expect("forget check should fail");
+    assert_eq!(failure.actual["status"], "error");
+}
+
 #[test]
 fn p0_replay_manifest_uses_canonical_trace_event_names() {
     let scenario = load_named_scenario("p0_stories").expect("load scenario");

--- a/crates/cairn-test-fixtures/tests/schema_fixtures.rs
+++ b/crates/cairn-test-fixtures/tests/schema_fixtures.rs
@@ -34,6 +34,7 @@ fn v0_directory_structure_exists() {
         "config",
         "envelopes",
         "search-filters",
+        "replay",
         "manifests",
     ] {
         let p = base.join(sub);
@@ -176,6 +177,27 @@ fn filter_or_with_not_deserializes() {
 fn search_args_keyword_deserializes() {
     let a: SearchArgs = load_json(filters_dir().join("search-args-keyword.json"));
     insta::assert_json_snapshot!("search_args_keyword", &a);
+}
+
+// ── Replay scenarios ─────────────────────────────────────────────────────────
+
+fn replay_dir() -> std::path::PathBuf {
+    v0().join("replay")
+}
+
+#[test]
+fn replay_scenarios_deserialize() {
+    for name in ["p0_stories.json", "p0_keyword_only.json"] {
+        let path = replay_dir().join(name);
+        let scenario = cairn_test_fixtures::replay::load_scenario_file(&path)
+            .unwrap_or_else(|e| panic!("load {}: {e}", path.display()));
+        assert_eq!(
+            path.file_stem().and_then(std::ffi::OsStr::to_str),
+            Some(scenario.id.as_str())
+        );
+        assert!(!scenario.records.is_empty());
+        assert!(!scenario.actions.is_empty());
+    }
 }
 
 // ── Plugin manifests ──────────────────────────────────────────────────────────

--- a/docs/superpowers/plans/2026-05-15-issue-97-replay-harness.md
+++ b/docs/superpowers/plans/2026-05-15-issue-97-replay-harness.md
@@ -1,0 +1,1177 @@
+# Issue 97 Replay Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a dev-only local replay harness that loads P0 scenario fixtures, executes deterministic replay checks against a temp SQLite vault, and returns machine-readable reports.
+
+**Architecture:** Add a `cairn_test_fixtures::replay` module plus versioned JSON fixtures under `fixtures/v0/replay/`. The harness seeds a temp vault with deterministic `MemoryRecord`s, uses `MockEmbedder` for local semantic/hybrid search, dispatches search through `cairn_core::verbs::search::run`, applies record-level tombstones through `MemoryStore`, and compares actual outcomes to fixture expectations.
+
+**Tech Stack:** Rust 2024, `cairn-test-fixtures`, `cairn-core`, `cairn-store-sqlite`, `cairn-embeddings-local::MockEmbedder`, `serde`, `serde_json`, `tokio`, `tempfile`.
+
+---
+
+### Task 1: Add Replay Fixture Manifests
+
+**Files:**
+- Create: `fixtures/v0/replay/p0_stories.json`
+- Create: `fixtures/v0/replay/p0_keyword_only.json`
+- Modify: `fixtures/README.md`
+
+- [ ] **Step 1: Create the fixture directory**
+
+Run:
+
+```bash
+mkdir -p fixtures/v0/replay
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 2: Add `fixtures/v0/replay/p0_stories.json`**
+
+Create the file with this content:
+
+```json
+{
+  "id": "p0_stories",
+  "description": "P0 replay scenario covering US1-US5, US7 all search modes, and US8 record-level forget.",
+  "config": {
+    "local_embeddings": true
+  },
+  "records": [
+    {
+      "id": "01HQZX9F5N0000000000000A0",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "rust memory safety session replay user question",
+      "session_id": "p0-session",
+      "turn_id": "1",
+      "sequence": 1,
+      "trace_event": "user_message"
+    },
+    {
+      "id": "01HQZX9F5N0000000000000A1",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "ownership borrowing prevent memory bugs at compile time",
+      "session_id": "p0-session",
+      "turn_id": "1",
+      "sequence": 2,
+      "trace_event": "assistant_message"
+    },
+    {
+      "id": "01HQZX9F5N0000000000000A2",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "cargo check tool result succeeded for memory safety example",
+      "session_id": "p0-session",
+      "turn_id": "1",
+      "sequence": 3,
+      "trace_event": "tool_call",
+      "tool_name": "cargo"
+    },
+    {
+      "id": "01HQZX9F5N0000000000000A3",
+      "kind": "user",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "user prefers concise rust memory explanations"
+    },
+    {
+      "id": "01HQZX9F5N0000000000000A4",
+      "kind": "reasoning",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "rolling summary p0 session covers rust memory safety and cargo check success",
+      "session_id": "p0-session",
+      "turn_id": "summary",
+      "sequence": 4,
+      "trace_event": "turn_summary"
+    },
+    {
+      "id": "01HQZX9F5N0000000000000A5",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "secret project codename aurora should be forgotten"
+    },
+    {
+      "id": "01HQZX9F5N0000000000000A6",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "unrelated cooking note tomato soup"
+    }
+  ],
+  "actions": [
+    {
+      "verb": "retrieve_session",
+      "story": "US1_US2",
+      "session_id": "p0-session",
+      "expected_turn_ids": ["1"],
+      "expected_trace_events": ["user_message", "assistant_message", "tool_call", "turn_summary"]
+    },
+    {
+      "verb": "retrieve_turn",
+      "story": "US5",
+      "session_id": "p0-session",
+      "turn_id": "1",
+      "expected_trace_events": ["user_message", "assistant_message", "tool_call"]
+    },
+    {
+      "verb": "record_present",
+      "story": "US3",
+      "record_id": "01HQZX9F5N0000000000000A3",
+      "expected_present": true
+    },
+    {
+      "verb": "record_present",
+      "story": "US4",
+      "record_id": "01HQZX9F5N0000000000000A4",
+      "expected_present": true
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "keyword",
+      "query": "ownership borrowing",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N0000000000000A1"]
+      }
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "semantic",
+      "query": "user prefers concise rust memory explanations",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N0000000000000A3"]
+      }
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "hybrid",
+      "query": "rust memory safety session replay user question",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N0000000000000A0"]
+      }
+    },
+    {
+      "verb": "forget_record",
+      "story": "US8",
+      "record_id": "01HQZX9F5N0000000000000A5",
+      "followup_query": "secret project codename aurora",
+      "expected_absent_from_search": true
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Add `fixtures/v0/replay/p0_keyword_only.json`**
+
+Create the file with this content:
+
+```json
+{
+  "id": "p0_keyword_only",
+  "description": "P0 degraded keyword-only replay scenario with local embeddings disabled.",
+  "config": {
+    "local_embeddings": false
+  },
+  "records": [
+    {
+      "id": "01HQZX9F5N0000000000000B0",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "keyword only mode still finds rust memory safety"
+    }
+  ],
+  "actions": [
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "keyword",
+      "query": "rust memory safety",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N0000000000000B0"]
+      }
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "semantic",
+      "query": "keyword only mode still finds rust memory safety",
+      "limit": 1,
+      "expected": {
+        "status": "capability_unavailable",
+        "capability": "cairn.mcp.v1.search.semantic"
+      }
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "hybrid",
+      "query": "keyword only mode still finds rust memory safety",
+      "limit": 1,
+      "expected": {
+        "status": "capability_unavailable",
+        "capability": "cairn.mcp.v1.search.hybrid"
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Document the replay fixtures**
+
+Append this bullet to the `fixtures/v0/` tree in `fixtures/README.md`:
+
+```markdown
+    ├── replay/            ← P0 replay scenarios + golden expectations
+```
+
+Add one sentence after the existing fixture description:
+
+```markdown
+Replay fixtures are consumed by `cairn_test_fixtures::replay` to create temp vaults and emit deterministic machine-readable reports for CI gates.
+```
+
+- [ ] **Step 5: Verify fixture files are visible**
+
+Run:
+
+```bash
+find fixtures/v0/replay -maxdepth 1 -type f | sort
+```
+
+Expected output includes both JSON files.
+
+### Task 2: Write Failing Replay Harness Tests
+
+**Files:**
+- Create: `crates/cairn-test-fixtures/tests/replay_harness.rs`
+
+- [ ] **Step 1: Add failing integration tests**
+
+Create `crates/cairn-test-fixtures/tests/replay_harness.rs` with:
+
+```rust
+use cairn_test_fixtures::replay::{run_named_scenario, load_named_scenario, ReplayExpectation};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn p0_stories_replay_passes_end_to_end() {
+    let report = run_named_scenario("p0_stories").await.expect("run scenario");
+    assert!(report.passed(), "{report:#?}");
+    assert_eq!(report.scenario_id, "p0_stories");
+    assert!(
+        report
+            .checks
+            .iter()
+            .any(|check| check.story == "US7" && check.verb == "search")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn keyword_only_replay_reports_capability_rejections() {
+    let report = run_named_scenario("p0_keyword_only").await.expect("run scenario");
+    assert!(report.passed(), "{report:#?}");
+    let capabilities: Vec<_> = report
+        .checks
+        .iter()
+        .filter(|check| check.actual["status"] == "capability_unavailable")
+        .map(|check| check.actual["capability"].as_str().unwrap_or_default().to_owned())
+        .collect();
+    assert_eq!(
+        capabilities,
+        vec![
+            "cairn.mcp.v1.search.semantic".to_owned(),
+            "cairn.mcp.v1.search.hybrid".to_owned()
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn failure_report_identifies_scenario_verb_query_expected_and_actual() {
+    let mut scenario = load_named_scenario("p0_stories").expect("load scenario");
+    let search = scenario
+        .actions
+        .iter_mut()
+        .find_map(|action| action.as_search_mut())
+        .expect("search action");
+    search.expected = ReplayExpectation::Hits {
+        record_ids: vec!["01HQZX9F5N0000000000000A6".to_owned()],
+    };
+
+    let report = cairn_test_fixtures::replay::run_scenario(&scenario)
+        .await
+        .expect("run scenario");
+    assert!(!report.passed(), "{report:#?}");
+    let failure = report.failures().next().expect("one failure");
+    assert_eq!(failure.scenario_id, "p0_stories");
+    assert_eq!(failure.verb, "search");
+    assert_eq!(failure.query.as_deref(), Some("ownership borrowing"));
+    assert_eq!(
+        failure.expected,
+        serde_json::json!({
+            "status": "hits",
+            "record_ids": ["01HQZX9F5N0000000000000A6"]
+        })
+    );
+    assert_ne!(failure.expected, failure.actual);
+}
+
+#[test]
+fn replay_manifests_deserialize() {
+    for name in ["p0_stories", "p0_keyword_only"] {
+        let scenario = load_named_scenario(name).expect("load scenario");
+        assert_eq!(scenario.id, name);
+        assert!(!scenario.records.is_empty());
+        assert!(!scenario.actions.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+cargo nextest run -p cairn-test-fixtures --test replay_harness
+```
+
+Expected: compile fails because `cairn_test_fixtures::replay` does not exist.
+
+### Task 3: Implement `cairn_test_fixtures::replay`
+
+**Files:**
+- Create: `crates/cairn-test-fixtures/src/replay.rs`
+- Modify: `crates/cairn-test-fixtures/src/lib.rs`
+
+- [ ] **Step 1: Export the new module**
+
+Add to `crates/cairn-test-fixtures/src/lib.rs`:
+
+```rust
+pub mod replay;
+```
+
+- [ ] **Step 2: Implement the replay module**
+
+Create `crates/cairn-test-fixtures/src/replay.rs` with:
+
+```rust
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cairn_core::config::{CairnConfig, EmbeddingModelKind};
+use cairn_core::contract::memory_store::{ListArgs, MemoryStore, TombstoneReason};
+use cairn_core::domain::record::MemoryRecord;
+use cairn_core::domain::taxonomy::{MemoryClass, MemoryKind, MemoryVisibility};
+use cairn_core::domain::{RecordId, Rfc3339Timestamp, ScopeTuple, TargetId};
+use cairn_core::verbs::search::{self, SearchError, SearchMode, SearchRequest};
+use cairn_embeddings_local::{EmbeddingModel, MockEmbedder};
+use cairn_store_sqlite::SqliteMemoryStore;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+/// Machine-readable report for one replay scenario.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ReplayReport {
+    /// Scenario identifier from the manifest.
+    pub scenario_id: String,
+    /// One check report per manifest action.
+    pub checks: Vec<ReplayCheckReport>,
+}
+
+impl ReplayReport {
+    /// True when every check passed.
+    #[must_use]
+    pub fn passed(&self) -> bool {
+        self.checks.iter().all(|check| check.passed)
+    }
+
+    /// Failed checks only.
+    pub fn failures(&self) -> impl Iterator<Item = &ReplayCheckReport> {
+        self.checks.iter().filter(|check| !check.passed)
+    }
+}
+
+/// Machine-readable result for one replay action.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ReplayCheckReport {
+    /// Scenario identifier.
+    pub scenario_id: String,
+    /// User story label, e.g. `US7`.
+    pub story: String,
+    /// Verb or replay action under test.
+    pub verb: String,
+    /// Query text when the action is query-shaped.
+    pub query: Option<String>,
+    /// Expected normalized result.
+    pub expected: Value,
+    /// Actual normalized result.
+    pub actual: Value,
+    /// Whether expected and actual matched.
+    pub passed: bool,
+    /// Short diagnostic on failure.
+    pub message: Option<String>,
+}
+
+/// Versioned replay scenario manifest.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayScenario {
+    /// Stable scenario id.
+    pub id: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Scenario runtime knobs.
+    #[serde(default)]
+    pub config: ReplayConfig,
+    /// Records to seed into the temp vault.
+    pub records: Vec<ReplayRecord>,
+    /// Ordered replay actions.
+    pub actions: Vec<ReplayAction>,
+}
+
+/// Scenario runtime knobs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayConfig {
+    /// Whether local semantic/hybrid capabilities are advertised.
+    #[serde(default = "default_local_embeddings")]
+    pub local_embeddings: bool,
+}
+
+impl Default for ReplayConfig {
+    fn default() -> Self {
+        Self {
+            local_embeddings: default_local_embeddings(),
+        }
+    }
+}
+
+const fn default_local_embeddings() -> bool {
+    true
+}
+
+/// Seed record manifest.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayRecord {
+    /// Record id and default target id.
+    pub id: String,
+    /// Optional stable target id; defaults to `id`.
+    #[serde(default)]
+    pub target_id: Option<String>,
+    /// Memory kind.
+    pub kind: MemoryKind,
+    /// Memory class.
+    pub class: MemoryClass,
+    /// Visibility tier.
+    pub visibility: MemoryVisibility,
+    /// Record body.
+    pub body: String,
+    /// Optional session id for trace-shaped records.
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Optional turn id for trace-shaped records.
+    #[serde(default)]
+    pub turn_id: Option<String>,
+    /// Optional sequence for trace ordering.
+    #[serde(default)]
+    pub sequence: Option<u64>,
+    /// Optional trace event label.
+    #[serde(default)]
+    pub trace_event: Option<String>,
+    /// Optional tool name for tool-call records.
+    #[serde(default)]
+    pub tool_name: Option<String>,
+}
+
+/// Ordered replay action.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "verb", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ReplayAction {
+    /// Search query expectation.
+    Search(ReplaySearchAction),
+    /// Session replay expectation.
+    RetrieveSession {
+        /// User story label.
+        story: String,
+        /// Session id to inspect.
+        session_id: String,
+        /// Expected distinct turn ids.
+        expected_turn_ids: Vec<String>,
+        /// Expected trace events in sequence order.
+        expected_trace_events: Vec<String>,
+    },
+    /// Single-turn replay expectation.
+    RetrieveTurn {
+        /// User story label.
+        story: String,
+        /// Session id to inspect.
+        session_id: String,
+        /// Turn id to inspect.
+        turn_id: String,
+        /// Expected trace events in sequence order.
+        expected_trace_events: Vec<String>,
+    },
+    /// Direct record presence check.
+    RecordPresent {
+        /// User story label.
+        story: String,
+        /// Record id to inspect.
+        record_id: String,
+        /// Expected presence.
+        expected_present: bool,
+    },
+    /// Record-level forget expectation.
+    ForgetRecord {
+        /// User story label.
+        story: String,
+        /// Record id to tombstone.
+        record_id: String,
+        /// Follow-up keyword query.
+        followup_query: String,
+        /// Whether the record must be absent from follow-up search.
+        expected_absent_from_search: bool,
+    },
+}
+
+impl ReplayAction {
+    /// Mutable search-action view for tests that need to perturb expectations.
+    pub fn as_search_mut(&mut self) -> Option<&mut ReplaySearchAction> {
+        match self {
+            Self::Search(action) => Some(action),
+            _ => None,
+        }
+    }
+}
+
+/// Search replay action.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplaySearchAction {
+    /// User story label.
+    pub story: String,
+    /// Search mode.
+    pub mode: ReplaySearchMode,
+    /// Query string.
+    pub query: String,
+    /// Result limit.
+    pub limit: usize,
+    /// Expected outcome.
+    pub expected: ReplayExpectation,
+}
+
+/// Search mode in scenario manifests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplaySearchMode {
+    /// Keyword search.
+    Keyword,
+    /// Semantic search.
+    Semantic,
+    /// Hybrid search.
+    Hybrid,
+}
+
+impl ReplaySearchMode {
+    fn to_core(self) -> SearchMode {
+        match self {
+            Self::Keyword => SearchMode::Keyword,
+            Self::Semantic => SearchMode::Semantic,
+            Self::Hybrid => SearchMode::Hybrid,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Keyword => "keyword",
+            Self::Semantic => "semantic",
+            Self::Hybrid => "hybrid",
+        }
+    }
+}
+
+/// Expected search outcome.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ReplayExpectation {
+    /// Expected record ids, in order.
+    Hits {
+        /// Expected record ids.
+        record_ids: Vec<String>,
+    },
+    /// Expected capability rejection.
+    CapabilityUnavailable {
+        /// Missing capability name.
+        capability: String,
+    },
+}
+
+/// Errors from loading or running replay scenarios.
+#[derive(Debug)]
+pub enum ReplayError {
+    /// Fixture file read failed.
+    Io {
+        /// Path that failed.
+        path: PathBuf,
+        /// Source error.
+        source: std::io::Error,
+    },
+    /// Fixture JSON failed to parse.
+    Json {
+        /// Path that failed.
+        path: PathBuf,
+        /// Source error.
+        source: serde_json::Error,
+    },
+    /// Scenario data was malformed.
+    InvalidManifest(String),
+    /// Store setup or operation failed.
+    Store(String),
+}
+
+impl fmt::Display for ReplayError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, source } => write!(f, "read {}: {source}", path.display()),
+            Self::Json { path, source } => write!(f, "parse {}: {source}", path.display()),
+            Self::InvalidManifest(message) => write!(f, "invalid replay manifest: {message}"),
+            Self::Store(message) => write!(f, "store error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ReplayError {}
+
+struct ReplayVault {
+    _dir: TempDir,
+    store: SqliteMemoryStore,
+    _embedder: Arc<dyn EmbeddingModel>,
+}
+
+/// Load a named scenario from `fixtures/v0/replay/{name}.json`.
+pub fn load_named_scenario(name: &str) -> Result<ReplayScenario, ReplayError> {
+    let path = crate::fixture_v0_dir()
+        .join("replay")
+        .join(format!("{name}.json"));
+    load_scenario_file(&path)
+}
+
+/// Load a scenario from a specific file path.
+pub fn load_scenario_file(path: &Path) -> Result<ReplayScenario, ReplayError> {
+    let raw = std::fs::read_to_string(path).map_err(|source| ReplayError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str(&raw).map_err(|source| ReplayError::Json {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Load and run a named scenario.
+pub async fn run_named_scenario(name: &str) -> Result<ReplayReport, ReplayError> {
+    let scenario = load_named_scenario(name)?;
+    run_scenario(&scenario).await
+}
+
+/// Run a loaded replay scenario.
+pub async fn run_scenario(scenario: &ReplayScenario) -> Result<ReplayReport, ReplayError> {
+    let vault = build_vault(scenario).await?;
+    let mut checks = Vec::with_capacity(scenario.actions.len());
+    for action in &scenario.actions {
+        checks.push(run_action(&vault.store, scenario, action).await);
+    }
+    Ok(ReplayReport {
+        scenario_id: scenario.id.clone(),
+        checks,
+    })
+}
+
+async fn build_vault(scenario: &ReplayScenario) -> Result<ReplayVault, ReplayError> {
+    let dir = TempDir::new().map_err(|e| ReplayError::Store(format!("tempdir: {e}")))?;
+    let root = dir.path().to_path_buf();
+    let cairn_dir = root.join(".cairn");
+    std::fs::create_dir_all(&cairn_dir)
+        .map_err(|e| ReplayError::Store(format!("create {}: {e}", cairn_dir.display())))?;
+    std::fs::write(cairn_dir.join("vault.id"), b"01HZZ0000000000000000000AB\n")
+        .map_err(|e| ReplayError::Store(format!("write vault.id: {e}")))?;
+
+    let embedder: Arc<dyn EmbeddingModel> =
+        Arc::new(MockEmbedder::new(EmbeddingModelKind::default()));
+    let db_path = cairn_dir.join("cairn.db");
+    let store = cairn_store_sqlite::open_with_embedder(&db_path, Some(Arc::clone(&embedder)))
+        .await
+        .map_err(|e| ReplayError::Store(format!("open {}: {e}", db_path.display())))?;
+
+    for (index, seed) in scenario.records.iter().enumerate() {
+        let record = seed_record(seed, index)?;
+        store
+            .upsert(&record)
+            .await
+            .map_err(|e| ReplayError::Store(format!("upsert {}: {e}", seed.id)))?;
+    }
+
+    if let Some(conn) = store.raw_conn_for_admin() {
+        let conn = Arc::clone(conn);
+        for _ in 0..1000 {
+            let stats = cairn_store_sqlite::drain_once(Arc::clone(&conn), Arc::clone(&embedder))
+                .await
+                .map_err(|e| ReplayError::Store(format!("drain embeddings: {e}")))?;
+            if stats.remaining == 0 {
+                break;
+            }
+        }
+    }
+
+    Ok(ReplayVault {
+        _dir: dir,
+        store,
+        _embedder: embedder,
+    })
+}
+
+fn seed_record(seed: &ReplayRecord, index: usize) -> Result<MemoryRecord, ReplayError> {
+    let mut record = crate::sample_record(index as u64 + 1);
+    record.id = RecordId::parse(seed.id.clone()).map_err(|e| {
+        ReplayError::InvalidManifest(format!("record {} has invalid id: {e}", seed.id))
+    })?;
+    let target = seed.target_id.as_ref().unwrap_or(&seed.id);
+    record.target_id = TargetId::parse(target.clone()).map_err(|e| {
+        ReplayError::InvalidManifest(format!("record {} has invalid target_id: {e}", seed.id))
+    })?;
+    record.kind = seed.kind;
+    record.class = seed.class;
+    record.visibility = seed.visibility;
+    seed.body.clone_into(&mut record.body);
+    record.updated_at = timestamp_for(index)?;
+    record.extra_frontmatter = trace_frontmatter(seed);
+    Ok(record)
+}
+
+fn timestamp_for(index: usize) -> Result<Rfc3339Timestamp, ReplayError> {
+    let seconds = index % 60;
+    let raw = format!("2026-04-22T14:05:{seconds:02}Z");
+    Rfc3339Timestamp::parse(raw.clone())
+        .map_err(|e| ReplayError::InvalidManifest(format!("invalid timestamp {raw}: {e}")))
+}
+
+fn trace_frontmatter(seed: &ReplayRecord) -> BTreeMap<String, Value> {
+    let mut extra = BTreeMap::new();
+    if let Some(event) = &seed.trace_event {
+        extra.insert("trace_event".to_owned(), Value::String(event.clone()));
+    }
+    if seed.session_id.is_some() || seed.turn_id.is_some() || seed.sequence.is_some() {
+        let mut trace = serde_json::Map::new();
+        if let Some(session_id) = &seed.session_id {
+            trace.insert("session_id".to_owned(), Value::String(session_id.clone()));
+        }
+        if let Some(turn_id) = &seed.turn_id {
+            trace.insert("turn_id".to_owned(), Value::String(turn_id.clone()));
+        }
+        if let Some(sequence) = seed.sequence {
+            trace.insert("sequence".to_owned(), Value::Number(sequence.into()));
+        }
+        if let Some(tool_name) = &seed.tool_name {
+            trace.insert("tool_name".to_owned(), Value::String(tool_name.clone()));
+        }
+        trace.insert("capture_event_id".to_owned(), Value::String(seed.id.clone()));
+        extra.insert("trace".to_owned(), Value::Object(trace));
+    }
+    extra
+}
+
+async fn run_action(
+    store: &SqliteMemoryStore,
+    scenario: &ReplayScenario,
+    action: &ReplayAction,
+) -> ReplayCheckReport {
+    match action {
+        ReplayAction::Search(search) => run_search_action(store, scenario, search).await,
+        ReplayAction::RetrieveSession {
+            story,
+            session_id,
+            expected_turn_ids,
+            expected_trace_events,
+        } => {
+            let actual = trace_summary(store, Some(session_id), None)
+                .await
+                .unwrap_or_else(error_value);
+            let expected = json!({
+                "turn_ids": expected_turn_ids,
+                "trace_events": expected_trace_events
+            });
+            report_check(&scenario.id, story, "retrieve_session", None, expected, actual)
+        }
+        ReplayAction::RetrieveTurn {
+            story,
+            session_id,
+            turn_id,
+            expected_trace_events,
+        } => {
+            let actual = trace_summary(store, Some(session_id), Some(turn_id))
+                .await
+                .unwrap_or_else(error_value);
+            let expected = json!({
+                "turn_ids": [turn_id],
+                "trace_events": expected_trace_events
+            });
+            report_check(&scenario.id, story, "retrieve_turn", None, expected, actual)
+        }
+        ReplayAction::RecordPresent {
+            story,
+            record_id,
+            expected_present,
+        } => {
+            let actual = record_present(store, record_id).await.unwrap_or_else(error_value);
+            let expected = json!({ "present": expected_present });
+            report_check(&scenario.id, story, "record_present", None, expected, actual)
+        }
+        ReplayAction::ForgetRecord {
+            story,
+            record_id,
+            followup_query,
+            expected_absent_from_search,
+        } => {
+            let actual = forget_record(store, scenario, record_id, followup_query)
+                .await
+                .unwrap_or_else(error_value);
+            let expected = json!({
+                "retrieve_found": false,
+                "search_contains_record": !expected_absent_from_search
+            });
+            report_check(
+                &scenario.id,
+                story,
+                "forget_record",
+                Some(followup_query.clone()),
+                expected,
+                actual,
+            )
+        }
+    }
+}
+
+async fn run_search_action(
+    store: &SqliteMemoryStore,
+    scenario: &ReplayScenario,
+    action: &ReplaySearchAction,
+) -> ReplayCheckReport {
+    let expected = expected_search_value(&action.expected);
+    let actual = run_search(store, scenario, action).await;
+    report_check(
+        &scenario.id,
+        &action.story,
+        "search",
+        Some(action.query.clone()),
+        expected,
+        actual,
+    )
+}
+
+async fn run_search(
+    store: &SqliteMemoryStore,
+    scenario: &ReplayScenario,
+    action: &ReplaySearchAction,
+) -> Value {
+    let mut config = CairnConfig::default();
+    config.search.local_embeddings = scenario.config.local_embeddings;
+    let caps = config.capabilities(true);
+    let result = search::run(
+        store,
+        &config,
+        &caps,
+        SearchRequest {
+            query: action.query.clone(),
+            mode: action.mode.to_core(),
+            limit: action.limit,
+            include_reasoning: true,
+            visibility_allowlist: vec![],
+            auth_scope: ScopeTuple::default(),
+            model_label: config.search.embedding_model.as_str().to_owned(),
+            filter: None,
+            explain: false,
+        },
+    )
+    .await;
+
+    match result {
+        Ok(outcome) => {
+            let ids: Vec<String> = outcome
+                .candidates
+                .iter()
+                .map(|candidate| candidate.record_id.as_str().to_owned())
+                .collect();
+            json!({
+                "status": "hits",
+                "mode": action.mode.as_str(),
+                "record_ids": ids
+            })
+        }
+        Err(SearchError::CapabilityUnavailable { capability }) => json!({
+            "status": "capability_unavailable",
+            "capability": capability
+        }),
+        Err(err) => json!({
+            "status": "error",
+            "message": err.to_string()
+        }),
+    }
+}
+
+fn expected_search_value(expected: &ReplayExpectation) -> Value {
+    match expected {
+        ReplayExpectation::Hits { record_ids } => json!({
+            "status": "hits",
+            "record_ids": record_ids
+        }),
+        ReplayExpectation::CapabilityUnavailable { capability } => json!({
+            "status": "capability_unavailable",
+            "capability": capability
+        }),
+    }
+}
+
+async fn trace_summary(
+    store: &SqliteMemoryStore,
+    session_id: Option<&str>,
+    turn_id: Option<&str>,
+) -> Result<Value, ReplayError> {
+    let page = store
+        .list(&ListArgs {
+            limit: 1000,
+            ..ListArgs::default()
+        })
+        .await
+        .map_err(|e| ReplayError::Store(format!("list trace records: {e}")))?;
+    let mut rows: Vec<(u64, String, String)> = page
+        .records
+        .iter()
+        .filter_map(|record| trace_projection(record, session_id, turn_id))
+        .collect();
+    rows.sort_by_key(|(sequence, _, _)| *sequence);
+    let turn_ids: BTreeSet<String> = rows.iter().map(|(_, turn, _)| turn.clone()).collect();
+    let trace_events: Vec<String> = rows.into_iter().map(|(_, _, event)| event).collect();
+    Ok(json!({
+        "turn_ids": turn_ids.into_iter().collect::<Vec<_>>(),
+        "trace_events": trace_events
+    }))
+}
+
+fn trace_projection(
+    record: &MemoryRecord,
+    session_filter: Option<&str>,
+    turn_filter: Option<&str>,
+) -> Option<(u64, String, String)> {
+    let trace = record.extra_frontmatter.get("trace")?.as_object()?;
+    let session_id = trace.get("session_id")?.as_str()?;
+    if session_filter.is_some_and(|wanted| wanted != session_id) {
+        return None;
+    }
+    let turn_id = trace.get("turn_id")?.as_str()?;
+    if turn_filter.is_some_and(|wanted| wanted != turn_id) {
+        return None;
+    }
+    let sequence = trace.get("sequence").and_then(Value::as_u64).unwrap_or(0);
+    let event = record
+        .extra_frontmatter
+        .get("trace_event")
+        .and_then(Value::as_str)?;
+    Some((sequence, turn_id.to_owned(), event.to_owned()))
+}
+
+async fn record_present(store: &SqliteMemoryStore, record_id: &str) -> Result<Value, ReplayError> {
+    let id = RecordId::parse(record_id.to_owned())
+        .map_err(|e| ReplayError::InvalidManifest(format!("invalid record_id {record_id}: {e}")))?;
+    let found = store
+        .get(&id)
+        .await
+        .map_err(|e| ReplayError::Store(format!("get {record_id}: {e}")))?
+        .is_some();
+    Ok(json!({ "present": found }))
+}
+
+async fn forget_record(
+    store: &SqliteMemoryStore,
+    scenario: &ReplayScenario,
+    record_id: &str,
+    followup_query: &str,
+) -> Result<Value, ReplayError> {
+    let id = RecordId::parse(record_id.to_owned())
+        .map_err(|e| ReplayError::InvalidManifest(format!("invalid record_id {record_id}: {e}")))?;
+    store
+        .tombstone(&id, TombstoneReason::Forget)
+        .await
+        .map_err(|e| ReplayError::Store(format!("tombstone {record_id}: {e}")))?;
+    let retrieve_found = store
+        .get(&id)
+        .await
+        .map_err(|e| ReplayError::Store(format!("get after tombstone {record_id}: {e}")))?
+        .is_some();
+    let action = ReplaySearchAction {
+        story: "US8".to_owned(),
+        mode: ReplaySearchMode::Keyword,
+        query: followup_query.to_owned(),
+        limit: 10,
+        expected: ReplayExpectation::Hits { record_ids: vec![] },
+    };
+    let search_actual = run_search(store, scenario, &action).await;
+    let contains = search_actual
+        .get("record_ids")
+        .and_then(Value::as_array)
+        .is_some_and(|ids| ids.iter().any(|value| value.as_str() == Some(record_id)));
+    Ok(json!({
+        "retrieve_found": retrieve_found,
+        "search_contains_record": contains
+    }))
+}
+
+fn report_check(
+    scenario_id: &str,
+    story: &str,
+    verb: &str,
+    query: Option<String>,
+    expected: Value,
+    actual: Value,
+) -> ReplayCheckReport {
+    let passed = expected == actual;
+    ReplayCheckReport {
+        scenario_id: scenario_id.to_owned(),
+        story: story.to_owned(),
+        verb: verb.to_owned(),
+        query,
+        message: (!passed).then(|| "expected and actual replay outcomes differ".to_owned()),
+        expected,
+        actual,
+        passed,
+    }
+}
+
+fn error_value(error: ReplayError) -> Value {
+    json!({
+        "status": "error",
+        "message": error.to_string()
+    })
+}
+```
+
+- [ ] **Step 3: Run replay tests and verify GREEN**
+
+Run:
+
+```bash
+cargo nextest run -p cairn-test-fixtures --test replay_harness
+```
+
+Expected: all replay harness tests pass. If any search ranking expectation differs, inspect the actual report and update only the fixture expectation when the actual ranking is deterministic and defensible.
+
+### Task 4: Tighten Fixture Schema Coverage
+
+**Files:**
+- Modify: `crates/cairn-test-fixtures/tests/schema_fixtures.rs`
+
+- [ ] **Step 1: Add replay directory coverage to schema fixture tests**
+
+In `crates/cairn-test-fixtures/tests/schema_fixtures.rs`, add `replay` to the required `fixtures/v0` subdirectory assertions and add a test:
+
+```rust
+#[test]
+fn replay_scenarios_deserialize() {
+    let replay = v0().join("replay");
+    for name in ["p0_stories.json", "p0_keyword_only.json"] {
+        let path = replay.join(name);
+        let scenario = cairn_test_fixtures::replay::load_scenario_file(&path)
+            .unwrap_or_else(|e| panic!("load {}: {e}", path.display()));
+        insta::assert_json_snapshot!(
+            format!("replay_{}", name.trim_end_matches(".json")),
+            &scenario.id
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run schema fixture tests**
+
+Run:
+
+```bash
+cargo nextest run -p cairn-test-fixtures --test schema_fixtures
+```
+
+Expected: tests pass or write new accepted snapshots for the two replay scenario ids.
+
+### Task 5: Final Verification
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run replay harness verification**
+
+Run:
+
+```bash
+cargo nextest run -p cairn-test-fixtures --test replay_harness
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run existing golden query verification**
+
+Run:
+
+```bash
+cargo nextest run -p cairn-cli --test search_modes_golden
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run existing evaluation workflow verification**
+
+Run:
+
+```bash
+cargo nextest run -p cairn-workflows --test evaluation
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run core boundary check**
+
+Run:
+
+```bash
+scripts/check-core-boundary.sh
+```
+
+Expected: exits 0.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only replay harness, replay fixtures, fixture docs, and fixture tests changed.

--- a/docs/superpowers/specs/2026-05-15-issue-97-replay-harness-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-97-replay-harness-design.md
@@ -1,0 +1,92 @@
+# Issue 97 Replay Harness Design
+
+## Context
+
+GitHub issue #97 asks for a P0 local replay engine and golden-query fixture harness. The design source is the Cairn brief, especially §15 Evaluation and §18.c User Story Coverage. Both listed dependencies are closed upstream: #62 wires search, lint, forget, and capability-aware errors; #91 wires minimum Dream, Expiration, and Evaluation workflows.
+
+The branch for implementation starts from `origin/main`, because the initial detached worktree was behind the merged #91 workflow changes. The upstream code already includes `cairn_core::replay`, `cairn_workflows::evaluation`, search golden tests, SQLite store tests, and dev-only fixture helpers. This issue should compose those pieces into scenario-level replay fixtures and reports rather than reimplement search, forget, or workflow primitives.
+
+## Recommendation
+
+Build a CI/test-only Rust replay harness first. Do not add a user-facing `cairn eval replay` CLI in this issue.
+
+This keeps the initial surface dev-only, satisfies #97's acceptance criteria, and avoids freezing a CLI contract while the scenario manifest format is still new. A CLI can later wrap the same fixture/report model without changing the harness internals.
+
+## Scope
+
+In scope:
+
+- A versioned replay fixture directory under `fixtures/v0/replay/`.
+- A dev-only `cairn_test_fixtures::replay` module that loads scenario manifests, creates temp vaults, seeds deterministic records, applies replay actions, runs golden query checks, and returns machine-readable reports.
+- Scenario coverage for P0 stories from §18.c: US1, US2 active session reload, US3 user memory, US4 rolling summary presence, US5 tool-call records, US7 keyword/semantic/hybrid search, and US8 record-level forget.
+- A degraded keyword-only scenario where local embeddings are disabled and semantic/hybrid expectations are reported as capability rejections.
+- Integration tests that verify replay output identifies failing scenario, verb, query, expected value, and actual value.
+
+Out of scope:
+
+- Public benchmark dashboards.
+- Long-horizon multi-session coherence corpora.
+- A stable CLI command.
+- New production dependencies.
+- Any network, cloud credential, or real embedding model requirement.
+
+## Architecture
+
+The harness lives in `cairn-test-fixtures`, which is already the dev-only crate for workspace fixture helpers. It uses the existing `cairn_store_sqlite` temp-store helpers and `MockEmbedder` paths used by search golden tests. It does not become a dependency of `cairn-core`.
+
+Scenario manifests are JSON files in `fixtures/v0/replay/`. Each manifest has:
+
+- `id`, `description`, and `stories`.
+- `records` seed data with deterministic bodies and metadata.
+- `actions` such as `search`, `retrieve_session`, `retrieve_turn`, and `forget_record`.
+- `config` with `local_embeddings` so tests can run full-search and keyword-only variants.
+
+The harness executes actions against a temp vault and accumulates a `ReplayReport`. Reports are plain serializable Rust structs so CI can write JSON later if needed. Each failed check records:
+
+- `scenario_id`
+- `story`
+- `verb`
+- `query` when applicable
+- `expected`
+- `actual`
+- `message`
+
+## Data Flow
+
+1. Load a scenario manifest from `fixtures/v0/replay/<name>.json`.
+2. Create a temporary vault using existing fixture helpers.
+3. Seed deterministic records and trace/tool-call data into SQLite.
+4. Apply actions in manifest order.
+5. Normalize actual results to deterministic IDs, modes, snippets, and statuses.
+6. Compare actual results to expected outcomes.
+7. Return a `ReplayReport` with per-check pass/fail detail.
+
+The report format is intentionally independent from `EvaluationWorkflow` report records. `EvaluationWorkflow` can consume these results later, but #97 only needs a local CI/release gate harness.
+
+## Error Handling
+
+The harness fails closed. Invalid scenario manifests return typed load errors. Unsupported actions become failed checks with explicit `verb` and `scenario_id`. Search capability mismatches are expected outcomes only when the scenario says the runtime is keyword-only. All other store or search errors become failed checks rather than panics.
+
+Tests may use `expect("reason")` in line with repo test conventions, but the library helpers return `Result` so callers can produce reports.
+
+## Testing
+
+Tests are written first under `crates/cairn-test-fixtures/tests/replay_harness.rs`.
+
+Required test coverage:
+
+- The P0 replay scenario passes end to end with local embeddings enabled.
+- The keyword-only scenario reports keyword success and semantic/hybrid `CapabilityUnavailable` outcomes.
+- A deliberately failing in-memory check reports scenario, verb, query, expected, and actual fields.
+- Scenario manifests deserialize from `fixtures/v0/replay/`.
+
+Verification commands:
+
+- `cargo nextest run -p cairn-test-fixtures --test replay_harness`
+- `cargo nextest run -p cairn-cli --test search_modes_golden`
+- `cargo nextest run -p cairn-workflows --test evaluation`
+- `scripts/check-core-boundary.sh`
+
+## Future CLI Path
+
+If the manifest and report structs stabilize, a later issue can add `cairn eval replay --scenario <id> --json` as a thin wrapper over this harness. That wrapper should not change fixture semantics.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,6 +1,7 @@
 # Cairn test fixtures
 
 Golden records, config, envelopes, search filters, and plugin manifests for CI schema validation.
+Replay fixtures add deterministic temp-vault scenarios and machine-readable reports for CI gates.
 
 ## Layout
 
@@ -11,6 +12,7 @@ fixtures/
     ├── config/            ← CairnConfig JSON examples
     ├── envelopes/         ← SignedIntent + Response wire fixtures
     ├── search-filters/    ← SearchArgsFilters + SearchArgs examples
+    ├── replay/            ← P0 replay scenarios + golden expectations
     └── manifests/         ← plugin.toml manifests for each ContractKind
 ```
 

--- a/fixtures/v0/replay/p0_keyword_only.json
+++ b/fixtures/v0/replay/p0_keyword_only.json
@@ -1,0 +1,51 @@
+{
+  "id": "p0_keyword_only",
+  "description": "P0 degraded keyword-only replay scenario with local embeddings disabled.",
+  "config": {
+    "local_embeddings": false
+  },
+  "records": [
+    {
+      "id": "01HQZX9F5N00000000000000B0",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "keyword only mode still finds rust memory safety"
+    }
+  ],
+  "actions": [
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "keyword",
+      "query": "rust memory safety",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N00000000000000B0"]
+      }
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "semantic",
+      "query": "keyword only mode still finds rust memory safety",
+      "limit": 1,
+      "expected": {
+        "status": "capability_unavailable",
+        "capability": "cairn.mcp.v1.search.semantic"
+      }
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "hybrid",
+      "query": "keyword only mode still finds rust memory safety",
+      "limit": 1,
+      "expected": {
+        "status": "capability_unavailable",
+        "capability": "cairn.mcp.v1.search.hybrid"
+      }
+    }
+  ]
+}

--- a/fixtures/v0/replay/p0_stories.json
+++ b/fixtures/v0/replay/p0_stories.json
@@ -1,0 +1,143 @@
+{
+  "id": "p0_stories",
+  "description": "P0 replay scenario covering US1-US5, US7 all search modes, and US8 record-level forget.",
+  "config": {
+    "local_embeddings": true
+  },
+  "records": [
+    {
+      "id": "01HQZX9F5N00000000000000A0",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "rust memory safety session replay user question",
+      "session_id": "p0-session",
+      "turn_id": "1",
+      "sequence": 1,
+      "trace_event": "user_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000A1",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "ownership borrowing prevent memory bugs at compile time",
+      "session_id": "p0-session",
+      "turn_id": "1",
+      "sequence": 2,
+      "trace_event": "assistant_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000A2",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "cargo check tool result succeeded for memory safety example",
+      "session_id": "p0-session",
+      "turn_id": "1",
+      "sequence": 3,
+      "trace_event": "tool_call",
+      "tool_name": "cargo"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000A3",
+      "kind": "user",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "user prefers concise rust memory explanations"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000A4",
+      "kind": "reasoning",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "rolling summary p0 session covers rust memory safety and cargo check success",
+      "session_id": "p0-session",
+      "turn_id": "summary",
+      "sequence": 4,
+      "trace_event": "turn_summary"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000A5",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "secret project codename aurora should be forgotten"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000A6",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "unrelated cooking note tomato soup"
+    }
+  ],
+  "actions": [
+    {
+      "verb": "retrieve_session",
+      "story": "US1_US2",
+      "session_id": "p0-session",
+      "expected_turn_ids": ["1"],
+      "expected_trace_events": ["user_message", "assistant_message", "tool_call", "turn_summary"]
+    },
+    {
+      "verb": "retrieve_turn",
+      "story": "US5",
+      "session_id": "p0-session",
+      "turn_id": "1",
+      "expected_trace_events": ["user_message", "assistant_message", "tool_call"]
+    },
+    {
+      "verb": "record_present",
+      "story": "US3",
+      "record_id": "01HQZX9F5N00000000000000A3",
+      "expected_present": true
+    },
+    {
+      "verb": "record_present",
+      "story": "US4",
+      "record_id": "01HQZX9F5N00000000000000A4",
+      "expected_present": true
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "keyword",
+      "query": "ownership borrowing",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N00000000000000A1"]
+      }
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "semantic",
+      "query": "user prefers concise rust memory explanations",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N00000000000000A3"]
+      }
+    },
+    {
+      "verb": "search",
+      "story": "US7",
+      "mode": "hybrid",
+      "query": "rust memory safety session replay user question",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N00000000000000A0"]
+      }
+    },
+    {
+      "verb": "forget_record",
+      "story": "US8",
+      "record_id": "01HQZX9F5N00000000000000A5",
+      "followup_query": "secret project codename aurora",
+      "expected_absent_from_search": true
+    }
+  ]
+}

--- a/fixtures/v0/replay/p0_stories.json
+++ b/fixtures/v0/replay/p0_stories.json
@@ -25,19 +25,34 @@
       "session_id": "p0-session",
       "turn_id": "1",
       "sequence": 2,
-      "trace_event": "assistant_message"
+      "trace_event": "agent_message"
     },
     {
       "id": "01HQZX9F5N00000000000000A2",
       "kind": "trace",
       "class": "episodic",
       "visibility": "private",
-      "body": "cargo check tool result succeeded for memory safety example",
+      "body": "cargo check tool call requested for memory safety example",
       "session_id": "p0-session",
       "turn_id": "1",
       "sequence": 3,
-      "trace_event": "tool_call",
-      "tool_name": "cargo"
+      "trace_event": "pre_tool",
+      "tool_name": "cargo",
+      "tool_call_id": "toolu_cargo_check_01"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000A7",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "cargo check tool result succeeded for memory safety example",
+      "session_id": "p0-session",
+      "turn_id": "1",
+      "sequence": 4,
+      "trace_event": "tool_output",
+      "tool_name": "cargo",
+      "tool_call_id": "toolu_cargo_check_01",
+      "parent_event_id": "01HQZX9F5N00000000000000A2"
     },
     {
       "id": "01HQZX9F5N00000000000000A3",
@@ -54,7 +69,7 @@
       "body": "rolling summary p0 session covers rust memory safety and cargo check success",
       "session_id": "p0-session",
       "turn_id": "summary",
-      "sequence": 4,
+      "sequence": 5,
       "trace_event": "turn_summary"
     },
     {
@@ -78,14 +93,14 @@
       "story": "US1_US2",
       "session_id": "p0-session",
       "expected_turn_ids": ["1"],
-      "expected_trace_events": ["user_message", "assistant_message", "tool_call", "turn_summary"]
+      "expected_trace_events": ["user_message", "agent_message", "pre_tool", "tool_output", "turn_summary"]
     },
     {
       "verb": "retrieve_turn",
       "story": "US5",
       "session_id": "p0-session",
       "turn_id": "1",
-      "expected_trace_events": ["user_message", "assistant_message", "tool_call"]
+      "expected_trace_events": ["user_message", "agent_message", "pre_tool", "tool_output"]
     },
     {
       "verb": "record_present",


### PR DESCRIPTION
## Summary

- Add a reusable dev-only replay harness in `cairn-test-fixtures` for deterministic P0 search scenarios.
- Add replay fixtures for hybrid/semantic/keyword P0 stories and keyword-only capability rejection coverage.
- Extend fixture schema tests and documentation so replay scenarios are part of the fixture contract.

Closes #97.

## Validation

- `cargo nextest run -p cairn-cli --tests` — 682 passed, 12 skipped
- `cargo nextest run --workspace` — 4,394 passed, 19 skipped, 1 slow
- `cargo test --doc --workspace` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `scripts/check-core-boundary.sh` — passed