### PR TITLE
[codex] Implement ReflectionWorkflow pattern extraction

### DIFF
--- a/crates/cairn-core/src/domain/flush_plan/mod.rs
+++ b/crates/cairn-core/src/domain/flush_plan/mod.rs
@@ -412,6 +412,13 @@ pub enum PlanReason {
         /// Version of the skill before this evolution.
         previous_version: u32,
     },
+    /// Triggered by the reflection workflow.
+    Reflect {
+        /// Candidate memory kind produced by reflection.
+        candidate_kind: MemoryKind,
+        /// Number of evidence records consulted.
+        evidence_count: u32,
+    },
 }
 
 /// On-disk wrapper persisted under `.cairn/flush/`.

--- a/crates/cairn-core/src/generated/schemas/prelude/status.json
+++ b/crates/cairn-core/src/generated/schemas/prelude/status.json
@@ -674,7 +674,8 @@
             "enum": [
               "consolidate",
               "promote",
-              "expire"
+              "expire",
+              "reflect"
             ],
             "type": "string"
           }

--- a/crates/cairn-core/src/generated/status.rs
+++ b/crates/cairn-core/src/generated/status.rs
@@ -262,6 +262,7 @@ pub enum StatusResponseWorkflowsWorkflow {
     Consolidate,
     Promote,
     Expire,
+    Reflect,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/cairn-core/src/pipeline/mod.rs
+++ b/crates/cairn-core/src/pipeline/mod.rs
@@ -45,6 +45,7 @@ pub mod filter;
 pub mod lint;
 pub mod pre_compact;
 pub mod profile;
+pub mod reflection;
 pub mod salience;
 pub(crate) mod squash;
 pub mod turn;

--- a/crates/cairn-core/src/pipeline/reflection.rs
+++ b/crates/cairn-core/src/pipeline/reflection.rs
@@ -1,0 +1,440 @@
+//! Pure pattern extraction for `ReflectionWorkflow` (brief §5.0.b, §10.1).
+
+use std::collections::BTreeMap;
+
+use crate::domain::taxonomy::{MemoryClass, MemoryKind};
+use crate::domain::{RecordId, ScopeTuple};
+
+/// One recent, already-admitted observation considered by reflection.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReflectionSignal {
+    /// Durable record that backs this signal.
+    pub record_id: RecordId,
+    /// Coarse signal category.
+    pub kind: ReflectionSignalKind,
+    /// Text body after upstream redaction/admission.
+    pub body: String,
+    /// Scope inherited from the source record.
+    pub scope: ScopeTuple,
+    /// Signal salience in `[0.0, 1.0]`.
+    pub salience: f32,
+    /// Signal confidence in `[0.0, 1.0]`.
+    pub confidence: f32,
+    /// Whether upstream privacy, consent, and signature gates permit reuse.
+    pub policy: ReflectionPolicy,
+}
+
+/// Signal category extracted from recent trace-like records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReflectionSignalKind {
+    /// Repeated tool or command failure.
+    ToolError,
+    /// User corrected the agent's behavior.
+    UserCorrection,
+    /// A new named entity surfaced.
+    NovelEntity,
+    /// The agent lacked needed knowledge.
+    KnowledgeGap,
+}
+
+/// Policy state inherited from the admission/read boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReflectionPolicy {
+    /// Reuse is permitted.
+    Allowed,
+    /// Reuse must fail closed.
+    Rejected,
+}
+
+/// Candidate review disposition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReflectionDisposition {
+    /// Eligible for autonomous `FlushPlan` emission.
+    ReadyForFlush,
+    /// Preserved for human review instead of autonomous write.
+    ReviewRequired,
+}
+
+/// Candidate record draft produced by reflection.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReflectionCandidate {
+    /// Memory kind for the candidate record.
+    pub kind: MemoryKind,
+    /// Memory class for the candidate record.
+    pub class: MemoryClass,
+    /// Markdown body for the candidate.
+    pub body: String,
+    /// Scope shared by the evidence records.
+    pub scope: ScopeTuple,
+    /// Evidence records supporting the candidate.
+    pub evidence_record_ids: Vec<RecordId>,
+    /// Aggregate salience.
+    pub salience: f32,
+    /// Aggregate confidence.
+    pub confidence: f32,
+    /// Whether this candidate can be written automatically.
+    pub disposition: ReflectionDisposition,
+}
+
+/// Discarded reflection input or candidate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReflectionDiscard {
+    /// Evidence records that were rejected.
+    pub evidence_record_ids: Vec<RecordId>,
+    /// Reason the signal or candidate did not become an autonomous record.
+    pub reason: ReflectionDiscardReason,
+}
+
+/// Reason a signal or candidate was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReflectionDiscardReason {
+    /// Upstream policy did not permit reuse.
+    PolicyRejected,
+    /// Confidence fell below the configured floor.
+    LowConfidence,
+    /// Salience fell below the configured floor.
+    LowSalience,
+}
+
+/// Tunable gates for reflection extraction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ReflectionConfig {
+    /// Required repetitions before repeated-pattern candidates emit.
+    pub min_repetitions: usize,
+    /// Minimum signal salience considered.
+    pub min_salience: f32,
+    /// Minimum signal confidence considered.
+    pub min_confidence: f32,
+    /// Candidates below this confidence require review.
+    pub auto_confidence: f32,
+}
+
+impl Default for ReflectionConfig {
+    fn default() -> Self {
+        Self {
+            min_repetitions: 3,
+            min_salience: 0.5,
+            min_confidence: 0.3,
+            auto_confidence: 0.7,
+        }
+    }
+}
+
+/// Result of one reflection extraction pass.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ReflectionOutcome {
+    /// Candidate records.
+    pub candidates: Vec<ReflectionCandidate>,
+    /// Signals or groups rejected with auditable reason codes.
+    pub discards: Vec<ReflectionDiscard>,
+}
+
+/// Extract mid-depth reflection candidates from recent admitted signals.
+#[must_use]
+pub fn extract_reflection_candidates(
+    signals: &[ReflectionSignal],
+    config: ReflectionConfig,
+) -> ReflectionOutcome {
+    let mut outcome = ReflectionOutcome::default();
+    let mut groups: BTreeMap<String, Vec<&ReflectionSignal>> = BTreeMap::new();
+
+    for signal in signals {
+        match gate_signal(signal, config) {
+            Ok(()) => {
+                let normalized = normalize_pattern(&signal.body);
+                if normalized.is_empty() {
+                    continue;
+                }
+                let key = format!(
+                    "{}:{}:{normalized}",
+                    signal.kind.as_str(),
+                    signal.scope.canonical_wire()
+                );
+                groups.entry(key).or_default().push(signal);
+            }
+            Err(reason) => outcome.discards.push(ReflectionDiscard {
+                evidence_record_ids: vec![signal.record_id.clone()],
+                reason,
+            }),
+        }
+    }
+
+    for group in groups.into_values() {
+        let Some(first) = group.first().copied() else {
+            continue;
+        };
+        let required = if first.kind == ReflectionSignalKind::NovelEntity {
+            1
+        } else {
+            config.min_repetitions.max(1)
+        };
+        if group.len() < required {
+            continue;
+        }
+
+        let evidence_record_ids = group.iter().map(|s| s.record_id.clone()).collect();
+        let salience = average(group.iter().map(|s| s.salience));
+        let confidence = average(group.iter().map(|s| s.confidence));
+        outcome.candidates.push(ReflectionCandidate {
+            kind: first.kind.candidate_kind(),
+            class: first.kind.candidate_class(),
+            body: render_candidate_body(first.kind, &normalize_pattern(&first.body), group.len()),
+            scope: first.scope.clone(),
+            evidence_record_ids,
+            salience,
+            confidence,
+            disposition: if confidence >= config.auto_confidence {
+                ReflectionDisposition::ReadyForFlush
+            } else {
+                ReflectionDisposition::ReviewRequired
+            },
+        });
+    }
+
+    outcome
+}
+
+impl ReflectionSignalKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::ToolError => "tool_error",
+            Self::UserCorrection => "user_correction",
+            Self::NovelEntity => "novel_entity",
+            Self::KnowledgeGap => "knowledge_gap",
+        }
+    }
+
+    const fn candidate_kind(self) -> MemoryKind {
+        match self {
+            Self::ToolError | Self::KnowledgeGap => MemoryKind::KnowledgeGap,
+            Self::UserCorrection => MemoryKind::Rule,
+            Self::NovelEntity => MemoryKind::Entity,
+        }
+    }
+
+    const fn candidate_class(self) -> MemoryClass {
+        match self {
+            Self::ToolError | Self::KnowledgeGap | Self::NovelEntity => MemoryClass::Semantic,
+            Self::UserCorrection => MemoryClass::Procedural,
+        }
+    }
+}
+
+fn gate_signal(
+    signal: &ReflectionSignal,
+    config: ReflectionConfig,
+) -> Result<(), ReflectionDiscardReason> {
+    if signal.policy != ReflectionPolicy::Allowed {
+        return Err(ReflectionDiscardReason::PolicyRejected);
+    }
+    if !signal.confidence.is_finite() || signal.confidence < config.min_confidence {
+        return Err(ReflectionDiscardReason::LowConfidence);
+    }
+    if !signal.salience.is_finite() || signal.salience < config.min_salience {
+        return Err(ReflectionDiscardReason::LowSalience);
+    }
+    Ok(())
+}
+
+fn normalize_pattern(body: &str) -> String {
+    body.split_whitespace()
+        .map(str::to_ascii_lowercase)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn average(values: impl Iterator<Item = f32>) -> f32 {
+    let mut avg = 0.0_f32;
+    let mut count = 0.0_f32;
+    for value in values {
+        count += 1.0;
+        avg += (value - avg) / count;
+    }
+    avg
+}
+
+fn render_candidate_body(kind: ReflectionSignalKind, pattern: &str, count: usize) -> String {
+    match kind {
+        ReflectionSignalKind::ToolError => {
+            format!("Repeated tool error observed {count} times: {pattern}")
+        }
+        ReflectionSignalKind::UserCorrection => {
+            format!(
+                "Candidate rule from repeated user correction ({count} observations): {pattern}"
+            )
+        }
+        ReflectionSignalKind::NovelEntity => {
+            format!("Candidate entity observed by reflection: {pattern}")
+        }
+        ReflectionSignalKind::KnowledgeGap => {
+            format!("Repeated knowledge gap observed {count} times: {pattern}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rid(n: u8) -> RecordId {
+        RecordId::parse(format!("000000000000000000000000{n:02}")).expect("valid test ULID")
+    }
+
+    fn signal(n: u8, kind: ReflectionSignalKind, body: &str) -> ReflectionSignal {
+        ReflectionSignal {
+            record_id: rid(n),
+            kind,
+            body: body.to_owned(),
+            scope: ScopeTuple {
+                user: Some("hmn:test-user".to_owned()),
+                ..ScopeTuple::default()
+            },
+            salience: 0.8,
+            confidence: 0.8,
+            policy: ReflectionPolicy::Allowed,
+        }
+    }
+
+    #[test]
+    fn repeated_tool_errors_emit_knowledge_gap_with_evidence_links() {
+        let signals = vec![
+            signal(
+                1,
+                ReflectionSignalKind::ToolError,
+                "sqlite vec index missing",
+            ),
+            signal(
+                2,
+                ReflectionSignalKind::ToolError,
+                "SQLite vec index missing",
+            ),
+            signal(
+                3,
+                ReflectionSignalKind::ToolError,
+                " sqlite   vec index missing ",
+            ),
+        ];
+
+        let outcome = extract_reflection_candidates(&signals, ReflectionConfig::default());
+
+        assert_eq!(outcome.candidates.len(), 1);
+        let candidate = &outcome.candidates[0];
+        assert_eq!(candidate.kind, MemoryKind::KnowledgeGap);
+        assert_eq!(candidate.class, MemoryClass::Semantic);
+        assert_eq!(candidate.evidence_record_ids, vec![rid(1), rid(2), rid(3)]);
+        assert_eq!(candidate.disposition, ReflectionDisposition::ReadyForFlush);
+        assert!(candidate.body.contains("sqlite vec index missing"));
+    }
+
+    #[test]
+    fn policy_rejected_signals_never_emit_candidates() {
+        let mut signals = vec![
+            signal(
+                1,
+                ReflectionSignalKind::UserCorrection,
+                "always run privacy tests",
+            ),
+            signal(
+                2,
+                ReflectionSignalKind::UserCorrection,
+                "always run privacy tests",
+            ),
+            signal(
+                3,
+                ReflectionSignalKind::UserCorrection,
+                "always run privacy tests",
+            ),
+        ];
+        for signal in &mut signals {
+            signal.policy = ReflectionPolicy::Rejected;
+        }
+
+        let outcome = extract_reflection_candidates(&signals, ReflectionConfig::default());
+
+        assert!(outcome.candidates.is_empty());
+        assert_eq!(outcome.discards.len(), 3);
+        assert!(
+            outcome
+                .discards
+                .iter()
+                .all(|discard| discard.reason == ReflectionDiscardReason::PolicyRejected)
+        );
+    }
+
+    #[test]
+    fn low_confidence_group_is_reviewable_or_discarded_with_reason() {
+        let mut signals = vec![
+            signal(
+                1,
+                ReflectionSignalKind::UserCorrection,
+                "prefer cargo nextest",
+            ),
+            signal(
+                2,
+                ReflectionSignalKind::UserCorrection,
+                "prefer cargo nextest",
+            ),
+            signal(
+                3,
+                ReflectionSignalKind::UserCorrection,
+                "prefer cargo nextest",
+            ),
+        ];
+        for signal in &mut signals {
+            signal.confidence = 0.45;
+        }
+
+        let outcome = extract_reflection_candidates(&signals, ReflectionConfig::default());
+
+        assert_eq!(outcome.candidates.len(), 1);
+        assert_eq!(
+            outcome.candidates[0].disposition,
+            ReflectionDisposition::ReviewRequired
+        );
+
+        signals[0].confidence = 0.1;
+        signals[1].confidence = 0.1;
+        signals[2].confidence = 0.1;
+        let outcome = extract_reflection_candidates(&signals, ReflectionConfig::default());
+        assert!(outcome.candidates.is_empty());
+        assert!(
+            outcome
+                .discards
+                .iter()
+                .all(|discard| discard.reason == ReflectionDiscardReason::LowConfidence)
+        );
+    }
+
+    #[test]
+    fn novel_entity_emits_single_candidate() {
+        let signals = vec![signal(
+            1,
+            ReflectionSignalKind::NovelEntity,
+            "Cairn ReflectionWorkflow",
+        )];
+
+        let outcome = extract_reflection_candidates(&signals, ReflectionConfig::default());
+
+        assert_eq!(outcome.candidates.len(), 1);
+        assert_eq!(outcome.candidates[0].kind, MemoryKind::Entity);
+        assert_eq!(outcome.candidates[0].class, MemoryClass::Semantic);
+        assert_eq!(outcome.candidates[0].evidence_record_ids, vec![rid(1)]);
+    }
+
+    #[test]
+    fn repeated_patterns_do_not_merge_across_scopes() {
+        let mut signals = vec![
+            signal(1, ReflectionSignalKind::UserCorrection, "prefer nextest"),
+            signal(2, ReflectionSignalKind::UserCorrection, "prefer nextest"),
+            signal(3, ReflectionSignalKind::UserCorrection, "prefer nextest"),
+        ];
+        signals[2].scope = ScopeTuple {
+            user: Some("hmn:other-user".to_owned()),
+            ..ScopeTuple::default()
+        };
+
+        let outcome = extract_reflection_candidates(&signals, ReflectionConfig::default());
+
+        assert!(outcome.candidates.is_empty());
+    }
+}

--- a/crates/cairn-idl/schema/prelude/status.json
+++ b/crates/cairn-idl/schema/prelude/status.json
@@ -155,7 +155,7 @@
         "properties": {
           "workflow": {
             "type": "string",
-            "enum": ["consolidate", "promote", "expire"],
+            "enum": ["consolidate", "promote", "expire", "reflect"],
             "description": "Stable workflow class name."
           },
           "drained_plans": {

--- a/crates/cairn-idl/tests/snapshots/wire_compat_v1__file__prelude_status_json.snap
+++ b/crates/cairn-idl/tests/snapshots/wire_compat_v1__file__prelude_status_json.snap
@@ -159,7 +159,7 @@ expression: body
         "properties": {
           "workflow": {
             "type": "string",
-            "enum": ["consolidate", "promote", "expire"],
+            "enum": ["consolidate", "promote", "expire", "reflect"],
             "description": "Stable workflow class name."
           },
           "drained_plans": {

--- a/crates/cairn-idl/tests/snapshots/wire_compat_v1__manifest_fingerprint.snap
+++ b/crates/cairn-idl/tests/snapshots/wire_compat_v1__manifest_fingerprint.snap
@@ -2,4 +2,4 @@
 source: crates/cairn-idl/tests/wire_compat_v1.rs
 expression: digest
 ---
-758ea8008463747dcf31524d0f8bb04518436a07f77f0842bf762efd36a211e8
+28b9c460e2b07035b0f59f316fccaa34f321b40a186ad4c7993505084dad231d

--- a/crates/cairn-mcp/src/generated/schemas/prelude/status.json
+++ b/crates/cairn-mcp/src/generated/schemas/prelude/status.json
@@ -674,7 +674,8 @@
             "enum": [
               "consolidate",
               "promote",
-              "expire"
+              "expire",
+              "reflect"
             ],
             "type": "string"
           }

--- a/crates/cairn-workflows/src/drainer.rs
+++ b/crates/cairn-workflows/src/drainer.rs
@@ -533,6 +533,7 @@ fn workflow_to_wire(workflow: &str) -> Option<StatusResponseWorkflowsWorkflow> {
         "consolidate" => Some(StatusResponseWorkflowsWorkflow::Consolidate),
         "promote" => Some(StatusResponseWorkflowsWorkflow::Promote),
         "expire" => Some(StatusResponseWorkflowsWorkflow::Expire),
+        "reflect" => Some(StatusResponseWorkflowsWorkflow::Reflect),
         _ => None,
     }
 }

--- a/crates/cairn-workflows/src/lib.rs
+++ b/crates/cairn-workflows/src/lib.rs
@@ -43,11 +43,15 @@ pub use evaluation::{
 pub use expiration::{
     EXPIRATION_KIND, ExpirationHandler, ExpirationPayload, ExpirationSweepReport,
 };
-pub use planners::{ConsolidatePlanSource, ExpirePlanSource, PromotePlanSource};
+pub use planners::{
+    ConsolidatePlanSource, ExpirePlanSource, PromotePlanSource, ReflectionPlanSource,
+};
 pub use scheduler::{Clock, MockClock, Scheduler, SchedulerConfig, SystemClock};
 pub use sqlite_apply::SqliteFlushPlanApply;
 pub use sqlite_store::{SqliteJobStore, SqliteJobStoreInitError};
-pub use workflows::{ConsolidateWorkflow, ExpireWorkflow, PromoteWorkflow, WorkflowPlanSource};
+pub use workflows::{
+    ConsolidateWorkflow, ExpireWorkflow, PromoteWorkflow, ReflectionWorkflow, WorkflowPlanSource,
+};
 
 use cairn_core::contract::version::{ContractVersion, VersionRange};
 use cairn_core::contract::workflow_orchestrator::{

--- a/crates/cairn-workflows/src/planners.rs
+++ b/crates/cairn-workflows/src/planners.rs
@@ -8,12 +8,22 @@ use cairn_core::contract::memory_store::{ListArgs, ListCursor, MemoryStore};
 use cairn_core::domain::flush_plan::{
     ExpirationReason, FlushMode, FlushPlan, PlanReason, PlannedMutation,
 };
-use cairn_core::domain::{Identity, MemoryKind, MemoryRecord};
+use cairn_core::domain::record::{Ed25519Signature, RecordId};
+use cairn_core::domain::taxonomy::{MemoryKind, MemoryVisibility};
+use cairn_core::domain::{
+    ActorChainEntry, ChainRole, EvidenceVector, Identity, MemoryRecord, Provenance,
+    Rfc3339Timestamp, SourceId, TargetId,
+};
 use cairn_core::generated::common::Ulid;
+use cairn_core::pipeline::reflection::{
+    ReflectionCandidate, ReflectionConfig, ReflectionDisposition, ReflectionPolicy,
+    ReflectionSignal, ReflectionSignalKind, extract_reflection_candidates,
+};
 use chrono::{Duration, SecondsFormat};
 use sha2::{Digest, Sha256};
 
 use crate::drainer::{WorkflowContext, WorkflowError};
+use crate::synthetic::sha256_hex;
 use crate::workflows::WorkflowPlanSource;
 
 /// Store-backed expiration planner.
@@ -69,6 +79,14 @@ pub struct ConsolidatePlanSource {
     page_limit: usize,
 }
 
+/// Store-backed reflection planner.
+pub struct ReflectionPlanSource {
+    store: Arc<dyn MemoryStore>,
+    issuer: Identity,
+    config: ReflectionConfig,
+    page_limit: usize,
+}
+
 impl ConsolidatePlanSource {
     const DEFAULT_PAGE_LIMIT: usize = 1000;
 
@@ -81,6 +99,35 @@ impl ConsolidatePlanSource {
             issuer,
             page_limit: Self::DEFAULT_PAGE_LIMIT,
         }
+    }
+
+    /// Override the planner's store page size.
+    #[must_use]
+    pub fn with_page_limit(mut self, page_limit: usize) -> Self {
+        self.page_limit = page_limit.max(1);
+        self
+    }
+}
+
+impl ReflectionPlanSource {
+    const DEFAULT_PAGE_LIMIT: usize = 1000;
+
+    /// Create a reflection planner with default gates.
+    #[must_use]
+    pub fn new(store: Arc<dyn MemoryStore>, issuer: Identity) -> Self {
+        Self {
+            store,
+            issuer,
+            config: ReflectionConfig::default(),
+            page_limit: Self::DEFAULT_PAGE_LIMIT,
+        }
+    }
+
+    /// Override extraction gates.
+    #[must_use]
+    pub fn with_config(mut self, config: ReflectionConfig) -> Self {
+        self.config = config;
+        self
     }
 
     /// Override the planner's store page size.
@@ -211,6 +258,29 @@ impl WorkflowPlanSource for ConsolidatePlanSource {
     }
 }
 
+#[async_trait::async_trait]
+impl WorkflowPlanSource for ReflectionPlanSource {
+    async fn plan(
+        &self,
+        workflow: &'static str,
+        _ctx: &WorkflowContext,
+    ) -> Result<Vec<FlushPlan>, WorkflowError> {
+        if workflow != "reflect" {
+            return Ok(Vec::new());
+        }
+
+        let records = list_active_records(&self.store, workflow, self.page_limit).await?;
+        let signals: Vec<_> = records.iter().filter_map(record_to_signal).collect();
+        let outcome = extract_reflection_candidates(&signals, self.config);
+
+        outcome
+            .candidates
+            .iter()
+            .map(|candidate| self.plan_for_candidate(candidate))
+            .collect()
+    }
+}
+
 impl ExpirePlanSource {
     fn plan_for_record(&self, record: &MemoryRecord) -> FlushPlan {
         let issued_at = now_rfc3339();
@@ -318,6 +388,187 @@ impl ConsolidatePlanSource {
     }
 }
 
+impl ReflectionPlanSource {
+    fn plan_for_candidate(
+        &self,
+        candidate: &ReflectionCandidate,
+    ) -> Result<FlushPlan, WorkflowError> {
+        let issued_at = now_rfc3339();
+        let expires_at = expires_at_rfc3339();
+        let record = self.build_candidate_record(candidate, &issued_at)?;
+        let evidence_count = u32::try_from(candidate.evidence_record_ids.len()).unwrap_or(u32::MAX);
+        Ok(FlushPlan {
+            operation_id: stable_plan_ulid(&[
+                "reflect",
+                record.target_id.as_str(),
+                candidate.kind.as_str(),
+                &evidence_count.to_string(),
+                &candidate.confidence.to_bits().to_string(),
+            ]),
+            issued_at,
+            issuer: self.issuer.clone(),
+            principal: None,
+            scope: record.scope.clone(),
+            mode: match candidate.disposition {
+                ReflectionDisposition::ReadyForFlush => FlushMode::Autonomous,
+                ReflectionDisposition::ReviewRequired => FlushMode::HumanReview,
+            },
+            mutations: vec![PlannedMutation::Upsert {
+                record: Box::new(record),
+                prior_version: None,
+            }],
+            reason: PlanReason::Reflect {
+                candidate_kind: candidate.kind,
+                evidence_count,
+            },
+            source_events: candidate
+                .evidence_record_ids
+                .iter()
+                .map(|id| Ulid(id.as_str().to_owned()))
+                .collect(),
+            target_hashes: BTreeMap::new(),
+            dependencies: Vec::new(),
+            expires_at,
+            placeholder: false,
+        })
+    }
+
+    fn build_candidate_record(
+        &self,
+        candidate: &ReflectionCandidate,
+        issued_at: &str,
+    ) -> Result<MemoryRecord, WorkflowError> {
+        let evidence_key = candidate
+            .evidence_record_ids
+            .iter()
+            .map(RecordId::as_str)
+            .collect::<Vec<_>>()
+            .join(",");
+        let target_id = stable_target_id(&[
+            "reflection",
+            candidate.kind.as_str(),
+            candidate.class.as_str(),
+            &candidate.body,
+            &evidence_key,
+        ])
+        .map_err(|e| WorkflowError::Internal {
+            workflow: "reflect",
+            message: format!("reflection target id: {e}"),
+        })?;
+        let record_id = RecordId::parse(target_id.as_str().to_owned()).map_err(|e| {
+            WorkflowError::Internal {
+                workflow: "reflect",
+                message: format!("reflection record id: {e}"),
+            }
+        })?;
+        let now =
+            Rfc3339Timestamp::parse(issued_at.to_owned()).map_err(|e| WorkflowError::Internal {
+                workflow: "reflect",
+                message: format!("reflection timestamp: {e}"),
+            })?;
+        let source_sensor = Identity::parse("snr:cairn-workflows:reflection:v1").map_err(|e| {
+            WorkflowError::Internal {
+                workflow: "reflect",
+                message: format!("reflection sensor identity: {e}"),
+            }
+        })?;
+        let self_source = SourceId::parse(target_id.as_str().to_owned()).map_err(|e| {
+            WorkflowError::Internal {
+                workflow: "reflect",
+                message: format!("reflection source id: {e}"),
+            }
+        })?;
+        let evidence_ids: Vec<_> = candidate
+            .evidence_record_ids
+            .iter()
+            .map(|id| serde_json::Value::String(id.as_str().to_owned()))
+            .collect();
+        let mut extra_frontmatter = BTreeMap::new();
+        extra_frontmatter.insert(
+            "reflection".to_owned(),
+            serde_json::json!({
+                "evidence_record_ids": evidence_ids,
+                "candidate_disposition": match candidate.disposition {
+                    ReflectionDisposition::ReadyForFlush => "ready_for_flush",
+                    ReflectionDisposition::ReviewRequired => "review_required",
+                },
+                "produced_by": "cairn-workflows::ReflectionPlanSource",
+            }),
+        );
+
+        Ok(MemoryRecord {
+            id: record_id,
+            target_id,
+            kind: candidate.kind,
+            class: candidate.class,
+            visibility: MemoryVisibility::Private,
+            scope: candidate.scope.clone(),
+            body: candidate.body.clone(),
+            source_ids: Vec::new(),
+            provenance: Provenance {
+                source_sensor,
+                created_at: now.clone(),
+                originating_agent_id: self.issuer.clone(),
+                source_hash: format!("sha256:{}", sha256_hex(candidate.body.as_bytes())),
+                consent_ref: "consent:system:reflection-workflow".to_owned(),
+                llm_id_if_any: None,
+                source_ids: vec![self_source],
+                source_refs: Vec::new(),
+            },
+            updated_at: now.clone(),
+            evidence: EvidenceVector {
+                recall_count: evidence_count_for(candidate),
+                score: candidate.confidence,
+                unique_queries: 1,
+                recency_half_life_days: 14,
+            },
+            salience: candidate.salience,
+            confidence: candidate.confidence,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: self.issuer.clone(),
+                at: now,
+            }],
+            signature: Ed25519Signature::flush_mutated_sentinel(),
+            tags: vec!["reflection_candidate".to_owned()],
+            extra_frontmatter,
+            consent_model: None,
+        })
+    }
+}
+
+fn record_to_signal(record: &MemoryRecord) -> Option<ReflectionSignal> {
+    let kind = match record.kind {
+        MemoryKind::Feedback => ReflectionSignalKind::UserCorrection,
+        MemoryKind::KnowledgeGap => ReflectionSignalKind::KnowledgeGap,
+        MemoryKind::Entity => ReflectionSignalKind::NovelEntity,
+        MemoryKind::Trace if looks_like_tool_error(&record.body) => ReflectionSignalKind::ToolError,
+        _ => return None,
+    };
+    Some(ReflectionSignal {
+        record_id: record.id.clone(),
+        kind,
+        body: record.body.clone(),
+        scope: record.scope.clone(),
+        salience: record.salience,
+        confidence: record.confidence,
+        policy: if record.signature_attests_author() {
+            ReflectionPolicy::Allowed
+        } else {
+            ReflectionPolicy::Rejected
+        },
+    })
+}
+
+fn looks_like_tool_error(body: &str) -> bool {
+    let lowered = body.to_ascii_lowercase();
+    lowered.contains("error") || lowered.contains("failed") || lowered.contains("failure")
+}
+
+fn evidence_count_for(candidate: &ReflectionCandidate) -> u32 {
+    u32::try_from(candidate.evidence_record_ids.len()).unwrap_or(u32::MAX)
+}
+
 async fn list_active_records(
     store: &Arc<dyn MemoryStore>,
     workflow: &'static str,
@@ -366,6 +617,10 @@ fn stable_plan_ulid(parts: &[&str]) -> Ulid {
     let mut bytes = [0_u8; 16];
     bytes.copy_from_slice(&digest[..16]);
     Ulid(ulid::Ulid::from_bytes(bytes).to_string())
+}
+
+fn stable_target_id(parts: &[&str]) -> Result<TargetId, cairn_core::domain::DomainError> {
+    TargetId::parse(stable_plan_ulid(parts).0)
 }
 
 fn now_rfc3339() -> String {

--- a/crates/cairn-workflows/src/workflows.rs
+++ b/crates/cairn-workflows/src/workflows.rs
@@ -65,3 +65,8 @@ workflow_type!(
     "expire",
     "Expiration workflow class: emits `FlushPlan` batches for TTL and salience expiration candidates."
 );
+workflow_type!(
+    ReflectionWorkflow,
+    "reflect",
+    "Reflection workflow class: emits candidate-record `FlushPlan` batches from repeated recent patterns."
+);

--- a/crates/cairn-workflows/tests/expire_plan_source.rs
+++ b/crates/cairn-workflows/tests/expire_plan_source.rs
@@ -4,12 +4,15 @@
 use std::sync::Arc;
 
 use cairn_core::contract::memory_store::MemoryStore as _;
+use cairn_core::domain::record::Ed25519Signature;
+use cairn_core::domain::taxonomy::MemoryClass;
 use cairn_core::domain::{
     ExpirationReason, FlushMode, Identity, MemoryKind, PlanReason, PlannedMutation,
 };
 use cairn_test_fixtures::{FixtureStore, memstore, sample_record};
 use cairn_workflows::{
-    ConsolidatePlanSource, ExpirePlanSource, PromotePlanSource, WorkflowContext, WorkflowPlanSource,
+    ConsolidatePlanSource, ExpirePlanSource, PromotePlanSource, ReflectionPlanSource,
+    WorkflowContext, WorkflowPlanSource,
 };
 
 #[tokio::test]
@@ -274,4 +277,286 @@ async fn consolidate_plan_source_reuses_operation_ids_for_same_duplicates() {
     assert_eq!(first.len(), 1);
     assert_eq!(second.len(), 1);
     assert_eq!(first[0].operation_id, second[0].operation_id);
+}
+
+#[tokio::test]
+async fn reflection_plan_source_emits_upsert_candidate_with_evidence_links() {
+    let store = Arc::new(memstore().await);
+    for seed in 20..=22 {
+        let mut record = sample_record(seed);
+        record.kind = MemoryKind::Feedback;
+        record.class = MemoryClass::Episodic;
+        record.body = "Always run privacy bypass tests".to_owned();
+        record.salience = 0.8;
+        record.confidence = 0.8;
+        store.upsert(&record).await.expect("seed reflection signal");
+    }
+
+    let source = ReflectionPlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    );
+
+    let plans = source
+        .plan("reflect", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].mode, FlushMode::Autonomous);
+    let expected_scope = sample_record(20).scope;
+    assert_eq!(plans[0].scope, expected_scope);
+    assert!(matches!(
+        plans[0].reason,
+        PlanReason::Reflect {
+            candidate_kind: MemoryKind::Rule,
+            evidence_count: 3,
+        }
+    ));
+    let PlannedMutation::Upsert { record, .. } = &plans[0].mutations[0] else {
+        panic!("expected reflection upsert");
+    };
+    assert_eq!(record.kind, MemoryKind::Rule);
+    assert_eq!(record.class, MemoryClass::Procedural);
+    assert_eq!(record.scope, expected_scope);
+    record
+        .validate()
+        .expect("reflection candidate record validates");
+    let evidence = record
+        .extra_frontmatter
+        .get("reflection")
+        .and_then(|v| v.get("evidence_record_ids"))
+        .and_then(|v| v.as_array())
+        .expect("reflection evidence ids");
+    assert_eq!(evidence.len(), 3);
+}
+
+#[tokio::test]
+async fn reflection_plan_source_emits_review_plan_for_low_confidence_candidates() {
+    let store = Arc::new(memstore().await);
+    for seed in 23..=25 {
+        let mut record = sample_record(seed);
+        record.kind = MemoryKind::Feedback;
+        record.class = MemoryClass::Episodic;
+        record.body = "Prefer cargo nextest".to_owned();
+        record.salience = 0.8;
+        record.confidence = 0.45;
+        store.upsert(&record).await.expect("seed reflection signal");
+    }
+
+    let source = ReflectionPlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    );
+
+    let plans = source
+        .plan("reflect", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].mode, FlushMode::HumanReview);
+}
+
+#[tokio::test]
+async fn reflection_plan_source_ignores_unsigned_source_records() {
+    let store = Arc::new(memstore().await);
+    for seed in 26..=28 {
+        let mut record = sample_record(seed);
+        record.kind = MemoryKind::Feedback;
+        record.class = MemoryClass::Episodic;
+        record.body = "Always run privacy bypass tests".to_owned();
+        record.salience = 0.8;
+        record.confidence = 0.8;
+        record.signature = Ed25519Signature::flush_mutated_sentinel();
+        store.upsert(&record).await.expect("seed reflection signal");
+    }
+
+    let source = ReflectionPlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    );
+
+    let plans = source
+        .plan("reflect", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert!(plans.is_empty());
+}
+
+#[tokio::test]
+async fn reflection_plan_source_maps_repeated_trace_errors_to_knowledge_gap() {
+    let store = Arc::new(memstore().await);
+    for seed in 29..=31 {
+        let mut record = sample_record(seed);
+        record.kind = MemoryKind::Trace;
+        record.class = MemoryClass::Episodic;
+        record.body = "tool failed: sqlite vec index missing".to_owned();
+        record.salience = 0.8;
+        record.confidence = 0.8;
+        store.upsert(&record).await.expect("seed reflection signal");
+    }
+
+    let source = ReflectionPlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    );
+
+    let plans = source
+        .plan("reflect", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert_eq!(plans.len(), 1);
+    assert!(matches!(
+        plans[0].reason,
+        PlanReason::Reflect {
+            candidate_kind: MemoryKind::KnowledgeGap,
+            evidence_count: 3,
+        }
+    ));
+}
+
+#[tokio::test]
+async fn reflection_plan_source_returns_empty_for_other_workflow_names() {
+    let store = Arc::new(memstore().await);
+    for seed in 32..=34 {
+        let mut record = sample_record(seed);
+        record.kind = MemoryKind::Feedback;
+        record.body = "Always run privacy bypass tests".to_owned();
+        record.salience = 0.8;
+        record.confidence = 0.8;
+        store.upsert(&record).await.expect("seed reflection signal");
+    }
+
+    let source = ReflectionPlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    );
+
+    let plans = source
+        .plan("expire", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert!(plans.is_empty());
+}
+
+#[tokio::test]
+async fn reflection_plan_source_paginates_past_first_store_page() {
+    let store = Arc::new(memstore().await);
+    for seed in 35..=37 {
+        let mut record = sample_record(seed);
+        record.kind = MemoryKind::Feedback;
+        record.body = "Prefer deterministic reflection plans".to_owned();
+        record.salience = 0.8;
+        record.confidence = 0.8;
+        store.upsert(&record).await.expect("seed reflection signal");
+    }
+
+    let source = ReflectionPlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    )
+    .with_page_limit(2);
+
+    let plans = source
+        .plan("reflect", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert_eq!(plans.len(), 1);
+    assert!(matches!(
+        plans[0].reason,
+        PlanReason::Reflect {
+            candidate_kind: MemoryKind::Rule,
+            evidence_count: 3,
+        }
+    ));
+}
+
+#[tokio::test]
+async fn reflection_plan_source_emits_single_novel_entity_candidate() {
+    let store = Arc::new(memstore().await);
+    let mut record = sample_record(38);
+    record.kind = MemoryKind::Entity;
+    record.class = MemoryClass::Semantic;
+    record.body = "Cairn ReflectionWorkflow".to_owned();
+    record.salience = 0.8;
+    record.confidence = 0.8;
+    store.upsert(&record).await.expect("seed reflection signal");
+
+    let source = ReflectionPlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    );
+
+    let plans = source
+        .plan("reflect", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].mode, FlushMode::Autonomous);
+    assert!(matches!(
+        plans[0].reason,
+        PlanReason::Reflect {
+            candidate_kind: MemoryKind::Entity,
+            evidence_count: 1,
+        }
+    ));
+}
+
+#[tokio::test]
+async fn reflection_plan_source_does_not_merge_repeated_patterns_across_scopes() {
+    let store = Arc::new(memstore().await);
+    for seed in 39..=41 {
+        let mut record = sample_record(seed);
+        record.kind = MemoryKind::Feedback;
+        record.body = "Prefer deterministic reflection plans".to_owned();
+        record.salience = 0.8;
+        record.confidence = 0.8;
+        if seed == 41 {
+            record.scope.user = Some("hmn:other-user".to_owned());
+        }
+        store.upsert(&record).await.expect("seed reflection signal");
+    }
+
+    let source = ReflectionPlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    );
+
+    let plans = source
+        .plan("reflect", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert!(plans.is_empty());
+}
+
+#[tokio::test]
+async fn reflection_plan_source_discards_low_salience_patterns() {
+    let store = Arc::new(memstore().await);
+    for seed in 42..=44 {
+        let mut record = sample_record(seed);
+        record.kind = MemoryKind::Feedback;
+        record.body = "Prefer deterministic reflection plans".to_owned();
+        record.salience = 0.2;
+        record.confidence = 0.8;
+        store.upsert(&record).await.expect("seed reflection signal");
+    }
+
+    let source = ReflectionPlanSource::new(
+        store,
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    );
+
+    let plans = source
+        .plan("reflect", &WorkflowContext::default())
+        .await
+        .expect("plan");
+
+    assert!(plans.is_empty());
 }

--- a/crates/cairn-workflows/tests/workflow_e2e.rs
+++ b/crates/cairn-workflows/tests/workflow_e2e.rs
@@ -4,12 +4,13 @@
 use std::sync::Arc;
 
 use cairn_core::contract::memory_store::MemoryStore as _;
-use cairn_core::domain::{Identity, MemoryKind};
+use cairn_core::domain::{FlushMode, Identity, MemoryKind, PlannedMutation};
 use cairn_core::generated::status::StatusResponseWorkflowsWorkflow;
 use cairn_test_fixtures::{memstore, sample_record};
 use cairn_workflows::{
     ConsolidatePlanSource, ConsolidateWorkflow, ExpirePlanSource, ExpireWorkflow,
-    PromotePlanSource, PromoteWorkflow, SqliteFlushPlanApply, WorkflowContext, WorkflowDrainer,
+    PromotePlanSource, PromoteWorkflow, ReflectionPlanSource, ReflectionWorkflow,
+    SqliteFlushPlanApply, WorkflowContext, WorkflowDrainer, WorkflowPlanSource,
 };
 
 #[tokio::test]
@@ -210,4 +211,79 @@ async fn consolidate_workflow_drains_planned_flushes_into_sqlite_store_end_to_en
     assert_eq!(second.applied, 0);
     assert_eq!(second.already_applied, 0);
     assert!(!second.cancelled);
+}
+
+#[tokio::test]
+async fn reflection_workflow_drains_candidate_record_into_sqlite_store_end_to_end() {
+    let store = Arc::new(memstore().await);
+    for seed in 8..=10 {
+        let mut record = sample_record(seed);
+        record.kind = MemoryKind::Feedback;
+        record.body = "Always run privacy bypass tests".to_owned();
+        record.salience = 0.8;
+        record.confidence = 0.8;
+        store.upsert(&record).await.expect("seed reflection signal");
+    }
+
+    let source = Arc::new(ReflectionPlanSource::new(
+        store.clone(),
+        Identity::parse("agt:cairn-workflows:reflection:v1").expect("valid issuer"),
+    ));
+    let planned = source
+        .plan("reflect", &WorkflowContext::default())
+        .await
+        .expect("plan reflection candidate");
+    assert_eq!(planned.len(), 1);
+    assert_eq!(planned[0].mode, FlushMode::Autonomous);
+    let PlannedMutation::Upsert { record, .. } = &planned[0].mutations[0] else {
+        panic!("expected reflection upsert");
+    };
+    let target = record.target_id.clone();
+
+    let drainer = WorkflowDrainer::new(
+        WorkflowContext::default(),
+        Arc::new(SqliteFlushPlanApply::new(store.clone())),
+    );
+
+    let first = drainer
+        .run(Arc::new(ReflectionWorkflow::new(source)))
+        .await
+        .expect("first reflection drain");
+
+    assert_eq!(first.workflow, "reflect");
+    assert_eq!(first.planned, 1);
+    assert_eq!(first.applied, 1);
+    assert_eq!(first.already_applied, 0);
+    assert!(!first.cancelled);
+
+    let candidate = store
+        .get_active_by_target(&target)
+        .await
+        .expect("get reflection target")
+        .expect("reflection candidate was applied")
+        .record;
+    assert_eq!(candidate.kind, MemoryKind::Rule);
+    assert!(
+        candidate
+            .tags
+            .iter()
+            .any(|tag| tag == "reflection_candidate")
+    );
+    let reflection = candidate
+        .extra_frontmatter
+        .get("reflection")
+        .expect("reflection frontmatter");
+    assert_eq!(
+        reflection
+            .get("candidate_disposition")
+            .and_then(serde_json::Value::as_str),
+        Some("ready_for_flush")
+    );
+    assert_eq!(
+        reflection
+            .get("evidence_record_ids")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::len),
+        Some(3)
+    );
 }


### PR DESCRIPTION
## Summary

Closes #110.

Implements the brief §5.0.b auto-learning loop and §10.1 mid-depth reflection slice by adding a pure reflection extractor plus a store-backed `ReflectionPlanSource` and `ReflectionWorkflow`.

## What changed

- Added `cairn-core::pipeline::reflection` for grouping admitted signals into candidate records with evidence links, confidence/salience gates, review disposition, and scope isolation.
- Added `PlanReason::Reflect` and `reflect` workflow/status wiring.
- Added `ReflectionPlanSource` that maps eligible signed source records into `FlushPlan::Upsert` candidate records without bypassing consent/signature policy.
- Added generated status schema/code updates for the `reflect` workflow.
- Added focused plan-source tests and an E2E drainer/apply test that verifies the reflection candidate lands in SQLite with evidence metadata.

## Invariants touched

- CLI/core/workflow remains wrapper-oriented: extraction is pure in `cairn-core`; workflow code plans through existing `FlushPlan` machinery.
- Reflection fails closed on source signatures by rejecting records that do not attest author identity.
- Candidate records preserve evidence links and review/autonomous disposition.

## Verification

- `cargo test -p cairn-workflows reflection_plan_source --locked` — 9 passed
- `cargo test -p cairn-workflows --test workflow_e2e --locked` — 4 passed
- `cargo test -p cairn-core pipeline::reflection::tests --locked` — 5 passed
- `cargo clippy -p cairn-core -p cairn-workflows --all-targets --locked -- -D warnings`
- `cargo check -p cairn-core -p cairn-workflows --all-targets --locked`
- `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
- `./scripts/check-core-boundary.sh`
- `cargo fmt --all --check`
- `git diff --check`

## Notes

The branch is currently based on an older `origin/main` snapshot and may need a rebase before merge.
