### PR TITLE
feat(workflows): add dream consolidation tiers

### DIFF
--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::Context as _;
-use cairn_core::config::{CairnConfig, ConsolidationConfig};
+use cairn_core::config::{CairnConfig, ConsolidationConfig, DreamConfig, DreamTier};
 use cairn_core::contract::job_store::JobStore;
 use cairn_core::domain::capture::{
     CaptureEvent, CaptureMode, CapturePayload, CaptureRefs, PayloadHash, SourceFamily,
@@ -61,7 +61,7 @@ use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt as _, BufReader};
 use ulid::Ulid;
 
-use cairn_workflows::consolidation::enqueue_if_due_scoped;
+use cairn_workflows::{consolidation::enqueue_if_due_scoped, enqueue_tier_with_dedupe_token};
 
 use crate::identity::{guard::refuse_if_degraded, status::ReconciliationReport};
 use crate::sensor_gate::{
@@ -156,6 +156,7 @@ pub async fn run_handler(
         None,
         None,
         &ConsolidationConfig::default(),
+        &DreamConfig::default(),
     )
     .await
 }
@@ -175,6 +176,7 @@ pub async fn run_handler_with_scope(
         None,
         None,
         &ConsolidationConfig::default(),
+        &DreamConfig::default(),
     )
     .await
 }
@@ -199,6 +201,7 @@ pub async fn run_events_handler(
         None,
         None,
         &ConsolidationConfig::default(),
+        &DreamConfig::default(),
     )
     .await
 }
@@ -219,6 +222,7 @@ pub async fn run_events_handler_with_scope(
         None,
         None,
         &ConsolidationConfig::default(),
+        &DreamConfig::default(),
     )
     .await
 }
@@ -282,6 +286,7 @@ async fn run_blocks_handler_with_scope(
 }
 
 #[allow(
+    clippy::too_many_arguments,
     clippy::too_many_lines,
     reason = "trace import keeps validation, projection, and per-turn atomicity in one ordered transaction flow"
 )]
@@ -293,6 +298,7 @@ async fn run_handler_inner(
     sensor_config: Option<&CairnConfig>,
     job_store: Option<&dyn JobStore>,
     consolidation_config: &ConsolidationConfig,
+    dream_config: &DreamConfig,
 ) -> anyhow::Result<CaptureTraceResponse> {
     capture_trace_guard()?;
     let events = read_jsonl_events(from).await?;
@@ -304,6 +310,7 @@ async fn run_handler_inner(
         sensor_config,
         job_store,
         consolidation_config,
+        dream_config,
     )
     .await
 }
@@ -314,6 +321,7 @@ fn capture_trace_guard() -> anyhow::Result<()> {
 }
 
 #[allow(
+    clippy::too_many_arguments,
     clippy::too_many_lines,
     reason = "trace import keeps validation, projection, and per-turn atomicity in one ordered transaction flow"
 )]
@@ -325,6 +333,7 @@ async fn run_events_handler_inner_no_guard(
     sensor_config: Option<&CairnConfig>,
     job_store: Option<&dyn JobStore>,
     consolidation_config: &ConsolidationConfig,
+    dream_config: &DreamConfig,
 ) -> anyhow::Result<CaptureTraceResponse> {
     // Group by (session_id, turn_id). Events missing either ref, or
     // failing structural validation, are reported as failed and skipped
@@ -769,6 +778,13 @@ async fn run_events_handler_inner_no_guard(
             // review #1). Watermark itself stays monotone via
             // `latest_consolidation_watermark_scoped` which counts
             // tombstoned summaries.
+            let now_ms = i64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis(),
+            )
+            .unwrap_or(i64::MAX);
             let since_sequence = store
                 .latest_consolidation_watermark_scoped(&session_str, scope_binding)
                 .await
@@ -780,21 +796,28 @@ async fn run_events_handler_inner_no_guard(
                 .await
                 .ok()
                 .map(|h| u32::try_from(h.len()).unwrap_or(u32::MAX));
+            let dream_dedupe_token =
+                active_eligible_opt.map(|active| since_sequence.saturating_add(active).to_string());
             if let Some(active_eligible) = active_eligible_opt {
                 let turn_count = since_sequence.saturating_add(active_eligible);
-                let now_ms = i64::try_from(
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis(),
-                )
-                .unwrap_or(i64::MAX);
                 let _ = enqueue_if_due_scoped(
                     js,
                     consolidation_config,
                     &session_str,
                     turn_count,
                     since_sequence,
+                    now_ms,
+                    scope_binding,
+                )
+                .await;
+            }
+            if let (true, Some(dedupe_token)) = (had_stop, dream_dedupe_token.as_deref()) {
+                let _ = enqueue_tier_with_dedupe_token(
+                    js,
+                    dream_config,
+                    DreamTier::LightSleep,
+                    &session_str,
+                    dedupe_token,
                     now_ms,
                     scope_binding,
                 )
@@ -1551,7 +1574,6 @@ async fn run_async(input: CaptureTraceInput, vault_root: PathBuf, config: CairnC
         entity: Some(CAPTURE_TRACE_ENTITY.to_owned()),
         ..ScopeTuple::default()
     };
-    let consolidation_config = ctx.config.consolidation;
     let job_store_ref = ctx.job_store.as_deref();
     let result = match input {
         CaptureTraceInput::Jsonl(from) => {
@@ -1562,7 +1584,8 @@ async fn run_async(input: CaptureTraceInput, vault_root: PathBuf, config: CairnC
                 Some(&scope_binding),
                 Some(&ctx.config),
                 job_store_ref,
-                &consolidation_config,
+                &ctx.config.consolidation,
+                &ctx.config.dream,
             )
             .await
         }
@@ -1713,7 +1736,137 @@ fn response_exit_code(resp: &Response) -> ExitCode {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+    use cairn_core::contract::job_store::{
+        EnqueueRequest, FailDisposition, FailureClass, JobId, JobKind, JobStoreError, LeaseToken,
+        LeasedJob, ReclaimedRow,
+    };
+
+    const STOP_EVENT_ID: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
+    const STOP_SESSION_ID: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    const STOP_SOURCE_HASH: &str =
+        "sha256:a11c3d917a2149a4b548217038bc8f2dd2130a1966e0c7af5c4225d81f25a8c3";
+    const STOP_SOURCE_REF: &str = "sources/hook/01ARZ3NDEKTSV4RRFFQ69G5FAW.json";
+
+    struct RecordingJobStore {
+        requests: Mutex<Vec<EnqueueRequest>>,
+    }
+
+    impl RecordingJobStore {
+        fn new() -> Self {
+            Self {
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl JobStore for RecordingJobStore {
+        async fn enqueue(&self, req: EnqueueRequest) -> Result<(), JobStoreError> {
+            self.requests.lock().expect("invariant: mutex").push(req);
+            Ok(())
+        }
+
+        async fn enqueue_leased(
+            &self,
+            _: EnqueueRequest,
+            _: &str,
+            _: i64,
+            _: i64,
+        ) -> Result<LeasedJob, JobStoreError> {
+            Err(JobStoreError::Backend("unused in test".into()))
+        }
+
+        async fn lease(&self, _: &str, _: i64, _: i64) -> Result<Option<LeasedJob>, JobStoreError> {
+            Ok(None)
+        }
+
+        async fn lease_specific(
+            &self,
+            _: &JobId,
+            _: &JobKind,
+            _: &str,
+            _: i64,
+            _: i64,
+        ) -> Result<Option<LeasedJob>, JobStoreError> {
+            Ok(None)
+        }
+
+        async fn heartbeat(
+            &self,
+            _: &JobId,
+            _: &LeaseToken,
+            _: i64,
+            _: i64,
+        ) -> Result<(), JobStoreError> {
+            Err(JobStoreError::Backend("unused in test".into()))
+        }
+
+        async fn complete(&self, _: &JobId, _: &LeaseToken, _: i64) -> Result<(), JobStoreError> {
+            Err(JobStoreError::Backend("unused in test".into()))
+        }
+
+        async fn fail(
+            &self,
+            _: &JobId,
+            _: &LeaseToken,
+            _: FailDisposition,
+            _: FailureClass,
+            _: &str,
+            _: i64,
+        ) -> Result<(), JobStoreError> {
+            Err(JobStoreError::Backend("unused in test".into()))
+        }
+
+        async fn reap_expired(&self, _: i64) -> Result<Vec<ReclaimedRow>, JobStoreError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[allow(
+        clippy::expect_used,
+        reason = "test fixture: panics surface broken invariants immediately"
+    )]
+    fn write_stop_source(vault: &Path) {
+        std::fs::create_dir_all(vault.join("sources/hook")).expect("mkdir sources");
+        std::fs::write(vault.join(STOP_SOURCE_REF), b"stop\n").expect("write source");
+    }
+
+    #[allow(
+        clippy::expect_used,
+        reason = "test fixture: panics surface broken invariants immediately"
+    )]
+    fn stop_hook_event() -> CaptureEvent {
+        let sensor =
+            Identity::parse("snr:local:hook:cc-session:v1").expect("invariant: valid sensor id");
+        let captured_at =
+            Rfc3339Timestamp::parse("2026-05-17T12:00:00Z").expect("invariant: valid RFC-3339");
+        CaptureEvent {
+            event_id: CaptureEventId::parse(STOP_EVENT_ID).expect("invariant: valid ULID"),
+            sensor_id: sensor.clone(),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: sensor,
+                at: captured_at.clone(),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some(STOP_SESSION_ID.to_owned()),
+                turn_id: Some("turn-1".to_owned()),
+                tool_id: None,
+            }),
+            payload_hash: PayloadHash::parse(STOP_SOURCE_HASH).expect("invariant: valid sha256"),
+            payload_ref: STOP_SOURCE_REF.into(),
+            captured_at,
+            payload: CapturePayload::Hook {
+                hook_name: "Stop".to_owned(),
+                tool_name: None,
+            },
+            source_family: SourceFamily::Hook,
+        }
+    }
 
     #[test]
     fn public_failed_turn_reason_redacts_internal_sensor_gate_errors() {
@@ -1763,6 +1916,7 @@ mod tests {
             None,
             None,
             &ConsolidationConfig::default(),
+            &DreamConfig::default(),
         )
         .await
         .expect("run_handler_inner should succeed on empty input");
@@ -1794,5 +1948,86 @@ mod tests {
             ..ConsolidationConfig::default()
         };
         assert!(!cfg.enabled, "disabled config must not be enabled");
+    }
+
+    #[tokio::test]
+    #[allow(
+        clippy::expect_used,
+        reason = "test: panics surface broken invariants immediately"
+    )]
+    async fn stop_hook_enqueues_light_sleep_dream_job() {
+        let store = cairn_store_sqlite::open_in_memory()
+            .await
+            .expect("in-memory store");
+        let jobs = RecordingJobStore::new();
+        let vault = tempfile::tempdir().expect("tempdir");
+        write_stop_source(vault.path());
+        let consolidation = ConsolidationConfig {
+            enabled: false,
+            ..ConsolidationConfig::default()
+        };
+        let dream_config = DreamConfig {
+            enabled: true,
+            ..DreamConfig::default()
+        };
+
+        let result = run_events_handler_inner_no_guard(
+            &store,
+            vault.path(),
+            vec![stop_hook_event()],
+            None,
+            None,
+            Some(&jobs),
+            &consolidation,
+            &dream_config,
+        )
+        .await
+        .expect("capture_trace");
+        assert!(
+            result.failed_turns.is_empty(),
+            "unexpected failed turns: {:?}",
+            result.failed_turns
+        );
+
+        {
+            let requests = jobs.requests.lock().expect("invariant: mutex");
+            let dream_request = requests
+                .iter()
+                .find(|req| req.kind.as_str() == cairn_workflows::DREAM_KIND)
+                .expect("queued dream job");
+            let payload = cairn_workflows::DreamPayload::from_bytes(&dream_request.payload)
+                .expect("dream payload");
+            assert_eq!(payload.tier, DreamTier::LightSleep);
+            assert_eq!(payload.key, STOP_SESSION_ID);
+        }
+
+        let replay = run_events_handler_inner_no_guard(
+            &store,
+            vault.path(),
+            vec![stop_hook_event()],
+            None,
+            None,
+            Some(&jobs),
+            &consolidation,
+            &dream_config,
+        )
+        .await
+        .expect("capture_trace replay");
+        assert!(
+            replay.failed_turns.is_empty(),
+            "unexpected replay failed turns: {:?}",
+            replay.failed_turns
+        );
+
+        let requests = jobs.requests.lock().expect("invariant: mutex");
+        let dream_requests = requests
+            .iter()
+            .filter(|req| req.kind.as_str() == cairn_workflows::DREAM_KIND)
+            .collect::<Vec<_>>();
+        assert_eq!(dream_requests.len(), 2);
+        assert_eq!(
+            dream_requests[0].dedupe_key, dream_requests[1].dedupe_key,
+            "idempotent Stop-hook replay must target the same dream dedupe slot"
+        );
     }
 }

--- a/crates/cairn-core/src/config/dream.rs
+++ b/crates/cairn-core/src/config/dream.rs
@@ -1,12 +1,181 @@
-//! `DreamWorkflow` configuration (issue #91, brief §10.1, §10.2).
+//! `DreamWorkflow` configuration (brief §10.1, §10.2).
 //!
-//! Minimum P0 surface: a single `LLMDreamWorker` tier. Cron cadence and
-//! the REM / Deep tiers are deferred. Operators may override values
-//! per-vault via `.cairn/config.yaml` or per-folder via `_policy.yaml`.
+//! P1 exposes all three dream tiers as explicit configuration:
+//! Light Sleep, REM Sleep, and Deep Dreaming. Each tier carries the
+//! cadence, input window, output kind, worker mode, and budget needed
+//! by the workflow host while keeping this crate pure data.
 
 use serde::{Deserialize, Serialize};
 
-/// Typed configuration for the minimum-path `DreamWorkflow`.
+/// Dream tier from brief §10.1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamTier {
+    /// Light Sleep: cheap session/current-day maintenance.
+    #[default]
+    LightSleep,
+    /// REM Sleep: hourly or high-salience mid-depth consolidation.
+    RemSleep,
+    /// Deep Dreaming: nightly or cron full-vault sweep.
+    DeepDreaming,
+}
+
+impl DreamTier {
+    /// Stable lowercase discriminator used in job ids, queue keys, and
+    /// workflow metadata.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LightSleep => "light_sleep",
+            Self::RemSleep => "rem_sleep",
+            Self::DeepDreaming => "deep_dreaming",
+        }
+    }
+}
+
+impl std::fmt::Display for DreamTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Pluggable worker mode from brief §10.2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamWorkerMode {
+    /// `LLMDreamWorker`: one bounded LLM call over the selected window.
+    Llm,
+    /// `HybridDreamWorker`: deterministic prune, then bounded LLM call.
+    Hybrid,
+}
+
+/// Tier cadence descriptor from brief §10.1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamCadence {
+    /// Every Stop hook and every configured N turns.
+    StopHookAndTurns,
+    /// Hourly or immediately after high-salience writes.
+    HourlyOrHighSalience,
+    /// Nightly or externally triggered cron.
+    NightlyOrCron,
+}
+
+/// Tier input window descriptor from brief §10.1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamInputWindow {
+    /// Current session and the last 24 hours.
+    CurrentSessionAndLast24h,
+    /// Last seven days.
+    Last7Days,
+    /// Entire vault.
+    EntireVault,
+}
+
+/// Tier output descriptor from brief §10.1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DreamOutputKind {
+    /// Index updates and conflict markers.
+    IndexUpdatesAndConflictMarkers,
+    /// Consolidated records and reflection kicks.
+    ConsolidatedRecordsAndReflectionKicks,
+    /// Promotions, skills, synthesis pages, and lint report updates.
+    PromotionsSkillsSynthesisAndLint,
+}
+
+/// Budget and metadata for one dream tier.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DreamTierConfig {
+    /// Slot this config belongs to.
+    #[serde(default)]
+    pub tier: DreamTier,
+    /// When the tier is eligible to run.
+    pub cadence: DreamCadence,
+    /// Records the tier may read.
+    pub input_window: DreamInputWindow,
+    /// Durable output shape the tier may produce.
+    pub output_kind: DreamOutputKind,
+    /// Worker dispatch mode.
+    pub worker: DreamWorkerMode,
+    /// Number of recent eligible records the worker reads per run.
+    pub window_size_records: u32,
+
+    /// Approximate hard cap on the LLM completion in tokens. Mirrors
+    /// `ConsolidationConfig::token_budget` semantics.
+    pub completion_token_budget: u32,
+
+    /// Maximum wall-clock budget for one tier run.
+    pub max_wall_ms: u32,
+
+    /// Maximum tool calls allowed. P1 `llm` and `hybrid` workers do
+    /// not use tool calls, so defaults are zero. P2 agent mode owns
+    /// nonzero values.
+    pub max_tool_calls: u32,
+
+    /// LLM sampling temperature for distillation calls. Range `[0.0,
+    /// 2.0]`. Brief §10.2 expects deterministic distillation by
+    /// default; 0.0 keeps the dream record byte-stable for the same
+    /// input window.
+    pub llm_temperature: f32,
+}
+
+impl DreamTierConfig {
+    /// Default Light Sleep config.
+    #[must_use]
+    pub const fn light_sleep_default() -> Self {
+        Self {
+            tier: DreamTier::LightSleep,
+            cadence: DreamCadence::StopHookAndTurns,
+            input_window: DreamInputWindow::CurrentSessionAndLast24h,
+            output_kind: DreamOutputKind::IndexUpdatesAndConflictMarkers,
+            worker: DreamWorkerMode::Llm,
+            window_size_records: 16,
+            completion_token_budget: 1024,
+            max_wall_ms: 60_000,
+            max_tool_calls: 0,
+            llm_temperature: 0.0,
+        }
+    }
+
+    /// Default REM Sleep config.
+    #[must_use]
+    pub const fn rem_sleep_default() -> Self {
+        Self {
+            tier: DreamTier::RemSleep,
+            cadence: DreamCadence::HourlyOrHighSalience,
+            input_window: DreamInputWindow::Last7Days,
+            output_kind: DreamOutputKind::ConsolidatedRecordsAndReflectionKicks,
+            worker: DreamWorkerMode::Hybrid,
+            window_size_records: 128,
+            completion_token_budget: 4096,
+            max_wall_ms: 180_000,
+            max_tool_calls: 0,
+            llm_temperature: 0.0,
+        }
+    }
+
+    /// Default Deep Dreaming config.
+    #[must_use]
+    pub const fn deep_dreaming_default() -> Self {
+        Self {
+            tier: DreamTier::DeepDreaming,
+            cadence: DreamCadence::NightlyOrCron,
+            input_window: DreamInputWindow::EntireVault,
+            output_kind: DreamOutputKind::PromotionsSkillsSynthesisAndLint,
+            worker: DreamWorkerMode::Hybrid,
+            window_size_records: 1024,
+            completion_token_budget: 16_384,
+            max_wall_ms: 900_000,
+            max_tool_calls: 0,
+            llm_temperature: 0.0,
+        }
+    }
+}
+
+/// Typed configuration for the tiered `DreamWorkflow`.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DreamConfig {
@@ -16,32 +185,26 @@ pub struct DreamConfig {
     #[serde(default = "defaults::enabled")]
     pub enabled: bool,
 
-    /// Number of recent records the LLM worker reads per dream call.
-    /// Caps prompt size and per-call latency. Brief §10.1 calls this
-    /// the "window" — equivalent to the consolidation window.
-    #[serde(default = "defaults::window_size_records")]
-    pub window_size_records: u32,
+    /// Light Sleep tier.
+    #[serde(default = "DreamTierConfig::light_sleep_default")]
+    pub light_sleep: DreamTierConfig,
 
-    /// Approximate hard cap on the LLM completion in tokens. Mirrors
-    /// `ConsolidationConfig::token_budget` semantics.
-    #[serde(default = "defaults::completion_token_budget")]
-    pub completion_token_budget: u32,
+    /// REM Sleep tier.
+    #[serde(default = "DreamTierConfig::rem_sleep_default")]
+    pub rem_sleep: DreamTierConfig,
 
-    /// LLM sampling temperature for distillation calls. Range `[0.0,
-    /// 2.0]`. Brief §10.2 expects deterministic distillation by
-    /// default; 0.0 keeps the dream record byte-stable for the same
-    /// input window.
-    #[serde(default = "defaults::llm_temperature")]
-    pub llm_temperature: f32,
+    /// Deep Dreaming tier.
+    #[serde(default = "DreamTierConfig::deep_dreaming_default")]
+    pub deep_dreaming: DreamTierConfig,
 }
 
 impl Default for DreamConfig {
     fn default() -> Self {
         Self {
             enabled: defaults::enabled(),
-            window_size_records: defaults::window_size_records(),
-            completion_token_budget: defaults::completion_token_budget(),
-            llm_temperature: defaults::llm_temperature(),
+            light_sleep: DreamTierConfig::light_sleep_default(),
+            rem_sleep: DreamTierConfig::rem_sleep_default(),
+            deep_dreaming: DreamTierConfig::deep_dreaming_default(),
         }
     }
 }
@@ -54,15 +217,6 @@ mod defaults {
         // advertises a workflow that would `Permanent`-fail every
         // handle call.
         false
-    }
-    pub const fn window_size_records() -> u32 {
-        16
-    }
-    pub const fn completion_token_budget() -> u32 {
-        1024
-    }
-    pub const fn llm_temperature() -> f32 {
-        0.0
     }
 }
 
@@ -89,6 +243,16 @@ pub enum DreamConfigError {
         /// Maximum accepted value.
         max: f32,
     },
+    /// A tier config was placed in the wrong slot.
+    #[error("dream.{slot} has tier {actual}; expected {expected}")]
+    TierSlotMismatch {
+        /// Config slot.
+        slot: &'static str,
+        /// Expected tier.
+        expected: DreamTier,
+        /// Actual tier.
+        actual: DreamTier,
+    },
 }
 
 impl DreamConfig {
@@ -98,30 +262,58 @@ impl DreamConfig {
     /// Highest-acceptable `llm_temperature`.
     pub const TEMPERATURE_MAX: f32 = 2.0;
 
+    /// Return the config for `tier`.
+    #[must_use]
+    pub const fn tier_config(&self, tier: DreamTier) -> DreamTierConfig {
+        match tier {
+            DreamTier::LightSleep => self.light_sleep,
+            DreamTier::RemSleep => self.rem_sleep,
+            DreamTier::DeepDreaming => self.deep_dreaming,
+        }
+    }
+
     /// Validate semantic invariants the serde layer cannot express.
     ///
     /// # Errors
     /// Returns the first violated invariant.
     pub fn validate(&self) -> Result<(), DreamConfigError> {
-        if self.window_size_records == 0 {
-            return Err(DreamConfigError::ZeroWindow);
-        }
-        if self.completion_token_budget < Self::COMPLETION_BUDGET_FLOOR {
-            return Err(DreamConfigError::BudgetTooLow {
-                actual: self.completion_token_budget,
-                floor: Self::COMPLETION_BUDGET_FLOOR,
-            });
-        }
-        if !(0.0..=Self::TEMPERATURE_MAX).contains(&self.llm_temperature)
-            || self.llm_temperature.is_nan()
-        {
-            return Err(DreamConfigError::TemperatureOutOfRange {
-                actual: self.llm_temperature,
-                max: Self::TEMPERATURE_MAX,
-            });
-        }
+        validate_tier_slot("light_sleep", DreamTier::LightSleep, self.light_sleep)?;
+        validate_tier_slot("rem_sleep", DreamTier::RemSleep, self.rem_sleep)?;
+        validate_tier_slot("deep_dreaming", DreamTier::DeepDreaming, self.deep_dreaming)?;
         Ok(())
     }
+}
+
+fn validate_tier_slot(
+    slot: &'static str,
+    expected: DreamTier,
+    cfg: DreamTierConfig,
+) -> Result<(), DreamConfigError> {
+    if cfg.tier != expected {
+        return Err(DreamConfigError::TierSlotMismatch {
+            slot,
+            expected,
+            actual: cfg.tier,
+        });
+    }
+    if cfg.window_size_records == 0 {
+        return Err(DreamConfigError::ZeroWindow);
+    }
+    if cfg.completion_token_budget < DreamConfig::COMPLETION_BUDGET_FLOOR {
+        return Err(DreamConfigError::BudgetTooLow {
+            actual: cfg.completion_token_budget,
+            floor: DreamConfig::COMPLETION_BUDGET_FLOOR,
+        });
+    }
+    if !(0.0..=DreamConfig::TEMPERATURE_MAX).contains(&cfg.llm_temperature)
+        || cfg.llm_temperature.is_nan()
+    {
+        return Err(DreamConfigError::TemperatureOutOfRange {
+            actual: cfg.llm_temperature,
+            max: DreamConfig::TEMPERATURE_MAX,
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -129,18 +321,52 @@ mod tests {
     use super::*;
 
     #[test]
-    fn defaults_match_brief_p0() {
+    fn defaults_match_brief_p1_tiers() {
         let cfg = DreamConfig::default();
         assert!(!cfg.enabled, "dream P0 default is OFF (no llm provider)");
-        assert_eq!(cfg.window_size_records, 16);
-        assert_eq!(cfg.completion_token_budget, 1024);
-        assert!(cfg.llm_temperature.abs() < f32::EPSILON);
+        assert_eq!(cfg.light_sleep.tier, DreamTier::LightSleep);
+        assert_eq!(cfg.light_sleep.cadence, DreamCadence::StopHookAndTurns);
+        assert_eq!(
+            cfg.light_sleep.input_window,
+            DreamInputWindow::CurrentSessionAndLast24h
+        );
+        assert_eq!(
+            cfg.light_sleep.output_kind,
+            DreamOutputKind::IndexUpdatesAndConflictMarkers
+        );
+        assert_eq!(cfg.light_sleep.worker, DreamWorkerMode::Llm);
+        assert_eq!(cfg.light_sleep.window_size_records, 16);
+        assert_eq!(cfg.light_sleep.completion_token_budget, 1024);
+
+        assert_eq!(cfg.rem_sleep.tier, DreamTier::RemSleep);
+        assert_eq!(cfg.rem_sleep.cadence, DreamCadence::HourlyOrHighSalience);
+        assert_eq!(cfg.rem_sleep.input_window, DreamInputWindow::Last7Days);
+        assert_eq!(
+            cfg.rem_sleep.output_kind,
+            DreamOutputKind::ConsolidatedRecordsAndReflectionKicks
+        );
+        assert_eq!(cfg.rem_sleep.worker, DreamWorkerMode::Hybrid);
+
+        assert_eq!(cfg.deep_dreaming.tier, DreamTier::DeepDreaming);
+        assert_eq!(cfg.deep_dreaming.cadence, DreamCadence::NightlyOrCron);
+        assert_eq!(
+            cfg.deep_dreaming.input_window,
+            DreamInputWindow::EntireVault
+        );
+        assert_eq!(
+            cfg.deep_dreaming.output_kind,
+            DreamOutputKind::PromotionsSkillsSynthesisAndLint
+        );
+        assert_eq!(cfg.deep_dreaming.worker, DreamWorkerMode::Hybrid);
     }
 
     #[test]
     fn rejects_zero_window() {
         let cfg = DreamConfig {
-            window_size_records: 0,
+            light_sleep: DreamTierConfig {
+                window_size_records: 0,
+                ..DreamTierConfig::light_sleep_default()
+            },
             ..DreamConfig::default()
         };
         assert!(matches!(cfg.validate(), Err(DreamConfigError::ZeroWindow)));
@@ -149,7 +375,10 @@ mod tests {
     #[test]
     fn rejects_budget_below_floor() {
         let cfg = DreamConfig {
-            completion_token_budget: 63,
+            rem_sleep: DreamTierConfig {
+                completion_token_budget: 63,
+                ..DreamTierConfig::rem_sleep_default()
+            },
             ..DreamConfig::default()
         };
         assert!(matches!(
@@ -161,7 +390,10 @@ mod tests {
     #[test]
     fn rejects_temperature_out_of_range() {
         let cfg = DreamConfig {
-            llm_temperature: 2.5,
+            deep_dreaming: DreamTierConfig {
+                llm_temperature: 2.5,
+                ..DreamTierConfig::deep_dreaming_default()
+            },
             ..DreamConfig::default()
         };
         assert!(matches!(
@@ -173,7 +405,10 @@ mod tests {
     #[test]
     fn rejects_negative_temperature() {
         let cfg = DreamConfig {
-            llm_temperature: -0.1,
+            light_sleep: DreamTierConfig {
+                llm_temperature: -0.1,
+                ..DreamTierConfig::light_sleep_default()
+            },
             ..DreamConfig::default()
         };
         assert!(matches!(
@@ -185,12 +420,47 @@ mod tests {
     #[test]
     fn rejects_nan_temperature() {
         let cfg = DreamConfig {
-            llm_temperature: f32::NAN,
+            light_sleep: DreamTierConfig {
+                llm_temperature: f32::NAN,
+                ..DreamTierConfig::light_sleep_default()
+            },
             ..DreamConfig::default()
         };
         assert!(matches!(
             cfg.validate(),
             Err(DreamConfigError::TemperatureOutOfRange { .. })
         ));
+    }
+
+    #[test]
+    fn rejects_mismatched_tier_slot() {
+        let cfg = DreamConfig {
+            rem_sleep: DreamTierConfig {
+                tier: DreamTier::DeepDreaming,
+                ..DreamTierConfig::rem_sleep_default()
+            },
+            ..DreamConfig::default()
+        };
+        assert!(matches!(
+            cfg.validate(),
+            Err(DreamConfigError::TierSlotMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn resolves_tier_config() {
+        let cfg = DreamConfig::default();
+        assert_eq!(
+            cfg.tier_config(DreamTier::LightSleep).cadence,
+            DreamCadence::StopHookAndTurns
+        );
+        assert_eq!(
+            cfg.tier_config(DreamTier::RemSleep).input_window,
+            DreamInputWindow::Last7Days
+        );
+        assert_eq!(
+            cfg.tier_config(DreamTier::DeepDreaming).output_kind,
+            DreamOutputKind::PromotionsSkillsSynthesisAndLint
+        );
     }
 }

--- a/crates/cairn-core/src/config/mod.rs
+++ b/crates/cairn-core/src/config/mod.rs
@@ -4,7 +4,10 @@ pub mod consolidation;
 pub use consolidation::{ConsolidationConfig, ConsolidationConfigError};
 
 pub mod dream;
-pub use dream::{DreamConfig, DreamConfigError};
+pub use dream::{
+    DreamCadence, DreamConfig, DreamConfigError, DreamInputWindow, DreamOutputKind, DreamTier,
+    DreamTierConfig, DreamWorkerMode,
+};
 
 pub mod evaluation;
 pub use evaluation::{EvaluationConfig, EvaluationConfigError};

--- a/crates/cairn-core/src/config/snapshots/cairn_core__config__tests__default_config_snapshot.snap
+++ b/crates/cairn-core/src/config/snapshots/cairn_core__config__tests__default_config_snapshot.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cairn-core/src/config/mod.rs
-assertion_line: 2452
 expression: json
 ---
 {
@@ -203,9 +202,42 @@ expression: json
   },
   "dream": {
     "enabled": false,
-    "window_size_records": 16,
-    "completion_token_budget": 1024,
-    "llm_temperature": 0.0
+    "light_sleep": {
+      "tier": "light_sleep",
+      "cadence": "stop_hook_and_turns",
+      "input_window": "current_session_and_last24h",
+      "output_kind": "index_updates_and_conflict_markers",
+      "worker": "llm",
+      "window_size_records": 16,
+      "completion_token_budget": 1024,
+      "max_wall_ms": 60000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    },
+    "rem_sleep": {
+      "tier": "rem_sleep",
+      "cadence": "hourly_or_high_salience",
+      "input_window": "last7_days",
+      "output_kind": "consolidated_records_and_reflection_kicks",
+      "worker": "hybrid",
+      "window_size_records": 128,
+      "completion_token_budget": 4096,
+      "max_wall_ms": 180000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    },
+    "deep_dreaming": {
+      "tier": "deep_dreaming",
+      "cadence": "nightly_or_cron",
+      "input_window": "entire_vault",
+      "output_kind": "promotions_skills_synthesis_and_lint",
+      "worker": "hybrid",
+      "window_size_records": 1024,
+      "completion_token_budget": 16384,
+      "max_wall_ms": 900000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    }
   },
   "expiration": {
     "enabled": false,

--- a/crates/cairn-mcp/src/lib.rs
+++ b/crates/cairn-mcp/src/lib.rs
@@ -163,7 +163,7 @@ pub async fn serve_stdio_with_store_at_vault(
     principal: cairn_core::domain::ScopeTuple,
     vault_root: PathBuf,
 ) -> Result<(), TransportError> {
-    serve_stdio_with_store_io_at_vault(
+    Box::pin(serve_stdio_with_store_io_at_vault(
         store,
         sqlite_store,
         scope,
@@ -172,7 +172,7 @@ pub async fn serve_stdio_with_store_at_vault(
         vault_root,
         tokio::io::stdin(),
         tokio::io::stdout(),
-    )
+    ))
     .await
 }
 

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
-assertion_line: 110
 expression: "&c"
 ---
 {
@@ -238,9 +237,42 @@ expression: "&c"
   },
   "dream": {
     "enabled": false,
-    "window_size_records": 16,
-    "completion_token_budget": 1024,
-    "llm_temperature": 0.0
+    "light_sleep": {
+      "tier": "light_sleep",
+      "cadence": "stop_hook_and_turns",
+      "input_window": "current_session_and_last24h",
+      "output_kind": "index_updates_and_conflict_markers",
+      "worker": "llm",
+      "window_size_records": 16,
+      "completion_token_budget": 1024,
+      "max_wall_ms": 60000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    },
+    "rem_sleep": {
+      "tier": "rem_sleep",
+      "cadence": "hourly_or_high_salience",
+      "input_window": "last7_days",
+      "output_kind": "consolidated_records_and_reflection_kicks",
+      "worker": "hybrid",
+      "window_size_records": 128,
+      "completion_token_budget": 4096,
+      "max_wall_ms": 180000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    },
+    "deep_dreaming": {
+      "tier": "deep_dreaming",
+      "cadence": "nightly_or_cron",
+      "input_window": "entire_vault",
+      "output_kind": "promotions_skills_synthesis_and_lint",
+      "worker": "hybrid",
+      "window_size_records": 1024,
+      "completion_token_budget": 16384,
+      "max_wall_ms": 900000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    }
   },
   "expiration": {
     "enabled": false,

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
-assertion_line: 103
 expression: "&c"
 ---
 {
@@ -216,9 +215,42 @@ expression: "&c"
   },
   "dream": {
     "enabled": false,
-    "window_size_records": 16,
-    "completion_token_budget": 1024,
-    "llm_temperature": 0.0
+    "light_sleep": {
+      "tier": "light_sleep",
+      "cadence": "stop_hook_and_turns",
+      "input_window": "current_session_and_last24h",
+      "output_kind": "index_updates_and_conflict_markers",
+      "worker": "llm",
+      "window_size_records": 16,
+      "completion_token_budget": 1024,
+      "max_wall_ms": 60000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    },
+    "rem_sleep": {
+      "tier": "rem_sleep",
+      "cadence": "hourly_or_high_salience",
+      "input_window": "last7_days",
+      "output_kind": "consolidated_records_and_reflection_kicks",
+      "worker": "hybrid",
+      "window_size_records": 128,
+      "completion_token_budget": 4096,
+      "max_wall_ms": 180000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    },
+    "deep_dreaming": {
+      "tier": "deep_dreaming",
+      "cadence": "nightly_or_cron",
+      "input_window": "entire_vault",
+      "output_kind": "promotions_skills_synthesis_and_lint",
+      "worker": "hybrid",
+      "window_size_records": 1024,
+      "completion_token_budget": 16384,
+      "max_wall_ms": 900000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    }
   },
   "expiration": {
     "enabled": false,

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cairn-test-fixtures/tests/schema_fixtures.rs
-assertion_line: 96
 expression: "&c"
 ---
 {
@@ -203,9 +202,42 @@ expression: "&c"
   },
   "dream": {
     "enabled": false,
-    "window_size_records": 16,
-    "completion_token_budget": 1024,
-    "llm_temperature": 0.0
+    "light_sleep": {
+      "tier": "light_sleep",
+      "cadence": "stop_hook_and_turns",
+      "input_window": "current_session_and_last24h",
+      "output_kind": "index_updates_and_conflict_markers",
+      "worker": "llm",
+      "window_size_records": 16,
+      "completion_token_budget": 1024,
+      "max_wall_ms": 60000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    },
+    "rem_sleep": {
+      "tier": "rem_sleep",
+      "cadence": "hourly_or_high_salience",
+      "input_window": "last7_days",
+      "output_kind": "consolidated_records_and_reflection_kicks",
+      "worker": "hybrid",
+      "window_size_records": 128,
+      "completion_token_budget": 4096,
+      "max_wall_ms": 180000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    },
+    "deep_dreaming": {
+      "tier": "deep_dreaming",
+      "cadence": "nightly_or_cron",
+      "input_window": "entire_vault",
+      "output_kind": "promotions_skills_synthesis_and_lint",
+      "worker": "hybrid",
+      "window_size_records": 1024,
+      "completion_token_budget": 16384,
+      "max_wall_ms": 900000,
+      "max_tool_calls": 0,
+      "llm_temperature": 0.0
+    }
   },
   "expiration": {
     "enabled": false,

--- a/crates/cairn-workflows/src/dream/handler.rs
+++ b/crates/cairn-workflows/src/dream/handler.rs
@@ -1,24 +1,23 @@
-//! `DreamHandler` — minimum-path P0 distillation worker (issue #91,
-//! brief §10.1, §10.2).
+//! `DreamHandler` — tiered dream distillation worker (brief §10.1, §10.2).
 //!
-//! The "Light"-tier `LLMDreamWorker`: reads up to `window_size_records`
-//! recent records bound by the payload's scope, asks an `LLMProvider`
-//! for a short distillation, and upserts a deterministic `reasoning`
-//! record summarizing the dream. When no `LLMProvider` is wired the
-//! handler returns
+//! The `llm` mode reads up to the tier's configured
+//! `window_size_records` recent records bound by the payload's scope.
+//! The `hybrid` mode first prunes duplicate bodies, then uses the same
+//! bounded LLM distillation call. Both modes upsert a deterministic
+//! `reasoning` record carrying tier, worker, budget, and source
+//! evidence metadata. When no `LLMProvider` is wired the handler returns
 //! [`HandlerOutcome::Permanent`](crate::scheduler::HandlerOutcome) so
 //! the scheduler stops retrying — the capability gate in `status`
 //! mirrors this by holding back `cairn.workflows.v1.dream`.
 //!
 //! Out of scope (deferred to follow-ups, brief §10.1):
-//! * REM / Deep tiers (cron-driven, multi-bucket workflows).
-//! * `AgentDreamWorker` / `HybridDreamWorker` pluggable workers.
+//! * `AgentDreamWorker` / P2 tool-loop workers.
 //! * WAL `FlushPlan` integration — the minimum path upserts directly via
 //!   `MemoryStore::upsert` like the existing consolidation handler.
 
 use std::sync::Arc;
 
-use cairn_core::config::DreamConfig;
+use cairn_core::config::{DreamConfig, DreamTierConfig, DreamWorkerMode, ExtractBudget};
 use cairn_core::contract::job_store::{FailureClass, JobKind, JobPayload};
 use cairn_core::contract::llm_provider::{CompletionOutput, CompletionRequest, LLMProvider};
 use cairn_core::contract::memory_store::{ListArgs, MemoryStore, TombstoneReason};
@@ -86,6 +85,8 @@ impl DreamHandler {
             return Err("no llm provider configured".into());
         };
 
+        let tier_config = self.config.tier_config(payload.tier);
+
         // Collect `window_size_records` *non-dream* records, paging
         // through `list` until we either reach the cap or exhaust
         // the store. Without this, a single capped page that
@@ -93,9 +94,10 @@ impl DreamHandler {
         // would silently shrink the source set, shift the
         // sources-hash in `target_key`, and produce a new target on
         // replay (round-2 adversarial review #2).
-        let window_cap = self.config.window_size_records as usize;
+        let window_cap = tier_config.window_size_records as usize;
         let mut filtered: Vec<cairn_core::domain::record::MemoryRecord> =
             Vec::with_capacity(window_cap);
+        let mut seen_body_hashes = std::collections::BTreeSet::new();
         let mut cursor = None;
         let mut cursor_exhausted = false;
         for _ in 0..DREAM_FETCH_PAGE_CAP {
@@ -116,6 +118,12 @@ impl DreamHandler {
                         == Some("cairn-workflows::DreamHandler")
                 }) {
                     continue;
+                }
+                if tier_config.worker == DreamWorkerMode::Hybrid {
+                    let body_hash = crate::synthetic::sha256_hex(r.body.as_bytes());
+                    if !seen_body_hashes.insert(body_hash) {
+                        continue;
+                    }
                 }
                 filtered.push(r);
                 if filtered.len() >= window_cap {
@@ -176,7 +184,11 @@ impl DreamHandler {
             .map(ScopeTuple::canonical_wire)
             .unwrap_or_default();
         let sources_hash = crate::synthetic::sha256_hex(source_record_ids.join(",").as_bytes());
-        let target_key = format!("dream:{scope_wire}:{key}:{sources_hash}", key = payload.key);
+        let target_key = format!(
+            "dream:{tier}:{scope_wire}:{key}:{sources_hash}",
+            tier = payload.tier.as_str(),
+            key = payload.key
+        );
 
         // Pre-LLM existence check: if an active dream record already
         // exists at this deterministic target, skip the LLM call. Two
@@ -240,8 +252,15 @@ impl DreamHandler {
             }
         }
 
-        let prompt = render_dream_prompt(&payload.key, &filtered);
-        let req = CompletionRequest::builder().prompt(prompt).build();
+        let prompt = render_dream_prompt(&payload.key, &filtered, &tier_config);
+        let req = CompletionRequest::builder()
+            .prompt(prompt)
+            .budget(ExtractBudget {
+                max_tokens: Some(tier_config.completion_token_budget),
+                max_wall_ms: Some(tier_config.max_wall_ms),
+                max_turns: None,
+            })
+            .build();
         let body = match llm.complete(&req).await? {
             CompletionOutput::Text(s) => s,
             CompletionOutput::Json(v) => serde_json::to_string(&v).unwrap_or_default(),
@@ -250,6 +269,16 @@ impl DreamHandler {
             // crashing the workflow.
             other => format!("{other:?}"),
         };
+        let body_budget = tier_config.completion_token_budget as usize * 4;
+        if body.len() > body_budget {
+            return Err(format!(
+                "dream budget exceeded for tier {tier}: body length {actual} > char budget {budget}",
+                tier = payload.tier,
+                actual = body.len(),
+                budget = body_budget,
+            )
+            .into());
+        }
 
         let mut extras = std::collections::BTreeMap::new();
         extras.insert(
@@ -257,6 +286,19 @@ impl DreamHandler {
             serde_json::json!({
                 "source_record_ids": source_record_ids,
                 "window_size":        filtered.len(),
+                "tier":               payload.tier.as_str(),
+                "worker":             match tier_config.worker {
+                    DreamWorkerMode::Llm => "llm",
+                    DreamWorkerMode::Hybrid => "hybrid",
+                },
+                "cadence":            tier_config.cadence,
+                "input_window":       tier_config.input_window,
+                "output_kind":        tier_config.output_kind,
+                "budget": {
+                    "max_tokens":     tier_config.completion_token_budget,
+                    "max_wall_ms":    tier_config.max_wall_ms,
+                    "max_tool_calls": tier_config.max_tool_calls,
+                },
                 "produced_by":        "cairn-workflows::DreamHandler",
             }),
         );
@@ -387,9 +429,19 @@ fn scope_for(payload: &DreamPayload) -> ScopeTuple {
 pub fn render_dream_prompt(
     key: &str,
     records: &[cairn_core::domain::record::MemoryRecord],
+    tier_config: &DreamTierConfig,
 ) -> String {
     let mut s = String::with_capacity(256 + records.len() * 128);
     s.push_str("# Dream distillation\n\n");
+    s.push_str("Tier: ");
+    s.push_str(tier_config.tier.as_str());
+    s.push('\n');
+    s.push_str("Worker: ");
+    s.push_str(match tier_config.worker {
+        DreamWorkerMode::Llm => "llm",
+        DreamWorkerMode::Hybrid => "hybrid",
+    });
+    s.push('\n');
     s.push_str("Key: ");
     s.push_str(key);
     s.push_str("\nRecords:\n");
@@ -461,6 +513,7 @@ impl JobHandler for DreamHandler {
 mod tests {
     use super::*;
     use crate::test_support::NoopMemoryStore;
+    use cairn_core::config::DreamTier;
 
     #[tokio::test]
     async fn handle_returns_permanent_when_no_llm() {
@@ -474,6 +527,7 @@ mod tests {
             None,
         );
         let p = DreamPayload {
+            tier: DreamTier::LightSleep,
             key: "sess-1".into(),
             bound_scope: None,
         };
@@ -492,8 +546,9 @@ mod tests {
 
     #[test]
     fn render_dream_prompt_is_deterministic_for_empty_window() {
-        let a = render_dream_prompt("k", &[]);
-        let b = render_dream_prompt("k", &[]);
+        let tier = DreamTierConfig::light_sleep_default();
+        let a = render_dream_prompt("k", &[], &tier);
+        let b = render_dream_prompt("k", &[], &tier);
         assert_eq!(a, b);
     }
 }

--- a/crates/cairn-workflows/src/dream/mod.rs
+++ b/crates/cairn-workflows/src/dream/mod.rs
@@ -1,9 +1,11 @@
-//! Minimum-path `DreamWorkflow` (issue #91, brief §10.1, §10.2).
+//! Tiered `DreamWorkflow` support (brief §10.1, §10.2).
 //!
 //! See [`handler::DreamHandler`] for the entry point and scope notes.
 
 pub mod handler;
 pub mod payload;
+pub mod trigger;
 
 pub use handler::{DREAM_KIND, DreamHandler, render_dream_prompt};
 pub use payload::DreamPayload;
+pub use trigger::{DreamEnqueueDecision, enqueue_tier, enqueue_tier_with_dedupe_token};

--- a/crates/cairn-workflows/src/dream/payload.rs
+++ b/crates/cairn-workflows/src/dream/payload.rs
@@ -4,13 +4,17 @@
 //! [`crate::consolidation::ConsolidationPayload`].
 
 use cairn_core::contract::job_store::JobPayload;
-use cairn_core::domain::ScopeTuple;
+use cairn_core::{config::DreamTier, domain::ScopeTuple};
 use serde::{Deserialize, Serialize};
 
 /// One enqueued dream-distillation request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DreamPayload {
+    /// Dream tier being run. Defaults to Light Sleep so old queued
+    /// v0.1 payloads can still drain after an upgrade.
+    #[serde(default)]
+    pub tier: DreamTier,
     /// Logical key the handler uses when building the synthesized
     /// dream record's stable `target_id`. For session-scoped Light
     /// dreams this is the session id; future Deep dreams may pass a
@@ -51,7 +55,11 @@ impl DreamPayload {
             .as_ref()
             .map(cairn_core::domain::ScopeTuple::canonical_wire)
             .unwrap_or_default();
-        format!("dream:{scope_wire}:{key}", key = self.key)
+        format!(
+            "dream:{tier}:{scope_wire}:{key}",
+            tier = self.tier.as_str(),
+            key = self.key
+        )
     }
 
     /// Serialize to `JobPayload`.
@@ -78,6 +86,7 @@ mod tests {
     #[test]
     fn roundtrip() {
         let p = DreamPayload {
+            tier: DreamTier::LightSleep,
             key: "sess-1".into(),
             bound_scope: None,
         };
@@ -89,6 +98,7 @@ mod tests {
     #[test]
     fn roundtrip_with_scope() {
         let p = DreamPayload {
+            tier: DreamTier::RemSleep,
             key: "sess-1".into(),
             bound_scope: Some(ScopeTuple {
                 tenant: Some("acme".into()),
@@ -109,11 +119,13 @@ mod tests {
     #[test]
     fn queue_key_distinguishes_by_scope() {
         let a = DreamPayload {
+            tier: DreamTier::LightSleep,
             key: "k".into(),
             bound_scope: None,
         }
         .recommended_queue_key();
         let b = DreamPayload {
+            tier: DreamTier::LightSleep,
             key: "k".into(),
             bound_scope: Some(ScopeTuple {
                 tenant: Some("acme".into()),
@@ -124,10 +136,25 @@ mod tests {
         assert_ne!(a, b, "scope must split the queue key");
         // Same scope + key → same queue key.
         let c = DreamPayload {
+            tier: DreamTier::LightSleep,
             key: "k".into(),
             bound_scope: None,
         }
         .recommended_queue_key();
         assert_eq!(a, c);
+
+        let d = DreamPayload {
+            tier: DreamTier::RemSleep,
+            key: "k".into(),
+            bound_scope: None,
+        }
+        .recommended_queue_key();
+        assert_ne!(a, d, "tier must split the queue key");
+    }
+
+    #[test]
+    fn legacy_payload_defaults_to_light_sleep() {
+        let back = DreamPayload::from_bytes(br#"{"key":"sess-legacy"}"#).expect("decode");
+        assert_eq!(back.tier, DreamTier::LightSleep);
     }
 }

--- a/crates/cairn-workflows/src/dream/trigger.rs
+++ b/crates/cairn-workflows/src/dream/trigger.rs
@@ -1,0 +1,158 @@
+//! Enqueue tiered `DreamWorkflow` jobs from scheduled or hook triggers.
+
+use cairn_core::config::{DreamConfig, DreamTier};
+use cairn_core::contract::job_store::{
+    EnqueueRequest, JobId, JobKind, JobStore, JobStoreError, RetryPolicy,
+};
+
+use super::{DREAM_KIND, DreamPayload};
+
+/// Result of evaluating a dream tier trigger.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DreamEnqueueDecision {
+    /// A job was accepted or deduplicated.
+    Enqueued {
+        /// Stable job id used for the enqueue attempt.
+        job_id: JobId,
+    },
+    /// Dream workflow is disabled.
+    Disabled,
+}
+
+/// Enqueue one tier run.
+///
+/// # Errors
+/// Returns backend errors from the job store. Duplicate dedupe keys are
+/// idempotent success.
+pub async fn enqueue_tier(
+    store: &dyn JobStore,
+    config: &DreamConfig,
+    tier: DreamTier,
+    key: &str,
+    now_ms: i64,
+    bound_scope: Option<&cairn_core::domain::ScopeTuple>,
+) -> Result<DreamEnqueueDecision, JobStoreError> {
+    enqueue_tier_with_dedupe_token(
+        store,
+        config,
+        tier,
+        key,
+        &now_ms.to_string(),
+        now_ms,
+        bound_scope,
+    )
+    .await
+}
+
+/// Same as [`enqueue_tier`], but lets hook-triggered callers provide a stable
+/// token such as a closed-turn sequence while retaining wall-clock
+/// `not_before_ms` scheduling.
+///
+/// # Errors
+/// Returns backend errors from the job store. Duplicate dedupe keys are
+/// idempotent success.
+pub async fn enqueue_tier_with_dedupe_token(
+    store: &dyn JobStore,
+    config: &DreamConfig,
+    tier: DreamTier,
+    key: &str,
+    dedupe_token: &str,
+    not_before_ms: i64,
+    bound_scope: Option<&cairn_core::domain::ScopeTuple>,
+) -> Result<DreamEnqueueDecision, JobStoreError> {
+    if !config.enabled {
+        return Ok(DreamEnqueueDecision::Disabled);
+    }
+
+    let payload = DreamPayload {
+        tier,
+        key: key.to_owned(),
+        bound_scope: bound_scope.cloned(),
+    };
+    let bytes = payload
+        .to_bytes()
+        .map_err(|e| JobStoreError::Backend(e.to_string()))?;
+    let queue_key = payload.recommended_queue_key();
+    let job_id = JobId::new(format!("dream:{}:{key}:{dedupe_token}", tier.as_str()));
+    let req = EnqueueRequest {
+        job_id: job_id.clone(),
+        kind: JobKind::new(DREAM_KIND),
+        payload: bytes,
+        queue_key: Some(queue_key.clone()),
+        dedupe_key: Some(format!("{queue_key}:{dedupe_token}")),
+        not_before_ms,
+        retry: RetryPolicy::DEFAULT,
+    };
+    match store.enqueue(req).await {
+        Ok(()) | Err(JobStoreError::DuplicateDedupeKey { .. }) => {
+            Ok(DreamEnqueueDecision::Enqueued { job_id })
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::SqliteJobStore;
+    use crate::sqlite_store::install_for_tests;
+    use rusqlite::Connection;
+
+    fn store() -> Arc<dyn JobStore> {
+        let conn = Connection::open_in_memory().expect("conn");
+        install_for_tests(&conn);
+        Arc::new(SqliteJobStore::new(conn).expect("store"))
+    }
+
+    #[tokio::test]
+    async fn disabled_returns_disabled() {
+        let s = store();
+        let cfg = DreamConfig::default();
+        let decision = enqueue_tier(&*s, &cfg, DreamTier::LightSleep, "session", 1_000, None)
+            .await
+            .expect("ok");
+        assert_eq!(decision, DreamEnqueueDecision::Disabled);
+    }
+
+    #[tokio::test]
+    async fn enqueues_each_tier_with_distinct_job_ids() {
+        let s = store();
+        let cfg = DreamConfig {
+            enabled: true,
+            ..DreamConfig::default()
+        };
+        let light = enqueue_tier(&*s, &cfg, DreamTier::LightSleep, "session", 1_000, None)
+            .await
+            .expect("light");
+        let rem = enqueue_tier(&*s, &cfg, DreamTier::RemSleep, "session", 1_000, None)
+            .await
+            .expect("rem");
+        let deep = enqueue_tier(&*s, &cfg, DreamTier::DeepDreaming, "vault", 1_000, None)
+            .await
+            .expect("deep");
+
+        assert_ne!(light, rem);
+        assert_ne!(rem, deep);
+        assert!(matches!(light, DreamEnqueueDecision::Enqueued { .. }));
+        assert!(matches!(rem, DreamEnqueueDecision::Enqueued { .. }));
+        assert!(matches!(deep, DreamEnqueueDecision::Enqueued { .. }));
+    }
+
+    #[tokio::test]
+    async fn second_enqueue_is_idempotent() {
+        let s = store();
+        let cfg = DreamConfig {
+            enabled: true,
+            ..DreamConfig::default()
+        };
+        let first = enqueue_tier(&*s, &cfg, DreamTier::RemSleep, "session", 1_000, None)
+            .await
+            .expect("first");
+        let second = enqueue_tier(&*s, &cfg, DreamTier::RemSleep, "session", 1_000, None)
+            .await
+            .expect("second");
+        assert_eq!(first, second);
+    }
+}

--- a/crates/cairn-workflows/src/lib.rs
+++ b/crates/cairn-workflows/src/lib.rs
@@ -35,7 +35,10 @@ pub use drainer::{
     WorkflowCheckpointStore, WorkflowContext, WorkflowDrainer, WorkflowError,
     WorkflowStatusSnapshot,
 };
-pub use dream::{DREAM_KIND, DreamHandler, DreamPayload};
+pub use dream::{
+    DREAM_KIND, DreamEnqueueDecision, DreamHandler, DreamPayload, enqueue_tier,
+    enqueue_tier_with_dedupe_token,
+};
 pub use evaluation::{
     CheckOutcome, EVALUATION_KIND, EvaluationHandler, EvaluationPayload, EvaluationReport,
     GoldenCheck, OrphanCheck, TombstoneConsistencyCheck, default_checks as default_golden_checks,

--- a/crates/cairn-workflows/src/planners.rs
+++ b/crates/cairn-workflows/src/planners.rs
@@ -45,6 +45,9 @@ pub struct PromotePlanSource {
 
 impl PromotePlanSource {
     const DEFAULT_PAGE_LIMIT: usize = 1000;
+    const MIN_RECALL_COUNT: u32 = 3;
+    const MIN_EVIDENCE_SCORE: f32 = 0.7;
+    const MIN_UNIQUE_QUERIES: u32 = 2;
 
     /// Create a promotion planner for active records with confidence greater
     /// than or equal to `confidence_threshold`.
@@ -218,7 +221,10 @@ impl WorkflowPlanSource for PromotePlanSource {
 
         let mut plans = Vec::new();
         for record in list_active_records(&self.store, workflow, self.page_limit).await? {
-            if record.kind == self.to_kind || record.confidence < self.confidence_threshold {
+            if record.kind == self.to_kind
+                || record.confidence < self.confidence_threshold
+                || !Self::evidence_gate_passes(&record)
+            {
                 continue;
             }
             plans.push(self.plan_for_record(&record));
@@ -316,9 +322,23 @@ impl ExpirePlanSource {
 }
 
 impl PromotePlanSource {
+    fn evidence_gate_passes(record: &MemoryRecord) -> bool {
+        record.evidence.validate().is_ok()
+            && record.evidence.recall_count >= Self::MIN_RECALL_COUNT
+            && record.evidence.score >= Self::MIN_EVIDENCE_SCORE
+            && record.evidence.unique_queries >= Self::MIN_UNIQUE_QUERIES
+    }
+
     fn plan_for_record(&self, record: &MemoryRecord) -> FlushPlan {
         let issued_at = now_rfc3339();
         let expires_at = expires_at_rfc3339();
+        let evidence_refs = promotion_evidence_refs(record);
+        let evidence_key = evidence_refs
+            .iter()
+            .map(|id| id.0.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+        let evidence_count = u32::try_from(evidence_refs.len()).unwrap_or(u32::MAX);
         FlushPlan {
             operation_id: stable_plan_ulid(&[
                 "promote",
@@ -328,6 +348,7 @@ impl PromotePlanSource {
                 self.to_kind.as_str(),
                 &record.confidence.to_bits().to_string(),
                 &self.confidence_threshold.to_bits().to_string(),
+                &evidence_key,
             ]),
             issued_at,
             issuer: self.issuer.clone(),
@@ -337,13 +358,13 @@ impl PromotePlanSource {
             mutations: vec![PlannedMutation::Promote {
                 from: record.target_id.clone(),
                 to_kind: self.to_kind,
-                evidence: Vec::new(),
+                evidence: evidence_refs.clone(),
             }],
             reason: PlanReason::Promote {
                 confidence: record.confidence,
-                evidence_count: 0,
+                evidence_count,
             },
-            source_events: Vec::new(),
+            source_events: evidence_refs,
             target_hashes: std::collections::BTreeMap::new(),
             dependencies: Vec::new(),
             expires_at,
@@ -567,6 +588,17 @@ fn looks_like_tool_error(body: &str) -> bool {
 
 fn evidence_count_for(candidate: &ReflectionCandidate) -> u32 {
     u32::try_from(candidate.evidence_record_ids.len()).unwrap_or(u32::MAX)
+}
+
+fn promotion_evidence_refs(record: &MemoryRecord) -> Vec<Ulid> {
+    if record.source_ids.is_empty() {
+        return vec![Ulid(record.id.as_str().to_owned())];
+    }
+    record
+        .source_ids
+        .iter()
+        .map(|id| Ulid(id.as_str().to_owned()))
+        .collect()
 }
 
 async fn list_active_records(

--- a/crates/cairn-workflows/tests/dream.rs
+++ b/crates/cairn-workflows/tests/dream.rs
@@ -2,10 +2,10 @@
 //! record when an `LLMProvider` is wired, and declines `Permanent`
 //! when none is configured (issue #91).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use cairn_core::config::DreamConfig;
+use cairn_core::config::{DreamConfig, DreamTier, DreamTierConfig};
 use cairn_core::contract::llm_provider::{
     CompletionOutput, CompletionRequest, LLMProvider, LLMProviderCapabilities, LlmError,
 };
@@ -41,6 +41,33 @@ impl LLMProvider for FakeLlm {
     }
 }
 
+struct CapturingLlm {
+    body: String,
+    prompt: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait]
+impl LLMProvider for CapturingLlm {
+    fn name(&self) -> &'static str {
+        "capturing-llm"
+    }
+    fn capabilities(&self) -> &LLMProviderCapabilities {
+        static CAPS: LLMProviderCapabilities = LLMProviderCapabilities {
+            json_mode: false,
+            streaming: false,
+            tool_calls: false,
+        };
+        &CAPS
+    }
+    fn supported_contract_versions(&self) -> VersionRange {
+        VersionRange::new(ContractVersion::new(0, 1, 0), ContractVersion::new(0, 2, 0))
+    }
+    async fn complete(&self, req: &CompletionRequest) -> Result<CompletionOutput, LlmError> {
+        *self.prompt.lock().expect("prompt lock") = Some(req.prompt.clone());
+        Ok(CompletionOutput::Text(self.body.clone()))
+    }
+}
+
 #[tokio::test]
 async fn no_llm_returns_permanent() {
     let store: Arc<dyn MemoryStore> = Arc::new(memstore().await);
@@ -53,6 +80,7 @@ async fn no_llm_returns_permanent() {
         None,
     );
     let payload = DreamPayload {
+        tier: DreamTier::LightSleep,
         key: "sess-1".into(),
         bound_scope: None,
     };
@@ -71,7 +99,10 @@ async fn with_llm_upserts_dream_record() {
         dyn_store,
         DreamConfig {
             enabled: true,
-            window_size_records: 4,
+            light_sleep: DreamTierConfig {
+                window_size_records: 4,
+                ..DreamTierConfig::light_sleep_default()
+            },
             ..DreamConfig::default()
         },
         Some(Arc::new(FakeLlm {
@@ -79,6 +110,7 @@ async fn with_llm_upserts_dream_record() {
         })),
     );
     let payload = DreamPayload {
+        tier: DreamTier::LightSleep,
         key: "sess-1".into(),
         bound_scope: None,
     };
@@ -106,6 +138,165 @@ async fn with_llm_upserts_dream_record() {
         dream.is_some(),
         "no dream record found in: {:?}",
         listed.records.iter().map(|r| &r.body).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn rem_sleep_records_tier_worker_budget_and_source_evidence() {
+    let store = Arc::new(memstore().await);
+    store.upsert(&sample_record(11)).await.expect("seed record");
+
+    let dyn_store: Arc<dyn MemoryStore> = store.clone();
+    let handler = DreamHandler::new(
+        dyn_store,
+        DreamConfig {
+            enabled: true,
+            rem_sleep: DreamTierConfig {
+                window_size_records: 4,
+                completion_token_budget: 128,
+                max_wall_ms: 12_345,
+                ..DreamTierConfig::rem_sleep_default()
+            },
+            ..DreamConfig::default()
+        },
+        Some(Arc::new(FakeLlm {
+            body: "rem dream body",
+        })),
+    );
+    let payload = DreamPayload {
+        tier: DreamTier::RemSleep,
+        key: "sess-rem".into(),
+        bound_scope: None,
+    };
+
+    let outcome = handler.handle(&payload.to_bytes().expect("encode")).await;
+    assert!(
+        matches!(outcome, HandlerOutcome::Done),
+        "expected Done, got {outcome:?}"
+    );
+
+    let listed = store
+        .list(&ListArgs {
+            limit: 100,
+            ..ListArgs::default()
+        })
+        .await
+        .expect("list");
+    let dream = listed
+        .records
+        .iter()
+        .find(|r| r.body == "rem dream body")
+        .expect("rem dream record");
+    let meta = dream
+        .extra_frontmatter
+        .get("dream")
+        .expect("dream metadata");
+    assert_eq!(meta["tier"], "rem_sleep");
+    assert_eq!(meta["worker"], "hybrid");
+    assert_eq!(meta["budget"]["max_tokens"], 128);
+    assert_eq!(meta["budget"]["max_wall_ms"], 12_345);
+    assert_eq!(
+        meta["source_record_ids"].as_array().expect("sources").len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn budget_exceeded_retries_without_upsert() {
+    let store = Arc::new(memstore().await);
+    store.upsert(&sample_record(12)).await.expect("seed record");
+
+    let dyn_store: Arc<dyn MemoryStore> = store.clone();
+    let handler = DreamHandler::new(
+        dyn_store,
+        DreamConfig {
+            enabled: true,
+            light_sleep: DreamTierConfig {
+                completion_token_budget: DreamConfig::COMPLETION_BUDGET_FLOOR,
+                ..DreamTierConfig::light_sleep_default()
+            },
+            ..DreamConfig::default()
+        },
+        Some(Arc::new(CapturingLlm {
+            body: "x".repeat((DreamConfig::COMPLETION_BUDGET_FLOOR as usize * 4) + 1),
+            prompt: Arc::new(Mutex::new(None)),
+        })),
+    );
+    let payload = DreamPayload {
+        tier: DreamTier::LightSleep,
+        key: "sess-budget".into(),
+        bound_scope: None,
+    };
+
+    let outcome = handler.handle(&payload.to_bytes().expect("encode")).await;
+    assert!(
+        matches!(outcome, HandlerOutcome::Retry { .. }),
+        "expected Retry, got {outcome:?}"
+    );
+
+    let listed = store
+        .list(&ListArgs {
+            limit: 100,
+            ..ListArgs::default()
+        })
+        .await
+        .expect("list");
+    assert!(
+        listed.records.iter().all(|r| !r.body.starts_with('x')),
+        "budget-exceeded body must not be upserted"
+    );
+}
+
+#[tokio::test]
+async fn hybrid_worker_prunes_duplicate_bodies_before_prompting() {
+    let store = Arc::new(memstore().await);
+    let mut first = sample_record(21);
+    first.body = "duplicate source body".into();
+    let mut second = sample_record(22);
+    second.body = "duplicate source body".into();
+    store.upsert(&first).await.expect("seed first");
+    store.upsert(&second).await.expect("seed second");
+
+    let prompt = Arc::new(Mutex::new(None));
+    let dyn_store: Arc<dyn MemoryStore> = store.clone();
+    let handler = DreamHandler::new(
+        dyn_store,
+        DreamConfig {
+            enabled: true,
+            rem_sleep: DreamTierConfig {
+                window_size_records: 4,
+                ..DreamTierConfig::rem_sleep_default()
+            },
+            ..DreamConfig::default()
+        },
+        Some(Arc::new(CapturingLlm {
+            body: "hybrid body".into(),
+            prompt: prompt.clone(),
+        })),
+    );
+    let payload = DreamPayload {
+        tier: DreamTier::RemSleep,
+        key: "sess-hybrid".into(),
+        bound_scope: None,
+    };
+
+    let outcome = handler.handle(&payload.to_bytes().expect("encode")).await;
+    assert!(
+        matches!(outcome, HandlerOutcome::Done),
+        "expected Done, got {outcome:?}"
+    );
+    let captured = prompt
+        .lock()
+        .expect("prompt lock")
+        .clone()
+        .expect("prompt captured");
+    let record_lines = captured
+        .lines()
+        .filter(|line| line.starts_with("- "))
+        .count();
+    assert_eq!(
+        record_lines, 1,
+        "hybrid prune should keep one duplicate body"
     );
 }
 
@@ -160,12 +351,16 @@ async fn second_run_skips_llm_when_target_already_exists() {
         dyn_store,
         DreamConfig {
             enabled: true,
-            window_size_records: 4,
+            light_sleep: DreamTierConfig {
+                window_size_records: 4,
+                ..DreamTierConfig::light_sleep_default()
+            },
             ..DreamConfig::default()
         },
         Some(llm as Arc<dyn LLMProvider>),
     );
     let payload = DreamPayload {
+        tier: DreamTier::LightSleep,
         key: "sess-42".into(),
         bound_scope: None,
     };
@@ -200,12 +395,16 @@ async fn replay_is_idempotent() {
         dyn_store,
         DreamConfig {
             enabled: true,
-            window_size_records: 4,
+            light_sleep: DreamTierConfig {
+                window_size_records: 4,
+                ..DreamTierConfig::light_sleep_default()
+            },
             ..DreamConfig::default()
         },
         Some(Arc::new(FakeLlm { body: "stable" })),
     );
     let payload = DreamPayload {
+        tier: DreamTier::LightSleep,
         key: "sess-2".into(),
         bound_scope: None,
     };

--- a/crates/cairn-workflows/tests/expire_plan_source.rs
+++ b/crates/cairn-workflows/tests/expire_plan_source.rs
@@ -7,7 +7,8 @@ use cairn_core::contract::memory_store::MemoryStore as _;
 use cairn_core::domain::record::Ed25519Signature;
 use cairn_core::domain::taxonomy::MemoryClass;
 use cairn_core::domain::{
-    ExpirationReason, FlushMode, Identity, MemoryKind, PlanReason, PlannedMutation,
+    EvidenceVector, ExpirationReason, FlushMode, Identity, MemoryKind, PlanReason, PlannedMutation,
+    SourceId,
 };
 use cairn_test_fixtures::{FixtureStore, memstore, sample_record};
 use cairn_workflows::{
@@ -138,6 +139,12 @@ async fn promote_plan_source_emits_promote_plan_for_confident_non_target_kind() 
     let mut candidate = sample_record(4);
     candidate.kind = MemoryKind::Reference;
     candidate.confidence = 0.95;
+    candidate.evidence = EvidenceVector {
+        recall_count: 3,
+        score: 0.72,
+        unique_queries: 2,
+        recency_half_life_days: 14,
+    };
     let mut already_promoted = sample_record(5);
     already_promoted.kind = MemoryKind::Fact;
     already_promoted.confidence = 0.99;
@@ -159,6 +166,11 @@ async fn promote_plan_source_emits_promote_plan_for_confident_non_target_kind() 
         .await
         .expect("plan");
 
+    let expected_evidence = candidate
+        .source_ids
+        .iter()
+        .map(SourceId::as_str)
+        .collect::<Vec<_>>();
     assert_eq!(plans.len(), 1);
     assert_eq!(plans[0].mode, FlushMode::Autonomous);
     assert!(matches!(
@@ -167,13 +179,14 @@ async fn promote_plan_source_emits_promote_plan_for_confident_non_target_kind() 
             from,
             to_kind: MemoryKind::Fact,
             evidence,
-        } if from == &candidate.target_id && evidence.is_empty()
+        } if from == &candidate.target_id
+            && evidence.iter().map(|id| id.0.as_str()).collect::<Vec<_>>() == expected_evidence
     ));
     assert!(matches!(
         plans[0].reason,
         PlanReason::Promote {
             confidence,
-            evidence_count: 0,
+            evidence_count: 1,
         } if (confidence - 0.95).abs() < f32::EPSILON
     ));
 }
@@ -184,6 +197,12 @@ async fn promote_plan_source_reuses_operation_ids_for_same_candidates() {
     let mut candidate = sample_record(10);
     candidate.kind = MemoryKind::Reference;
     candidate.confidence = 0.95;
+    candidate.evidence = EvidenceVector {
+        recall_count: 3,
+        score: 0.72,
+        unique_queries: 2,
+        recency_half_life_days: 14,
+    };
     store.upsert(&candidate).await.expect("seed candidate");
 
     let source = PromotePlanSource::new(

--- a/crates/cairn-workflows/tests/issue_91_e2e.rs
+++ b/crates/cairn-workflows/tests/issue_91_e2e.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use cairn_core::config::{DreamConfig, EvaluationConfig, ExpirationConfig};
+use cairn_core::config::{
+    DreamConfig, DreamTier, DreamTierConfig, EvaluationConfig, ExpirationConfig,
+};
 use cairn_core::contract::job_store::{EnqueueRequest, JobId, JobKind, JobStore, RetryPolicy};
 use cairn_core::contract::llm_provider::{
     CompletionOutput, CompletionRequest, LLMProvider, LLMProviderCapabilities, LlmError,
@@ -86,7 +88,10 @@ async fn three_workflows_drain_through_one_scheduler() {
         dyn_store.clone(),
         DreamConfig {
             enabled: true,
-            window_size_records: 8,
+            light_sleep: DreamTierConfig {
+                window_size_records: 8,
+                ..DreamTierConfig::light_sleep_default()
+            },
             ..DreamConfig::default()
         },
         Some(Arc::new(StubLlm) as Arc<dyn LLMProvider>),
@@ -132,6 +137,7 @@ async fn three_workflows_drain_through_one_scheduler() {
     // Enqueue one job per kind. now_ms for expiration is well past the
     // sample fixture's `updated_at` (2026-04-22) so every seed expires.
     let dream_payload = DreamPayload {
+        tier: DreamTier::LightSleep,
         key: "e2e-sess".into(),
         bound_scope: None,
     }

--- a/crates/cairn-workflows/tests/workflow_e2e.rs
+++ b/crates/cairn-workflows/tests/workflow_e2e.rs
@@ -4,7 +4,9 @@
 use std::sync::Arc;
 
 use cairn_core::contract::memory_store::MemoryStore as _;
-use cairn_core::domain::{FlushMode, Identity, MemoryKind, PlannedMutation};
+use cairn_core::domain::{
+    EvidenceVector, FlushMode, Identity, MemoryKind, PlanReason, PlannedMutation,
+};
 use cairn_core::generated::status::StatusResponseWorkflowsWorkflow;
 use cairn_test_fixtures::{memstore, sample_record};
 use cairn_workflows::{
@@ -93,6 +95,12 @@ async fn promote_workflow_drains_planned_flushes_into_sqlite_store_end_to_end() 
     let mut candidate = sample_record(3);
     candidate.kind = MemoryKind::Reference;
     candidate.confidence = 0.95;
+    candidate.evidence = EvidenceVector {
+        recall_count: 3,
+        score: 0.72,
+        unique_queries: 2,
+        recency_half_life_days: 14,
+    };
     let mut already_promoted = sample_record(4);
     already_promoted.kind = MemoryKind::Fact;
     already_promoted.confidence = 0.99;
@@ -111,6 +119,32 @@ async fn promote_workflow_drains_planned_flushes_into_sqlite_store_end_to_end() 
     let drainer = WorkflowDrainer::new(
         WorkflowContext::default(),
         Arc::new(SqliteFlushPlanApply::new(store.clone())),
+    );
+    let planned = source
+        .plan("promote", &WorkflowContext::default())
+        .await
+        .expect("plan promote");
+    assert_eq!(planned.len(), 1);
+    assert!(
+        matches!(
+            &planned[0].mutations[0],
+            PlannedMutation::Promote { evidence, .. }
+                if evidence.iter().map(|id| id.0.as_str()).collect::<Vec<_>>()
+                    == vec![candidate.source_ids[0].as_str()]
+        ),
+        "promotion plan must cite source evidence: {:?}",
+        planned[0].mutations
+    );
+    assert!(
+        matches!(
+            planned[0].reason,
+            PlanReason::Promote {
+                confidence,
+                evidence_count: 1
+            } if confidence >= 0.95
+        ),
+        "promotion reason must count cited evidence refs: {:?}",
+        planned[0].reason
     );
 
     let first = drainer
@@ -140,6 +174,47 @@ async fn promote_workflow_drains_planned_flushes_into_sqlite_store_end_to_end() 
     assert_eq!(second.applied, 0);
     assert_eq!(second.already_applied, 0);
     assert!(!second.cancelled);
+}
+
+#[tokio::test]
+async fn promote_workflow_skips_high_confidence_candidate_without_evidence_gate() {
+    let store = Arc::new(memstore().await);
+    let mut candidate = sample_record(30);
+    candidate.kind = MemoryKind::Reference;
+    candidate.confidence = 0.99;
+    candidate.evidence = EvidenceVector {
+        recall_count: 2,
+        score: 0.95,
+        unique_queries: 2,
+        recency_half_life_days: 14,
+    };
+    store.upsert(&candidate).await.expect("seed candidate");
+
+    let source = Arc::new(PromotePlanSource::new(
+        store.clone(),
+        Identity::parse("agt:cairn-workflows:promote:v1").expect("valid issuer"),
+        MemoryKind::Fact,
+        0.9,
+    ));
+    let drainer = WorkflowDrainer::new(
+        WorkflowContext::default(),
+        Arc::new(SqliteFlushPlanApply::new(store.clone())),
+    );
+
+    let result = drainer
+        .run(Arc::new(PromoteWorkflow::new(source)))
+        .await
+        .expect("promote drain");
+
+    assert_eq!(result.workflow, "promote");
+    assert_eq!(result.planned, 0);
+    assert_eq!(result.applied, 0);
+    let active = store
+        .get_active_by_target(&candidate.target_id)
+        .await
+        .expect("get candidate")
+        .expect("candidate remains active");
+    assert_eq!(active.record.kind, MemoryKind::Reference);
 }
 
 #[tokio::test]

--- a/docs/site/src/reference/generated/config-defaults.md
+++ b/docs/site/src/reference/generated/config-defaults.md
@@ -154,9 +154,39 @@ consolidation:
   salience_floor: 0.4
 dream:
   enabled: false
-  window_size_records: 16
-  completion_token_budget: 1024
-  llm_temperature: 0.0
+  light_sleep:
+    tier: light_sleep
+    cadence: stop_hook_and_turns
+    input_window: current_session_and_last24h
+    output_kind: index_updates_and_conflict_markers
+    worker: llm
+    window_size_records: 16
+    completion_token_budget: 1024
+    max_wall_ms: 60000
+    max_tool_calls: 0
+    llm_temperature: 0.0
+  rem_sleep:
+    tier: rem_sleep
+    cadence: hourly_or_high_salience
+    input_window: last7_days
+    output_kind: consolidated_records_and_reflection_kicks
+    worker: hybrid
+    window_size_records: 128
+    completion_token_budget: 4096
+    max_wall_ms: 180000
+    max_tool_calls: 0
+    llm_temperature: 0.0
+  deep_dreaming:
+    tier: deep_dreaming
+    cadence: nightly_or_cron
+    input_window: entire_vault
+    output_kind: promotions_skills_synthesis_and_lint
+    worker: hybrid
+    window_size_records: 1024
+    completion_token_budget: 16384
+    max_wall_ms: 900000
+    max_tool_calls: 0
+    llm_temperature: 0.0
 expiration:
   enabled: false
   ttl_days: 30


### PR DESCRIPTION
## Summary

Draft implementation for #111, covering design brief §10.1, §10.2, and the promotion gate in §11.3.

Closes #111.

- Replace the single P0 dream worker config with Light Sleep, REM Sleep, and Deep Dreaming tier configs.
- Carry tier information through `DreamPayload`, queue keys, handler target ids, prompt context, budgets, worker mode, and emitted frontmatter.
- Add tier enqueue support plus Stop-hook Light Sleep scheduling from `capture_trace`.
- Keep stable promotion behind policy/evidence gates: `PromotePlanSource` now requires confidence plus the default evidence vector thresholds before emitting a promotion `FlushPlan`, and promotion plans cite source evidence refs.
- Add tests for tier defaults/validation, payload compatibility, tier enqueue idempotency, budget enforcement, hybrid duplicate pruning, source evidence metadata, Stop-hook enqueue wiring, and promotion evidence gating.
- Regenerate config defaults docs and config snapshots for the nested dream tier config.

## Review Loop Fixes

- Fixed full-workspace clippy failure by boxing the large `serve_stdio_with_store_at_vault` future in `cairn-mcp`.
- Refactored the new Stop-hook `capture_trace` test so it clears `clippy::too_many_lines` under full `--all-targets` clippy.
- Tightened promotion evidence audit semantics: plans cite source evidence refs, `source_events` mirrors those refs, and `PlanReason::Promote.evidence_count` counts the cited refs rather than the recall counter.
- Updated config/schema snapshots and promotion-plan fixtures after CI showed they still encoded the pre-tier config and confidence-only promotion assumptions.


- Manual CLI replay testing found that importing the same consented Stop-hook trace twice could enqueue duplicate Light Sleep dream jobs because the dedupe key used wall-clock milliseconds. Fixed Stop-hook dream scheduling to use a stable closed-turn dedupe token while preserving wall-clock `not_before_ms` scheduling for execution.

## Invariants / Notes

- CLI remains the trigger surface for Stop-hook Light Sleep scheduling; REM/Deep can be enqueued via the tier helper, but this PR does not invent a cron/hourly scheduler path where the current workflow host has no hook yet.
- `DreamPayload` defaults missing `tier` to Light Sleep so old queued payloads can still drain.
- Promotion to stable kinds is no longer confidence-only; records must clear the evidence gate before the promotion workflow plans/apply path can change their kind.

## Verification

Passed locally:

```bash
cargo fmt --all --check
git diff --check
cargo test -p cairn-workflows --test dream --locked
cargo test -p cairn-core config::dream::tests:: --locked
cargo test -p cairn-workflows dream::trigger::tests:: --locked
cargo test -p cairn-workflows dream::payload::tests:: --locked
cargo test -p cairn-workflows --test issue_91_e2e --locked
cargo test -p cairn-cli verbs::capture_trace::tests::stop_hook_enqueues_light_sleep_dream_job --locked
cargo test -p cairn-workflows --test workflow_e2e --locked
cargo test -p cairn-test-fixtures --test schema_fixtures --locked
cargo test -p cairn-workflows --test expire_plan_source --locked promote_plan_source
cargo clippy -p cairn-core -p cairn-test-fixtures -p cairn-workflows --all-targets --locked -- -D warnings
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo run -p cairn-cli --bin cairn-docgen --locked -- --write
```

Additional manual / focused verification after the replay fix:

```bash
cargo build -p cairn-cli --bin cairn --locked
# Manual CLI smoke on a fresh bootstrapped vault:
# 1. capture_trace Stop hook without hook consent => privacy_denied, 0 workflow jobs
# 2. sensor enable hook
# 3. capture_trace same Stop-hook JSONL twice => 1 dream.distill_window job, tier=light_sleep
cargo test -p cairn-workflows dream::trigger::tests:: --locked
cargo test -p cairn-cli verbs::capture_trace::tests::stop_hook_enqueues_light_sleep_dream_job --locked
cargo fmt --all --check
git diff --check
cargo clippy -p cairn-workflows -p cairn-cli --all-targets --locked -- -D warnings
```

CI on `d80378de` is green, including:

- `format / cargo fmt`
- `lint / cargo clippy`
- `test / ubuntu-latest`
- `test / macos-latest`
- `gates / latency + memory + privacy` on Ubuntu and macOS
- docs, codegen, contract drift, deny/audit/machete, and invariants

Local full `cargo nextest run --workspace --locked --no-fail-fast` was attempted, but the macOS linker segfaulted while linking `cairn-mcp`'s `relay` test binary before tests ran. CI's Ubuntu and macOS full test jobs passed on the pushed commit.


