### PR TITLE
Add v0.2 session-link migration metadata

### DIFF
--- a/crates/cairn-store-sqlite/src/lint.rs
+++ b/crates/cairn-store-sqlite/src/lint.rs
@@ -44,10 +44,12 @@ pub fn lint_edges(conn: &Connection) -> Result<EdgeLintReport, StoreError> {
     let mut findings = contradiction_findings(conn)?;
     let ambiguous_findings = ambiguous_findings(conn)?;
     let purge_findings = lint_purge_pending(conn)?;
+    let review_findings = lint_record_link_review(conn)?;
     let contradictions = usize_to_u64(findings.len());
     let ambiguous_edges = usize_to_u64(ambiguous_findings.len());
     findings.extend(ambiguous_findings);
     findings.extend(purge_findings);
+    findings.extend(review_findings);
 
     Ok(EdgeLintReport {
         findings,
@@ -55,6 +57,48 @@ pub fn lint_edges(conn: &Connection) -> Result<EdgeLintReport, StoreError> {
         ambiguous_edges,
         auto_resolved: 0,
     })
+}
+
+fn lint_record_link_review(conn: &Connection) -> Result<Vec<Finding>, StoreError> {
+    ensure_table(conn, "record_link_review")?;
+
+    let mut stmt = conn.prepare(
+        "SELECT record_id, reason, scope_session_id, trace_session_id
+           FROM record_link_review
+          ORDER BY record_id",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut findings = Vec::new();
+
+    while let Some(row) = rows.next()? {
+        let record_id: String = row.get(0)?;
+        let reason: String = row.get(1)?;
+        let scope_session_id: Option<String> = row.get(2)?;
+        let trace_session_id: Option<String> = row.get(3)?;
+        let scope_label = scope_session_id.as_deref().unwrap_or("<missing>");
+        let trace_label = trace_session_id.as_deref().unwrap_or("<missing>");
+        findings.push(Finding {
+            kind: Kind::DeferredCheck,
+            severity: Severity::Warning,
+            message: format!(
+                "manual review required: record {record_id} has {reason} \
+                 (scope_session_id={scope_label}, trace_session_id={trace_label})"
+            ),
+            entities: Some(vec![record_id.clone()]),
+            suggested_fix: Some(
+                "repair or re-ingest the record after choosing the authoritative session link"
+                    .to_owned(),
+            ),
+            target: Some(Target {
+                operation_id: None,
+                path: None,
+                record_id: Some(Ulid(record_id)),
+            }),
+            tracking_issue: Some(109),
+        });
+    }
+
+    Ok(findings)
 }
 
 /// Find record-forget operations whose Phase B purge work is still incomplete.

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -127,6 +127,9 @@ const M0062_SESSION_TREE: &str = include_str!("sql/0062_session_tree.sql");
 // Renumbered from 0062 → 0063 during merge with main: #133 shipped
 // 0062_session_tree first.
 const M0063_WORKFLOW_DEAD_LETTER: &str = include_str!("sql/0063_workflow_dead_letter.sql");
+// Issue #109 — v0.2 additive session-link metadata for cold rehydration and
+// session-level forget migrations.
+const M0064_V02_RECORD_SESSION_LINKS: &str = include_str!("sql/0064_v02_record_session_links.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -315,6 +318,11 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
     (61, "0061_salience_access", M0061_SALIENCE_ACCESS),
     (62, "0062_session_tree", M0062_SESSION_TREE),
     (63, "0063_workflow_dead_letter", M0063_WORKFLOW_DEAD_LETTER),
+    (
+        64,
+        "0064_v02_record_session_links",
+        M0064_V02_RECORD_SESSION_LINKS,
+    ),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -379,5 +387,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0061_SALIENCE_ACCESS),
         M::up(M0062_SESSION_TREE),
         M::up(M0063_WORKFLOW_DEAD_LETTER),
+        M::up(M0064_V02_RECORD_SESSION_LINKS),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/sql/0064_v02_record_session_links.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0064_v02_record_session_links.sql
@@ -1,0 +1,87 @@
+-- Migration 0064: v0.2 metadata for cold/session delete links.
+-- Issue #109. Brief sources: §19 v0.2 in-place migration, §3.0 SQLite
+-- authority, §5.6 forget_session.
+--
+-- Additive only: do not rewrite records.scope or record_json. Existing v0.1
+-- rows remain the authoritative bodies; this table records deterministic,
+-- auditable links derived from scope.session_id and trace.session_id.
+
+CREATE TABLE record_session_links (
+  record_id       TEXT NOT NULL PRIMARY KEY
+                       REFERENCES records(record_id) ON DELETE CASCADE,
+  target_id       TEXT NOT NULL,
+  session_id      TEXT NOT NULL,
+  tenant          TEXT,
+  workspace       TEXT,
+  link_source     TEXT NOT NULL CHECK (link_source IN ('scope', 'trace')),
+  link_confidence TEXT NOT NULL CHECK (link_confidence IN ('explicit', 'derived')),
+  created_at      INTEGER NOT NULL
+);
+
+CREATE INDEX record_session_links_session_idx
+  ON record_session_links(session_id, tenant, workspace, target_id);
+
+CREATE INDEX record_session_links_target_idx
+  ON record_session_links(target_id, session_id);
+
+CREATE TABLE record_link_review (
+  record_id         TEXT NOT NULL PRIMARY KEY
+                         REFERENCES records(record_id) ON DELETE CASCADE,
+  reason            TEXT NOT NULL CHECK (reason IN ('session_id_mismatch')),
+  scope_session_id  TEXT,
+  trace_session_id  TEXT,
+  detail_json       TEXT NOT NULL,
+  created_at        INTEGER NOT NULL
+);
+
+CREATE INDEX record_link_review_reason_idx
+  ON record_link_review(reason, record_id);
+
+INSERT INTO record_link_review (
+  record_id, reason, scope_session_id, trace_session_id, detail_json, created_at
+)
+SELECT
+  record_id,
+  'session_id_mismatch',
+  json_extract(scope, '$.session_id'),
+  trace_session_id,
+  json_object(
+    'scope_session_id', json_extract(scope, '$.session_id'),
+    'trace_session_id', trace_session_id,
+    'migration_id', 64
+  ),
+  strftime('%s','now') * 1000
+FROM records
+WHERE json_extract(scope, '$.session_id') IS NOT NULL
+  AND trace_session_id IS NOT NULL
+  AND json_extract(scope, '$.session_id') <> trace_session_id;
+
+INSERT INTO record_session_links (
+  record_id, target_id, session_id, tenant, workspace,
+  link_source, link_confidence, created_at
+)
+SELECT
+  record_id,
+  target_id,
+  COALESCE(json_extract(scope, '$.session_id'), trace_session_id),
+  json_extract(scope, '$.tenant'),
+  json_extract(scope, '$.workspace'),
+  CASE
+    WHEN json_extract(scope, '$.session_id') IS NOT NULL THEN 'scope'
+    ELSE 'trace'
+  END,
+  CASE
+    WHEN json_extract(scope, '$.session_id') IS NOT NULL THEN 'explicit'
+    ELSE 'derived'
+  END,
+  strftime('%s','now') * 1000
+FROM records
+WHERE COALESCE(json_extract(scope, '$.session_id'), trace_session_id) IS NOT NULL
+  AND NOT (
+    json_extract(scope, '$.session_id') IS NOT NULL
+    AND trace_session_id IS NOT NULL
+    AND json_extract(scope, '$.session_id') <> trace_session_id
+  );
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (64, '0064_v02_record_session_links', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/migrations/sql/0064_v02_record_session_links.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0064_v02_record_session_links.sql
@@ -3,8 +3,9 @@
 -- authority, §5.6 forget_session.
 --
 -- Additive only: do not rewrite records.scope or record_json. Existing v0.1
--- rows remain the authoritative bodies; this table records deterministic,
--- auditable links derived from scope.session_id and trace.session_id.
+-- rows remain the authoritative bodies; these tables record deterministic,
+-- auditable links derived from scope/session traces, summary frontmatter, and
+-- DB-owned markdown projection columns.
 
 CREATE TABLE record_session_links (
   record_id       TEXT NOT NULL PRIMARY KEY
@@ -36,6 +37,39 @@ CREATE TABLE record_link_review (
 
 CREATE INDEX record_link_review_reason_idx
   ON record_link_review(reason, record_id);
+
+CREATE TABLE record_summary_links (
+  summary_record_id TEXT NOT NULL
+                         REFERENCES records(record_id) ON DELETE CASCADE,
+  source_record_id  TEXT NOT NULL
+                         REFERENCES records(record_id) ON DELETE CASCADE,
+  summary_kind      TEXT NOT NULL CHECK (summary_kind IN ('turn_summary', 'consolidation')),
+  link_source       TEXT NOT NULL CHECK (link_source IN ('trace', 'consolidation')),
+  created_at        INTEGER NOT NULL,
+  PRIMARY KEY (summary_record_id, source_record_id, summary_kind)
+);
+
+CREATE INDEX record_summary_links_source_idx
+  ON record_summary_links(source_record_id, summary_record_id);
+
+CREATE INDEX record_summary_links_summary_idx
+  ON record_summary_links(summary_record_id, source_record_id);
+
+CREATE TABLE record_projection_links (
+  record_id       TEXT NOT NULL PRIMARY KEY
+                       REFERENCES records(record_id) ON DELETE CASCADE,
+  target_id       TEXT NOT NULL,
+  projection_kind TEXT NOT NULL CHECK (projection_kind IN ('markdown')),
+  path            TEXT NOT NULL,
+  body_hash       TEXT NOT NULL,
+  created_at      INTEGER NOT NULL
+);
+
+CREATE INDEX record_projection_links_target_idx
+  ON record_projection_links(target_id, projection_kind);
+
+CREATE INDEX record_projection_links_path_idx
+  ON record_projection_links(path);
 
 INSERT INTO record_link_review (
   record_id, reason, scope_session_id, trace_session_id, detail_json, created_at
@@ -82,6 +116,55 @@ WHERE COALESCE(json_extract(scope, '$.session_id'), trace_session_id) IS NOT NUL
     AND trace_session_id IS NOT NULL
     AND json_extract(scope, '$.session_id') <> trace_session_id
   );
+
+INSERT INTO record_summary_links (
+  summary_record_id, source_record_id, summary_kind, link_source, created_at
+)
+SELECT
+  summary.record_id,
+  source.value,
+  'turn_summary',
+  'trace',
+  strftime('%s','now') * 1000
+FROM records AS summary
+JOIN json_each(json_extract(summary.extra_frontmatter, '$.trace.member_event_ids')) AS source
+JOIN records AS source_record
+  ON source_record.record_id = source.value
+WHERE summary.trace_event = 'turn_summary'
+  AND source.type = 'text';
+
+INSERT INTO record_summary_links (
+  summary_record_id, source_record_id, summary_kind, link_source, created_at
+)
+SELECT
+  summary.record_id,
+  source.value,
+  'consolidation',
+  'consolidation',
+  strftime('%s','now') * 1000
+FROM records AS summary
+JOIN json_each(json_extract(summary.extra_frontmatter, '$.consolidation.source_record_ids')) AS source
+JOIN records AS source_record
+  ON source_record.record_id = source.value
+WHERE json_extract(summary.extra_frontmatter, '$.consolidation') IS NOT NULL
+  AND source.type = 'text'
+ON CONFLICT(summary_record_id, source_record_id, summary_kind) DO NOTHING;
+
+INSERT INTO record_projection_links (
+  record_id, target_id, projection_kind, path, body_hash, created_at
+)
+SELECT
+  record_id,
+  target_id,
+  'markdown',
+  path,
+  body_hash,
+  strftime('%s','now') * 1000
+FROM records
+WHERE path IS NOT NULL
+  AND path <> ''
+  AND body_hash IS NOT NULL
+  AND body_hash <> '';
 
 INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
   VALUES (64, '0064_v02_record_session_links', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/store/forget.rs
+++ b/crates/cairn-store-sqlite/src/store/forget.rs
@@ -366,6 +366,16 @@ impl crate::store::tx::StoreTx<'_> {
         let projector = MarkdownProjector;
         let mut paths = BTreeSet::new();
         for target in targets {
+            let mut stmt = self.tx.prepare(
+                "SELECT DISTINCT path \
+                   FROM record_projection_links \
+                  WHERE target_id = ?1 AND projection_kind = 'markdown' \
+                  ORDER BY path",
+            )?;
+            let rows = stmt.query_map(params![target.as_str()], |row| row.get::<_, String>(0))?;
+            for raw in rows {
+                paths.insert(PathBuf::from(raw?));
+            }
             if let Some(stored) = self.get_active_by_target(target)? {
                 paths.insert(projector.project(&stored).path);
             }
@@ -380,16 +390,28 @@ impl crate::store::tx::StoreTx<'_> {
         let mut target_ids = BTreeSet::new();
         for record_id in source_record_ids {
             let mut stmt = self.tx.prepare(
-                "SELECT DISTINCT target_id \
-                   FROM records \
-                  WHERE active = 1 AND tombstoned = 0 \
-                    AND json_extract(extra_frontmatter, '$.consolidation') IS NOT NULL \
-                    AND EXISTS ( \
-                        SELECT 1 \
-                          FROM json_each(json_extract(extra_frontmatter, \
-                                           '$.consolidation.source_record_ids')) \
-                         WHERE value = ?1 \
-                    )",
+                "SELECT DISTINCT target_id
+                   FROM (
+                        SELECT r.target_id
+                          FROM record_summary_links AS links
+                          JOIN records AS r
+                            ON r.record_id = links.summary_record_id
+                         WHERE links.source_record_id = ?1
+                           AND r.active = 1
+                           AND r.tombstoned = 0
+                        UNION
+                        SELECT target_id
+                          FROM records
+                         WHERE active = 1 AND tombstoned = 0
+                           AND json_extract(extra_frontmatter, '$.consolidation') IS NOT NULL
+                           AND EXISTS (
+                               SELECT 1
+                                 FROM json_each(json_extract(extra_frontmatter,
+                                                  '$.consolidation.source_record_ids'))
+                                WHERE value = ?1
+                           )
+                   )
+                  ORDER BY target_id",
             )?;
             let rows =
                 stmt.query_map(params![record_id.as_str()], |row| row.get::<_, String>(0))?;

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -210,10 +210,20 @@ impl StoreTx<'_> {
                     SELECT target_id
                       FROM record_session_links
                      WHERE session_id = ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM record_link_review AS review
+                            WHERE review.record_id = record_session_links.record_id
+                       )
                     UNION
                     SELECT target_id
                       FROM records
                      WHERE json_extract(scope, '$.session_id') = ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM record_link_review AS review
+                            WHERE review.record_id = records.record_id
+                       )
                )
               ORDER BY target_id",
         )?;
@@ -245,11 +255,21 @@ impl StoreTx<'_> {
                     SELECT tenant, workspace
                       FROM record_session_links
                      WHERE session_id = ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM record_link_review AS review
+                            WHERE review.record_id = record_session_links.record_id
+                       )
                     UNION
                     SELECT json_extract(scope, '$.tenant') AS tenant,
                            json_extract(scope, '$.workspace') AS workspace
                       FROM records
                      WHERE json_extract(scope, '$.session_id') = ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM record_link_review AS review
+                            WHERE review.record_id = records.record_id
+                       )
                )
               ORDER BY tenant, workspace",
         )?;
@@ -282,12 +302,22 @@ impl StoreTx<'_> {
                     SELECT target_id, tenant, workspace
                       FROM record_session_links
                      WHERE session_id = ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM record_link_review AS review
+                            WHERE review.record_id = record_session_links.record_id
+                       )
                     UNION
                     SELECT target_id,
                            json_extract(scope, '$.tenant') AS tenant,
                            json_extract(scope, '$.workspace') AS workspace
                       FROM records
                      WHERE json_extract(scope, '$.session_id') = ?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM record_link_review AS review
+                            WHERE review.record_id = records.record_id
+                       )
                )
               WHERE (
                     (?2 IS NULL AND tenant IS NULL)

--- a/crates/cairn-store-sqlite/src/store/tx.rs
+++ b/crates/cairn-store-sqlite/src/store/tx.rs
@@ -206,8 +206,15 @@ impl StoreTx<'_> {
     ) -> Result<Vec<TargetId>, StoreError> {
         let mut stmt = self.tx.prepare(
             "SELECT DISTINCT target_id
-               FROM records
-              WHERE json_extract(scope, '$.session_id') = ?1
+               FROM (
+                    SELECT target_id
+                      FROM record_session_links
+                     WHERE session_id = ?1
+                    UNION
+                    SELECT target_id
+                      FROM records
+                     WHERE json_extract(scope, '$.session_id') = ?1
+               )
               ORDER BY target_id",
         )?;
         let mut rows = stmt.query([session_id])?;
@@ -233,10 +240,17 @@ impl StoreTx<'_> {
     ) -> Result<Vec<SessionScopePartition>, StoreError> {
         let mut stmt = self.tx.prepare(
             "SELECT DISTINCT \
-                json_extract(scope, '$.tenant') AS tenant, \
-                json_extract(scope, '$.workspace') AS workspace \
-               FROM records \
-              WHERE json_extract(scope, '$.session_id') = ?1 \
+                tenant, workspace
+               FROM (
+                    SELECT tenant, workspace
+                      FROM record_session_links
+                     WHERE session_id = ?1
+                    UNION
+                    SELECT json_extract(scope, '$.tenant') AS tenant,
+                           json_extract(scope, '$.workspace') AS workspace
+                      FROM records
+                     WHERE json_extract(scope, '$.session_id') = ?1
+               )
               ORDER BY tenant, workspace",
         )?;
         let mut rows = stmt.query([session_id])?;
@@ -264,16 +278,25 @@ impl StoreTx<'_> {
     ) -> Result<Vec<TargetId>, StoreError> {
         let mut stmt = self.tx.prepare(
             "SELECT DISTINCT target_id
-               FROM records
-               WHERE json_extract(scope, '$.session_id') = ?1
-                 AND (
-                       (?2 IS NULL AND json_extract(scope, '$.tenant') IS NULL)
-                    OR json_extract(scope, '$.tenant') = ?2
-                 )
-                 AND (
-                       (?3 IS NULL AND json_extract(scope, '$.workspace') IS NULL)
-                    OR json_extract(scope, '$.workspace') = ?3
-                 )
+               FROM (
+                    SELECT target_id, tenant, workspace
+                      FROM record_session_links
+                     WHERE session_id = ?1
+                    UNION
+                    SELECT target_id,
+                           json_extract(scope, '$.tenant') AS tenant,
+                           json_extract(scope, '$.workspace') AS workspace
+                      FROM records
+                     WHERE json_extract(scope, '$.session_id') = ?1
+               )
+              WHERE (
+                    (?2 IS NULL AND tenant IS NULL)
+                 OR tenant = ?2
+              )
+                AND (
+                    (?3 IS NULL AND workspace IS NULL)
+                 OR workspace = ?3
+              )
                ORDER BY target_id",
         )?;
         let mut rows = stmt.query(params![session_id, tenant, workspace])?;

--- a/crates/cairn-store-sqlite/src/verify.rs
+++ b/crates/cairn-store-sqlite/src/verify.rs
@@ -197,6 +197,14 @@ const EXPECTED_OBJECTS: &[(&str, &str)] = &[
     ("index", "records_trace_seq"),
     ("index", "records_trace_parent"),
     ("index", "records_trace_payload_hash"),
+    // 0064_v02_record_session_links (issue #109; brief §19 + §5.6):
+    // deterministic session-delete metadata derived from legacy v0.1
+    // scope/trace rows, plus a review queue for ambiguous conflicts.
+    ("table", "record_session_links"),
+    ("index", "record_session_links_session_idx"),
+    ("index", "record_session_links_target_idx"),
+    ("table", "record_link_review"),
+    ("index", "record_link_review_reason_idx"),
     // 0031_records_consent_model — Phase-A per-row consent gate (#253, brief §14).
     ("index", "records_consent_model_idx"),
     // 0032_consent_timeline — append-only receipt event log (#253, brief §14).

--- a/crates/cairn-store-sqlite/src/verify.rs
+++ b/crates/cairn-store-sqlite/src/verify.rs
@@ -205,6 +205,12 @@ const EXPECTED_OBJECTS: &[(&str, &str)] = &[
     ("index", "record_session_links_target_idx"),
     ("table", "record_link_review"),
     ("index", "record_link_review_reason_idx"),
+    ("table", "record_summary_links"),
+    ("index", "record_summary_links_source_idx"),
+    ("index", "record_summary_links_summary_idx"),
+    ("table", "record_projection_links"),
+    ("index", "record_projection_links_target_idx"),
+    ("index", "record_projection_links_path_idx"),
     // 0031_records_consent_model — Phase-A per-row consent gate (#253, brief §14).
     ("index", "records_consent_model_idx"),
     // 0032_consent_timeline — append-only receipt event log (#253, brief §14).

--- a/crates/cairn-store-sqlite/tests/forget_session.rs
+++ b/crates/cairn-store-sqlite/tests/forget_session.rs
@@ -52,6 +52,19 @@ fn consolidation_summary_record(
     record
 }
 
+fn unscoped_record(record_id: &str, target_id: &str, body: &str) -> MemoryRecord {
+    let mut record = sample_record();
+    record.id = RecordId::parse(record_id).expect("valid record id");
+    record.target_id = TargetId::parse(target_id).expect("valid target id");
+    body.clone_into(&mut record.body);
+    record.scope = ScopeTuple {
+        user: record.scope.user.clone(),
+        agent: record.scope.agent.clone(),
+        ..ScopeTuple::default()
+    };
+    record
+}
+
 #[tokio::test]
 async fn forget_session_purges_all_session_targets_through_wal() {
     let store = open_in_memory().await.expect("open store");
@@ -152,6 +165,60 @@ async fn forget_session_purges_all_session_targets_through_wal() {
     })
     .await
     .expect("wal assertion");
+}
+
+#[tokio::test]
+async fn forget_session_uses_migrated_record_session_links() {
+    let store = open_in_memory().await.expect("open store");
+    let record = unscoped_record(
+        "01J00000000000000000001091",
+        "01HQZX9F5N0000000000010901",
+        "issue109 migrated trace body",
+    );
+    store.upsert(&record).await.expect("upsert migrated record");
+
+    let conn = store.raw_conn_for_admin().expect("raw conn").clone();
+    let record_id = record.id.as_str().to_owned();
+    let target_id = record.target_id.as_str().to_owned();
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO record_session_links (
+                record_id, target_id, session_id, tenant, workspace,
+                link_source, link_confidence, created_at
+             ) VALUES (?1, ?2, 'sess-109-derived', NULL, NULL, 'trace', 'derived', 109)",
+            params![record_id, target_id],
+        )?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("seed migrated session link");
+
+    let outcome = store
+        .forget_session("sess-109-derived")
+        .await
+        .expect("forget derived session");
+
+    assert_eq!(outcome.deleted_count, 1);
+    assert!(outcome.tombstones.contains(&record.id));
+
+    let conn = store.raw_conn_for_admin().expect("raw conn").clone();
+    conn.call(move |c| {
+        let leaked_records: i64 = c.query_row(
+            "SELECT COUNT(*) FROM records WHERE record_id = '01J00000000000000000001091'",
+            [],
+            |row| row.get(0),
+        )?;
+        let leaked_links: i64 = c.query_row(
+            "SELECT COUNT(*) FROM record_session_links WHERE session_id = 'sess-109-derived'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(leaked_records, 0);
+        assert_eq!(leaked_links, 0);
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("derived link assertion");
 }
 
 #[tokio::test]

--- a/crates/cairn-store-sqlite/tests/forget_session.rs
+++ b/crates/cairn-store-sqlite/tests/forget_session.rs
@@ -3,6 +3,7 @@
 #![allow(missing_docs)]
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use cairn_core::contract::memory_store::{ListArgs, MemoryStore};
@@ -219,6 +220,72 @@ async fn forget_session_uses_migrated_record_session_links() {
     })
     .await
     .expect("derived link assertion");
+}
+
+#[tokio::test]
+async fn forget_session_uses_migrated_summary_and_projection_links() {
+    let store = open_in_memory().await.expect("open store");
+    let source = session_record(
+        "01J00000000000000000001092",
+        "01HQZX9F5N0000000000010902",
+        "issue109 source body",
+        "sess-109-summary-links",
+    );
+    let summary = unscoped_record(
+        "01J00000000000000000001093",
+        "01HQZX9F5N0000000000010903",
+        "issue109 linked summary body",
+    );
+    store.upsert(&source).await.expect("upsert source");
+    store.upsert(&summary).await.expect("upsert summary");
+
+    let conn = store.raw_conn_for_admin().expect("raw conn").clone();
+    let source_record_id = source.id.as_str().to_owned();
+    let source_target_id = source.target_id.as_str().to_owned();
+    let summary_record_id = summary.id.as_str().to_owned();
+    let summary_target_id = summary.target_id.as_str().to_owned();
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO record_summary_links (
+                summary_record_id, source_record_id, summary_kind, link_source, created_at
+             ) VALUES (?1, ?2, 'consolidation', 'consolidation', 109)",
+            params![summary_record_id, source_record_id],
+        )?;
+        c.execute(
+            "INSERT INTO record_projection_links (
+                record_id, target_id, projection_kind, path, body_hash, created_at
+             ) VALUES (?1, ?2, 'markdown', 'raw/custom-source.md', 'sha256:source', 109)",
+            params![source_record_id, source_target_id],
+        )?;
+        c.execute(
+            "INSERT INTO record_projection_links (
+                record_id, target_id, projection_kind, path, body_hash, created_at
+             ) VALUES (?1, ?2, 'markdown', 'raw/custom-summary.md', 'sha256:summary', 109)",
+            params![summary_record_id, summary_target_id],
+        )?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("seed migrated summary/projection links");
+
+    let outcome = store
+        .forget_session("sess-109-summary-links")
+        .await
+        .expect("forget session");
+
+    assert_eq!(outcome.deleted_count, 2);
+    assert!(outcome.tombstones.contains(&source.id));
+    assert!(outcome.tombstones.contains(&summary.id));
+    assert!(
+        outcome
+            .projection_paths
+            .contains(&PathBuf::from("raw/custom-source.md"))
+    );
+    assert!(
+        outcome
+            .projection_paths
+            .contains(&PathBuf::from("raw/custom-summary.md"))
+    );
 }
 
 #[tokio::test]

--- a/crates/cairn-store-sqlite/tests/forget_session.rs
+++ b/crates/cairn-store-sqlite/tests/forget_session.rs
@@ -223,6 +223,59 @@ async fn forget_session_uses_migrated_record_session_links() {
 }
 
 #[tokio::test]
+async fn forget_session_skips_manual_review_session_conflicts() {
+    let store = open_in_memory().await.expect("open store");
+    let record = session_record(
+        "01J00000000000000000001094",
+        "01HQZX9F5N0000000000010904",
+        "issue109 ambiguous session body",
+        "sess-109-scope",
+    );
+    store
+        .upsert(&record)
+        .await
+        .expect("upsert ambiguous record");
+
+    let conn = store.raw_conn_for_admin().expect("raw conn").clone();
+    let record_id = record.id.as_str().to_owned();
+    let target_id = record.target_id.as_str().to_owned();
+    conn.call(move |c| {
+        c.execute(
+            "INSERT INTO record_session_links (
+                record_id, target_id, session_id, tenant, workspace,
+                link_source, link_confidence, created_at
+             ) VALUES (?1, ?2, 'sess-109-scope', NULL, NULL, 'scope', 'explicit', 109)",
+            params![record_id, target_id],
+        )?;
+        c.execute(
+            "INSERT INTO record_link_review (
+                record_id, reason, scope_session_id, trace_session_id, detail_json, created_at
+             ) VALUES (
+                ?1, 'session_id_mismatch', 'sess-109-scope', 'sess-109-trace',
+                '{\"migration_id\":64}', 109
+             )",
+            params![record_id],
+        )?;
+        Ok::<_, tokio_rusqlite::Error>(())
+    })
+    .await
+    .expect("seed manual-review conflict");
+
+    let err = store
+        .forget_session("sess-109-scope")
+        .await
+        .expect_err("manual-review records must not be guessed from fallback scope metadata");
+    assert!(
+        matches!(err, StoreError::NotFound { .. }),
+        "expected NotFound when every matching row is under manual review, got {err:?}"
+    );
+
+    let listed = store.list(&ListArgs::default()).await.expect("list");
+    assert_eq!(listed.records.len(), 1);
+    assert_eq!(listed.records[0].id, record.id);
+}
+
+#[tokio::test]
 async fn forget_session_uses_migrated_summary_and_projection_links() {
     let store = open_in_memory().await.expect("open store");
     let source = session_record(

--- a/crates/cairn-store-sqlite/tests/lint_edges.rs
+++ b/crates/cairn-store-sqlite/tests/lint_edges.rs
@@ -32,6 +32,30 @@ fn allow_corrupt_overlaps(conn: &Connection) {
     .expect("drop overlap guards for corruption fixture");
 }
 
+fn insert_record_stub(conn: &Connection, record_id: &str, target_id: &str) {
+    let record_json = serde_json::json!({
+        "id": record_id,
+        "target_id": target_id,
+        "body": "record link review fixture",
+        "extra_frontmatter": {}
+    })
+    .to_string();
+    conn.execute(
+        "INSERT INTO records (
+            record_id, target_id, version, path, kind, class, visibility,
+            scope, actor_chain, body, body_hash, created_at, updated_at,
+            active, tombstoned, is_static, record_json, confidence, salience,
+            tags_json
+         ) VALUES (
+            ?1, ?2, 1, 'raw/link-review.md', 'note', 'episodic', 'session',
+            '{}', '[]', 'record link review fixture', 'sha256:lint', 1, 1,
+            1, 0, 0, ?3, 0.5, 0.5, '[]'
+         )",
+        params![record_id, target_id, record_json],
+    )
+    .expect("insert record stub");
+}
+
 #[allow(clippy::too_many_arguments)]
 fn insert_edge(
     conn: &Connection,
@@ -67,6 +91,46 @@ fn insert_edge(
         ],
     )
     .expect("insert edge");
+}
+
+#[test]
+fn read_only_lint_surfaces_record_link_review_conflicts() {
+    let conn = conn();
+    insert_record_stub(
+        &conn,
+        "01J00000000000000000001901",
+        "01HQZX9F5N0000000000019001",
+    );
+    conn.execute(
+        "INSERT INTO record_link_review (
+            record_id, reason, scope_session_id, trace_session_id, detail_json, created_at
+         ) VALUES (
+            '01J00000000000000000001901', 'session_id_mismatch',
+            'scope-session', 'trace-session',
+            '{\"migration_id\":64}', 109
+         )",
+        [],
+    )
+    .expect("insert review row");
+
+    let report = lint_edges(&conn).expect("lint report");
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|finding| finding.tracking_issue == Some(109))
+        .expect("issue 109 lint finding");
+    assert_eq!(finding.kind, Kind::DeferredCheck);
+    assert_eq!(finding.severity, Severity::Warning);
+    assert_eq!(
+        finding.entities.as_deref(),
+        Some(&["01J00000000000000000001901".to_owned()][..])
+    );
+    assert!(
+        finding.message.contains("scope-session")
+            && finding.message.contains("trace-session")
+            && finding.message.contains("manual review")
+    );
 }
 
 #[test]

--- a/crates/cairn-store-sqlite/tests/migrations.rs
+++ b/crates/cairn-store-sqlite/tests/migrations.rs
@@ -8,6 +8,8 @@ use rusqlite::params;
 use tempfile::tempdir;
 
 type SessionLinkRow = (String, String, Option<String>, Option<String>, String);
+type SummaryLinkRow = (String, String, String, String);
+type ProjectionLinkRow = (String, String, String, String);
 
 #[allow(
     clippy::expect_used,
@@ -57,6 +59,36 @@ fn insert_legacy_trace_record(
         params![record_id, target_id, scope_json, record_json],
     )
     .expect("insert legacy trace record");
+}
+
+fn insert_legacy_record_with_extra(
+    conn: &rusqlite::Connection,
+    record_id: &str,
+    target_id: &str,
+    kind: &str,
+    extra_frontmatter: &serde_json::Value,
+) {
+    let path = format!("raw/{record_id}.md");
+    let body_hash = format!("sha256:{record_id}");
+    let record_json = serde_json::json!({
+        "id": record_id,
+        "target_id": target_id,
+        "body": "legacy linked body",
+        "extra_frontmatter": extra_frontmatter,
+    })
+    .to_string();
+
+    conn.execute(
+        "INSERT INTO records \
+           (record_id, target_id, version, path, kind, class, visibility, scope, \
+            actor_chain, body, body_hash, created_at, updated_at, active, tombstoned, \
+            is_static, record_json, confidence, salience, tags_json) \
+         VALUES (?1, ?2, 1, ?3, ?4, 'episodic', 'session', '{}', \
+                 '[]', 'legacy linked body', ?5, 0, 0, 1, 0, \
+                 0, ?6, 0.5, 0.5, '[]')",
+        params![record_id, target_id, path, kind, body_hash, record_json],
+    )
+    .expect("insert legacy record with extra frontmatter");
 }
 
 #[test]
@@ -199,6 +231,174 @@ fn migration_0064_reports_conflicting_session_links_for_manual_review() {
             "sess-scope".to_owned(),
             "sess-trace".to_owned(),
         )
+    );
+}
+
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "migration acceptance fixture keeps source, summary, and projection assertions together"
+)]
+fn migration_0064_backfills_summary_and_projection_links() {
+    register_vec0();
+    let mut conn = rusqlite::Connection::open_in_memory().expect("open raw in-memory db");
+    migrations()
+        .to_version(&mut conn, 57)
+        .expect("apply migrations through pre-0064 head");
+
+    insert_legacy_record_with_extra(
+        &conn,
+        "01JTS6R4J7000000000000001A",
+        "01JTS6R4J7000000000000001A",
+        "trace",
+        &serde_json::json!({
+            "trace_event": "user_message",
+            "trace": {
+                "session_id": "sess-109-summary",
+                "turn_id": "turn-1",
+                "sequence": 0,
+                "capture_event_id": "01JTS6R4J7000000000000001A",
+                "payload_hash": "sha256:source-a"
+            }
+        }),
+    );
+    insert_legacy_record_with_extra(
+        &conn,
+        "01JTS6R4J7000000000000001B",
+        "01JTS6R4J7000000000000001B",
+        "trace",
+        &serde_json::json!({
+            "trace_event": "assistant_message",
+            "trace": {
+                "session_id": "sess-109-summary",
+                "turn_id": "turn-1",
+                "sequence": 1,
+                "capture_event_id": "01JTS6R4J7000000000000001B",
+                "payload_hash": "sha256:source-b"
+            }
+        }),
+    );
+    insert_legacy_record_with_extra(
+        &conn,
+        "01JTS6R4J7000000000000001C",
+        "01JTS6R4J7000000000000001C",
+        "trace",
+        &serde_json::json!({
+            "trace_event": "turn_summary",
+            "trace": {
+                "session_id": "sess-109-summary",
+                "turn_id": "turn-1",
+                "sequence": 2,
+                "capture_event_id": "01JTS6R4J7000000000000001C",
+                "payload_hash": "sha256:summary",
+                "member_event_ids": [
+                    "01JTS6R4J7000000000000001A",
+                    "01JTS6R4J7000000000000001B"
+                ]
+            }
+        }),
+    );
+    insert_legacy_record_with_extra(
+        &conn,
+        "01JTS6R4J7000000000000001D",
+        "01JTS6R4J7000000000000001D",
+        "reasoning",
+        &serde_json::json!({
+            "consolidation": {
+                "source_record_ids": ["01JTS6R4J7000000000000001A"],
+                "last_sequence": 2
+            }
+        }),
+    );
+
+    migrations()
+        .to_latest(&mut conn)
+        .expect("apply migration 0064");
+
+    let summary_links: Vec<SummaryLinkRow> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT summary_record_id, source_record_id, summary_kind, link_source \
+                   FROM record_summary_links \
+                  ORDER BY summary_record_id, source_record_id",
+            )
+            .expect("prepare summary links query");
+        stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .expect("query summary links")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect summary links")
+    };
+    assert_eq!(
+        summary_links,
+        vec![
+            (
+                "01JTS6R4J7000000000000001C".to_owned(),
+                "01JTS6R4J7000000000000001A".to_owned(),
+                "turn_summary".to_owned(),
+                "trace".to_owned(),
+            ),
+            (
+                "01JTS6R4J7000000000000001C".to_owned(),
+                "01JTS6R4J7000000000000001B".to_owned(),
+                "turn_summary".to_owned(),
+                "trace".to_owned(),
+            ),
+            (
+                "01JTS6R4J7000000000000001D".to_owned(),
+                "01JTS6R4J7000000000000001A".to_owned(),
+                "consolidation".to_owned(),
+                "consolidation".to_owned(),
+            ),
+        ]
+    );
+
+    let projection_links: Vec<ProjectionLinkRow> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT record_id, target_id, projection_kind, path \
+                   FROM record_projection_links \
+                  WHERE record_id IN (
+                    '01JTS6R4J7000000000000001A',
+                    '01JTS6R4J7000000000000001D'
+                  ) \
+                  ORDER BY record_id",
+            )
+            .expect("prepare projection links query");
+        stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .expect("query projection links")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect projection links")
+    };
+    assert_eq!(
+        projection_links,
+        vec![
+            (
+                "01JTS6R4J7000000000000001A".to_owned(),
+                "01JTS6R4J7000000000000001A".to_owned(),
+                "markdown".to_owned(),
+                "raw/01JTS6R4J7000000000000001A.md".to_owned(),
+            ),
+            (
+                "01JTS6R4J7000000000000001D".to_owned(),
+                "01JTS6R4J7000000000000001D".to_owned(),
+                "markdown".to_owned(),
+                "raw/01JTS6R4J7000000000000001D.md".to_owned(),
+            ),
+        ]
     );
 }
 

--- a/crates/cairn-store-sqlite/tests/migrations.rs
+++ b/crates/cairn-store-sqlite/tests/migrations.rs
@@ -7,6 +7,58 @@ use cairn_store_sqlite::{
 use rusqlite::params;
 use tempfile::tempdir;
 
+type SessionLinkRow = (String, String, Option<String>, Option<String>, String);
+
+#[allow(
+    clippy::expect_used,
+    reason = "test fixture helper: invalid seed SQL should fail loudly"
+)]
+fn insert_legacy_trace_record(
+    conn: &rusqlite::Connection,
+    record_id: &str,
+    target_id: &str,
+    scope_json: &str,
+    trace_session_id: Option<&str>,
+) {
+    let trace = match trace_session_id {
+        Some(session_id) => serde_json::json!({
+            "session_id": session_id,
+            "turn_id": "turn-1",
+            "sequence": 0,
+            "capture_event_id": record_id,
+            "payload_hash": "sha256:legacy",
+        }),
+        None => serde_json::json!({
+            "turn_id": "turn-1",
+            "sequence": 0,
+            "capture_event_id": record_id,
+            "payload_hash": "sha256:legacy",
+        }),
+    };
+    let record_json = serde_json::json!({
+        "id": record_id,
+        "target_id": target_id,
+        "body": "legacy trace body",
+        "extra_frontmatter": {
+            "trace_event": "user_message",
+            "trace": trace,
+        },
+    })
+    .to_string();
+
+    conn.execute(
+        "INSERT INTO records \
+           (record_id, target_id, version, path, kind, class, visibility, scope, \
+            actor_chain, body, body_hash, created_at, updated_at, active, tombstoned, \
+            is_static, record_json, confidence, salience, tags_json) \
+         VALUES (?1, ?2, 1, 'raw/legacy.md', 'trace', 'episodic', 'session', ?3, \
+                 '[]', 'legacy trace body', 'sha256:legacy', 0, 0, 1, 0, \
+                 0, ?4, 0.5, 0.5, '[]')",
+        params![record_id, target_id, scope_json, record_json],
+    )
+    .expect("insert legacy trace record");
+}
+
 #[test]
 fn fresh_in_memory_opens_to_head() {
     let conn = open_in_memory().expect("open in-memory store");
@@ -15,7 +67,7 @@ fn fresh_in_memory_opens_to_head() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 63);
+    assert_eq!(head, 64);
 }
 
 #[test]
@@ -31,7 +83,123 @@ fn fresh_vault_opens_and_reopens_idempotent() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 63);
+    assert_eq!(head, 64);
+}
+
+#[test]
+fn migration_0064_backfills_trace_derived_session_links() {
+    register_vec0();
+    let mut conn = rusqlite::Connection::open_in_memory().expect("open raw in-memory db");
+    migrations()
+        .to_version(&mut conn, 57)
+        .expect("apply migrations through pre-0064 head");
+
+    insert_legacy_trace_record(
+        &conn,
+        "01JTS6R4J7000000000000000A",
+        "01JTS6R4J7000000000000000A",
+        "{}",
+        Some("sess-109"),
+    );
+    insert_legacy_trace_record(
+        &conn,
+        "01JTS6R4J7000000000000000B",
+        "01JTS6R4J7000000000000000B",
+        r#"{"session_id":"sess-scope","tenant":"t1","workspace":"w1"}"#,
+        Some("sess-scope"),
+    );
+
+    migrations()
+        .to_latest(&mut conn)
+        .expect("apply migration 0064");
+
+    let linked: Vec<SessionLinkRow> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT record_id, session_id, tenant, workspace, link_source \
+                   FROM record_session_links \
+                  ORDER BY record_id",
+            )
+            .expect("prepare links query");
+        stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })
+        .expect("query links")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect links")
+    };
+
+    assert_eq!(
+        linked,
+        vec![
+            (
+                "01JTS6R4J7000000000000000A".to_owned(),
+                "sess-109".to_owned(),
+                None,
+                None,
+                "trace".to_owned(),
+            ),
+            (
+                "01JTS6R4J7000000000000000B".to_owned(),
+                "sess-scope".to_owned(),
+                Some("t1".to_owned()),
+                Some("w1".to_owned()),
+                "scope".to_owned(),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn migration_0064_reports_conflicting_session_links_for_manual_review() {
+    register_vec0();
+    let mut conn = rusqlite::Connection::open_in_memory().expect("open raw in-memory db");
+    migrations()
+        .to_version(&mut conn, 57)
+        .expect("apply migrations through pre-0064 head");
+
+    insert_legacy_trace_record(
+        &conn,
+        "01JTS6R4J7000000000000000C",
+        "01JTS6R4J7000000000000000C",
+        r#"{"session_id":"sess-scope"}"#,
+        Some("sess-trace"),
+    );
+
+    migrations()
+        .to_latest(&mut conn)
+        .expect("apply migration 0064");
+
+    let link_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM record_session_links", [], |row| {
+            row.get(0)
+        })
+        .expect("count links");
+    assert_eq!(link_count, 0, "conflicting links must not be guessed");
+
+    let review: (String, String, String, String) = conn
+        .query_row(
+            "SELECT record_id, reason, scope_session_id, trace_session_id \
+               FROM record_link_review",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("manual-review row");
+    assert_eq!(
+        review,
+        (
+            "01JTS6R4J7000000000000000C".to_owned(),
+            "session_id_mismatch".to_owned(),
+            "sess-scope".to_owned(),
+            "sess-trace".to_owned(),
+        )
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #109.

## Summary
- Add migration 0064 for v0.2 record session-link metadata derived from legacy v0.1 scope/trace rows.
- Backfill summary-source links from trace `member_event_ids` and consolidation `source_record_ids` where the source rows still exist.
- Backfill markdown projection links from DB-owned record path/body-hash columns so projection cleanup is auditable.
- Route session-level forget through migrated session, summary, and projection link metadata while preserving existing JSON/projection fallbacks.
- Surface ambiguous scope-vs-trace session conflicts through lint as manual-review `DeferredCheck` findings.

## Brief Sections
- §19 v0.2 in-place migration
- §3.0 SQLite authority and repairable projections
- §5.6 session forget / WAL-backed deletion

## Invariants Touched
- SQLite remains authoritative for queryable metadata; record bodies are not rewritten by the migration.
- Ambiguous session links fail closed into `record_link_review` instead of being guessed.
- Summary and projection metadata is derived/additive and remains rebuildable from authoritative DB rows.
- Session forget remains WAL-backed; the migration only changes target/projection discovery metadata.

## Verification
- `cargo test -p cairn-store-sqlite --test migrations --locked`
- `cargo test -p cairn-store-sqlite --test forget_session --locked`
- `cargo test -p cairn-store-sqlite --test lint_edges --locked`
- `cargo fmt --all --check`
- `cargo check -p cairn-store-sqlite --all-targets --locked`
- `cargo clippy -p cairn-store-sqlite --all-targets --locked -- -D warnings`
- `git diff --check`
- `./scripts/check-core-boundary.sh`
