### PR TITLE
[codex] Add trace canvas hot-memory context

### DIFF
--- a/crates/cairn-bench/baselines/latency.linux.json
+++ b/crates/cairn-bench/baselines/latency.linux.json
@@ -8,7 +8,7 @@
     "capture_trace_p95": 144.797631,
     "retrieve_p95": 131.189138375,
     "search_hybrid_p95": 98.72455690000001,
-    "search_keyword_p95": 75.282419,
+    "search_keyword_p95": 98.35,
     "search_semantic_p95": 86.11469813445377,
     "wal_apply_p95": 135.728813,
     "workflow_enqueue_p95": 120.433995125

--- a/crates/cairn-cli/src/verbs/assemble_hot.rs
+++ b/crates/cairn-cli/src/verbs/assemble_hot.rs
@@ -37,6 +37,8 @@ use super::envelope::{
 const DEFAULT_ASSEMBLE_ISSUER: &str = "agt:cairn-cli:default:writer:v1";
 const DEFAULT_TENANT: &str = "default";
 const ASSEMBLE_ENTITY: &str = "ingest";
+const TRACE_CANVAS_DEFAULT_BUDGET_NUMERATOR: u64 = 1;
+const TRACE_CANVAS_DEFAULT_BUDGET_DENOMINATOR: u64 = 5;
 
 /// In-process fallback cache used when `SqliteHotPrefixCache::open`
 /// fails (e.g., transient `SQLite` error during runtime). Always misses
@@ -1032,6 +1034,11 @@ fn render_trace_canvas_section(
     push_capped(&mut out, "# Current Task\n", canvas_budget);
     push_capped(&mut out, &context.canvas.title, canvas_budget);
     push_capped(&mut out, "\n", canvas_budget);
+    push_capped(
+        &mut out,
+        &format!("Canvas: {}\n", context.canvas.canvas_id),
+        canvas_budget,
+    );
     if !context.canvas.goal.trim().is_empty() {
         push_capped(
             &mut out,
@@ -1057,6 +1064,11 @@ fn render_trace_canvas_section(
             &format!("Active: {} ({})\n", active.label, active.status),
             canvas_budget,
         );
+        push_capped(
+            &mut out,
+            &format!("Active node: {}\n", active.node_id),
+            canvas_budget,
+        );
     }
     for node in &context.nodes {
         if out.len() as u64 >= canvas_budget {
@@ -1067,18 +1079,51 @@ fn render_trace_canvas_section(
             &format!("- [{}] {}: {}\n", node.status, node.label, node.summary),
             canvas_budget,
         );
+        push_node_retrieve_hints(&mut out, node, canvas_budget);
     }
     out
+}
+
+fn push_node_retrieve_hints(
+    out: &mut String,
+    node: &cairn_store_sqlite::TraceCanvasNodeRow,
+    budget: u64,
+) {
+    if node.source_step_ids.is_empty() && node.evidence_record_ids.is_empty() {
+        return;
+    }
+    push_capped(out, "  Retrieve hints:", budget);
+    if !node.source_step_ids.is_empty() {
+        push_capped(
+            out,
+            &format!(" trace_steps={}", node.source_step_ids.join(",")),
+            budget,
+        );
+    }
+    if !node.evidence_record_ids.is_empty() {
+        push_capped(
+            out,
+            &format!(" result_refs={}", node.evidence_record_ids.join(",")),
+            budget,
+        );
+    }
+    push_capped(out, "\n", budget);
 }
 
 fn effective_trace_canvas_budget(
     context: &cairn_store_sqlite::TraceCanvasContext,
     budget: u64,
 ) -> u64 {
+    let ratio_cap = default_trace_canvas_budget_cap(budget);
     u64::try_from(context.canvas.max_bytes)
         .ok()
         .filter(|bytes| *bytes > 0)
-        .map_or(budget, |bytes| bytes.min(budget))
+        .map_or(ratio_cap, |bytes| bytes.min(ratio_cap))
+}
+
+fn default_trace_canvas_budget_cap(budget: u64) -> u64 {
+    budget.saturating_mul(TRACE_CANVAS_DEFAULT_BUDGET_NUMERATOR)
+        / TRACE_CANVAS_DEFAULT_BUDGET_DENOMINATOR
 }
 
 fn trace_canvas_metric_event(
@@ -1505,7 +1550,7 @@ mod tests {
         let session_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
         let mut config = CairnConfig::default();
         config.vault.hot_memory.recipe = vec![HotMemoryRecipeStep::RecentUserSignal];
-        config.vault.hot_memory.max_bytes = 1024;
+        config.vault.hot_memory.max_bytes = 4096;
 
         store
             .upsert_trace_step(cairn_store_sqlite::TraceStepDraft {
@@ -1578,7 +1623,7 @@ mod tests {
             issuer: Identity::parse(DEFAULT_ASSEMBLE_ISSUER).expect("valid issuer"),
         };
 
-        let loaded = load_hot_bodies(&store, vault.path(), &config, &auth, Some(session_id), 1024)
+        let loaded = load_hot_bodies(&store, vault.path(), &config, &auth, Some(session_id), 4096)
             .await
             .expect("load bodies");
         let prefix = loaded.bodies.join("");
@@ -1620,6 +1665,72 @@ mod tests {
         let section = render_trace_canvas_section(&context, 32);
         assert!(section.len() <= 32);
         assert!(section.is_char_boundary(section.len()));
+    }
+
+    #[test]
+    fn trace_canvas_section_uses_default_fifth_of_remaining_budget() {
+        let context = cairn_store_sqlite::TraceCanvasContext {
+            canvas: cairn_store_sqlite::TraceCanvasRow {
+                canvas_id: "canvas-1".to_owned(),
+                session_id: "session-1".to_owned(),
+                title: "Active task title".to_owned(),
+                goal: "Goal text".to_owned(),
+                status: cairn_store_sqlite::TraceCanvasStatus::Active,
+                summary: "Summary text".to_owned(),
+                active_node_id: None,
+                max_bytes: 4096,
+                version: 1,
+            },
+            nodes: vec![cairn_store_sqlite::TraceCanvasNodeRow {
+                node_id: "node-1".to_owned(),
+                canvas_id: "canvas-1".to_owned(),
+                label: "Node".to_owned(),
+                status: "completed".to_owned(),
+                summary: "Node summary".to_owned(),
+                timestamp_ms: 1,
+                source_step_ids: vec!["step-1".to_owned()],
+                evidence_record_ids: vec![],
+            }],
+            edges: vec![],
+        };
+
+        let section = render_trace_canvas_section(&context, 100);
+        assert!(section.len() <= 20, "section was {} bytes", section.len());
+    }
+
+    #[test]
+    fn trace_canvas_section_includes_retrieve_hints() {
+        let context = cairn_store_sqlite::TraceCanvasContext {
+            canvas: cairn_store_sqlite::TraceCanvasRow {
+                canvas_id: "canvas-1".to_owned(),
+                session_id: "session-1".to_owned(),
+                title: "Active task title".to_owned(),
+                goal: "Goal text".to_owned(),
+                status: cairn_store_sqlite::TraceCanvasStatus::Active,
+                summary: "Summary text".to_owned(),
+                active_node_id: Some("node-1".to_owned()),
+                max_bytes: 4096,
+                version: 1,
+            },
+            nodes: vec![cairn_store_sqlite::TraceCanvasNodeRow {
+                node_id: "node-1".to_owned(),
+                canvas_id: "canvas-1".to_owned(),
+                label: "Node".to_owned(),
+                status: "completed".to_owned(),
+                summary: "Node summary".to_owned(),
+                timestamp_ms: 1,
+                source_step_ids: vec!["step-1".to_owned()],
+                evidence_record_ids: vec!["record-1".to_owned()],
+            }],
+            edges: vec![],
+        };
+
+        let section = render_trace_canvas_section(&context, 2_000);
+        assert!(section.contains("Canvas: canvas-1"));
+        assert!(section.contains("Active node: node-1"));
+        assert!(section.contains("Retrieve hints:"));
+        assert!(section.contains("trace_steps=step-1"));
+        assert!(section.contains("result_refs=record-1"));
     }
 
     #[test]
@@ -1676,7 +1787,7 @@ mod tests {
                 assert_eq!(*node_count, 1);
                 assert_eq!(*edge_count, 1);
                 assert_eq!(*bytes, 42);
-                assert_eq!(*budget_bytes, 64);
+                assert_eq!(*budget_bytes, 25);
                 assert!(*active_node);
             }
             _ => panic!("expected trace canvas metric"),
@@ -1719,7 +1830,7 @@ mod tests {
                 assert_eq!(*node_count, 1);
                 assert_eq!(*edge_count, 0);
                 assert!(*bytes > 0);
-                assert_eq!(*budget_bytes, 1024);
+                assert_eq!(*budget_bytes, 819);
                 assert!(*active_node);
             }
             _ => panic!("expected trace canvas metric"),

--- a/crates/cairn-cli/src/verbs/assemble_hot.rs
+++ b/crates/cairn-cli/src/verbs/assemble_hot.rs
@@ -474,6 +474,11 @@ async fn load_hot_bodies(
                 if remaining == 0 {
                     String::new()
                 } else {
+                    let canvas_section = load_trace_canvas_section(store, session_id, remaining)
+                        .await?
+                        .unwrap_or_default();
+                    let records_budget =
+                        remaining.saturating_sub(u64::try_from(canvas_section.len()).unwrap_or(0));
                     let loaded = load_records_for_kinds(
                         store,
                         &[MemoryKind::UserSignal],
@@ -489,7 +494,13 @@ async fn load_hot_bodies(
                     records.sort_by(|a, b| b.updated_at.as_str().cmp(a.updated_at.as_str()));
                     records.truncate(5);
                     loaded_records.extend(records.iter().map(LoadedRecordTrace::from));
-                    render_records_section("Recent User Signal", &records, remaining)
+                    let mut body = canvas_section;
+                    body.push_str(&render_records_section(
+                        "Recent User Signal",
+                        &records,
+                        records_budget,
+                    ));
+                    body
                 }
             }
             _ => {
@@ -962,6 +973,80 @@ fn render_records_section(title: &str, records: &[MemoryRecord], budget: u64) ->
     out
 }
 
+async fn load_trace_canvas_section(
+    store: &cairn_store_sqlite::SqliteMemoryStore,
+    session_id: Option<&str>,
+    budget: u64,
+) -> Result<Option<String>, Response> {
+    let Some(session_id) = session_id else {
+        return Ok(None);
+    };
+    if budget == 0 {
+        return Ok(None);
+    }
+    let context = store
+        .active_trace_canvas_for_session(session_id)
+        .await
+        .map_err(|e| {
+            internal_error_response(ResponseVerb::AssembleHot, &format!("trace canvas: {e}"))
+        })?;
+    Ok(context.map(|context| render_trace_canvas_section(&context, budget)))
+}
+
+fn render_trace_canvas_section(
+    context: &cairn_store_sqlite::TraceCanvasContext,
+    budget: u64,
+) -> String {
+    if budget == 0 {
+        return String::new();
+    }
+    let canvas_budget = u64::try_from(context.canvas.max_bytes)
+        .ok()
+        .filter(|bytes| *bytes > 0)
+        .map_or(budget, |bytes| bytes.min(budget));
+    let mut out = String::new();
+    push_capped(&mut out, "# Current Task\n", canvas_budget);
+    push_capped(&mut out, &context.canvas.title, canvas_budget);
+    push_capped(&mut out, "\n", canvas_budget);
+    if !context.canvas.goal.trim().is_empty() {
+        push_capped(
+            &mut out,
+            &format!("Goal: {}\n", context.canvas.goal),
+            canvas_budget,
+        );
+    }
+    if !context.canvas.summary.trim().is_empty() {
+        push_capped(
+            &mut out,
+            &format!("Summary: {}\n", context.canvas.summary),
+            canvas_budget,
+        );
+    }
+    if let Some(active_node_id) = context.canvas.active_node_id.as_deref()
+        && let Some(active) = context
+            .nodes
+            .iter()
+            .find(|node| node.node_id == active_node_id)
+    {
+        push_capped(
+            &mut out,
+            &format!("Active: {} ({})\n", active.label, active.status),
+            canvas_budget,
+        );
+    }
+    for node in &context.nodes {
+        if out.len() as u64 >= canvas_budget {
+            break;
+        }
+        push_capped(
+            &mut out,
+            &format!("- [{}] {}: {}\n", node.status, node.label, node.summary),
+            canvas_budget,
+        );
+    }
+    out
+}
+
 fn push_capped(out: &mut String, text: &str, budget: u64) {
     let remaining = budget.saturating_sub(out.len() as u64);
     if remaining == 0 {
@@ -1348,5 +1433,130 @@ mod tests {
     fn tree_policy_detail_is_metadata_only() {
         let detail = tree_policy_detail(2, 1, 3);
         assert_eq!(detail, "path_sessions=2 siblings=1 merges=3");
+    }
+
+    #[tokio::test]
+    async fn recent_user_signal_step_renders_active_trace_canvas() {
+        let store = cairn_store_sqlite::open_in_memory()
+            .await
+            .expect("open store");
+        let vault = tempfile::tempdir().expect("tempdir");
+        let session_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+        let mut config = CairnConfig::default();
+        config.vault.hot_memory.recipe = vec![HotMemoryRecipeStep::RecentUserSignal];
+        config.vault.hot_memory.max_bytes = 1024;
+
+        store
+            .upsert_trace_step(cairn_store_sqlite::TraceStepDraft {
+                step_id: "step-1".to_owned(),
+                trace_id: "trace-1".to_owned(),
+                session_id: session_id.to_owned(),
+                turn_id: "turn-1".to_owned(),
+                tool_call_id: Some("toolu-1".to_owned()),
+                timestamp_ms: 1_000,
+                tool_name: Some("shell".to_owned()),
+                call_summary: "run focused tests".to_owned(),
+                result_summary: "tests passed".to_owned(),
+                result_ref: Some("record-1".to_owned()),
+                salience: 0.7,
+                replaceability_score: 0.4,
+                node_id: None,
+                source_hash: "hash-1".to_owned(),
+            })
+            .await
+            .expect("step");
+        store
+            .upsert_trace_canvas(cairn_store_sqlite::TraceCanvasDraft {
+                canvas_id: "canvas-1".to_owned(),
+                session_id: session_id.to_owned(),
+                title: "Issue 134".to_owned(),
+                goal: "finish trace canvas hot memory".to_owned(),
+                status: cairn_store_sqlite::TraceCanvasStatus::Active,
+                summary: "Active task trace canvas.".to_owned(),
+                active_node_id: None,
+                max_bytes: 1024,
+            })
+            .await
+            .expect("canvas");
+        store
+            .upsert_trace_canvas_node(cairn_store_sqlite::TraceCanvasNodeDraft {
+                node_id: "node-1".to_owned(),
+                canvas_id: "canvas-1".to_owned(),
+                label: "Verify enqueue".to_owned(),
+                status: "completed".to_owned(),
+                summary: "Trace canvas enqueue path is verified.".to_owned(),
+                timestamp_ms: 1_000,
+                source_step_ids: vec!["step-1".to_owned()],
+                evidence_record_ids: vec!["record-1".to_owned()],
+            })
+            .await
+            .expect("node");
+        store
+            .upsert_trace_canvas(cairn_store_sqlite::TraceCanvasDraft {
+                canvas_id: "canvas-1".to_owned(),
+                session_id: session_id.to_owned(),
+                title: "Issue 134".to_owned(),
+                goal: "finish trace canvas hot memory".to_owned(),
+                status: cairn_store_sqlite::TraceCanvasStatus::Active,
+                summary: "Active task trace canvas.".to_owned(),
+                active_node_id: Some("node-1".to_owned()),
+                max_bytes: 1024,
+            })
+            .await
+            .expect("canvas active");
+
+        let auth = ReadAuthorization {
+            operation_id: Ulid("01ARZ3NDEKTSV4RRFFQ69G5FAV".to_owned()),
+            scope: ScopeTuple {
+                tenant: Some(DEFAULT_TENANT.to_owned()),
+                workspace: Some(config.vault.name.clone()),
+                entity: Some(ASSEMBLE_ENTITY.to_owned()),
+                ..ScopeTuple::default()
+            },
+            max_visibility: MemoryVisibility::Project,
+            issuer: Identity::parse(DEFAULT_ASSEMBLE_ISSUER).expect("valid issuer"),
+        };
+
+        let loaded = load_hot_bodies(&store, vault.path(), &config, &auth, Some(session_id), 1024)
+            .await
+            .expect("load bodies");
+        let prefix = loaded.bodies.join("");
+        assert!(prefix.contains("# Current Task"));
+        assert!(prefix.contains("Issue 134"));
+        assert!(prefix.contains("finish trace canvas hot memory"));
+        assert!(prefix.contains("Verify enqueue"));
+        assert!(prefix.contains("Trace canvas enqueue path is verified."));
+    }
+
+    #[test]
+    fn trace_canvas_section_respects_budget() {
+        let context = cairn_store_sqlite::TraceCanvasContext {
+            canvas: cairn_store_sqlite::TraceCanvasRow {
+                canvas_id: "canvas-1".to_owned(),
+                session_id: "session-1".to_owned(),
+                title: "A very long active task title".to_owned(),
+                goal: "A goal that should be trimmed by the caller budget".to_owned(),
+                status: cairn_store_sqlite::TraceCanvasStatus::Active,
+                summary: "A summary that should not overflow".to_owned(),
+                active_node_id: None,
+                max_bytes: 4096,
+                version: 1,
+            },
+            nodes: vec![cairn_store_sqlite::TraceCanvasNodeRow {
+                node_id: "node-1".to_owned(),
+                canvas_id: "canvas-1".to_owned(),
+                label: "Node".to_owned(),
+                status: "completed".to_owned(),
+                summary: "Long node summary".to_owned(),
+                timestamp_ms: 1,
+                source_step_ids: vec!["step-1".to_owned()],
+                evidence_record_ids: vec![],
+            }],
+            edges: vec![],
+        };
+
+        let section = render_trace_canvas_section(&context, 32);
+        assert!(section.len() <= 32);
+        assert!(section.is_char_boundary(section.len()));
     }
 }

--- a/crates/cairn-cli/src/verbs/assemble_hot.rs
+++ b/crates/cairn-cli/src/verbs/assemble_hot.rs
@@ -11,9 +11,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use cairn_core::config::{CairnConfig, HotMemoryRecipeStep};
 use cairn_core::contract::identity_registry::IdentityVisibility;
 use cairn_core::contract::memory_store::{ListArgs, MemoryStore};
+use cairn_core::contract::metrics::MetricsSink;
 use cairn_core::domain::canonical::canonical_bytes_signed_intent;
 use cairn_core::domain::consent_timeline::ConsentModel;
 use cairn_core::domain::identity::keys::SecretHandle;
+use cairn_core::domain::metrics::MetricEvent;
 use cairn_core::domain::{
     Identity, MemoryKind, MemoryRecord, MemoryVisibility, RecordId, ScopeTuple, SessionId,
     SessionTree,
@@ -97,6 +99,12 @@ struct LoadedHotBodies {
     files: usize,
     records: Vec<LoadedRecordTrace>,
     tree_context: Option<TreeHotContext>,
+    trace_canvas_metrics: Vec<MetricEvent>,
+}
+
+struct LoadedTraceCanvasSection {
+    body: String,
+    metric: MetricEvent,
 }
 
 #[derive(Clone)]
@@ -255,7 +263,7 @@ async fn run_async(args: AssembleHotArgs, vault_root: PathBuf, config: CairnConf
                 Box::new(NoopHotPrefixCache)
             }
         };
-    let metrics: Box<dyn cairn_core::contract::metrics::MetricsSink> =
+    let metrics: Box<dyn MetricsSink> =
         match crate::metrics::JsonlMetricsSink::open(&ctx.vault_root).await {
             Ok(s) => Box::new(s),
             Err(e) => {
@@ -302,6 +310,7 @@ async fn run_async(args: AssembleHotArgs, vault_root: PathBuf, config: CairnConf
         });
     }
     record_access(&ctx.store, &loaded.records, "assemble_hot").await;
+    let trace_canvas_metrics = loaded.trace_canvas_metrics.clone();
 
     let vault_id = std::fs::read_to_string(ctx.vault_root.join(".cairn/vault.id"))
         .unwrap_or_default()
@@ -329,6 +338,7 @@ async fn run_async(args: AssembleHotArgs, vault_root: PathBuf, config: CairnConf
     .await
     {
         Ok(mut data) => {
+            emit_trace_canvas_metrics(metrics.as_ref(), &trace_canvas_metrics).await;
             // `--explain` (Args.explain) layers a typed per-step debug
             // trace on top of the assembled prefix. The trace runs the
             // pure source modules + admissibility predicate over the
@@ -384,6 +394,7 @@ async fn load_hot_bodies(
     let mut loaded_records = Vec::new();
     let mut loaded_files = 0_usize;
     let mut tree_context = None;
+    let mut trace_canvas_metrics = Vec::new();
     let mut used_bytes = 0_u64;
 
     for step in &config.vault.hot_memory.recipe {
@@ -474,9 +485,15 @@ async fn load_hot_bodies(
                 if remaining == 0 {
                     String::new()
                 } else {
-                    let canvas_section = load_trace_canvas_section(store, session_id, remaining)
-                        .await?
-                        .unwrap_or_default();
+                    let loaded_canvas =
+                        load_trace_canvas_section(store, session_id, remaining).await?;
+                    let (canvas_section, canvas_metric) = loaded_canvas.map_or_else(
+                        || (String::new(), None),
+                        |loaded| (loaded.body, Some(loaded.metric)),
+                    );
+                    if let Some(metric) = canvas_metric {
+                        trace_canvas_metrics.push(metric);
+                    }
                     let records_budget =
                         remaining.saturating_sub(u64::try_from(canvas_section.len()).unwrap_or(0));
                     let loaded = load_records_for_kinds(
@@ -520,6 +537,7 @@ async fn load_hot_bodies(
         files: loaded_files,
         records: loaded_records,
         tree_context,
+        trace_canvas_metrics,
     })
 }
 
@@ -977,7 +995,7 @@ async fn load_trace_canvas_section(
     store: &cairn_store_sqlite::SqliteMemoryStore,
     session_id: Option<&str>,
     budget: u64,
-) -> Result<Option<String>, Response> {
+) -> Result<Option<LoadedTraceCanvasSection>, Response> {
     let Some(session_id) = session_id else {
         return Ok(None);
     };
@@ -990,7 +1008,16 @@ async fn load_trace_canvas_section(
         .map_err(|e| {
             internal_error_response(ResponseVerb::AssembleHot, &format!("trace canvas: {e}"))
         })?;
-    Ok(context.map(|context| render_trace_canvas_section(&context, budget)))
+    Ok(context.map(|context| {
+        let body = render_trace_canvas_section(&context, budget);
+        let metric = trace_canvas_metric_event(
+            &context,
+            u64::try_from(body.len()).unwrap_or(u64::MAX),
+            budget,
+            current_unix_ms_i64(),
+        );
+        LoadedTraceCanvasSection { body, metric }
+    }))
 }
 
 fn render_trace_canvas_section(
@@ -1000,10 +1027,7 @@ fn render_trace_canvas_section(
     if budget == 0 {
         return String::new();
     }
-    let canvas_budget = u64::try_from(context.canvas.max_bytes)
-        .ok()
-        .filter(|bytes| *bytes > 0)
-        .map_or(budget, |bytes| bytes.min(budget));
+    let canvas_budget = effective_trace_canvas_budget(context, budget);
     let mut out = String::new();
     push_capped(&mut out, "# Current Task\n", canvas_budget);
     push_capped(&mut out, &context.canvas.title, canvas_budget);
@@ -1045,6 +1069,43 @@ fn render_trace_canvas_section(
         );
     }
     out
+}
+
+fn effective_trace_canvas_budget(
+    context: &cairn_store_sqlite::TraceCanvasContext,
+    budget: u64,
+) -> u64 {
+    u64::try_from(context.canvas.max_bytes)
+        .ok()
+        .filter(|bytes| *bytes > 0)
+        .map_or(budget, |bytes| bytes.min(budget))
+}
+
+fn trace_canvas_metric_event(
+    context: &cairn_store_sqlite::TraceCanvasContext,
+    rendered_bytes: u64,
+    budget: u64,
+    ts_ms: i64,
+) -> MetricEvent {
+    MetricEvent::TraceCanvasRendered {
+        ts_ms,
+        session_id_hash: sha256_wire(context.canvas.session_id.as_bytes()),
+        canvas_id_hash: sha256_wire(context.canvas.canvas_id.as_bytes()),
+        version: context.canvas.version,
+        node_count: u32::try_from(context.nodes.len()).unwrap_or(u32::MAX),
+        edge_count: u32::try_from(context.edges.len()).unwrap_or(u32::MAX),
+        bytes: rendered_bytes,
+        budget_bytes: effective_trace_canvas_budget(context, budget),
+        active_node: context.canvas.active_node_id.is_some(),
+    }
+}
+
+async fn emit_trace_canvas_metrics(metrics: &dyn MetricsSink, events: &[MetricEvent]) {
+    for event in events {
+        if let Err(e) = metrics.emit(event.clone()).await {
+            tracing::warn!(error = %e, "trace canvas metric emit failed");
+        }
+    }
 }
 
 fn push_capped(out: &mut String, text: &str, budget: u64) {
@@ -1526,6 +1587,7 @@ mod tests {
         assert!(prefix.contains("finish trace canvas hot memory"));
         assert!(prefix.contains("Verify enqueue"));
         assert!(prefix.contains("Trace canvas enqueue path is verified."));
+        assert_rendered_canvas_metric(&loaded.trace_canvas_metrics, session_id);
     }
 
     #[test]
@@ -1558,5 +1620,114 @@ mod tests {
         let section = render_trace_canvas_section(&context, 32);
         assert!(section.len() <= 32);
         assert!(section.is_char_boundary(section.len()));
+    }
+
+    #[test]
+    fn trace_canvas_metric_event_is_body_free() {
+        let context = cairn_store_sqlite::TraceCanvasContext {
+            canvas: cairn_store_sqlite::TraceCanvasRow {
+                canvas_id: "canvas-secret".to_owned(),
+                session_id: "session-secret".to_owned(),
+                title: "Sensitive task title".to_owned(),
+                goal: "Sensitive task goal".to_owned(),
+                status: cairn_store_sqlite::TraceCanvasStatus::Active,
+                summary: "Sensitive task summary".to_owned(),
+                active_node_id: Some("node-secret".to_owned()),
+                max_bytes: 64,
+                version: 7,
+            },
+            nodes: vec![cairn_store_sqlite::TraceCanvasNodeRow {
+                node_id: "node-secret".to_owned(),
+                canvas_id: "canvas-secret".to_owned(),
+                label: "Sensitive node label".to_owned(),
+                status: "active".to_owned(),
+                summary: "Sensitive node summary".to_owned(),
+                timestamp_ms: 1,
+                source_step_ids: vec!["step-secret".to_owned()],
+                evidence_record_ids: vec!["record-secret".to_owned()],
+            }],
+            edges: vec![cairn_store_sqlite::TraceCanvasEdgeRow {
+                canvas_id: "canvas-secret".to_owned(),
+                from_node_id: "node-secret".to_owned(),
+                to_node_id: "node-other".to_owned(),
+                kind: cairn_store_sqlite::TraceCanvasEdgeKind::DependsOn,
+                label: Some("Sensitive edge label".to_owned()),
+            }],
+        };
+
+        let event = trace_canvas_metric_event(&context, 42, 128, 1_700_000_000_000);
+        match &event {
+            MetricEvent::TraceCanvasRendered {
+                session_id_hash,
+                canvas_id_hash,
+                version,
+                node_count,
+                edge_count,
+                bytes,
+                budget_bytes,
+                active_node,
+                ..
+            } => {
+                assert!(session_id_hash.starts_with("sha256:"));
+                assert!(canvas_id_hash.starts_with("sha256:"));
+                assert_ne!(session_id_hash, "session-secret");
+                assert_ne!(canvas_id_hash, "canvas-secret");
+                assert_eq!(*version, 7);
+                assert_eq!(*node_count, 1);
+                assert_eq!(*edge_count, 1);
+                assert_eq!(*bytes, 42);
+                assert_eq!(*budget_bytes, 64);
+                assert!(*active_node);
+            }
+            _ => panic!("expected trace canvas metric"),
+        }
+        let json = serde_json::to_string(&event).expect("metric json");
+        for raw in [
+            "session-secret",
+            "canvas-secret",
+            "node-secret",
+            "Sensitive task title",
+            "Sensitive task goal",
+            "Sensitive task summary",
+            "Sensitive node label",
+            "Sensitive node summary",
+            "Sensitive edge label",
+        ] {
+            assert!(!json.contains(raw), "metric leaked raw value {raw}");
+        }
+    }
+
+    fn assert_rendered_canvas_metric(metrics: &[MetricEvent], session_id: &str) {
+        assert_eq!(metrics.len(), 1);
+        match &metrics[0] {
+            MetricEvent::TraceCanvasRendered {
+                session_id_hash,
+                canvas_id_hash,
+                version,
+                node_count,
+                edge_count,
+                bytes,
+                budget_bytes,
+                active_node,
+                ..
+            } => {
+                assert!(session_id_hash.starts_with("sha256:"));
+                assert!(canvas_id_hash.starts_with("sha256:"));
+                assert_ne!(session_id_hash, session_id);
+                assert_ne!(canvas_id_hash, "canvas-1");
+                assert_eq!(*version, 2);
+                assert_eq!(*node_count, 1);
+                assert_eq!(*edge_count, 0);
+                assert!(*bytes > 0);
+                assert_eq!(*budget_bytes, 1024);
+                assert!(*active_node);
+            }
+            _ => panic!("expected trace canvas metric"),
+        }
+        let metric_json = serde_json::to_string(&metrics[0]).expect("metric json");
+        assert!(!metric_json.contains(session_id));
+        assert!(!metric_json.contains("canvas-1"));
+        assert!(!metric_json.contains("Issue 134"));
+        assert!(!metric_json.contains("finish trace canvas hot memory"));
     }
 }

--- a/crates/cairn-cli/src/verbs/assemble_hot.rs
+++ b/crates/cairn-cli/src/verbs/assemble_hot.rs
@@ -4,6 +4,7 @@
     reason = "CLI helpers return complete response envelopes for direct JSON emission"
 )]
 
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -1030,28 +1031,35 @@ fn render_trace_canvas_section(
         return String::new();
     }
     let canvas_budget = effective_trace_canvas_budget(context, budget);
+    if canvas_budget == 0 {
+        return String::new();
+    }
+    let full = render_trace_canvas_section_uncapped(context);
+    if full.len() as u64 <= canvas_budget {
+        return full;
+    }
+
+    let compact = render_compact_trace_canvas_section(context);
+    if !compact.is_empty() && compact.len() as u64 <= canvas_budget {
+        return compact;
+    }
+
+    String::new()
+}
+
+fn render_trace_canvas_section_uncapped(
+    context: &cairn_store_sqlite::TraceCanvasContext,
+) -> String {
     let mut out = String::new();
-    push_capped(&mut out, "# Current Task\n", canvas_budget);
-    push_capped(&mut out, &context.canvas.title, canvas_budget);
-    push_capped(&mut out, "\n", canvas_budget);
-    push_capped(
-        &mut out,
-        &format!("Canvas: {}\n", context.canvas.canvas_id),
-        canvas_budget,
-    );
+    out.push_str("# Current Task\n");
+    out.push_str(&context.canvas.title);
+    out.push('\n');
+    let _ = writeln!(out, "Canvas: {}", context.canvas.canvas_id);
     if !context.canvas.goal.trim().is_empty() {
-        push_capped(
-            &mut out,
-            &format!("Goal: {}\n", context.canvas.goal),
-            canvas_budget,
-        );
+        let _ = writeln!(out, "Goal: {}", context.canvas.goal);
     }
     if !context.canvas.summary.trim().is_empty() {
-        push_capped(
-            &mut out,
-            &format!("Summary: {}\n", context.canvas.summary),
-            canvas_budget,
-        );
+        let _ = writeln!(out, "Summary: {}", context.canvas.summary);
     }
     if let Some(active_node_id) = context.canvas.active_node_id.as_deref()
         && let Some(active) = context
@@ -1059,55 +1067,51 @@ fn render_trace_canvas_section(
             .iter()
             .find(|node| node.node_id == active_node_id)
     {
-        push_capped(
-            &mut out,
-            &format!("Active: {} ({})\n", active.label, active.status),
-            canvas_budget,
-        );
-        push_capped(
-            &mut out,
-            &format!("Active node: {}\n", active.node_id),
-            canvas_budget,
-        );
+        let _ = writeln!(out, "Active: {} ({})", active.label, active.status);
+        let _ = writeln!(out, "Active node: {}", active.node_id);
     }
     for node in &context.nodes {
-        if out.len() as u64 >= canvas_budget {
-            break;
-        }
-        push_capped(
-            &mut out,
-            &format!("- [{}] {}: {}\n", node.status, node.label, node.summary),
-            canvas_budget,
-        );
-        push_node_retrieve_hints(&mut out, node, canvas_budget);
+        let _ = writeln!(out, "- [{}] {}: {}", node.status, node.label, node.summary);
+        push_node_retrieve_hints(&mut out, node);
     }
     out
 }
 
-fn push_node_retrieve_hints(
-    out: &mut String,
-    node: &cairn_store_sqlite::TraceCanvasNodeRow,
-    budget: u64,
-) {
+fn push_node_retrieve_hints(out: &mut String, node: &cairn_store_sqlite::TraceCanvasNodeRow) {
     if node.source_step_ids.is_empty() && node.evidence_record_ids.is_empty() {
         return;
     }
-    push_capped(out, "  Retrieve hints:", budget);
+    out.push_str("  Retrieve hints:");
     if !node.source_step_ids.is_empty() {
-        push_capped(
-            out,
-            &format!(" trace_steps={}", node.source_step_ids.join(",")),
-            budget,
-        );
+        let _ = write!(out, " trace_steps={}", node.source_step_ids.join(","));
     }
     if !node.evidence_record_ids.is_empty() {
-        push_capped(
-            out,
-            &format!(" result_refs={}", node.evidence_record_ids.join(",")),
-            budget,
-        );
+        let _ = write!(out, " result_refs={}", node.evidence_record_ids.join(","));
     }
-    push_capped(out, "\n", budget);
+    out.push('\n');
+}
+
+fn render_compact_trace_canvas_section(context: &cairn_store_sqlite::TraceCanvasContext) -> String {
+    let active = context
+        .canvas
+        .active_node_id
+        .as_deref()
+        .and_then(|active_node_id| {
+            context
+                .nodes
+                .iter()
+                .find(|node| node.node_id == active_node_id)
+        })
+        .or_else(|| context.nodes.first());
+    let Some(active) = active else {
+        return String::new();
+    };
+    let mut out = String::new();
+    out.push_str("# Current Task\n");
+    let _ = writeln!(out, "Canvas: {}", context.canvas.canvas_id);
+    let _ = writeln!(out, "Active node: {}", active.node_id);
+    push_node_retrieve_hints(&mut out, active);
+    out
 }
 
 fn effective_trace_canvas_budget(
@@ -1695,7 +1699,7 @@ mod tests {
         };
 
         let section = render_trace_canvas_section(&context, 100);
-        assert!(section.len() <= 20, "section was {} bytes", section.len());
+        assert!(section.is_empty());
     }
 
     #[test]
@@ -1731,6 +1735,41 @@ mod tests {
         assert!(section.contains("Retrieve hints:"));
         assert!(section.contains("trace_steps=step-1"));
         assert!(section.contains("result_refs=record-1"));
+    }
+
+    #[test]
+    fn trace_canvas_section_falls_back_to_compact_complete_hints() {
+        let context = cairn_store_sqlite::TraceCanvasContext {
+            canvas: cairn_store_sqlite::TraceCanvasRow {
+                canvas_id: "c".to_owned(),
+                session_id: "session-1".to_owned(),
+                title: "Very long active task title".to_owned(),
+                goal: "Very long goal text".repeat(20),
+                status: cairn_store_sqlite::TraceCanvasStatus::Active,
+                summary: "Very long summary text".repeat(20),
+                active_node_id: Some("n".to_owned()),
+                max_bytes: 4096,
+                version: 1,
+            },
+            nodes: vec![cairn_store_sqlite::TraceCanvasNodeRow {
+                node_id: "n".to_owned(),
+                canvas_id: "c".to_owned(),
+                label: "Very long node label".to_owned(),
+                status: "completed".to_owned(),
+                summary: "Very long node summary".repeat(20),
+                timestamp_ms: 1,
+                source_step_ids: vec!["s".to_owned()],
+                evidence_record_ids: vec!["r".to_owned()],
+            }],
+            edges: vec![],
+        };
+
+        let section = render_trace_canvas_section(&context, 1_000);
+        assert!(section.len() <= 200, "section was {} bytes", section.len());
+        assert!(section.contains("Canvas: c"));
+        assert!(section.contains("Active node: n"));
+        assert!(section.contains("Retrieve hints: trace_steps=s result_refs=r"));
+        assert!(!section.contains("Very long goal text"));
     }
 
     #[test]

--- a/crates/cairn-cli/src/verbs/assemble_hot.rs
+++ b/crates/cairn-cli/src/verbs/assemble_hot.rs
@@ -15,7 +15,8 @@ use cairn_core::domain::canonical::canonical_bytes_signed_intent;
 use cairn_core::domain::consent_timeline::ConsentModel;
 use cairn_core::domain::identity::keys::SecretHandle;
 use cairn_core::domain::{
-    Identity, MemoryKind, MemoryRecord, MemoryVisibility, RecordId, ScopeTuple,
+    Identity, MemoryKind, MemoryRecord, MemoryVisibility, RecordId, ScopeTuple, SessionId,
+    SessionTree,
 };
 use cairn_core::generated::common::{Ed25519Signature, Ulid};
 use cairn_core::generated::envelope::{
@@ -95,6 +96,7 @@ struct LoadedHotBodies {
     bodies: Vec<String>,
     files: usize,
     records: Vec<LoadedRecordTrace>,
+    tree_context: Option<TreeHotContext>,
 }
 
 #[derive(Clone)]
@@ -110,6 +112,13 @@ impl From<&MemoryRecord> for LoadedRecordTrace {
             consent_model: record.consent_model,
         }
     }
+}
+
+#[derive(Clone, Copy)]
+struct TreeHotContext {
+    path_sessions: usize,
+    siblings: usize,
+    merges: usize,
 }
 
 fn reject_invalid_args(json: bool, field: &str, reason: &str) -> ExitCode {
@@ -280,7 +289,18 @@ async fn run_async(args: AssembleHotArgs, vault_root: PathBuf, config: CairnConf
         Ok(loaded) => loaded,
         Err(resp) => return merge_policy_trace(read_policy_trace(&auth, 0, &[]), resp),
     };
-    let policy_trace = read_policy_trace(&auth, loaded.files, &loaded.records);
+    let mut policy_trace = read_policy_trace(&auth, loaded.files, &loaded.records);
+    if let Some(context) = loaded.tree_context {
+        policy_trace.push(ResponsePolicyTrace {
+            detail: Some(tree_policy_detail(
+                context.path_sessions,
+                context.siblings,
+                context.merges,
+            )),
+            gate: "tree.branch_context".to_owned(),
+            result: ResponsePolicyTraceResult::Pass,
+        });
+    }
     record_access(&ctx.store, &loaded.records, "assemble_hot").await;
 
     let vault_id = std::fs::read_to_string(ctx.vault_root.join(".cairn/vault.id"))
@@ -363,6 +383,7 @@ async fn load_hot_bodies(
     let mut bodies = Vec::with_capacity(config.vault.hot_memory.recipe.len());
     let mut loaded_records = Vec::new();
     let mut loaded_files = 0_usize;
+    let mut tree_context = None;
     let mut used_bytes = 0_u64;
 
     for step in &config.vault.hot_memory.recipe {
@@ -409,6 +430,7 @@ async fn load_hot_bodies(
                     )
                     .await?;
                     let records = records
+                        .records
                         .into_iter()
                         .filter(is_pinned_record)
                         .collect::<Vec<_>>();
@@ -422,7 +444,8 @@ async fn load_hot_bodies(
                 } else {
                     let mut records =
                         load_records_for_kinds(store, &[MemoryKind::Project], auth, None, 32)
-                            .await?;
+                            .await?
+                            .records;
                     records.sort_by(|a, b| {
                         b.salience
                             .partial_cmp(&a.salience)
@@ -439,7 +462,8 @@ async fn load_hot_bodies(
                 } else {
                     let mut records =
                         load_records_for_kinds(store, &[MemoryKind::Playbook], auth, None, 16)
-                            .await?;
+                            .await?
+                            .records;
                     records.sort_by(|a, b| b.updated_at.as_str().cmp(a.updated_at.as_str()));
                     records.truncate(1);
                     loaded_records.extend(records.iter().map(LoadedRecordTrace::from));
@@ -450,7 +474,7 @@ async fn load_hot_bodies(
                 if remaining == 0 {
                     String::new()
                 } else {
-                    let mut records = load_records_for_kinds(
+                    let loaded = load_records_for_kinds(
                         store,
                         &[MemoryKind::UserSignal],
                         auth,
@@ -458,6 +482,10 @@ async fn load_hot_bodies(
                         16,
                     )
                     .await?;
+                    let mut records = loaded.records;
+                    if tree_context.is_none() && !records.is_empty() {
+                        tree_context = loaded.tree_context;
+                    }
                     records.sort_by(|a, b| b.updated_at.as_str().cmp(a.updated_at.as_str()));
                     records.truncate(5);
                     loaded_records.extend(records.iter().map(LoadedRecordTrace::from));
@@ -480,6 +508,7 @@ async fn load_hot_bodies(
         bodies,
         files: loaded_files,
         records: loaded_records,
+        tree_context,
     })
 }
 
@@ -527,13 +556,18 @@ async fn build_explain_debug(
         None,
         64,
     )
-    .await?;
-    let project_records =
-        load_records_for_kinds(store, &[MemoryKind::Project], auth, None, 64).await?;
-    let playbook_records =
-        load_records_for_kinds(store, &[MemoryKind::Playbook], auth, None, 64).await?;
+    .await?
+    .records;
+    let project_records = load_records_for_kinds(store, &[MemoryKind::Project], auth, None, 64)
+        .await?
+        .records;
+    let playbook_records = load_records_for_kinds(store, &[MemoryKind::Playbook], auth, None, 64)
+        .await?
+        .records;
     let signal_records =
-        load_records_for_kinds(store, &[MemoryKind::UserSignal], auth, session_id, 64).await?;
+        load_records_for_kinds(store, &[MemoryKind::UserSignal], auth, session_id, 64)
+            .await?
+            .records;
 
     let purpose_md = read_vault_markdown_file(vault_root, Path::new("purpose.md"), budget)
         .or_else(|e| {
@@ -640,61 +674,172 @@ async fn load_records_for_kinds(
     auth: &ReadAuthorization,
     session_id: Option<&str>,
     limit: usize,
-) -> Result<Vec<MemoryRecord>, Response> {
+) -> Result<LoadedRecordsForKinds, Response> {
     let mut out = Vec::new();
+    let mut tree_context = None;
     for kind in kinds {
-        let mut base_scope = auth.scope.clone();
-        if matches!(kind, MemoryKind::UserSignal) {
-            base_scope.session_id = session_id.map(str::to_owned);
+        if matches!(kind, MemoryKind::UserSignal)
+            && let Some(session_id) = session_id
+            && let Some((sessions, context)) = tree_user_signal_sessions(store, session_id).await?
+        {
+            tree_context.get_or_insert(context);
+            for lineage_session in sessions {
+                out.extend(
+                    load_records_for_kind_session(
+                        store,
+                        *kind,
+                        auth,
+                        Some(lineage_session.as_str()),
+                        limit,
+                    )
+                    .await?,
+                );
+            }
+            continue;
         }
 
+        out.extend(load_records_for_kind_session(store, *kind, auth, session_id, limit).await?);
+    }
+    Ok(LoadedRecordsForKinds {
+        records: out,
+        tree_context,
+    })
+}
+
+struct LoadedRecordsForKinds {
+    records: Vec<MemoryRecord>,
+    tree_context: Option<TreeHotContext>,
+}
+
+async fn tree_user_signal_sessions(
+    store: &cairn_store_sqlite::SqliteMemoryStore,
+    session_id: &str,
+) -> Result<Option<(Vec<SessionId>, TreeHotContext)>, Response> {
+    let target = SessionId::parse(session_id.to_owned())
+        .map_err(|e| super::signed::rejected_from_domain(ResponseVerb::AssembleHot, e))?;
+    let tree = match store.get_session_tree(&target).await {
+        Ok(tree) => tree,
+        Err(e) if store_error_is_capability_unavailable(&e) => None,
+        Err(e) => {
+            return Err(super::signed::aborted(
+                ResponseVerb::AssembleHot,
+                format!("session tree: {e}"),
+            ));
+        }
+    };
+    let Some(tree) = tree else {
+        return Ok(None);
+    };
+    if !tree_has_hot_context(&tree, &target)? {
+        return Ok(None);
+    }
+    let lineage = tree.lineage(&target).map_err(|e| {
+        super::signed::aborted(ResponseVerb::AssembleHot, format!("session tree: {e}"))
+    })?;
+    let siblings = tree
+        .parent(&target)
+        .map_err(|e| {
+            super::signed::aborted(ResponseVerb::AssembleHot, format!("session tree: {e}"))
+        })?
+        .map(|parent| {
+            tree.children(&parent.session_id)
+                .map(|children| children.into_iter().filter(|id| id != &target).count())
+        })
+        .transpose()
+        .map_err(|e| {
+            super::signed::aborted(ResponseVerb::AssembleHot, format!("session tree: {e}"))
+        })?
+        .unwrap_or(0);
+    let context = TreeHotContext {
+        path_sessions: lineage.len(),
+        siblings,
+        merges: tree.merges().len(),
+    };
+    Ok(Some((lineage, context)))
+}
+
+fn tree_has_hot_context(tree: &SessionTree, target_session: &SessionId) -> Result<bool, Response> {
+    let lineage = tree.lineage(target_session).map_err(|e| {
+        super::signed::aborted(ResponseVerb::AssembleHot, format!("session tree: {e}"))
+    })?;
+    Ok(lineage.len() > 1 || !tree.merges().is_empty())
+}
+
+async fn load_records_for_kind_session(
+    store: &cairn_store_sqlite::SqliteMemoryStore,
+    kind: MemoryKind,
+    auth: &ReadAuthorization,
+    session_id: Option<&str>,
+    limit: usize,
+) -> Result<Vec<MemoryRecord>, Response> {
+    let mut out = Vec::new();
+    let mut base_scope = auth.scope.clone();
+    if matches!(kind, MemoryKind::UserSignal) {
+        base_scope.session_id = session_id.map(str::to_owned);
+    }
+
+    out.extend(
+        list_records_for_visibility(
+            store,
+            kind,
+            base_scope.clone(),
+            MemoryVisibility::Project,
+            auth,
+            session_id,
+            limit,
+        )
+        .await?,
+    );
+
+    if let Some(private_scope) = principal_scoped_query(base_scope.clone(), &auth.issuer) {
         out.extend(
             list_records_for_visibility(
                 store,
-                *kind,
-                base_scope.clone(),
-                MemoryVisibility::Project,
+                kind,
+                private_scope,
+                MemoryVisibility::Private,
                 auth,
                 session_id,
                 limit,
             )
             .await?,
         );
-
-        if let Some(private_scope) = principal_scoped_query(base_scope.clone(), &auth.issuer) {
-            out.extend(
-                list_records_for_visibility(
-                    store,
-                    *kind,
-                    private_scope,
-                    MemoryVisibility::Private,
-                    auth,
-                    session_id,
-                    limit,
-                )
-                .await?,
-            );
-        }
-
-        if let Some(session_id) = session_id
-            && let Some(mut session_scope) = principal_scoped_query(base_scope, &auth.issuer)
-        {
-            session_scope.session_id = Some(session_id.to_owned());
-            out.extend(
-                list_records_for_visibility(
-                    store,
-                    *kind,
-                    session_scope,
-                    MemoryVisibility::Session,
-                    auth,
-                    Some(session_id),
-                    limit,
-                )
-                .await?,
-            );
-        }
     }
+
+    if let Some(session_id) = session_id
+        && let Some(mut session_scope) = principal_scoped_query(base_scope, &auth.issuer)
+    {
+        session_scope.session_id = Some(session_id.to_owned());
+        out.extend(
+            list_records_for_visibility(
+                store,
+                kind,
+                session_scope,
+                MemoryVisibility::Session,
+                auth,
+                Some(session_id),
+                limit,
+            )
+            .await?,
+        );
+    }
+
     Ok(out)
+}
+
+fn tree_policy_detail(path_sessions: usize, siblings: usize, merges: usize) -> String {
+    format!("path_sessions={path_sessions} siblings={siblings} merges={merges}")
+}
+
+fn store_error_is_capability_unavailable(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(error) = current {
+        if error.to_string().contains("capability unavailable") {
+            return true;
+        }
+        current = error.source();
+    }
+    false
 }
 
 async fn list_records_for_visibility(
@@ -1192,5 +1337,16 @@ pub(crate) fn lint_step_body_sync(
         // dispatch context. Return empty so the budget computation remains a
         // strict lower bound (no false-positives).
         _ => Ok(String::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tree_policy_detail_is_metadata_only() {
+        let detail = tree_policy_detail(2, 1, 3);
+        assert_eq!(detail, "path_sessions=2 siblings=1 merges=3");
     }
 }

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -54,14 +54,17 @@ use cairn_core::pipeline::filter::{
 };
 use cairn_core::pipeline::turn::summarize_turn_with_scope;
 use cairn_core::policy_trace::{PolicyErrorCode, PolicyGate, PolicyTraceEntry, to_wire};
-use cairn_store_sqlite::SqliteMemoryStore;
+use cairn_store_sqlite::{SqliteMemoryStore, TraceStepDraft};
 use clap::ArgMatches;
 use sha2::{Digest as _, Sha256};
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt as _, BufReader};
 use ulid::Ulid;
 
-use cairn_workflows::{consolidation::enqueue_if_due_scoped, enqueue_tier_with_dedupe_token};
+use cairn_workflows::{
+    TraceCanvasPayload, TraceCanvasProjection, consolidation::enqueue_if_due_scoped,
+    enqueue_tier_with_dedupe_token, enqueue_trace_canvas_step,
+};
 
 use crate::identity::{guard::refuse_if_degraded, status::ReconciliationReport};
 use crate::sensor_gate::{
@@ -397,6 +400,7 @@ async fn run_events_handler_inner_no_guard(
         // the sync tx closure — tokio::fs reads must not run on the DB
         // worker thread.
         let mut projected: Vec<cairn_core::domain::MemoryRecord> = Vec::with_capacity(group.len());
+        let mut trace_canvas_projections: Vec<TraceCanvasProjection> = Vec::new();
         let mut had_stop = false;
         let mut group_failed = false;
 
@@ -617,6 +621,10 @@ async fn run_events_handler_inner_no_guard(
                 let key = tool_call_id.clone().unwrap_or_default();
                 needs_parent_from_store.push((projected.len(), key));
             }
+            if let Some(projection) = trace_canvas_projection_for_record(event, classified, &record)
+            {
+                trace_canvas_projections.push(projection);
+            }
             projected.push(record);
 
             // Register this PreTool so later PostTool/ToolOutput events can
@@ -761,6 +769,25 @@ async fn run_events_handler_inner_no_guard(
         // Failure is non-fatal — the CLI verb succeeds even if the scheduler
         // is absent or the enqueue fails.
         if let Some(js) = job_store {
+            let now_ms = i64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis(),
+            )
+            .unwrap_or(i64::MAX);
+
+            for projection in &trace_canvas_projections {
+                let _ = enqueue_trace_canvas_step(
+                    js,
+                    TraceCanvasPayload {
+                        projection: projection.clone(),
+                    },
+                    now_ms,
+                )
+                .await;
+            }
+
             // Scope both reads + enqueue by the caller's bound scope so
             // queries narrow to this issuer's data (round-4 adversarial
             // review #1). At single-tenant P0 `scope_binding` is `None`
@@ -1058,6 +1085,128 @@ fn classify_trace_event(
         CapturePayload::RecordingBatch { .. } => Ok(TraceEvent::UserMessage),
         _ => core_classify(event),
     }
+}
+
+fn trace_canvas_projection_for_record(
+    event: &CaptureEvent,
+    classified: TraceEvent,
+    record: &cairn_core::domain::MemoryRecord,
+) -> Option<TraceCanvasProjection> {
+    if !matches!(
+        classified,
+        TraceEvent::PreTool | TraceEvent::PostTool | TraceEvent::ToolOutput
+    ) {
+        return None;
+    }
+
+    let refs = event.refs.as_ref()?;
+    let session_id = refs.session_id.as_ref()?.clone();
+    let turn_id = refs.turn_id.as_ref()?.clone();
+    let tool_call_id = refs.tool_id.clone();
+    let tool_name = trace_canvas_tool_name(event);
+    let record_id = record.id.as_str().to_owned();
+    let timestamp_ms = event.captured_at.as_chrono().timestamp_millis();
+    let (call_summary, result_summary, node_label, node_status, node_summary) =
+        trace_canvas_summaries(classified, tool_name.as_deref());
+    let step_id = format!("trace-step:{record_id}");
+
+    Some(TraceCanvasProjection {
+        step: TraceStepDraft {
+            step_id: step_id.clone(),
+            trace_id: event.event_id.as_str().to_owned(),
+            session_id,
+            turn_id,
+            tool_call_id: tool_call_id.clone(),
+            timestamp_ms,
+            tool_name,
+            call_summary,
+            result_summary,
+            result_ref: Some(record_id),
+            salience: trace_canvas_salience(classified),
+            replaceability_score: trace_canvas_replaceability(classified),
+            node_id: Some(format!("trace-node:{step_id}")),
+            source_hash: trace_canvas_source_hash(event, classified, tool_call_id.as_deref()),
+        },
+        canvas_title: "Current task".to_owned(),
+        canvas_goal: "Continue the current session task".to_owned(),
+        node_label,
+        node_status,
+        node_summary,
+    })
+}
+
+fn trace_canvas_tool_name(event: &CaptureEvent) -> Option<String> {
+    match &event.payload {
+        CapturePayload::Hook { tool_name, .. } => tool_name.clone(),
+        CapturePayload::Terminal { .. } => Some("terminal".to_owned()),
+        _ => None,
+    }
+}
+
+fn trace_canvas_summaries(
+    event: TraceEvent,
+    tool_name: Option<&str>,
+) -> (String, String, String, String, String) {
+    let label_tool = tool_name.unwrap_or("tool");
+    match event {
+        TraceEvent::PreTool => (
+            "tool call started".to_owned(),
+            "result pending".to_owned(),
+            format!("{label_tool} started"),
+            "active".to_owned(),
+            "Tool call was dispatched.".to_owned(),
+        ),
+        TraceEvent::PostTool => (
+            "tool call completed".to_owned(),
+            "tool result captured".to_owned(),
+            format!("{label_tool} completed"),
+            "completed".to_owned(),
+            "Tool call completed and its result is available.".to_owned(),
+        ),
+        TraceEvent::ToolOutput => (
+            "tool output captured".to_owned(),
+            "tool output available".to_owned(),
+            format!("{label_tool} output"),
+            "completed".to_owned(),
+            "Tool output was captured for exact retrieval.".to_owned(),
+        ),
+        _ => unreachable!("caller filters to tool lifecycle events"),
+    }
+}
+
+fn trace_canvas_salience(event: TraceEvent) -> f64 {
+    match event {
+        TraceEvent::PreTool => 0.45,
+        TraceEvent::PostTool | TraceEvent::ToolOutput => 0.65,
+        _ => 0.5,
+    }
+}
+
+fn trace_canvas_replaceability(event: TraceEvent) -> f64 {
+    match event {
+        TraceEvent::PreTool => 0.75,
+        TraceEvent::PostTool | TraceEvent::ToolOutput => 0.55,
+        _ => 0.7,
+    }
+}
+
+fn trace_canvas_source_hash(
+    event: &CaptureEvent,
+    classified: TraceEvent,
+    tool_call_id: Option<&str>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"cairn:trace-canvas-step:v1\0");
+    hasher.update(event.event_id.as_str().as_bytes());
+    hasher.update([0]);
+    hasher.update(event.payload_hash.as_str().as_bytes());
+    hasher.update([0]);
+    hasher.update(format!("{classified:?}").as_bytes());
+    hasher.update([0]);
+    if let Some(tool_call_id) = tool_call_id {
+        hasher.update(tool_call_id.as_bytes());
+    }
+    format!("sha256:{:x}", hasher.finalize())
 }
 
 fn voice_transcript_text(body_bytes: &[u8]) -> anyhow::Result<String> {
@@ -2029,5 +2178,151 @@ mod tests {
             dream_requests[0].dedupe_key, dream_requests[1].dedupe_key,
             "idempotent Stop-hook replay must target the same dream dedupe slot"
         );
+    }
+
+    #[tokio::test]
+    #[allow(
+        clippy::expect_used,
+        reason = "test: panics surface broken invariants immediately"
+    )]
+    async fn capture_trace_enqueues_trace_canvas_tool_steps() {
+        let store = cairn_store_sqlite::open_in_memory()
+            .await
+            .expect("in-memory store");
+        let vault = tempfile::tempdir().expect("tempdir");
+        let conn = rusqlite::Connection::open_in_memory().expect("job conn");
+        cairn_workflows::sqlite_store::install_for_tests(&conn);
+        let jobs = cairn_workflows::SqliteJobStore::new(conn).expect("job store");
+
+        let session_id = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+        let turn_id = "turn-canvas";
+        let tool_id = "toolu_canvas_01";
+        let pre_id = "01ARZ3NDEKTSV4RRFFQ69G5FA1";
+        let post_id = "01ARZ3NDEKTSV4RRFFQ69G5FA2";
+        let pre_body = r#"{"tool":"shell","input":{}}"#;
+        let post_body = r#"{"ok":true}"#;
+        let pre_ref = write_test_source(vault.path(), pre_id, pre_body);
+        let post_ref = write_test_source(vault.path(), post_id, post_body);
+        let events = vec![
+            test_hook_event(
+                pre_id,
+                "PreToolUse",
+                session_id,
+                turn_id,
+                "2026-05-02T00:00:02Z",
+                Some(tool_id),
+                &pre_ref,
+                pre_body,
+            ),
+            test_hook_event(
+                post_id,
+                "PostToolUse",
+                session_id,
+                turn_id,
+                "2026-05-02T00:00:03Z",
+                Some(tool_id),
+                &post_ref,
+                post_body,
+            ),
+        ];
+
+        let response = run_events_handler_inner_no_guard(
+            &store,
+            vault.path(),
+            events,
+            None,
+            None,
+            Some(&jobs),
+            &ConsolidationConfig::default(),
+            &DreamConfig::default(),
+        )
+        .await
+        .expect("capture trace");
+        assert_eq!(
+            response.failed_turns,
+            Vec::<(String, String, String)>::new()
+        );
+
+        let job_id = cairn_core::contract::job_store::JobId::new(format!(
+            "trace-canvas:trace-step:{post_id}"
+        ));
+        let leased = cairn_core::contract::job_store::JobStore::lease_specific(
+            &jobs,
+            &job_id,
+            &cairn_core::contract::job_store::JobKind::new(cairn_workflows::TRACE_CANVAS_KIND),
+            "test-worker",
+            chrono::Utc::now().timestamp_millis(),
+            30_000,
+        )
+        .await
+        .expect("lease")
+        .expect("trace canvas job queued");
+        let payload =
+            cairn_workflows::TraceCanvasPayload::from_bytes(&leased.payload).expect("payload");
+        assert_eq!(
+            payload.projection.step.step_id,
+            format!("trace-step:{post_id}")
+        );
+        assert_eq!(payload.projection.step.session_id, session_id);
+        assert_eq!(payload.projection.step.turn_id, turn_id);
+        assert_eq!(
+            payload.projection.step.tool_call_id.as_deref(),
+            Some(tool_id)
+        );
+        assert_eq!(payload.projection.step.result_ref.as_deref(), Some(post_id));
+        assert_eq!(payload.projection.node_status, "completed");
+    }
+
+    fn write_test_source(vault: &Path, event_id: &str, body: &str) -> String {
+        let dir = vault.join("sources/hook");
+        std::fs::create_dir_all(&dir).expect("mkdir source dir");
+        let file_name = format!("{event_id}.txt");
+        std::fs::write(dir.join(&file_name), body).expect("write source");
+        format!("sources/hook/{file_name}")
+    }
+
+    #[allow(clippy::too_many_arguments, reason = "test fixture factory")]
+    fn test_hook_event(
+        event_id: &str,
+        hook_name: &str,
+        session_id: &str,
+        turn_id: &str,
+        timestamp: &str,
+        tool_id: Option<&str>,
+        payload_ref: &str,
+        body: &str,
+    ) -> CaptureEvent {
+        let sensor =
+            Identity::parse("snr:local:hook:cc-session:v1").expect("valid sensor identity");
+        CaptureEvent {
+            event_id: CaptureEventId::parse(event_id).expect("valid event id"),
+            sensor_id: sensor.clone(),
+            capture_mode: CaptureMode::Auto,
+            actor_chain: vec![ActorChainEntry {
+                role: ChainRole::Author,
+                identity: sensor,
+                at: Rfc3339Timestamp::parse(timestamp).expect("valid timestamp"),
+            }],
+            refs: Some(CaptureRefs {
+                session_id: Some(session_id.to_owned()),
+                turn_id: Some(turn_id.to_owned()),
+                tool_id: tool_id.map(ToOwned::to_owned),
+            }),
+            payload_hash: PayloadHash::parse(format!("sha256:{}", test_sha256_hex(body)))
+                .expect("valid payload hash"),
+            payload_ref: payload_ref.to_owned(),
+            captured_at: Rfc3339Timestamp::parse(timestamp).expect("valid timestamp"),
+            payload: CapturePayload::Hook {
+                hook_name: hook_name.to_owned(),
+                tool_name: Some("shell".to_owned()),
+            },
+            source_family: SourceFamily::Hook,
+        }
+    }
+
+    fn test_sha256_hex(body: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(body.as_bytes());
+        format!("{:x}", hasher.finalize())
     }
 }

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1305,6 +1305,8 @@ pub async fn lint_handler(
     };
     let mut data = run_checks(&inputs).await;
 
+    append_trace_canvas_findings(store, &lint_records, &source_resolver, &mut data).await?;
+
     if index_stats_skipped {
         push_index_stats_skipped(&mut data);
     }
@@ -2153,6 +2155,33 @@ fn push_projection_finding(
     data.findings.push(f);
 }
 
+async fn append_trace_canvas_findings(
+    store: &dyn cairn_core::contract::memory_store::MemoryStore,
+    records: &[cairn_core::verbs::lint::LintRecord],
+    source_resolver: &dyn SourceResolver,
+    data: &mut LintData,
+) -> anyhow::Result<()> {
+    let snapshot = match store.trace_canvas_lint_snapshot().await {
+        Ok(snapshot) => snapshot,
+        Err(e)
+            if e.to_string()
+                .contains("not supported by this store adapter") =>
+        {
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!("store: trace_canvas_lint_snapshot: {e}"))
+                .context("lint: trace_canvas_lint_snapshot");
+        }
+    };
+    let findings =
+        cairn_core::verbs::lint::checks::trace_canvas::run(&snapshot, records, source_resolver);
+    for finding in findings {
+        push_lint_finding(data, finding);
+    }
+    Ok(())
+}
+
 fn append_sensor_drop_findings(vault_root: &Path, data: &mut LintData) -> anyhow::Result<()> {
     let drops = crate::sensor_gate::read_sensor_drop_metrics(vault_root)
         .with_context(|| format!("lint: sensor drop metrics from {}", vault_root.display()))?;
@@ -2182,7 +2211,7 @@ fn append_sensor_drop_findings(vault_root: &Path, data: &mut LintData) -> anyhow
             }),
             tracking_issue: Some(88),
         };
-        push_sensor_drop_finding(data, finding);
+        push_lint_finding(data, finding);
     }
     Ok(())
 }
@@ -2195,7 +2224,7 @@ fn sensor_drop_kind(reason: cairn_core::domain::SensorGateReason) -> Option<Kind
     }
 }
 
-fn push_sensor_drop_finding(data: &mut LintData, finding: Finding) {
+fn push_lint_finding(data: &mut LintData, finding: Finding) {
     let key = kind_key(finding.kind);
     data.summary.total += 1;
     match finding.severity {

--- a/crates/cairn-cli/src/verbs/retrieve.rs
+++ b/crates/cairn-cli/src/verbs/retrieve.rs
@@ -4,7 +4,7 @@
     reason = "CLI helpers return complete response envelopes for direct JSON emission"
 )]
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -16,7 +16,10 @@ use cairn_core::domain::canonical::canonical_bytes_signed_intent;
 use cairn_core::domain::consent_timeline::ConsentModel;
 use cairn_core::domain::identity::keys::SecretHandle;
 use cairn_core::domain::taxonomy::MemoryVisibility;
-use cairn_core::domain::{Identity, MemoryKind, MemoryRecord, RecordId, ScopeTuple};
+use cairn_core::domain::{
+    Identity, MemoryKind, MemoryRecord, RecordId, ScopeTuple, SessionId, TreeReadRecord,
+    TreeReadWindow, TreeReadWindowInput, plan_tree_read_window,
+};
 use cairn_core::generated::common::{Cursor, Ed25519Signature, ScopeFilter, ScopeFilterTier, Ulid};
 use cairn_core::generated::envelope::{
     RequestArgs, RequestVerb, Response, ResponseData, ResponsePolicyTrace,
@@ -310,10 +313,10 @@ async fn retrieve_session(
         read_budget_chars,
     } = request;
     let rehydrate_started = rehydrate.then(Instant::now);
-    let mut args = scoped_list_args(auth);
-    if let Some(scope) = &mut args.scope {
-        scope.session_id = Some(session_id.clone());
-    }
+    let target_session = match SessionId::parse(session_id.clone()) {
+        Ok(session_id) => session_id,
+        Err(e) => return super::signed::rejected_from_domain(ResponseVerb::Retrieve, e),
+    };
     let order = order.unwrap_or(RetrieveArgsSessionOrder::Asc);
     let start = match parse_session_cursor(cursor.as_ref(), order) {
         Ok(start) => start,
@@ -322,11 +325,18 @@ async fn retrieve_session(
     let requested_limit = limit
         .and_then(|v| usize::try_from(v).ok())
         .unwrap_or(usize::MAX);
-    let mut hot_records = match list_records(store, args).await {
+    let (hot_records, mut tree_policy_trace) = match session_records_for_retrieve(
+        store,
+        auth,
+        &session_id,
+        &target_session,
+        read_budget_chars,
+    )
+    .await
+    {
         Ok(records) => records,
         Err(resp) => return resp,
     };
-    hot_records.retain(|record| record.scope.session_id.as_deref() == Some(session_id.as_str()));
     let (records, source_tier) = if rehydrate {
         match cold_records_for_hot(vault_root, &session_id, &hot_records) {
             Ok(Some(cold_records)) => (cold_records, "cold"),
@@ -367,7 +377,7 @@ async fn retrieve_session(
         .into_iter()
         .flat_map(|group| group.records)
         .collect::<Vec<_>>();
-    committed_after_access(
+    let mut response = committed_after_access(
         store,
         auth,
         cairn_core::verbs::retrieve::session_data_with_options(
@@ -380,7 +390,102 @@ async fn retrieve_session(
         &records,
         Some(&budget_report),
     )
-    .await
+    .await;
+    if records.is_empty() {
+        tree_policy_trace.clear();
+    }
+    response.policy_trace.append(&mut tree_policy_trace);
+    response
+}
+
+async fn session_records_for_retrieve(
+    store: &SqliteMemoryStore,
+    auth: &ReadAuthorization,
+    session_id: &str,
+    target_session: &SessionId,
+    read_budget_chars: usize,
+) -> Result<(Vec<MemoryRecord>, Vec<ResponsePolicyTrace>), Response> {
+    let tree = match store.get_session_tree(target_session).await {
+        Ok(tree) => tree,
+        Err(e) if store_error_is_capability_unavailable(&e) => None,
+        Err(e) => {
+            return Err(super::signed::aborted(
+                ResponseVerb::Retrieve,
+                format!("session tree: {e}"),
+            ));
+        }
+    };
+    if let Some(tree) = tree
+        && tree_has_retrieve_context(&tree, target_session)?
+    {
+        return tree_session_records_for_retrieve(
+            store,
+            auth,
+            target_session,
+            read_budget_chars,
+            &tree,
+        )
+        .await;
+    }
+    flat_session_records_for_retrieve(store, auth, session_id)
+        .await
+        .map(|records| (records, Vec::new()))
+}
+
+fn tree_has_retrieve_context(
+    tree: &cairn_core::domain::SessionTree,
+    target_session: &SessionId,
+) -> Result<bool, Response> {
+    let lineage = tree.lineage(target_session).map_err(|e| {
+        super::signed::aborted(ResponseVerb::Retrieve, format!("session tree: {e}"))
+    })?;
+    Ok(lineage.len() > 1 || !tree.merges().is_empty())
+}
+
+async fn tree_session_records_for_retrieve(
+    store: &SqliteMemoryStore,
+    auth: &ReadAuthorization,
+    target_session: &SessionId,
+    read_budget_chars: usize,
+    tree: &cairn_core::domain::SessionTree,
+) -> Result<(Vec<MemoryRecord>, Vec<ResponsePolicyTrace>), Response> {
+    let lineage = tree.lineage(target_session).map_err(|e| {
+        super::signed::aborted(ResponseVerb::Retrieve, format!("session tree: {e}"))
+    })?;
+    let mut lineage_records = Vec::new();
+    for lineage_session in lineage {
+        let mut session_records =
+            flat_session_records_for_retrieve(store, auth, lineage_session.as_str()).await?;
+        lineage_records.append(&mut session_records);
+    }
+    let tree_records = tree_read_records_from_memory_records(&lineage_records).map_err(|e| {
+        super::signed::aborted(ResponseVerb::Retrieve, format!("session tree records: {e}"))
+    })?;
+    let window = plan_tree_read_window(TreeReadWindowInput {
+        tree,
+        target_session,
+        records: &tree_records,
+        budget_bytes: read_budget_chars,
+    })
+    .map_err(|e| super::signed::aborted(ResponseVerb::Retrieve, format!("session tree: {e}")))?;
+    Ok((
+        memory_records_in_tree_order(lineage_records, &window),
+        tree_read_policy_trace(&window),
+    ))
+}
+
+async fn flat_session_records_for_retrieve(
+    store: &SqliteMemoryStore,
+    auth: &ReadAuthorization,
+    session_id: &str,
+) -> Result<Vec<MemoryRecord>, Response> {
+    let mut args = scoped_list_args(auth);
+    if let Some(scope) = &mut args.scope {
+        scope.session_id = Some(session_id.to_owned());
+    }
+    let mut records = list_records(store, args).await?;
+    records.retain(|record| record.scope.session_id.as_deref() == Some(session_id));
+    Ok(records)
 }
 
 async fn retrieve_turn(
@@ -848,6 +953,89 @@ fn read_policy_trace(
         }
     }
     trace
+}
+
+fn tree_read_records_from_memory_records(
+    records: &[MemoryRecord],
+) -> Result<Vec<TreeReadRecord>, cairn_core::domain::DomainError> {
+    records
+        .iter()
+        .map(|record| {
+            let session_id = record.scope.session_id.clone().ok_or(
+                cairn_core::domain::DomainError::MalformedScope {
+                    message: "tree read record missing session_id".to_owned(),
+                },
+            )?;
+            Ok(TreeReadRecord {
+                session_id: SessionId::parse(session_id)?,
+                turn_id: trace_turn_id(record),
+                record_id: record.id.clone(),
+                body: record.body.clone(),
+            })
+        })
+        .collect()
+}
+
+fn memory_records_in_tree_order(
+    records: Vec<MemoryRecord>,
+    window: &TreeReadWindow,
+) -> Vec<MemoryRecord> {
+    let records_by_id = records
+        .into_iter()
+        .map(|record| (record.id.clone(), record))
+        .collect::<BTreeMap<_, _>>();
+    window
+        .selected_records
+        .iter()
+        .filter_map(|record| records_by_id.get(&record.record_id).cloned())
+        .collect()
+}
+
+fn tree_read_policy_trace(window: &TreeReadWindow) -> Vec<ResponsePolicyTrace> {
+    if window.selected_records.is_empty() {
+        return Vec::new();
+    }
+    let mut trace = vec![ResponsePolicyTrace {
+        detail: Some(format!(
+            "path_sessions={} records_in={} records_out={} skipped_for_budget={} trimmed={}",
+            window.ancestry_path.len(),
+            window.budget.records_in,
+            window.budget.records_out,
+            window.budget.skipped_for_budget,
+            window.budget.trimmed
+        )),
+        gate: "tree.lineage".to_owned(),
+        result: ResponsePolicyTraceResult::Pass,
+    }];
+    if !window.sibling_sessions.is_empty() {
+        trace.push(ResponsePolicyTrace {
+            detail: Some(format!(
+                "sibling_sessions={}",
+                window.sibling_sessions.len()
+            )),
+            gate: "tree.sibling_context".to_owned(),
+            result: ResponsePolicyTraceResult::Pass,
+        });
+    }
+    if !window.merge_notes.is_empty() {
+        trace.push(ResponsePolicyTrace {
+            detail: Some(format!("merge_notes={}", window.merge_notes.len())),
+            gate: "tree.merge_context".to_owned(),
+            result: ResponsePolicyTraceResult::Pass,
+        });
+    }
+    trace
+}
+
+fn store_error_is_capability_unavailable(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(error) = current {
+        if error.to_string().contains("capability unavailable") {
+            return true;
+        }
+        current = error.source();
+    }
+    false
 }
 
 fn session_include_flags(include: Option<&[RetrieveArgsSessionInclude]>) -> (bool, bool) {
@@ -1542,4 +1730,123 @@ fn read_sequence() -> u64 {
 
 fn current_unix_ms_i64() -> i64 {
     i64::try_from(read_sequence()).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use cairn_core::domain::record::tests_export::sample_record;
+    use cairn_core::domain::{RecordId, ScopeTuple};
+
+    use super::*;
+
+    fn record(id: &str, session_id: &str, turn_id: &str, body: &str) -> MemoryRecord {
+        let mut record = sample_record();
+        record.id = RecordId::parse(id).expect("valid record id");
+        record.scope = ScopeTuple {
+            session_id: Some(session_id.to_owned()),
+            ..ScopeTuple::default()
+        };
+        record.body = body.to_owned();
+        record.extra_frontmatter.insert(
+            "trace".to_owned(),
+            serde_json::json!({
+                "turn_id": turn_id,
+            }),
+        );
+        record
+    }
+
+    #[test]
+    fn tree_records_from_memory_records_preserve_trace_turn_ids() {
+        let records = vec![
+            record("01JTS6R4J70000000000000001", "root", "turn-1", "root body"),
+            record(
+                "01JTS6R4J70000000000000002",
+                "branch",
+                "turn-2",
+                "branch body",
+            ),
+        ];
+
+        let tree_records = tree_read_records_from_memory_records(&records)
+            .expect("memory records should convert to tree read records");
+
+        assert_eq!(tree_records.len(), 2);
+        assert_eq!(tree_records[0].session_id.as_str(), "root");
+        assert_eq!(tree_records[0].turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(
+            tree_records[0].record_id.as_str(),
+            "01JTS6R4J70000000000000001"
+        );
+        assert_eq!(tree_records[0].body, "root body");
+        assert_eq!(tree_records[1].session_id.as_str(), "branch");
+        assert_eq!(tree_records[1].turn_id.as_deref(), Some("turn-2"));
+        assert_eq!(
+            tree_records[1].record_id.as_str(),
+            "01JTS6R4J70000000000000002"
+        );
+        assert_eq!(tree_records[1].body, "branch body");
+    }
+
+    #[test]
+    fn flat_tree_is_not_treated_as_tree_retrieve_context() {
+        let root = SessionId::parse("root").expect("root session");
+        let tree = cairn_core::domain::SessionTree::flat(root.clone());
+
+        assert!(
+            !tree_has_retrieve_context(&tree, &root).expect("flat context check"),
+            "synthesized flat trees must preserve legacy retrieve ordering and budget"
+        );
+    }
+
+    #[test]
+    fn tree_trace_is_non_identifying_and_suppressed_without_selected_records() {
+        let root = SessionId::parse("private-root").expect("root session");
+        let branch = SessionId::parse("private-branch").expect("branch session");
+        let sibling = SessionId::parse("private-peer").expect("sibling session");
+        let mut tree = cairn_core::domain::SessionTree::flat(root.clone());
+        tree.fork(&root, branch.clone(), "turn-2").expect("fork");
+        tree.fork(&root, sibling.clone(), "turn-2")
+            .expect("sibling fork");
+        let records = vec![TreeReadRecord {
+            session_id: sibling,
+            turn_id: Some("turn-3".to_owned()),
+            record_id: RecordId::parse("01JTS6R4J70000000000000003").expect("record id"),
+            body: "sibling secret body".to_owned(),
+        }];
+        let empty_window = plan_tree_read_window(TreeReadWindowInput {
+            tree: &tree,
+            target_session: &branch,
+            records: &records,
+            budget_bytes: 1024,
+        })
+        .expect("window");
+
+        assert!(tree_read_policy_trace(&empty_window).is_empty());
+
+        let authorized = vec![TreeReadRecord {
+            session_id: branch.clone(),
+            turn_id: Some("turn-4".to_owned()),
+            record_id: RecordId::parse("01JTS6R4J70000000000000004").expect("record id"),
+            body: "branch secret body".to_owned(),
+        }];
+        let window = plan_tree_read_window(TreeReadWindowInput {
+            tree: &tree,
+            target_session: &branch,
+            records: &authorized,
+            budget_bytes: 1024,
+        })
+        .expect("authorized window");
+        let detail = tree_read_policy_trace(&window)
+            .iter()
+            .filter_map(|entry| entry.detail.as_deref())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(detail.contains("path_sessions=2"));
+        assert!(!detail.contains("private-root"));
+        assert!(!detail.contains("private-branch"));
+        assert!(!detail.contains("private-peer"));
+        assert!(!detail.contains("secret body"));
+    }
 }

--- a/crates/cairn-cli/src/verbs/retrieve.rs
+++ b/crates/cairn-cli/src/verbs/retrieve.rs
@@ -659,7 +659,11 @@ async fn committed_after_access(
     budget: Option<&BudgetReport>,
 ) -> Response {
     record_access(store, records, "retrieve").await;
-    committed(auth, data, records, budget)
+    let mut response = committed(auth, data, records, budget);
+    response
+        .policy_trace
+        .extend(trace_step_result_ref_policy_trace(store, records).await);
+    response
 }
 
 async fn record_access(store: &SqliteMemoryStore, records: &[MemoryRecord], reason: &str) {
@@ -953,6 +957,46 @@ fn read_policy_trace(
         }
     }
     trace
+}
+
+async fn trace_step_result_ref_policy_trace(
+    store: &SqliteMemoryStore,
+    records: &[MemoryRecord],
+) -> Vec<ResponsePolicyTrace> {
+    if records.is_empty() {
+        return Vec::new();
+    }
+
+    let mut records_with_steps = 0_usize;
+    let mut steps = 0_usize;
+    for record in records {
+        match store
+            .find_trace_steps_by_result_ref(record.id.as_str())
+            .await
+        {
+            Ok(found) if !found.is_empty() => {
+                records_with_steps = records_with_steps.saturating_add(1);
+                steps = steps.saturating_add(found.len());
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "trace-step result-ref lookup failed during retrieve"
+                );
+            }
+        }
+    }
+
+    if steps == 0 {
+        return Vec::new();
+    }
+
+    vec![ResponsePolicyTrace {
+        detail: Some(format!("records={records_with_steps} steps={steps}")),
+        gate: "trace_canvas.result_ref".to_owned(),
+        result: ResponsePolicyTraceResult::Pass,
+    }]
 }
 
 fn tree_read_records_from_memory_records(
@@ -1848,5 +1892,47 @@ mod tests {
         assert!(!detail.contains("private-branch"));
         assert!(!detail.contains("private-peer"));
         assert!(!detail.contains("secret body"));
+    }
+
+    #[tokio::test]
+    async fn trace_step_result_ref_policy_trace_reports_counts_only() {
+        let store = cairn_store_sqlite::open_in_memory()
+            .await
+            .expect("open store");
+        let record = record(
+            "01JTS6R4J70000000000000005",
+            "session-1",
+            "turn-1",
+            "secret retrieved body",
+        );
+        store
+            .upsert_trace_step(cairn_store_sqlite::TraceStepDraft {
+                step_id: "step-1".to_owned(),
+                trace_id: "trace-1".to_owned(),
+                session_id: "session-1".to_owned(),
+                turn_id: "turn-1".to_owned(),
+                tool_call_id: Some("toolu-1".to_owned()),
+                timestamp_ms: 1,
+                tool_name: Some("shell".to_owned()),
+                call_summary: "call summary should not leak".to_owned(),
+                result_summary: "result summary should not leak".to_owned(),
+                result_ref: Some(record.id.as_str().to_owned()),
+                salience: 0.5,
+                replaceability_score: 0.5,
+                node_id: None,
+                source_hash: "hash-1".to_owned(),
+            })
+            .await
+            .expect("trace step");
+
+        let trace = trace_step_result_ref_policy_trace(&store, std::slice::from_ref(&record)).await;
+
+        assert_eq!(trace.len(), 1);
+        assert_eq!(trace[0].gate, "trace_canvas.result_ref");
+        assert_eq!(trace[0].detail.as_deref(), Some("records=1 steps=1"));
+        let detail = trace[0].detail.as_deref().unwrap_or_default();
+        assert!(!detail.contains(record.id.as_str()));
+        assert!(!detail.contains("secret"));
+        assert!(!detail.contains("step-1"));
     }
 }

--- a/crates/cairn-cli/src/verbs/summarize.rs
+++ b/crates/cairn-cli/src/verbs/summarize.rs
@@ -4,7 +4,7 @@
     reason = "CLI helpers return complete response envelopes for direct JSON emission"
 )]
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -20,7 +20,8 @@ use cairn_core::domain::consent_timeline::ConsentModel;
 use cairn_core::domain::identity::keys::SecretHandle;
 use cairn_core::domain::taxonomy::MemoryVisibility;
 use cairn_core::domain::{
-    Identity, MemoryRecord, RecordId, ScopeTuple, SignedAdmission, WalActionKind,
+    Identity, MemoryRecord, RecordId, ScopeTuple, SessionId, SignedAdmission, TreeReadRecord,
+    TreeReadWindowInput, WalActionKind, plan_tree_read_window,
 };
 use cairn_core::generated::common::{Ed25519Signature, Nonce16Base64, Ulid};
 use cairn_core::generated::envelope::{
@@ -102,6 +103,10 @@ async fn run_async(args: SummarizeArgs, vault_root: PathBuf, config: CairnConfig
     };
 
     let records = match load_source_records(&ctx.store, &args, &auth).await {
+        Ok(records) => records,
+        Err(resp) => return merge_policy_trace(read_policy_trace(&auth, &[]), resp),
+    };
+    let records = match tree_window_source_records(&ctx.store, records).await {
         Ok(records) => records,
         Err(resp) => return merge_policy_trace(read_policy_trace(&auth, &[]), resp),
     };
@@ -218,6 +223,118 @@ fn record_principal_matches_issuer(record: &MemoryRecord, issuer: &Identity) -> 
             record.provenance.source_sensor.as_str() == issuer.as_str()
         }
     }
+}
+
+fn common_session_id(records: &[MemoryRecord]) -> Option<&str> {
+    let first = records.first()?.scope.session_id.as_deref()?;
+    records
+        .iter()
+        .all(|record| record.scope.session_id.as_deref() == Some(first))
+        .then_some(first)
+}
+
+async fn tree_window_source_records(
+    store: &cairn_store_sqlite::SqliteMemoryStore,
+    records: Vec<MemoryRecord>,
+) -> Result<Vec<MemoryRecord>, Response> {
+    let Some(session_id) = common_session_id(&records).map(str::to_owned) else {
+        return Ok(records);
+    };
+    let target_session = SessionId::parse(session_id).map_err(|e| {
+        super::signed::aborted(ResponseVerb::Summarize, format!("session tree: {e}"))
+    })?;
+    let tree = match store.get_session_tree(&target_session).await {
+        Ok(tree) => tree,
+        Err(e) if store_error_is_capability_unavailable(&e) => None,
+        Err(e) => {
+            return Err(super::signed::aborted(
+                ResponseVerb::Summarize,
+                format!("session tree: {e}"),
+            ));
+        }
+    };
+    if let Some(tree) = tree
+        && tree_has_summary_context(&tree, &target_session)?
+    {
+        let tree_records = tree_read_records_from_memory_records(&records).map_err(|e| {
+            super::signed::aborted(
+                ResponseVerb::Summarize,
+                format!("session tree records: {e}"),
+            )
+        })?;
+        let window = plan_tree_read_window(TreeReadWindowInput {
+            tree: &tree,
+            target_session: &target_session,
+            records: &tree_records,
+            budget_bytes: usize::MAX,
+        })
+        .map_err(|e| {
+            super::signed::aborted(ResponseVerb::Summarize, format!("session tree: {e}"))
+        })?;
+        let records_by_id = records
+            .into_iter()
+            .map(|record| (record.id.clone(), record))
+            .collect::<BTreeMap<_, _>>();
+        let selected = window
+            .selected_records
+            .iter()
+            .filter_map(|record| records_by_id.get(&record.record_id).cloned())
+            .collect::<Vec<_>>();
+        return Ok(selected);
+    }
+    Ok(records)
+}
+
+fn tree_has_summary_context(
+    tree: &cairn_core::domain::SessionTree,
+    target_session: &SessionId,
+) -> Result<bool, Response> {
+    let lineage = tree.lineage(target_session).map_err(|e| {
+        super::signed::aborted(ResponseVerb::Summarize, format!("session tree: {e}"))
+    })?;
+    Ok(lineage.len() > 1 || !tree.merges().is_empty())
+}
+
+fn tree_read_records_from_memory_records(
+    records: &[MemoryRecord],
+) -> Result<Vec<TreeReadRecord>, cairn_core::domain::DomainError> {
+    records
+        .iter()
+        .map(|record| {
+            let session_id = record.scope.session_id.clone().ok_or(
+                cairn_core::domain::DomainError::MalformedScope {
+                    message: "tree read record missing session_id".to_owned(),
+                },
+            )?;
+            Ok(TreeReadRecord {
+                session_id: SessionId::parse(session_id)?,
+                turn_id: trace_turn_id(record),
+                record_id: record.id.clone(),
+                body: record.body.clone(),
+            })
+        })
+        .collect()
+}
+
+fn trace_turn_id(record: &MemoryRecord) -> Option<String> {
+    record
+        .extra_frontmatter
+        .get("trace")
+        .and_then(|trace| trace.get("turn_id"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn store_error_is_capability_unavailable(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(error) = current {
+        if error.to_string().contains("capability unavailable") {
+            return true;
+        }
+        current = error.source();
+    }
+    false
 }
 
 #[allow(
@@ -717,4 +834,40 @@ fn unix_time_millis_i64() -> i64 {
         .unwrap_or_default()
         .as_millis();
     i64::try_from(millis).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use cairn_core::domain::record::tests_export::sample_record;
+
+    use super::*;
+
+    fn record_with_session(session_id: Option<&str>) -> MemoryRecord {
+        let mut record = sample_record();
+        record.scope.session_id = session_id.map(str::to_owned);
+        record
+    }
+
+    #[test]
+    fn common_session_id_requires_all_records_to_match() {
+        let records = vec![
+            record_with_session(Some("branch-a")),
+            record_with_session(Some("branch-a")),
+        ];
+        assert_eq!(common_session_id(&records), Some("branch-a"));
+
+        let mismatched = vec![
+            record_with_session(Some("branch-a")),
+            record_with_session(Some("branch-b")),
+        ];
+        assert_eq!(common_session_id(&mismatched), None);
+
+        let missing = vec![
+            record_with_session(Some("branch-a")),
+            record_with_session(None),
+        ];
+        assert_eq!(common_session_id(&missing), None);
+
+        assert_eq!(common_session_id(&[]), None);
+    }
 }

--- a/crates/cairn-cli/tests/issue_61_signed_verbs.rs
+++ b/crates/cairn-cli/tests/issue_61_signed_verbs.rs
@@ -11,7 +11,7 @@ use cairn_cli::verbs::signed::{
 use cairn_core::contract::memory_store::MemoryStore;
 use cairn_core::domain::{
     ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs,
-    ChainRole, DomainError, Identity, MemoryVisibility, PayloadHash, Rfc3339Timestamp,
+    ChainRole, DomainError, Identity, MemoryVisibility, PayloadHash, Rfc3339Timestamp, SessionId,
     SourceFamily,
 };
 use cairn_core::generated::common::Ulid;
@@ -884,6 +884,121 @@ fn retrieve_session_windows_by_turn_with_cursor() {
 }
 
 #[test]
+fn retrieve_session_includes_tree_lineage_context() {
+    const ROOT_SESSION: &str = "root-session";
+    const BRANCH_SESSION: &str = "branch-session";
+    let vault = tempfile::tempdir().expect("vault");
+    bootstrap(&BootstrapOpts {
+        vault_path: vault.path().to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap");
+    let _ = ingest_reference(vault.path(), "seed default issuer before retrieve");
+    let root_trace = write_single_trace_fixture(
+        vault.path(),
+        "issue-134-root.jsonl",
+        "01ARZ3NDEKTSV4RRFFQ69G5FAJ",
+        ROOT_SESSION,
+        "turn-1",
+        "ancestor tree body",
+        "2026-05-02T00:00:01Z",
+    );
+    run_capture_trace(vault.path(), &root_trace);
+    let branch_trace = write_single_trace_fixture(
+        vault.path(),
+        "issue-134-branch.jsonl",
+        "01ARZ3NDEKTSV4RRFFQ69G5FAK",
+        BRANCH_SESSION,
+        "turn-2",
+        "branch tree body",
+        "2026-05-02T00:00:02Z",
+    );
+    run_capture_trace(vault.path(), &branch_trace);
+    insert_session_row(vault.path(), ROOT_SESSION, "/tmp/cairn-root-session");
+    insert_session_row(vault.path(), BRANCH_SESSION, "/tmp/cairn-branch-session");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(async {
+        let store = cairn_store_sqlite::open(vault.path().join(".cairn/cairn.db"))
+            .await
+            .expect("open store");
+        store
+            .record_session_fork(
+                &SessionId::parse(ROOT_SESSION).expect("root session id"),
+                &SessionId::parse(BRANCH_SESSION).expect("branch session id"),
+                "turn-1",
+            )
+            .await
+            .expect("record fork");
+    });
+
+    let value = retrieve_session_json_value(vault.path(), BRANCH_SESSION);
+    assert_tree_retrieve_response(&value);
+}
+
+fn retrieve_session_json_value(vault: &Path, session_id: &str) -> serde_json::Value {
+    let retrieve = cli()
+        .current_dir(vault)
+        .args([
+            "retrieve",
+            "--session",
+            session_id,
+            "--order",
+            "asc",
+            "--json",
+        ])
+        .output()
+        .expect("run retrieve session");
+    assert_eq!(
+        retrieve.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&retrieve.stderr)
+    );
+    serde_json::from_slice(&retrieve.stdout).expect("json")
+}
+
+fn assert_tree_retrieve_response(value: &serde_json::Value) {
+    let items = value["data"]["items"].as_array().expect("items");
+    assert!(
+        items
+            .iter()
+            .any(|item| item["content"] == "ancestor tree body"),
+        "ancestor context missing: {value}"
+    );
+    assert!(
+        items
+            .iter()
+            .any(|item| item["content"] == "branch tree body"),
+        "branch-local content missing: {value}"
+    );
+    let tree_trace = value["policy_trace"]
+        .as_array()
+        .expect("policy_trace")
+        .iter()
+        .filter(|entry| {
+            entry["gate"]
+                .as_str()
+                .is_some_and(|gate| gate.starts_with("tree."))
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        tree_trace
+            .iter()
+            .any(|entry| entry["gate"] == "tree.lineage"),
+        "tree lineage trace missing: {value}"
+    );
+    for entry in tree_trace {
+        let detail = entry["detail"].as_str().expect("tree trace detail");
+        assert!(!detail.contains("ancestor tree body"));
+        assert!(!detail.contains("branch tree body"));
+    }
+}
+
+#[test]
 fn retrieve_turn_and_tool_call_return_linkage() {
     const SESSION_ID: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
     let vault = tempfile::tempdir().expect("vault");
@@ -1587,6 +1702,19 @@ fn insert_session_record(vault: &Path, body: &str) -> String {
     record_id
 }
 
+fn insert_session_row(vault: &Path, session_id: &str, project_root: &str) {
+    let conn = Connection::open(vault.join(".cairn/cairn.db")).expect("open sqlite");
+    conn.pragma_update(None, "foreign_keys", "ON")
+        .expect("enable foreign keys");
+    conn.execute(
+        "INSERT OR IGNORE INTO sessions \
+         (session_id, user_id, agent_id, project_root, title, created_at, last_activity_at) \
+         VALUES (?1, 'hmn:cairn:test:v1', 'agt:cairn-cli:default:writer:v1', ?2, '', 1, 1)",
+        rusqlite::params![session_id, project_root],
+    )
+    .expect("insert session row");
+}
+
 fn provision_agent(vault: &Path, slug: &str) -> String {
     let provision = cli()
         .current_dir(vault)
@@ -1738,6 +1866,37 @@ fn write_issue_61_trace_fixture(vault: &Path, session_id: &str) -> PathBuf {
         )
         .expect("write trace event");
     }
+    trace_path
+}
+
+fn write_single_trace_fixture(
+    vault: &Path,
+    filename: &str,
+    event_id: &str,
+    session_id: &str,
+    turn_id: &str,
+    body: &str,
+    timestamp: &str,
+) -> PathBuf {
+    let trace_path = vault.join(filename);
+    let mut jsonl = std::fs::File::create(&trace_path).expect("create trace jsonl");
+    let payload_ref = write_trace_source(vault, event_id, body);
+    let event = capture_trace_event_with_hook(
+        event_id,
+        session_id,
+        turn_id,
+        "UserPromptSubmit",
+        None,
+        timestamp,
+        &payload_ref,
+        body,
+    );
+    writeln!(
+        jsonl,
+        "{}",
+        serde_json::to_string(&event).expect("event json")
+    )
+    .expect("write trace event");
     trace_path
 }
 

--- a/crates/cairn-core/src/contract/memory_store.rs
+++ b/crates/cairn-core/src/contract/memory_store.rs
@@ -444,6 +444,18 @@ pub trait MemoryStore: Send + Sync {
         None
     }
 
+    /// Return the adapter's read-only task-trace canvas snapshot for
+    /// lint checks, when the backend supports the issue #134 substrate.
+    ///
+    /// # Errors
+    /// Returns [`StoreError`] when the underlying read fails, or the
+    /// "not supported" sentinel for adapters that have not opted in.
+    async fn trace_canvas_lint_snapshot(
+        &self,
+    ) -> Result<crate::verbs::lint::checks::trace_canvas::TraceCanvasLintSnapshot, StoreError> {
+        Err("trace_canvas_lint_snapshot: not supported by this store adapter".into())
+    }
+
     // ── Bitemporal knowledge graph (#186) ─────────────────────────────────
 
     /// Upsert an entity node. Deduplication is by `name_norm` (UNIQUE in

--- a/crates/cairn-core/src/domain/metrics.rs
+++ b/crates/cairn-core/src/domain/metrics.rs
@@ -38,6 +38,31 @@ pub enum MetricEvent {
         /// Snapshot of every source-class watermark at assembly time.
         watermarks: SourceWatermarks,
     },
+    /// Emitted when an active task-trace canvas is rendered into the
+    /// hot-memory current-task section. The payload is intentionally
+    /// body-free: IDs are hashed and canvas text / node summaries are
+    /// omitted so metrics stay safe for append-only observability.
+    #[serde(rename = "trace_canvas_rendered")]
+    TraceCanvasRendered {
+        /// Wall-clock millis since UNIX epoch.
+        ts_ms: i64,
+        /// SHA-256 of the canvas session id.
+        session_id_hash: String,
+        /// SHA-256 of the rendered canvas id.
+        canvas_id_hash: String,
+        /// Monotonic canvas version rendered by the caller.
+        version: i64,
+        /// Number of canvas nodes available to the renderer.
+        node_count: u32,
+        /// Number of canvas edges available to the renderer.
+        edge_count: u32,
+        /// Bytes rendered into the hot prefix for this section.
+        bytes: u64,
+        /// Effective canvas-local render budget.
+        budget_bytes: u64,
+        /// True when the canvas identified an active node.
+        active_node: bool,
+    },
     /// Emitted at the end of each `EvaluationWorkflow` sweep (issue
     /// #91, brief §15). Drives release gating — CI rejects merges
     /// whose `failed` count grows beyond the previous baseline.
@@ -182,6 +207,45 @@ mod tests {
                 assert_eq!(failed, 0);
             }
             _ => panic!("expected EvaluationCompleted"),
+        }
+    }
+
+    #[test]
+    fn trace_canvas_rendered_round_trips_without_body_fields() {
+        let event = MetricEvent::TraceCanvasRendered {
+            ts_ms: 1_700_000_000_000,
+            session_id_hash: "sha256:session".into(),
+            canvas_id_hash: "sha256:canvas".into(),
+            version: 3,
+            node_count: 2,
+            edge_count: 1,
+            bytes: 512,
+            budget_bytes: 1024,
+            active_node: true,
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert!(json.contains("\"event\":\"trace_canvas_rendered\""));
+        assert!(!json.contains("Issue 134"));
+        assert!(!json.contains("finish trace canvas hot memory"));
+        let back: MetricEvent = serde_json::from_str(&json).expect("deserialize");
+        match back {
+            MetricEvent::TraceCanvasRendered {
+                version,
+                node_count,
+                edge_count,
+                bytes,
+                budget_bytes,
+                active_node,
+                ..
+            } => {
+                assert_eq!(version, 3);
+                assert_eq!(node_count, 2);
+                assert_eq!(edge_count, 1);
+                assert_eq!(bytes, 512);
+                assert_eq!(budget_bytes, 1024);
+                assert!(active_node);
+            }
+            _ => panic!("expected TraceCanvasRendered"),
         }
     }
 

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -51,6 +51,7 @@ pub mod taxonomy;
 pub mod time;
 pub mod timestamp;
 pub mod trace;
+pub mod tree_read_window;
 pub mod zero_capture;
 
 pub use actor_chain::{ActorChainEntry, ChainRole, validate_chain};
@@ -98,6 +99,10 @@ pub use taxonomy::{MemoryClass, MemoryKind, MemoryVisibility};
 pub use time::{Clock, SystemClock};
 pub use timestamp::Rfc3339Timestamp;
 pub use trace::{TraceBlock, TraceEvent, TraceLink, TraceLinkError};
+pub use tree_read_window::{
+    TreeBudgetReport, TreeReadRecord, TreeReadSegmentKind, TreeReadSelection, TreeReadWindow,
+    TreeReadWindowError, TreeReadWindowInput, plan_tree_read_window,
+};
 pub use zero_capture::{
     ZeroCaptureAuditInput, ZeroCaptureDecision, ZeroCaptureDecisionCode, ZeroCaptureNudge,
     ZeroCaptureReport, ZeroCaptureReportSummary, ZeroCaptureSuppression, ZeroCaptureTrigger,

--- a/crates/cairn-core/src/domain/tree_read_window.rs
+++ b/crates/cairn-core/src/domain/tree_read_window.rs
@@ -1,0 +1,254 @@
+//! Pure tree-aware read-window planning for session reads.
+//!
+//! Brief refs: §5.7 Sessions are trees, §7 Hot Memory. This module is pure:
+//! callers pre-authorize records and hydrate [`SessionTree`] before planning.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::domain::{RecordId, SessionId, SessionTree, SessionTreeError};
+
+/// Segment category assigned to a selected tree-read record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TreeReadSegmentKind {
+    /// Record belongs to the requested branch/session.
+    BranchLocal,
+    /// Record belongs to an ancestor session in the requested lineage.
+    AncestorContext,
+    /// Body-free metadata describing a merge summary.
+    MergeSummary,
+    /// Body-free metadata describing sibling branches.
+    SiblingSummary,
+}
+
+/// Pre-authorized record available to the read-window planner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeReadRecord {
+    /// Session that owns the record.
+    pub session_id: SessionId,
+    /// Optional turn id used for stable ordering inside a session.
+    pub turn_id: Option<String>,
+    /// Stable record id used as the final ordering tiebreaker.
+    pub record_id: RecordId,
+    /// Pre-authorized body text considered for the read window.
+    pub body: String,
+}
+
+/// Budget accounting for a planned read window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TreeBudgetReport {
+    /// Caller-provided body byte budget.
+    pub budget_bytes: usize,
+    /// Candidate records after lineage filtering, before trimming.
+    pub records_in: usize,
+    /// Records retained in the final window.
+    pub records_out: usize,
+    /// Candidate records skipped because of the byte budget.
+    pub skipped_for_budget: usize,
+    /// Whether any lineage candidate was skipped.
+    pub trimmed: bool,
+}
+
+/// A selected record annotated with its tree segment role.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeReadSelection {
+    /// Tree segment role for the selected record.
+    pub kind: TreeReadSegmentKind,
+    /// Selected pre-authorized record.
+    pub record: TreeReadRecord,
+}
+
+/// Planned tree-aware read window for a target session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeReadWindow {
+    /// Root-to-target lineage, inclusive.
+    pub ancestry_path: Vec<SessionId>,
+    /// Selected records without segment metadata for compatibility callers.
+    pub selected_records: Vec<TreeReadRecord>,
+    /// Selected records with segment metadata.
+    pub selections: Vec<TreeReadSelection>,
+    /// Sibling session ids for body-free policy/debug metadata.
+    pub sibling_sessions: Vec<SessionId>,
+    /// Body-free merge notes for policy/debug metadata.
+    pub merge_notes: Vec<String>,
+    /// Budget accounting for the selection.
+    pub budget: TreeBudgetReport,
+}
+
+/// Input required to plan a tree-aware read window.
+pub struct TreeReadWindowInput<'a> {
+    /// Hydrated session tree.
+    pub tree: &'a SessionTree,
+    /// Session requested by the read surface.
+    pub target_session: &'a SessionId,
+    /// Pre-authorized candidate records.
+    pub records: &'a [TreeReadRecord],
+    /// Maximum selected body bytes.
+    pub budget_bytes: usize,
+}
+
+/// Errors raised while planning a tree-aware read window.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum TreeReadWindowError {
+    /// Session tree lookup or validation failed.
+    #[error(transparent)]
+    SessionTree(#[from] SessionTreeError),
+}
+
+/// Plan a deterministic read window for `target_session`.
+pub fn plan_tree_read_window(
+    input: TreeReadWindowInput<'_>,
+) -> Result<TreeReadWindow, TreeReadWindowError> {
+    let ancestry_path = input.tree.lineage(input.target_session)?;
+    let ancestry = ancestry_path.iter().cloned().collect::<BTreeSet<_>>();
+    let mut selected = input
+        .records
+        .iter()
+        .filter(|record| ancestry.contains(&record.session_id))
+        .map(|record| TreeReadSelection {
+            kind: if &record.session_id == input.target_session {
+                TreeReadSegmentKind::BranchLocal
+            } else {
+                TreeReadSegmentKind::AncestorContext
+            },
+            record: record.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    selected.sort_by(compare_selection);
+    let records_in = selected.len();
+    let selected = trim_selections(selected, input.budget_bytes);
+    let records_out = selected.len();
+    let selected_records = selected
+        .iter()
+        .map(|selection| selection.record.clone())
+        .collect();
+
+    Ok(TreeReadWindow {
+        ancestry_path,
+        selected_records,
+        selections: selected,
+        sibling_sessions: siblings(input.tree, input.target_session)?,
+        merge_notes: merge_notes(input.tree, input.target_session),
+        budget: TreeBudgetReport {
+            budget_bytes: input.budget_bytes,
+            records_in,
+            records_out,
+            skipped_for_budget: records_in.saturating_sub(records_out),
+            trimmed: records_out < records_in,
+        },
+    })
+}
+
+fn compare_selection(a: &TreeReadSelection, b: &TreeReadSelection) -> std::cmp::Ordering {
+    a.kind
+        .cmp(&b.kind)
+        .then_with(|| a.record.session_id.cmp(&b.record.session_id))
+        .then_with(|| a.record.turn_id.cmp(&b.record.turn_id))
+        .then_with(|| a.record.record_id.cmp(&b.record.record_id))
+}
+
+fn trim_selections(
+    selections: Vec<TreeReadSelection>,
+    budget_bytes: usize,
+) -> Vec<TreeReadSelection> {
+    let mut used = 0usize;
+    let mut out = Vec::with_capacity(selections.len());
+    for selection in selections {
+        let len = selection.record.body.len();
+        if used.saturating_add(len) <= budget_bytes {
+            used = used.saturating_add(len);
+            out.push(selection);
+        }
+    }
+    out
+}
+
+fn siblings(tree: &SessionTree, target: &SessionId) -> Result<Vec<SessionId>, TreeReadWindowError> {
+    let Some(parent) = tree.parent(target)? else {
+        return Ok(Vec::new());
+    };
+    let mut siblings = tree
+        .children(&parent.session_id)?
+        .into_iter()
+        .filter(|candidate| candidate != target)
+        .collect::<Vec<_>>();
+    siblings.sort();
+    Ok(siblings)
+}
+
+fn merge_notes(tree: &SessionTree, target: &SessionId) -> Vec<String> {
+    let mut notes = tree
+        .merges()
+        .iter()
+        .filter(|merge| &merge.source == target || &merge.destination == target)
+        .map(|merge| {
+            format!(
+                "source={} destination={} applied_at={}",
+                merge.source.as_str(),
+                merge.destination.as_str(),
+                merge.applied_at_turn_id
+            )
+        })
+        .collect::<Vec<_>>();
+    notes.sort();
+    notes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::session_tree::SessionTree;
+    use crate::domain::{RecordId, SessionId};
+
+    fn sid(raw: &str) -> SessionId {
+        SessionId::parse(raw).expect("valid session id")
+    }
+
+    fn rid(raw: &str) -> RecordId {
+        RecordId::parse(raw).expect("valid record id")
+    }
+
+    fn item(session_id: &str, turn_id: &str, record_id: &str, body: &str) -> TreeReadRecord {
+        TreeReadRecord {
+            session_id: sid(session_id),
+            turn_id: Some(turn_id.to_owned()),
+            record_id: rid(record_id),
+            body: body.to_owned(),
+        }
+    }
+
+    #[test]
+    fn flat_session_selects_branch_local_records_in_turn_order() {
+        let root = sid("root");
+        let tree = SessionTree::flat(root.clone());
+        let records = vec![
+            item("root", "turn-2", "01JTS6R4J70000000000000001", "second"),
+            item("root", "turn-1", "01JTS6R4J70000000000000002", "first"),
+        ];
+
+        let window = plan_tree_read_window(TreeReadWindowInput {
+            tree: &tree,
+            target_session: &root,
+            records: &records,
+            budget_bytes: 1024,
+        })
+        .expect("plan window");
+
+        assert_eq!(window.ancestry_path, vec![root]);
+        assert_eq!(
+            window
+                .selected_records
+                .iter()
+                .map(|r| r.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "second"]
+        );
+        assert!(!window.budget.trimmed);
+    }
+}

--- a/crates/cairn-core/src/domain/tree_read_window.rs
+++ b/crates/cairn-core/src/domain/tree_read_window.rs
@@ -147,11 +147,20 @@ pub fn plan_tree_read_window(
 }
 
 fn compare_selection(a: &TreeReadSelection, b: &TreeReadSelection) -> std::cmp::Ordering {
-    a.kind
-        .cmp(&b.kind)
+    segment_sort_rank(a.kind)
+        .cmp(&segment_sort_rank(b.kind))
         .then_with(|| a.record.session_id.cmp(&b.record.session_id))
         .then_with(|| a.record.turn_id.cmp(&b.record.turn_id))
         .then_with(|| a.record.record_id.cmp(&b.record.record_id))
+}
+
+fn segment_sort_rank(kind: TreeReadSegmentKind) -> u8 {
+    match kind {
+        TreeReadSegmentKind::AncestorContext => 0,
+        TreeReadSegmentKind::BranchLocal => 1,
+        TreeReadSegmentKind::MergeSummary => 2,
+        TreeReadSegmentKind::SiblingSummary => 3,
+    }
 }
 
 fn trim_selections(
@@ -280,8 +289,8 @@ mod tests {
                 .map(|s| (s.kind, s.record.body.as_str()))
                 .collect::<Vec<_>>(),
             vec![
-                (TreeReadSegmentKind::BranchLocal, "branch"),
                 (TreeReadSegmentKind::AncestorContext, "ancestor"),
+                (TreeReadSegmentKind::BranchLocal, "branch"),
             ]
         );
     }
@@ -291,34 +300,65 @@ mod tests {
         let root = sid("root");
         let branch_a = sid("branch-a");
         let branch_b = sid("branch-b");
+        let branch_c = sid("branch-c");
         let mut tree = SessionTree::flat(root.clone());
+        tree.fork(&root, branch_c.clone(), "turn-2")
+            .expect("fork c");
         tree.fork(&root, branch_b.clone(), "turn-2")
             .expect("fork b");
         tree.fork(&root, branch_a.clone(), "turn-2")
             .expect("fork a");
         tree.record_merge(
             branch_a.clone(),
-            root.clone(),
+            branch_c.clone(),
             crate::domain::MergeStrategy::ControlledSplice {
                 first_turn_id: "turn-3".to_owned(),
                 last_turn_id: "turn-4".to_owned(),
             },
-            "turn-5",
+            "turn-z",
         )
-        .expect("merge");
+        .expect("merge c");
+        tree.record_merge(
+            root.clone(),
+            branch_a.clone(),
+            crate::domain::MergeStrategy::ControlledSplice {
+                first_turn_id: "turn-6".to_owned(),
+                last_turn_id: "turn-7".to_owned(),
+            },
+            "turn-a",
+        )
+        .expect("merge root");
+        let records = vec![
+            item("branch-a", "turn-3", "01JTS6R4J70000000000000007", "branch body"),
+            item(
+                "branch-b",
+                "turn-3",
+                "01JTS6R4J70000000000000008",
+                "sibling body",
+            ),
+            item("root", "turn-1", "01JTS6R4J70000000000000009", "root body"),
+        ];
 
         let window = plan_tree_read_window(TreeReadWindowInput {
             tree: &tree,
             target_session: &branch_a,
-            records: &[],
+            records: &records,
             budget_bytes: 1024,
         })
         .expect("plan window");
 
-        assert_eq!(window.sibling_sessions, vec![branch_b]);
-        assert_eq!(window.merge_notes.len(), 1);
-        assert!(window.merge_notes[0].contains("applied_at=turn-5"));
-        assert!(!window.merge_notes[0].contains("branch body"));
+        assert_eq!(window.sibling_sessions, vec![branch_b, branch_c]);
+        assert_eq!(
+            window.merge_notes,
+            vec![
+                "source=branch-a destination=branch-c applied_at=turn-z".to_owned(),
+                "source=root destination=branch-a applied_at=turn-a".to_owned(),
+            ]
+        );
+        let metadata = format!("{:?} {:?}", window.sibling_sessions, window.merge_notes);
+        assert!(!metadata.contains("branch body"));
+        assert!(!metadata.contains("sibling body"));
+        assert!(!metadata.contains("root body"));
     }
 
     #[test]
@@ -336,6 +376,7 @@ mod tests {
             ),
             item("branch", "turn-3", "01JTS6R4J70000000000000006", "branch"),
         ];
+        let shuffled_records = vec![records[1].clone(), records[0].clone()];
 
         let window = plan_tree_read_window(TreeReadWindowInput {
             tree: &tree,
@@ -344,14 +385,39 @@ mod tests {
             budget_bytes: "branch".len(),
         })
         .expect("plan window");
+        let shuffled_window = plan_tree_read_window(TreeReadWindowInput {
+            tree: &tree,
+            target_session: &branch,
+            records: &shuffled_records,
+            budget_bytes: "branch".len(),
+        })
+        .expect("plan shuffled window");
 
+        let selected_bodies = window
+            .selected_records
+            .iter()
+            .map(|r| r.body.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(selected_bodies, vec!["branch"]);
         assert_eq!(
-            window
+            selected_bodies,
+            shuffled_window
                 .selected_records
                 .iter()
                 .map(|r| r.body.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            window
+                .selections
+                .iter()
+                .map(|selection| selection.kind)
                 .collect::<Vec<_>>(),
-            vec!["branch"]
+            shuffled_window
+                .selections
+                .iter()
+                .map(|selection| selection.kind)
+                .collect::<Vec<_>>()
         );
         assert!(window.budget.trimmed);
         assert_eq!(window.budget.skipped_for_budget, 1);

--- a/crates/cairn-core/src/domain/tree_read_window.rs
+++ b/crates/cairn-core/src/domain/tree_read_window.rs
@@ -121,9 +121,10 @@ pub fn plan_tree_read_window(
         })
         .collect::<Vec<_>>();
 
-    selected.sort_by(compare_selection);
+    selected.sort_by(compare_trim_priority);
     let records_in = selected.len();
-    let selected = trim_selections(selected, input.budget_bytes);
+    let mut selected = trim_selections(selected, input.budget_bytes);
+    selected.sort_by(compare_display_order);
     let records_out = selected.len();
     let selected_records = selected
         .iter()
@@ -146,18 +147,35 @@ pub fn plan_tree_read_window(
     })
 }
 
-fn compare_selection(a: &TreeReadSelection, b: &TreeReadSelection) -> std::cmp::Ordering {
-    segment_sort_rank(a.kind)
-        .cmp(&segment_sort_rank(b.kind))
+fn compare_display_order(a: &TreeReadSelection, b: &TreeReadSelection) -> std::cmp::Ordering {
+    display_sort_rank(a.kind)
+        .cmp(&display_sort_rank(b.kind))
         .then_with(|| a.record.session_id.cmp(&b.record.session_id))
         .then_with(|| a.record.turn_id.cmp(&b.record.turn_id))
         .then_with(|| a.record.record_id.cmp(&b.record.record_id))
 }
 
-fn segment_sort_rank(kind: TreeReadSegmentKind) -> u8 {
+fn compare_trim_priority(a: &TreeReadSelection, b: &TreeReadSelection) -> std::cmp::Ordering {
+    trim_priority_rank(a.kind)
+        .cmp(&trim_priority_rank(b.kind))
+        .then_with(|| a.record.session_id.cmp(&b.record.session_id))
+        .then_with(|| a.record.turn_id.cmp(&b.record.turn_id))
+        .then_with(|| a.record.record_id.cmp(&b.record.record_id))
+}
+
+fn display_sort_rank(kind: TreeReadSegmentKind) -> u8 {
     match kind {
         TreeReadSegmentKind::AncestorContext => 0,
         TreeReadSegmentKind::BranchLocal => 1,
+        TreeReadSegmentKind::MergeSummary => 2,
+        TreeReadSegmentKind::SiblingSummary => 3,
+    }
+}
+
+fn trim_priority_rank(kind: TreeReadSegmentKind) -> u8 {
+    match kind {
+        TreeReadSegmentKind::BranchLocal => 0,
+        TreeReadSegmentKind::AncestorContext => 1,
         TreeReadSegmentKind::MergeSummary => 2,
         TreeReadSegmentKind::SiblingSummary => 3,
     }
@@ -309,16 +327,6 @@ mod tests {
         tree.fork(&root, branch_a.clone(), "turn-2")
             .expect("fork a");
         tree.record_merge(
-            branch_a.clone(),
-            branch_c.clone(),
-            crate::domain::MergeStrategy::ControlledSplice {
-                first_turn_id: "turn-3".to_owned(),
-                last_turn_id: "turn-4".to_owned(),
-            },
-            "turn-z",
-        )
-        .expect("merge c");
-        tree.record_merge(
             root.clone(),
             branch_a.clone(),
             crate::domain::MergeStrategy::ControlledSplice {
@@ -328,6 +336,16 @@ mod tests {
             "turn-a",
         )
         .expect("merge root");
+        tree.record_merge(
+            branch_a.clone(),
+            branch_c.clone(),
+            crate::domain::MergeStrategy::ControlledSplice {
+                first_turn_id: "turn-3".to_owned(),
+                last_turn_id: "turn-4".to_owned(),
+            },
+            "turn-z",
+        )
+        .expect("merge c");
         let records = vec![
             item("branch-a", "turn-3", "01JTS6R4J70000000000000007", "branch body"),
             item(
@@ -372,9 +390,9 @@ mod tests {
                 "root",
                 "turn-1",
                 "01JTS6R4J70000000000000005",
-                "ancestor-long",
+                "elder",
             ),
-            item("branch", "turn-3", "01JTS6R4J70000000000000006", "branch"),
+            item("branch", "turn-3", "01JTS6R4J70000000000000006", "local"),
         ];
         let shuffled_records = vec![records[1].clone(), records[0].clone()];
 
@@ -382,14 +400,14 @@ mod tests {
             tree: &tree,
             target_session: &branch,
             records: &records,
-            budget_bytes: "branch".len(),
+            budget_bytes: "local".len(),
         })
         .expect("plan window");
         let shuffled_window = plan_tree_read_window(TreeReadWindowInput {
             tree: &tree,
             target_session: &branch,
             records: &shuffled_records,
-            budget_bytes: "branch".len(),
+            budget_bytes: "local".len(),
         })
         .expect("plan shuffled window");
 
@@ -398,7 +416,7 @@ mod tests {
             .iter()
             .map(|r| r.body.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(selected_bodies, vec!["branch"]);
+        assert_eq!(selected_bodies, vec!["local"]);
         assert_eq!(
             selected_bodies,
             shuffled_window

--- a/crates/cairn-core/src/domain/tree_read_window.rs
+++ b/crates/cairn-core/src/domain/tree_read_window.rs
@@ -347,7 +347,12 @@ mod tests {
         )
         .expect("merge c");
         let records = vec![
-            item("branch-a", "turn-3", "01JTS6R4J70000000000000007", "branch body"),
+            item(
+                "branch-a",
+                "turn-3",
+                "01JTS6R4J70000000000000007",
+                "branch body",
+            ),
             item(
                 "branch-b",
                 "turn-3",
@@ -386,12 +391,7 @@ mod tests {
         let mut tree = SessionTree::flat(root.clone());
         tree.fork(&root, branch.clone(), "turn-2").expect("fork");
         let records = vec![
-            item(
-                "root",
-                "turn-1",
-                "01JTS6R4J70000000000000005",
-                "elder",
-            ),
+            item("root", "turn-1", "01JTS6R4J70000000000000005", "elder"),
             item("branch", "turn-3", "01JTS6R4J70000000000000006", "local"),
         ];
         let shuffled_records = vec![records[1].clone(), records[0].clone()];

--- a/crates/cairn-core/src/domain/tree_read_window.rs
+++ b/crates/cairn-core/src/domain/tree_read_window.rs
@@ -252,4 +252,108 @@ mod tests {
         );
         assert!(!window.budget.trimmed);
     }
+
+    #[test]
+    fn branch_session_includes_ancestor_then_branch_local_records() {
+        let root = sid("root");
+        let branch = sid("branch");
+        let mut tree = SessionTree::flat(root.clone());
+        tree.fork(&root, branch.clone(), "turn-2").expect("fork");
+        let records = vec![
+            item("branch", "turn-3", "01JTS6R4J70000000000000003", "branch"),
+            item("root", "turn-1", "01JTS6R4J70000000000000004", "ancestor"),
+        ];
+
+        let window = plan_tree_read_window(TreeReadWindowInput {
+            tree: &tree,
+            target_session: &branch,
+            records: &records,
+            budget_bytes: 1024,
+        })
+        .expect("plan window");
+
+        assert_eq!(window.ancestry_path, vec![root, branch]);
+        assert_eq!(
+            window
+                .selections
+                .iter()
+                .map(|s| (s.kind, s.record.body.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (TreeReadSegmentKind::BranchLocal, "branch"),
+                (TreeReadSegmentKind::AncestorContext, "ancestor"),
+            ]
+        );
+    }
+
+    #[test]
+    fn sibling_and_merge_metadata_are_body_free_and_sorted() {
+        let root = sid("root");
+        let branch_a = sid("branch-a");
+        let branch_b = sid("branch-b");
+        let mut tree = SessionTree::flat(root.clone());
+        tree.fork(&root, branch_b.clone(), "turn-2")
+            .expect("fork b");
+        tree.fork(&root, branch_a.clone(), "turn-2")
+            .expect("fork a");
+        tree.record_merge(
+            branch_a.clone(),
+            root.clone(),
+            crate::domain::MergeStrategy::ControlledSplice {
+                first_turn_id: "turn-3".to_owned(),
+                last_turn_id: "turn-4".to_owned(),
+            },
+            "turn-5",
+        )
+        .expect("merge");
+
+        let window = plan_tree_read_window(TreeReadWindowInput {
+            tree: &tree,
+            target_session: &branch_a,
+            records: &[],
+            budget_bytes: 1024,
+        })
+        .expect("plan window");
+
+        assert_eq!(window.sibling_sessions, vec![branch_b]);
+        assert_eq!(window.merge_notes.len(), 1);
+        assert!(window.merge_notes[0].contains("applied_at=turn-5"));
+        assert!(!window.merge_notes[0].contains("branch body"));
+    }
+
+    #[test]
+    fn budget_trimming_is_deterministic_and_preserves_priority_order() {
+        let root = sid("root");
+        let branch = sid("branch");
+        let mut tree = SessionTree::flat(root.clone());
+        tree.fork(&root, branch.clone(), "turn-2").expect("fork");
+        let records = vec![
+            item(
+                "root",
+                "turn-1",
+                "01JTS6R4J70000000000000005",
+                "ancestor-long",
+            ),
+            item("branch", "turn-3", "01JTS6R4J70000000000000006", "branch"),
+        ];
+
+        let window = plan_tree_read_window(TreeReadWindowInput {
+            tree: &tree,
+            target_session: &branch,
+            records: &records,
+            budget_bytes: "branch".len(),
+        })
+        .expect("plan window");
+
+        assert_eq!(
+            window
+                .selected_records
+                .iter()
+                .map(|r| r.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["branch"]
+        );
+        assert!(window.budget.trimmed);
+        assert_eq!(window.budget.skipped_for_budget, 1);
+    }
 }

--- a/crates/cairn-core/src/domain/tree_read_window.rs
+++ b/crates/cairn-core/src/domain/tree_read_window.rs
@@ -80,6 +80,7 @@ pub struct TreeReadWindow {
 }
 
 /// Input required to plan a tree-aware read window.
+#[derive(Debug, Clone, Copy)]
 pub struct TreeReadWindowInput<'a> {
     /// Hydrated session tree.
     pub tree: &'a SessionTree,

--- a/crates/cairn-core/src/verbs/assemble_hot/cached.rs
+++ b/crates/cairn-core/src/verbs/assemble_hot/cached.rs
@@ -30,6 +30,12 @@ const FS_FINGERPRINT_PATHS: &[&str] = &["purpose.md", "index.md", ".cairn/config
 /// assembled prefix while leaving the fingerprint unchanged.
 const FS_FINGERPRINT_MAX_BYTES: u64 = 4 * 1024 * 1024; // 4 MiB
 
+/// Cache-key schema for assembled hot-prefix bytes.
+///
+/// Bump this when assembly semantics change without a corresponding recipe,
+/// budget, session, watermark, or filesystem-fingerprint change.
+const HOT_PREFIX_CACHE_KEY_VERSION: &[u8] = b"assemble-hot-cache-key-v2";
+
 /// Compute a content-hash fingerprint for filesystem-backed hot-memory
 /// sources. Returns an empty string when `vault_root` is `None` — the
 /// fingerprint check is then a no-op (cache hit relies solely on
@@ -135,6 +141,8 @@ pub fn cache_key_hash(
     effective_budget: u64,
 ) -> String {
     let mut h = Sha256::new();
+    h.update(HOT_PREFIX_CACHE_KEY_VERSION);
+    h.update(b"\x00");
     let recipe_bytes = serde_json::to_vec(recipe).unwrap_or_default();
     h.update(&recipe_bytes);
     h.update(b"\x00");
@@ -465,6 +473,24 @@ mod tests {
 
     fn config() -> HotMemoryConfig {
         HotMemoryConfig::default()
+    }
+
+    #[test]
+    fn cache_key_hash_includes_assembly_semantics_version() {
+        let cfg = config();
+        let current = cache_key_hash(&cfg.recipe, Some("session"), 100);
+
+        let mut legacy = Sha256::new();
+        let recipe_bytes = serde_json::to_vec(&cfg.recipe).expect("recipe serializes");
+        legacy.update(&recipe_bytes);
+        legacy.update(b"\x00");
+        legacy.update(b"sid:");
+        legacy.update(b"session");
+        legacy.update(b"\x00");
+        legacy.update(b"budget:");
+        legacy.update(100_u64.to_le_bytes());
+
+        assert_ne!(current, hex_lower(&legacy.finalize()));
     }
 
     /// Mock cache for the unit tests. All async work serialised through

--- a/crates/cairn-core/src/verbs/lint/checks/mod.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/mod.rs
@@ -11,5 +11,6 @@ pub mod provenance;
 pub mod salience;
 pub mod schema;
 pub mod taxonomy_conventions;
+pub mod trace_canvas;
 pub mod trace_reasoning;
 pub mod workflow_health;

--- a/crates/cairn-core/src/verbs/lint/checks/trace_canvas.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/trace_canvas.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use crate::contract::source_resolver::SourceResolver;
+use crate::domain::projection::{ProjectionStatus, compare_projection};
 use crate::generated::verbs::lint::{Finding, Kind, Severity};
 use crate::verbs::lint::{LintRecord, finding, target_path};
 
@@ -47,6 +48,8 @@ pub struct TraceCanvasLintCanvas {
     pub active_node_id: Option<String>,
     /// Canvas-local render budget.
     pub max_bytes: u64,
+    /// Last materialized markdown projection, if one exists.
+    pub projection_markdown: Option<String>,
 }
 
 /// Lint view of one `trace_canvas_nodes` row.
@@ -128,9 +131,66 @@ pub fn run(
         if bytes > canvas.max_bytes {
             findings.push(canvas_over_budget_finding(canvas, bytes));
         }
+
+        let canonical = render_markdown(canvas, &snapshot.nodes);
+        if let Some(finding) = projection_finding(canvas, &canonical) {
+            findings.push(finding);
+        }
     }
 
     findings
+}
+
+/// Render the canonical markdown projection for a trace canvas.
+#[must_use]
+pub fn render_markdown(canvas: &TraceCanvasLintCanvas, nodes: &[TraceCanvasLintNode]) -> String {
+    let active_node = canvas.active_node_id.as_deref().unwrap_or("none");
+    let mut out = String::new();
+    out.push_str("# ");
+    out.push_str(&canvas.title);
+    out.push('\n');
+    out.push('\n');
+    out.push_str("Canvas: ");
+    out.push_str(&canvas.canvas_id);
+    out.push('\n');
+    out.push_str("Session: ");
+    out.push_str(&canvas.session_id);
+    out.push('\n');
+    out.push_str("Goal: ");
+    out.push_str(&canvas.goal);
+    out.push('\n');
+    out.push_str("Active node: ");
+    out.push_str(active_node);
+    out.push('\n');
+    out.push('\n');
+    out.push_str("## Summary\n");
+    out.push_str(&canvas.summary);
+    out.push('\n');
+    out.push('\n');
+    out.push_str("## Nodes\n");
+
+    for node in nodes
+        .iter()
+        .filter(|node| node.canvas_id == canvas.canvas_id)
+    {
+        out.push_str("- ");
+        out.push_str(&node.label);
+        out.push_str(" [");
+        out.push_str(&node.node_id);
+        out.push_str("]\n");
+        out.push_str("  Summary: ");
+        out.push_str(&node.summary);
+        out.push('\n');
+        out.push_str("  Source steps: ");
+        if node.source_step_ids.is_empty() {
+            out.push_str("none");
+        } else {
+            out.push_str(&node.source_step_ids.join(", "));
+        }
+        out.push('\n');
+    }
+
+    out
 }
 
 fn broken_result_ref_finding(step: &TraceCanvasLintStep, result_ref: &str) -> Finding {
@@ -222,28 +282,42 @@ fn canvas_over_budget_finding(canvas: &TraceCanvasLintCanvas, bytes: u64) -> Fin
     f
 }
 
-fn rendered_canvas_bytes(canvas: &TraceCanvasLintCanvas, nodes: &[TraceCanvasLintNode]) -> u64 {
-    let mut bytes = "# Current Task\n".len()
-        + canvas.title.len()
-        + "\n".len()
-        + "Goal: \n".len()
-        + canvas.goal.len()
-        + "Summary: \n".len()
-        + canvas.summary.len();
-
-    for node in nodes
-        .iter()
-        .filter(|node| node.canvas_id == canvas.canvas_id)
-    {
-        bytes = bytes
-            .saturating_add("- ".len())
-            .saturating_add(node.label.len())
-            .saturating_add(": ".len())
-            .saturating_add(node.summary.len())
-            .saturating_add("\n".len());
+fn projection_finding(canvas: &TraceCanvasLintCanvas, canonical: &str) -> Option<Finding> {
+    let path = format!("trace_canvases/{}.md", canvas.canvas_id);
+    match compare_projection(canonical, canvas.projection_markdown.as_deref()) {
+        ProjectionStatus::Match => None,
+        ProjectionStatus::Drift {
+            expected_body_hash,
+            actual_body_hash,
+        } => {
+            let mut f = finding(
+                Kind::ProjectionDrift,
+                Severity::Warning,
+                format!(
+                    "trace canvas projection at {path} drifts from db; expected_body_hash={expected_body_hash} actual_body_hash={actual_body_hash}",
+                ),
+            );
+            f.target = Some(target_path(path));
+            f.suggested_fix = Some("rebuild the trace canvas markdown projection".to_owned());
+            Some(f)
+        }
+        ProjectionStatus::Missing { expected_body_hash } => {
+            let mut f = finding(
+                Kind::ProjectionMissing,
+                Severity::Warning,
+                format!(
+                    "trace canvas projection at {path} is missing; expected_body_hash={expected_body_hash}",
+                ),
+            );
+            f.target = Some(target_path(path));
+            f.suggested_fix = Some("rebuild the trace canvas markdown projection".to_owned());
+            Some(f)
+        }
     }
+}
 
-    u64::try_from(bytes).unwrap_or(u64::MAX)
+fn rendered_canvas_bytes(canvas: &TraceCanvasLintCanvas, nodes: &[TraceCanvasLintNode]) -> u64 {
+    u64::try_from(render_markdown(canvas, nodes).len()).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
@@ -279,6 +353,19 @@ mod tests {
             summary: "Canvas summary".to_owned(),
             active_node_id: Some("node-1".to_owned()),
             max_bytes: 256,
+            projection_markdown: Some(render_markdown(
+                &TraceCanvasLintCanvas {
+                    canvas_id: "canvas-1".to_owned(),
+                    session_id: "session-1".to_owned(),
+                    title: "Current task".to_owned(),
+                    goal: "Keep the trace canvas healthy".to_owned(),
+                    summary: "Canvas summary".to_owned(),
+                    active_node_id: Some("node-1".to_owned()),
+                    max_bytes: 256,
+                    projection_markdown: None,
+                },
+                &[node_fixture()],
+            )),
         }
     }
 
@@ -310,6 +397,70 @@ mod tests {
         };
 
         assert!(run(&snapshot, &records, empty_source_resolver()).is_empty());
+    }
+
+    #[test]
+    fn projection_markdown_is_rebuildable_and_includes_source_ids() {
+        let canvas = canvas_fixture();
+        let rendered = render_markdown(&canvas, &[node_fixture()]);
+
+        assert!(rendered.contains("# Current task"));
+        assert!(rendered.contains("Canvas: canvas-1"));
+        assert!(rendered.contains("Active node: node-1"));
+        assert!(rendered.contains("## Nodes"));
+        assert!(rendered.contains("- Mapped node [node-1]"));
+        assert!(rendered.contains("Source steps: step-1"));
+        assert!(rendered.ends_with('\n'));
+    }
+
+    #[test]
+    fn missing_or_drifted_projection_emits_projection_findings() {
+        let canonical = render_markdown(&canvas_fixture(), &[node_fixture()]);
+        let snapshot = TraceCanvasLintSnapshot {
+            steps: vec![TraceCanvasLintStep {
+                step_id: "step-1".to_owned(),
+                session_id: "session-1".to_owned(),
+                result_ref: None,
+                node_id: Some("node-1".to_owned()),
+            }],
+            canvases: vec![
+                TraceCanvasLintCanvas {
+                    projection_markdown: None,
+                    ..canvas_fixture()
+                },
+                TraceCanvasLintCanvas {
+                    canvas_id: "canvas-2".to_owned(),
+                    active_node_id: None,
+                    projection_markdown: Some(format!("{canonical}\nstale edit\n")),
+                    ..canvas_fixture()
+                },
+            ],
+            nodes: vec![
+                node_fixture(),
+                TraceCanvasLintNode {
+                    canvas_id: "canvas-2".to_owned(),
+                    node_id: "node-2".to_owned(),
+                    source_step_ids: Vec::new(),
+                    ..node_fixture()
+                },
+            ],
+        };
+
+        let findings = run(&snapshot, &[], empty_source_resolver());
+        assert!(
+            findings
+                .iter()
+                .any(|f| matches!(f.kind, Kind::ProjectionMissing)
+                    && f.message.contains("trace_canvases/canvas-1.md")),
+            "missing projection should be reported: {findings:?}",
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| matches!(f.kind, Kind::ProjectionDrift)
+                    && f.message.contains("trace_canvases/canvas-2.md")),
+            "drifted projection should be reported: {findings:?}",
+        );
     }
 
     #[test]

--- a/crates/cairn-core/src/verbs/lint/checks/trace_canvas.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/trace_canvas.rs
@@ -1,0 +1,374 @@
+//! Task-trace canvas lint checks for issue #134.
+
+use std::collections::HashSet;
+
+use crate::contract::source_resolver::SourceResolver;
+use crate::generated::verbs::lint::{Finding, Kind, Severity};
+use crate::verbs::lint::{LintRecord, finding, target_path};
+
+/// Read-only trace-canvas snapshot supplied by adapters.
+#[derive(Debug, Clone, Default)]
+pub struct TraceCanvasLintSnapshot {
+    /// Stored trace steps.
+    pub steps: Vec<TraceCanvasLintStep>,
+    /// Stored trace canvases.
+    pub canvases: Vec<TraceCanvasLintCanvas>,
+    /// Stored trace canvas nodes.
+    pub nodes: Vec<TraceCanvasLintNode>,
+}
+
+/// Lint view of one `trace_steps` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasLintStep {
+    /// Stable trace-step id.
+    pub step_id: String,
+    /// Session id owning the step.
+    pub session_id: String,
+    /// Optional exact drilldown reference.
+    pub result_ref: Option<String>,
+    /// Optional mapped canvas node id.
+    pub node_id: Option<String>,
+}
+
+/// Lint view of one `trace_canvases` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasLintCanvas {
+    /// Stable canvas id.
+    pub canvas_id: String,
+    /// Session id owning the canvas.
+    pub session_id: String,
+    /// Canvas title.
+    pub title: String,
+    /// Canvas goal.
+    pub goal: String,
+    /// Body-free canvas summary.
+    pub summary: String,
+    /// Optional active node id.
+    pub active_node_id: Option<String>,
+    /// Canvas-local render budget.
+    pub max_bytes: u64,
+}
+
+/// Lint view of one `trace_canvas_nodes` row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasLintNode {
+    /// Stable node id.
+    pub node_id: String,
+    /// Parent canvas id.
+    pub canvas_id: String,
+    /// Body-free node label.
+    pub label: String,
+    /// Body-free node summary.
+    pub summary: String,
+    /// Source trace step ids supporting this node.
+    pub source_step_ids: Vec<String>,
+}
+
+/// Run task-trace canvas checks.
+#[must_use]
+pub fn run(
+    snapshot: &TraceCanvasLintSnapshot,
+    records: &[LintRecord],
+    source_resolver: &dyn SourceResolver,
+) -> Vec<Finding> {
+    let node_ids = snapshot
+        .nodes
+        .iter()
+        .map(|node| node.node_id.as_str())
+        .collect::<HashSet<_>>();
+    let step_ids = snapshot
+        .steps
+        .iter()
+        .map(|step| step.step_id.as_str())
+        .collect::<HashSet<_>>();
+    let record_refs = records
+        .iter()
+        .flat_map(|record| {
+            [
+                record.stored.record.id.as_str(),
+                record.stored.record.target_id.as_str(),
+            ]
+        })
+        .collect::<HashSet<_>>();
+
+    let mut findings = Vec::new();
+    for step in &snapshot.steps {
+        if let Some(result_ref) = step.result_ref.as_deref()
+            && !record_refs.contains(result_ref)
+            && !source_resolver.exists(result_ref)
+        {
+            findings.push(broken_result_ref_finding(step, result_ref));
+        }
+
+        match step.node_id.as_deref() {
+            Some(node_id) if !node_ids.contains(node_id) => {
+                findings.push(step_missing_node_finding(step, node_id));
+            }
+            None => findings.push(pending_step_finding(step)),
+            _ => {}
+        }
+    }
+
+    for node in &snapshot.nodes {
+        for source_step_id in &node.source_step_ids {
+            if !step_ids.contains(source_step_id.as_str()) {
+                findings.push(node_missing_step_finding(node, source_step_id));
+            }
+        }
+    }
+
+    for canvas in &snapshot.canvases {
+        if let Some(active_node_id) = canvas.active_node_id.as_deref()
+            && !node_ids.contains(active_node_id)
+        {
+            findings.push(canvas_missing_active_node_finding(canvas, active_node_id));
+        }
+
+        let bytes = rendered_canvas_bytes(canvas, &snapshot.nodes);
+        if bytes > canvas.max_bytes {
+            findings.push(canvas_over_budget_finding(canvas, bytes));
+        }
+    }
+
+    findings
+}
+
+fn broken_result_ref_finding(step: &TraceCanvasLintStep, result_ref: &str) -> Finding {
+    let mut f = finding(
+        Kind::BrokenSourceLink,
+        Severity::Error,
+        format!(
+            "trace_step `{}` result_ref `{result_ref}` does not resolve to an active record or source artifact",
+            step.step_id,
+        ),
+    );
+    f.target = Some(target_path(format!("trace_steps/{}", step.step_id)));
+    f.suggested_fix =
+        Some("repair the result_ref or forget/replay the stale trace step".to_owned());
+    f
+}
+
+fn pending_step_finding(step: &TraceCanvasLintStep) -> Finding {
+    let mut f = finding(
+        Kind::DataGap,
+        Severity::Warning,
+        format!(
+            "trace_step `{}` in session `{}` has no canvas node assignment",
+            step.step_id, step.session_id,
+        ),
+    );
+    f.target = Some(target_path(format!("trace_steps/{}", step.step_id)));
+    f.suggested_fix = Some("run the trace_canvas materialization workflow".to_owned());
+    f
+}
+
+fn step_missing_node_finding(step: &TraceCanvasLintStep, node_id: &str) -> Finding {
+    let mut f = finding(
+        Kind::Orphan,
+        Severity::Error,
+        format!(
+            "trace_step `{}` references missing trace_canvas_node `{node_id}`",
+            step.step_id,
+        ),
+    );
+    f.target = Some(target_path(format!("trace_steps/{}", step.step_id)));
+    f.suggested_fix = Some("rebuild the trace canvas from trace_steps".to_owned());
+    f
+}
+
+fn node_missing_step_finding(node: &TraceCanvasLintNode, source_step_id: &str) -> Finding {
+    let mut f = finding(
+        Kind::Orphan,
+        Severity::Error,
+        format!(
+            "trace_canvas_node `{}` cites missing source trace_step `{source_step_id}`",
+            node.node_id,
+        ),
+    );
+    f.target = Some(target_path(format!("trace_canvas_nodes/{}", node.node_id)));
+    f.suggested_fix = Some("rebuild the trace canvas from trace_steps".to_owned());
+    f
+}
+
+fn canvas_missing_active_node_finding(
+    canvas: &TraceCanvasLintCanvas,
+    active_node_id: &str,
+) -> Finding {
+    let mut f = finding(
+        Kind::Orphan,
+        Severity::Error,
+        format!(
+            "trace_canvas `{}` references missing active_node_id `{active_node_id}`",
+            canvas.canvas_id,
+        ),
+    );
+    f.target = Some(target_path(format!("trace_canvases/{}", canvas.canvas_id)));
+    f.suggested_fix = Some("clear active_node_id or rebuild the canvas projection".to_owned());
+    f
+}
+
+fn canvas_over_budget_finding(canvas: &TraceCanvasLintCanvas, bytes: u64) -> Finding {
+    let mut f = finding(
+        Kind::HotMemoryOverBudget,
+        Severity::Error,
+        format!(
+            "trace_canvas `{}` renders to {bytes} bytes, exceeding its {} byte budget",
+            canvas.canvas_id, canvas.max_bytes,
+        ),
+    );
+    f.target = Some(target_path(format!("trace_canvases/{}", canvas.canvas_id)));
+    f.suggested_fix =
+        Some("compact the canvas summary or increase the trace canvas budget".to_owned());
+    f
+}
+
+fn rendered_canvas_bytes(canvas: &TraceCanvasLintCanvas, nodes: &[TraceCanvasLintNode]) -> u64 {
+    let mut bytes = "# Current Task\n".len()
+        + canvas.title.len()
+        + "\n".len()
+        + "Goal: \n".len()
+        + canvas.goal.len()
+        + "Summary: \n".len()
+        + canvas.summary.len();
+
+    for node in nodes
+        .iter()
+        .filter(|node| node.canvas_id == canvas.canvas_id)
+    {
+        bytes = bytes
+            .saturating_add("- ".len())
+            .saturating_add(node.label.len())
+            .saturating_add(": ".len())
+            .saturating_add(node.summary.len())
+            .saturating_add("\n".len());
+    }
+
+    u64::try_from(bytes).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CairnConfig;
+    use crate::contract::memory_store::StoredRecord;
+    use crate::domain::record::tests_export::sample_record;
+    use crate::generated::verbs::lint::{Kind, Severity};
+    use crate::verbs::lint::{ConsentModel, LintRecord, SchemaVersion, empty_source_resolver};
+
+    fn lint_record(record_id: &str, target_id: &str) -> LintRecord {
+        let mut record = sample_record();
+        record.id = crate::domain::RecordId::parse(record_id).expect("valid record id");
+        record.target_id =
+            crate::domain::TargetId::parse(target_id.to_owned()).expect("valid target id");
+        LintRecord {
+            stored: StoredRecord {
+                record,
+                version: 1,
+                schema_version: Some(SchemaVersion::current()),
+            },
+            consent_model: ConsentModel::LegacyEvent,
+        }
+    }
+
+    fn canvas_fixture() -> TraceCanvasLintCanvas {
+        TraceCanvasLintCanvas {
+            canvas_id: "canvas-1".to_owned(),
+            session_id: "session-1".to_owned(),
+            title: "Current task".to_owned(),
+            goal: "Keep the trace canvas healthy".to_owned(),
+            summary: "Canvas summary".to_owned(),
+            active_node_id: Some("node-1".to_owned()),
+            max_bytes: 256,
+        }
+    }
+
+    fn node_fixture() -> TraceCanvasLintNode {
+        TraceCanvasLintNode {
+            node_id: "node-1".to_owned(),
+            canvas_id: "canvas-1".to_owned(),
+            label: "Mapped node".to_owned(),
+            summary: "Node summary".to_owned(),
+            source_step_ids: vec!["step-1".to_owned()],
+        }
+    }
+
+    #[test]
+    fn healthy_canvas_snapshot_has_no_findings() {
+        let records = [lint_record(
+            "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+            "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+        )];
+        let snapshot = TraceCanvasLintSnapshot {
+            steps: vec![TraceCanvasLintStep {
+                step_id: "step-1".to_owned(),
+                session_id: "session-1".to_owned(),
+                result_ref: Some(records[0].stored.record.id.as_str().to_owned()),
+                node_id: Some("node-1".to_owned()),
+            }],
+            canvases: vec![canvas_fixture()],
+            nodes: vec![node_fixture()],
+        };
+
+        assert!(run(&snapshot, &records, empty_source_resolver()).is_empty());
+    }
+
+    #[test]
+    fn pending_step_broken_result_ref_orphan_node_and_budget_emit_findings() {
+        let _cfg = CairnConfig::default();
+        let snapshot = TraceCanvasLintSnapshot {
+            steps: vec![
+                TraceCanvasLintStep {
+                    step_id: "step-pending".to_owned(),
+                    session_id: "session-1".to_owned(),
+                    result_ref: Some("missing-result".to_owned()),
+                    node_id: None,
+                },
+                TraceCanvasLintStep {
+                    step_id: "step-mapped-missing-node".to_owned(),
+                    session_id: "session-1".to_owned(),
+                    result_ref: None,
+                    node_id: Some("node-missing".to_owned()),
+                },
+            ],
+            canvases: vec![TraceCanvasLintCanvas {
+                title: "A very long title".repeat(4),
+                goal: "A very long goal".repeat(4),
+                summary: "A very long summary".repeat(4),
+                max_bytes: 32,
+                ..canvas_fixture()
+            }],
+            nodes: vec![TraceCanvasLintNode {
+                source_step_ids: vec!["step-missing".to_owned()],
+                ..node_fixture()
+            }],
+        };
+
+        let findings = run(&snapshot, &[], empty_source_resolver());
+        assert!(
+            findings
+                .iter()
+                .any(|f| matches!((f.kind, f.severity), (Kind::DataGap, Severity::Warning))),
+            "pending trace steps should emit a DataGap warning: {findings:?}",
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| matches!(f.kind, Kind::BrokenSourceLink)
+                    && f.message.contains("missing-result")),
+            "broken result_ref should emit BrokenSourceLink: {findings:?}",
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| matches!(f.kind, Kind::Orphan) && f.message.contains("node-missing")),
+            "step mapped to a missing node should emit Orphan: {findings:?}",
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| matches!(f.kind, Kind::HotMemoryOverBudget)
+                    && f.message.contains("canvas-1")),
+            "oversized canvas text should emit HotMemoryOverBudget: {findings:?}",
+        );
+    }
+}

--- a/crates/cairn-core/src/verbs/lint/checks/trace_canvas.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/trace_canvas.rs
@@ -1,6 +1,6 @@
 //! Task-trace canvas lint checks for issue #134.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::contract::source_resolver::SourceResolver;
 use crate::domain::projection::{ProjectionStatus, compare_projection};
@@ -79,6 +79,11 @@ pub fn run(
         .iter()
         .map(|node| node.node_id.as_str())
         .collect::<HashSet<_>>();
+    let node_canvas_ids = snapshot
+        .nodes
+        .iter()
+        .map(|node| (node.node_id.as_str(), node.canvas_id.as_str()))
+        .collect::<HashMap<_, _>>();
     let step_ids = snapshot
         .steps
         .iter()
@@ -122,7 +127,7 @@ pub fn run(
 
     for canvas in &snapshot.canvases {
         if let Some(active_node_id) = canvas.active_node_id.as_deref()
-            && !node_ids.contains(active_node_id)
+            && node_canvas_ids.get(active_node_id).copied() != Some(canvas.canvas_id.as_str())
         {
             findings.push(canvas_missing_active_node_finding(canvas, active_node_id));
         }
@@ -520,6 +525,41 @@ mod tests {
                 .any(|f| matches!(f.kind, Kind::HotMemoryOverBudget)
                     && f.message.contains("canvas-1")),
             "oversized canvas text should emit HotMemoryOverBudget: {findings:?}",
+        );
+    }
+
+    #[test]
+    fn active_node_must_belong_to_its_canvas() {
+        let snapshot = TraceCanvasLintSnapshot {
+            steps: vec![],
+            canvases: vec![
+                TraceCanvasLintCanvas {
+                    canvas_id: "canvas-1".to_owned(),
+                    active_node_id: Some("node-2".to_owned()),
+                    projection_markdown: None,
+                    ..canvas_fixture()
+                },
+                TraceCanvasLintCanvas {
+                    canvas_id: "canvas-2".to_owned(),
+                    active_node_id: Some("node-2".to_owned()),
+                    projection_markdown: None,
+                    ..canvas_fixture()
+                },
+            ],
+            nodes: vec![TraceCanvasLintNode {
+                node_id: "node-2".to_owned(),
+                canvas_id: "canvas-2".to_owned(),
+                source_step_ids: Vec::new(),
+                ..node_fixture()
+            }],
+        };
+
+        let findings = run(&snapshot, &[], empty_source_resolver());
+        assert!(
+            findings.iter().any(|f| matches!(f.kind, Kind::Orphan)
+                && f.message.contains("canvas-1")
+                && f.message.contains("node-2")),
+            "cross-canvas active node should emit Orphan: {findings:?}",
         );
     }
 }

--- a/crates/cairn-store-sqlite/src/lib.rs
+++ b/crates/cairn-store-sqlite/src/lib.rs
@@ -27,7 +27,8 @@ pub mod store;
 pub mod trace_canvas;
 pub mod trace_window;
 pub use trace_canvas::{
-    TraceCanvasContext, TraceCanvasDraft, TraceCanvasNodeDraft, TraceCanvasNodeRow, TraceCanvasRow,
+    TraceCanvasContext, TraceCanvasDraft, TraceCanvasEdgeDraft, TraceCanvasEdgeKind,
+    TraceCanvasEdgeRow, TraceCanvasNodeDraft, TraceCanvasNodeRow, TraceCanvasRow,
     TraceCanvasStatus, TraceStepDraft, TraceStepRow, TraceStepUpsert,
 };
 pub use trace_window::ConsolidationBacklogEntry;

--- a/crates/cairn-store-sqlite/src/lib.rs
+++ b/crates/cairn-store-sqlite/src/lib.rs
@@ -24,7 +24,12 @@ pub mod record_wal;
 pub mod repair;
 pub mod replay;
 pub mod store;
+pub mod trace_canvas;
 pub mod trace_window;
+pub use trace_canvas::{
+    TraceCanvasContext, TraceCanvasDraft, TraceCanvasNodeDraft, TraceCanvasNodeRow, TraceCanvasRow,
+    TraceCanvasStatus, TraceStepDraft, TraceStepRow, TraceStepUpsert,
+};
 pub use trace_window::ConsolidationBacklogEntry;
 pub mod vec_ext;
 mod verify;

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -130,6 +130,8 @@ const M0063_WORKFLOW_DEAD_LETTER: &str = include_str!("sql/0063_workflow_dead_le
 // Issue #109 — v0.2 additive session-link metadata for cold rehydration and
 // session-level forget migrations.
 const M0064_V02_RECORD_SESSION_LINKS: &str = include_str!("sql/0064_v02_record_session_links.sql");
+// Issue #134 — task-trace canvas substrate layered after tree-aware read windows.
+const M0065_TRACE_CANVAS: &str = include_str!("sql/0065_trace_canvas.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -323,6 +325,7 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
         "0064_v02_record_session_links",
         M0064_V02_RECORD_SESSION_LINKS,
     ),
+    (65, "0065_trace_canvas", M0065_TRACE_CANVAS),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -388,5 +391,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0062_SESSION_TREE),
         M::up(M0063_WORKFLOW_DEAD_LETTER),
         M::up(M0064_V02_RECORD_SESSION_LINKS),
+        M::up(M0065_TRACE_CANVAS),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/mod.rs
+++ b/crates/cairn-store-sqlite/src/migrations/mod.rs
@@ -132,6 +132,8 @@ const M0063_WORKFLOW_DEAD_LETTER: &str = include_str!("sql/0063_workflow_dead_le
 const M0064_V02_RECORD_SESSION_LINKS: &str = include_str!("sql/0064_v02_record_session_links.sql");
 // Issue #134 — task-trace canvas substrate layered after tree-aware read windows.
 const M0065_TRACE_CANVAS: &str = include_str!("sql/0065_trace_canvas.sql");
+// Issue #134 follow-up — rebuildable markdown projection cache for lint drift checks.
+const M0066_TRACE_CANVAS_PROJECTION: &str = include_str!("sql/0066_trace_canvas_projection.sql");
 
 /// Canonical SQL for migration 0020 (`workflow_jobs`). Re-exported so
 /// downstream crates (notably `cairn-workflows`, which hashes the
@@ -326,6 +328,11 @@ pub(crate) const MIGRATION_SOURCES: &[(i64, &str, &str)] = &[
         M0064_V02_RECORD_SESSION_LINKS,
     ),
     (65, "0065_trace_canvas", M0065_TRACE_CANVAS),
+    (
+        66,
+        "0066_trace_canvas_projection",
+        M0066_TRACE_CANVAS_PROJECTION,
+    ),
 ];
 
 /// All migrations, in order. Returns a fresh `Migrations` set on every call
@@ -392,5 +399,6 @@ pub fn migrations() -> Migrations<'static> {
         M::up(M0063_WORKFLOW_DEAD_LETTER),
         M::up(M0064_V02_RECORD_SESSION_LINKS),
         M::up(M0065_TRACE_CANVAS),
+        M::up(M0066_TRACE_CANVAS_PROJECTION),
     ])
 }

--- a/crates/cairn-store-sqlite/src/migrations/sql/0065_trace_canvas.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0065_trace_canvas.sql
@@ -1,0 +1,110 @@
+-- Migration 0064: task-trace canvas storage substrate.
+-- Issue #134 addendum. Brief sources: §5.7 Sessions are trees, §7 Hot Memory,
+-- §10 Continuous Learning.
+--
+-- This migration stores durable trace steps and their projected canvas graph.
+-- It intentionally stops at the substrate: capture/workflow materialization,
+-- hot-memory selection, lint rules, and exact retrieve lookups can be layered
+-- on these tables without changing the schema shape.
+
+CREATE TABLE trace_canvases (
+  canvas_id       TEXT PRIMARY KEY,
+  session_id      TEXT NOT NULL,
+  title           TEXT NOT NULL CHECK (length(title) > 0),
+  goal            TEXT NOT NULL CHECK (length(goal) > 0),
+  status          TEXT NOT NULL
+                  CHECK (status IN ('active', 'completed', 'abandoned')),
+  summary         TEXT NOT NULL,
+  active_node_id  TEXT,
+  max_bytes       INTEGER NOT NULL DEFAULT 8192 CHECK (max_bytes > 0),
+  version         INTEGER NOT NULL DEFAULT 1 CHECK (version >= 1),
+  created_at_ms   INTEGER NOT NULL,
+  updated_at_ms   INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+);
+
+CREATE INDEX trace_canvases_session_idx
+  ON trace_canvases(session_id, status, updated_at_ms DESC, canvas_id);
+
+CREATE TABLE trace_canvas_nodes (
+  node_id             TEXT PRIMARY KEY,
+  canvas_id           TEXT NOT NULL
+                      REFERENCES trace_canvases(canvas_id) ON DELETE CASCADE,
+  label               TEXT NOT NULL CHECK (length(label) > 0),
+  status              TEXT NOT NULL
+                      CHECK (status IN ('planned', 'active', 'completed', 'blocked', 'discarded')),
+  summary             TEXT NOT NULL,
+  timestamp_ms        INTEGER NOT NULL,
+  source_step_ids     TEXT NOT NULL
+                      CHECK (
+                        json_valid(source_step_ids)
+                        AND json_type(source_step_ids) = 'array'
+                        AND json_array_length(source_step_ids) > 0
+                      ),
+  evidence_record_ids TEXT NOT NULL
+                      CHECK (
+                        json_valid(evidence_record_ids)
+                        AND json_type(evidence_record_ids) = 'array'
+                      )
+);
+
+CREATE INDEX trace_canvas_nodes_canvas_idx
+  ON trace_canvas_nodes(canvas_id, status, timestamp_ms, node_id);
+
+CREATE TABLE trace_canvas_edges (
+  canvas_id     TEXT NOT NULL
+                REFERENCES trace_canvases(canvas_id) ON DELETE CASCADE,
+  from_node_id  TEXT NOT NULL
+                REFERENCES trace_canvas_nodes(node_id) ON DELETE CASCADE,
+  to_node_id    TEXT NOT NULL
+                REFERENCES trace_canvas_nodes(node_id) ON DELETE CASCADE,
+  kind          TEXT NOT NULL
+                CHECK (kind IN ('depends_on', 'supersedes', 'branches_to', 'merges_into', 'supports')),
+  label         TEXT,
+
+  CHECK (from_node_id != to_node_id)
+);
+
+CREATE UNIQUE INDEX trace_canvas_edges_unique_idx
+  ON trace_canvas_edges(canvas_id, from_node_id, to_node_id, kind, COALESCE(label, ''));
+
+CREATE INDEX trace_canvas_edges_to_idx
+  ON trace_canvas_edges(to_node_id, kind, canvas_id);
+
+CREATE TABLE trace_steps (
+  step_id               TEXT PRIMARY KEY,
+  trace_id              TEXT NOT NULL,
+  session_id            TEXT NOT NULL,
+  turn_id               TEXT NOT NULL,
+  tool_call_id          TEXT,
+  timestamp_ms          INTEGER NOT NULL,
+  tool_name             TEXT,
+  call_summary          TEXT NOT NULL,
+  result_summary        TEXT NOT NULL,
+  result_ref            TEXT,
+  salience              REAL NOT NULL DEFAULT 0.5
+                        CHECK (salience >= 0.0 AND salience <= 1.0),
+  replaceability_score  REAL NOT NULL DEFAULT 0.5
+                        CHECK (replaceability_score >= 0.0 AND replaceability_score <= 1.0),
+  node_id               TEXT
+                        REFERENCES trace_canvas_nodes(node_id) ON DELETE SET NULL,
+  source_hash           TEXT NOT NULL CHECK (length(source_hash) > 0),
+  created_at_ms         INTEGER NOT NULL,
+  updated_at_ms         INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+);
+
+CREATE UNIQUE INDEX trace_steps_replay_key_idx
+  ON trace_steps(source_hash, COALESCE(tool_call_id, ''));
+
+CREATE INDEX trace_steps_session_turn_idx
+  ON trace_steps(session_id, turn_id, timestamp_ms, step_id);
+
+CREATE INDEX trace_steps_node_idx
+  ON trace_steps(node_id, timestamp_ms, step_id)
+  WHERE node_id IS NOT NULL;
+
+CREATE INDEX trace_steps_result_ref_idx
+  ON trace_steps(result_ref)
+  WHERE result_ref IS NOT NULL;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (65, '0065_trace_canvas', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/migrations/sql/0066_trace_canvas_projection.sql
+++ b/crates/cairn-store-sqlite/src/migrations/sql/0066_trace_canvas_projection.sql
@@ -1,0 +1,12 @@
+-- Migration 0065: cached task-trace canvas markdown projection.
+-- Issue #134 addendum. SQLite rows remain authoritative; this stores a
+-- rebuildable markdown cache so lint can detect projection drift.
+
+ALTER TABLE trace_canvases
+  ADD COLUMN projection_markdown TEXT;
+
+ALTER TABLE trace_canvases
+  ADD COLUMN projection_hash TEXT;
+
+INSERT INTO schema_migrations (migration_id, name, sql_hash, applied_at)
+  VALUES (66, '0066_trace_canvas_projection', '', strftime('%s','now') * 1000);

--- a/crates/cairn-store-sqlite/src/store/trait_impl.rs
+++ b/crates/cairn-store-sqlite/src/store/trait_impl.rs
@@ -237,6 +237,18 @@ impl MemoryStore for SqliteMemoryStore {
         self.do_list_consent_models().await.map_err(Into::into)
     }
 
+    async fn trace_canvas_lint_snapshot(
+        &self,
+    ) -> Result<cairn_core::verbs::lint::checks::trace_canvas::TraceCanvasLintSnapshot, StoreError>
+    {
+        if self.conn.is_none() {
+            return not_initialized("trace_canvas_lint_snapshot");
+        }
+        SqliteMemoryStore::trace_canvas_lint_snapshot(self)
+            .await
+            .map_err(Into::into)
+    }
+
     async fn record_access(
         &self,
         record_ids: &[RecordId],

--- a/crates/cairn-store-sqlite/src/trace_canvas.rs
+++ b/crates/cairn-store-sqlite/src/trace_canvas.rs
@@ -9,8 +9,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::StoreError;
 use crate::store::{SqliteMemoryStore, current_unix_ms};
+use cairn_core::domain::projection::body_hash;
 use cairn_core::verbs::lint::checks::trace_canvas::{
     TraceCanvasLintCanvas, TraceCanvasLintNode, TraceCanvasLintSnapshot, TraceCanvasLintStep,
+    render_markdown,
 };
 
 /// Draft row for inserting or replaying a trace step.
@@ -294,6 +296,17 @@ pub struct TraceCanvasContext {
     pub nodes: Vec<TraceCanvasNodeRow>,
     /// Canvas edges ordered by source, destination, kind, then label.
     pub edges: Vec<TraceCanvasEdgeRow>,
+}
+
+/// Cached markdown projection rebuilt from authoritative trace-canvas rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasProjectionCache {
+    /// Canvas id the projection describes.
+    pub canvas_id: String,
+    /// Canonical markdown body.
+    pub markdown: String,
+    /// Hash of the canonical markdown body.
+    pub hash: String,
 }
 
 impl SqliteMemoryStore {
@@ -581,6 +594,50 @@ impl SqliteMemoryStore {
             .await?)
     }
 
+    /// Rebuild and persist the markdown projection cache for one canvas.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Worker`] on background-thread failure, or
+    /// [`StoreError::Sqlite`] / [`StoreError::Codec`] for query errors.
+    pub async fn refresh_trace_canvas_projection(
+        &self,
+        canvas_id: &str,
+    ) -> Result<TraceCanvasProjectionCache, StoreError> {
+        let conn = self
+            .require_conn("refresh_trace_canvas_projection")?
+            .clone();
+        let canvas_id = canvas_id.to_owned();
+        let now_ms = current_unix_ms();
+        Ok(conn
+            .call(move |c| {
+                let canvas = trace_canvas_by_id(c, &canvas_id)?;
+                let nodes = trace_canvas_nodes_for_canvas(c, &canvas_id)?;
+                let lint_canvas = lint_canvas_from_row(canvas, None);
+                let lint_nodes = nodes
+                    .into_iter()
+                    .map(lint_node_from_row)
+                    .collect::<Vec<_>>();
+                let markdown = render_markdown(&lint_canvas, &lint_nodes);
+                let hash = body_hash(&markdown);
+                c.execute(
+                    "UPDATE trace_canvases
+                        SET projection_markdown = ?1,
+                            projection_hash = ?2,
+                            updated_at_ms = ?3
+                      WHERE canvas_id = ?4",
+                    params![&markdown, &hash, now_ms, &canvas_id],
+                )?;
+                Ok::<_, tokio_rusqlite::Error>(TraceCanvasProjectionCache {
+                    canvas_id,
+                    markdown,
+                    hash,
+                })
+            })
+            .await?)
+    }
+
     /// Return a read-only snapshot for task-trace canvas lint checks.
     ///
     /// # Errors
@@ -613,23 +670,12 @@ impl SqliteMemoryStore {
 
                 let mut canvas_stmt = c.prepare_cached(
                     "SELECT canvas_id, session_id, title, goal, status, summary,
-                            active_node_id, max_bytes, version
+                            active_node_id, max_bytes, version, projection_markdown
                        FROM trace_canvases
                       ORDER BY session_id ASC, canvas_id ASC",
                 )?;
                 let canvases = canvas_stmt
-                    .query_map([], trace_canvas_from_row)?
-                    .map(|row| {
-                        row.map(|canvas| TraceCanvasLintCanvas {
-                            canvas_id: canvas.canvas_id,
-                            session_id: canvas.session_id,
-                            title: canvas.title,
-                            goal: canvas.goal,
-                            summary: canvas.summary,
-                            active_node_id: canvas.active_node_id,
-                            max_bytes: u64::try_from(canvas.max_bytes).unwrap_or(u64::MAX),
-                        })
-                    })
+                    .query_map([], trace_canvas_lint_from_row)?
                     .collect::<Result<Vec<_>, _>>()?;
 
                 let mut node_stmt = c.prepare_cached(
@@ -640,15 +686,7 @@ impl SqliteMemoryStore {
                 )?;
                 let nodes = node_stmt
                     .query_map([], trace_canvas_node_from_row)?
-                    .map(|row| {
-                        row.map(|node| TraceCanvasLintNode {
-                            node_id: node.node_id,
-                            canvas_id: node.canvas_id,
-                            label: node.label,
-                            summary: node.summary,
-                            source_step_ids: node.source_step_ids,
-                        })
-                    })
+                    .map(|row| row.map(lint_node_from_row))
                     .collect::<Result<Vec<_>, _>>()?;
 
                 Ok::<_, tokio_rusqlite::Error>(TraceCanvasLintSnapshot {
@@ -711,6 +749,41 @@ fn trace_canvas_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TraceCanva
     })
 }
 
+fn trace_canvas_lint_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TraceCanvasLintCanvas> {
+    let status: String = row.get(4)?;
+    let canvas = TraceCanvasRow {
+        canvas_id: row.get(0)?,
+        session_id: row.get(1)?,
+        title: row.get(2)?,
+        goal: row.get(3)?,
+        status: TraceCanvasStatus::try_from(status).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(err))
+        })?,
+        summary: row.get(5)?,
+        active_node_id: row.get(6)?,
+        max_bytes: row.get(7)?,
+        version: row.get(8)?,
+    };
+    let projection_markdown = row.get(9)?;
+    Ok(lint_canvas_from_row(canvas, projection_markdown))
+}
+
+fn lint_canvas_from_row(
+    canvas: TraceCanvasRow,
+    projection_markdown: Option<String>,
+) -> TraceCanvasLintCanvas {
+    TraceCanvasLintCanvas {
+        canvas_id: canvas.canvas_id,
+        session_id: canvas.session_id,
+        title: canvas.title,
+        goal: canvas.goal,
+        summary: canvas.summary,
+        active_node_id: canvas.active_node_id,
+        max_bytes: u64::try_from(canvas.max_bytes).unwrap_or(u64::MAX),
+        projection_markdown,
+    }
+}
+
 fn trace_canvas_node_by_id(
     c: &rusqlite::Connection,
     node_id: &str,
@@ -723,6 +796,21 @@ fn trace_canvas_node_by_id(
         [node_id],
         trace_canvas_node_from_row,
     )
+}
+
+fn trace_canvas_nodes_for_canvas(
+    c: &rusqlite::Connection,
+    canvas_id: &str,
+) -> rusqlite::Result<Vec<TraceCanvasNodeRow>> {
+    let mut stmt = c.prepare_cached(
+        "SELECT node_id, canvas_id, label, status, summary, timestamp_ms,
+                source_step_ids, evidence_record_ids
+           FROM trace_canvas_nodes
+          WHERE canvas_id = ?1
+          ORDER BY timestamp_ms ASC, node_id ASC",
+    )?;
+    stmt.query_map([canvas_id], trace_canvas_node_from_row)?
+        .collect()
 }
 
 fn trace_canvas_node_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TraceCanvasNodeRow> {
@@ -742,6 +830,16 @@ fn trace_canvas_node_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Trace
             rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, Box::new(err))
         })?,
     })
+}
+
+fn lint_node_from_row(node: TraceCanvasNodeRow) -> TraceCanvasLintNode {
+    TraceCanvasLintNode {
+        node_id: node.node_id,
+        canvas_id: node.canvas_id,
+        label: node.label,
+        summary: node.summary,
+        source_step_ids: node.source_step_ids,
+    }
 }
 
 fn trace_canvas_edge_by_key(

--- a/crates/cairn-store-sqlite/src/trace_canvas.rs
+++ b/crates/cairn-store-sqlite/src/trace_canvas.rs
@@ -9,6 +9,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::StoreError;
 use crate::store::{SqliteMemoryStore, current_unix_ms};
+use cairn_core::verbs::lint::checks::trace_canvas::{
+    TraceCanvasLintCanvas, TraceCanvasLintNode, TraceCanvasLintSnapshot, TraceCanvasLintStep,
+};
 
 /// Draft row for inserting or replaying a trace step.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -574,6 +577,85 @@ impl SqliteMemoryStore {
                     nodes: nodes?,
                     edges: edges?,
                 }))
+            })
+            .await?)
+    }
+
+    /// Return a read-only snapshot for task-trace canvas lint checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Worker`] on background-thread failure, or
+    /// [`StoreError::Sqlite`] / [`StoreError::Codec`] for query errors.
+    pub async fn trace_canvas_lint_snapshot(&self) -> Result<TraceCanvasLintSnapshot, StoreError> {
+        let conn = self.require_conn("trace_canvas_lint_snapshot")?.clone();
+        Ok(conn
+            .call(move |c| {
+                let mut step_stmt = c.prepare_cached(
+                    "SELECT step_id, trace_id, session_id, turn_id, tool_call_id, timestamp_ms,
+                        tool_name, call_summary, result_summary, result_ref, salience,
+                        replaceability_score, node_id, source_hash
+                   FROM trace_steps
+                  ORDER BY session_id ASC, timestamp_ms ASC, step_id ASC",
+                )?;
+                let steps = step_stmt
+                    .query_map([], trace_step_from_row)?
+                    .map(|row| {
+                        row.map(|step| TraceCanvasLintStep {
+                            step_id: step.step_id,
+                            session_id: step.session_id,
+                            result_ref: step.result_ref,
+                            node_id: step.node_id,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let mut canvas_stmt = c.prepare_cached(
+                    "SELECT canvas_id, session_id, title, goal, status, summary,
+                            active_node_id, max_bytes, version
+                       FROM trace_canvases
+                      ORDER BY session_id ASC, canvas_id ASC",
+                )?;
+                let canvases = canvas_stmt
+                    .query_map([], trace_canvas_from_row)?
+                    .map(|row| {
+                        row.map(|canvas| TraceCanvasLintCanvas {
+                            canvas_id: canvas.canvas_id,
+                            session_id: canvas.session_id,
+                            title: canvas.title,
+                            goal: canvas.goal,
+                            summary: canvas.summary,
+                            active_node_id: canvas.active_node_id,
+                            max_bytes: u64::try_from(canvas.max_bytes).unwrap_or(u64::MAX),
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let mut node_stmt = c.prepare_cached(
+                    "SELECT node_id, canvas_id, label, status, summary, timestamp_ms,
+                        source_step_ids, evidence_record_ids
+                   FROM trace_canvas_nodes
+                  ORDER BY canvas_id ASC, timestamp_ms ASC, node_id ASC",
+                )?;
+                let nodes = node_stmt
+                    .query_map([], trace_canvas_node_from_row)?
+                    .map(|row| {
+                        row.map(|node| TraceCanvasLintNode {
+                            node_id: node.node_id,
+                            canvas_id: node.canvas_id,
+                            label: node.label,
+                            summary: node.summary,
+                            source_step_ids: node.source_step_ids,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                Ok::<_, tokio_rusqlite::Error>(TraceCanvasLintSnapshot {
+                    steps,
+                    canvases,
+                    nodes,
+                })
             })
             .await?)
     }

--- a/crates/cairn-store-sqlite/src/trace_canvas.rs
+++ b/crates/cairn-store-sqlite/src/trace_canvas.rs
@@ -5,12 +5,14 @@
 //! materialization and hot-memory selection are settled.
 
 use rusqlite::{OptionalExtension, params};
+use serde::{Deserialize, Serialize};
 
 use crate::error::StoreError;
 use crate::store::{SqliteMemoryStore, current_unix_ms};
 
 /// Draft row for inserting or replaying a trace step.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TraceStepDraft {
     /// Stable step id minted by the projector.
     pub step_id: String,

--- a/crates/cairn-store-sqlite/src/trace_canvas.rs
+++ b/crates/cairn-store-sqlite/src/trace_canvas.rs
@@ -206,13 +206,89 @@ pub struct TraceCanvasNodeRow {
     pub evidence_record_ids: Vec<String>,
 }
 
-/// Active canvas plus its ordered nodes.
+/// Canvas edge kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceCanvasEdgeKind {
+    /// `from_node_id` depends on `to_node_id`.
+    DependsOn,
+    /// `from_node_id` supersedes `to_node_id`.
+    Supersedes,
+    /// `from_node_id` branches to `to_node_id`.
+    BranchesTo,
+    /// `from_node_id` merges into `to_node_id`.
+    MergesInto,
+    /// `from_node_id` supports `to_node_id`.
+    Supports,
+}
+
+impl TraceCanvasEdgeKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DependsOn => "depends_on",
+            Self::Supersedes => "supersedes",
+            Self::BranchesTo => "branches_to",
+            Self::MergesInto => "merges_into",
+            Self::Supports => "supports",
+        }
+    }
+}
+
+impl TryFrom<String> for TraceCanvasEdgeKind {
+    type Error = StoreError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "depends_on" => Ok(Self::DependsOn),
+            "supersedes" => Ok(Self::Supersedes),
+            "branches_to" => Ok(Self::BranchesTo),
+            "merges_into" => Ok(Self::MergesInto),
+            "supports" => Ok(Self::Supports),
+            _ => Err(StoreError::Invariant {
+                what: format!("unknown trace canvas edge kind `{value}`"),
+            }),
+        }
+    }
+}
+
+/// Draft row for inserting or updating a canvas edge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasEdgeDraft {
+    /// Parent canvas id.
+    pub canvas_id: String,
+    /// Source node id.
+    pub from_node_id: String,
+    /// Destination node id.
+    pub to_node_id: String,
+    /// Edge kind.
+    pub kind: TraceCanvasEdgeKind,
+    /// Optional edge label.
+    pub label: Option<String>,
+}
+
+/// Stored canvas edge row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasEdgeRow {
+    /// Parent canvas id.
+    pub canvas_id: String,
+    /// Source node id.
+    pub from_node_id: String,
+    /// Destination node id.
+    pub to_node_id: String,
+    /// Edge kind.
+    pub kind: TraceCanvasEdgeKind,
+    /// Optional edge label.
+    pub label: Option<String>,
+}
+
+/// Active canvas plus its ordered nodes and edges.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraceCanvasContext {
     /// Active canvas row.
     pub canvas: TraceCanvasRow,
     /// Canvas nodes ordered by timestamp then id.
     pub nodes: Vec<TraceCanvasNodeRow>,
+    /// Canvas edges ordered by source, destination, kind, then label.
+    pub edges: Vec<TraceCanvasEdgeRow>,
 }
 
 impl SqliteMemoryStore {
@@ -398,6 +474,45 @@ impl SqliteMemoryStore {
             .await?)
     }
 
+    /// Insert or update a task-trace canvas edge.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Worker`] on background-thread failure, or
+    /// [`StoreError::Sqlite`] for storage errors.
+    pub async fn upsert_trace_canvas_edge(
+        &self,
+        draft: TraceCanvasEdgeDraft,
+    ) -> Result<TraceCanvasEdgeRow, StoreError> {
+        let conn = self.require_conn("upsert_trace_canvas_edge")?.clone();
+        Ok(conn
+            .call(move |c| {
+                c.execute(
+                    "INSERT OR IGNORE INTO trace_canvas_edges
+                        (canvas_id, from_node_id, to_node_id, kind, label)
+                     VALUES
+                        (?1, ?2, ?3, ?4, ?5)",
+                    params![
+                        draft.canvas_id,
+                        draft.from_node_id,
+                        draft.to_node_id,
+                        draft.kind.as_str(),
+                        draft.label,
+                    ],
+                )?;
+                Ok(trace_canvas_edge_by_key(
+                    c,
+                    &draft.canvas_id,
+                    &draft.from_node_id,
+                    &draft.to_node_id,
+                    draft.kind,
+                    draft.label.as_deref(),
+                )?)
+            })
+            .await?)
+    }
+
     /// Return the latest active trace canvas and its ordered nodes.
     ///
     /// # Errors
@@ -442,10 +557,20 @@ impl SqliteMemoryStore {
                 let nodes: Result<Vec<_>, rusqlite::Error> = stmt
                     .query_map([canvas.canvas_id.as_str()], trace_canvas_node_from_row)?
                     .collect();
+                let mut edge_stmt = c.prepare_cached(
+                    "SELECT canvas_id, from_node_id, to_node_id, kind, label
+                       FROM trace_canvas_edges
+                      WHERE canvas_id = ?1
+                      ORDER BY from_node_id ASC, to_node_id ASC, kind ASC, label ASC",
+                )?;
+                let edges: Result<Vec<_>, rusqlite::Error> = edge_stmt
+                    .query_map([canvas.canvas_id.as_str()], trace_canvas_edge_from_row)?
+                    .collect();
 
                 Ok(Some(TraceCanvasContext {
                     canvas,
                     nodes: nodes?,
+                    edges: edges?,
                 }))
             })
             .await?)
@@ -532,5 +657,39 @@ fn trace_canvas_node_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Trace
         evidence_record_ids: serde_json::from_str(&evidence_record_ids).map_err(|err| {
             rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, Box::new(err))
         })?,
+    })
+}
+
+fn trace_canvas_edge_by_key(
+    c: &rusqlite::Connection,
+    canvas_id: &str,
+    from_node_id: &str,
+    to_node_id: &str,
+    kind: TraceCanvasEdgeKind,
+    label: Option<&str>,
+) -> rusqlite::Result<TraceCanvasEdgeRow> {
+    c.query_row(
+        "SELECT canvas_id, from_node_id, to_node_id, kind, label
+           FROM trace_canvas_edges
+          WHERE canvas_id = ?1
+            AND from_node_id = ?2
+            AND to_node_id = ?3
+            AND kind = ?4
+            AND COALESCE(label, '') = COALESCE(?5, '')",
+        params![canvas_id, from_node_id, to_node_id, kind.as_str(), label],
+        trace_canvas_edge_from_row,
+    )
+}
+
+fn trace_canvas_edge_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TraceCanvasEdgeRow> {
+    let kind: String = row.get(3)?;
+    Ok(TraceCanvasEdgeRow {
+        canvas_id: row.get(0)?,
+        from_node_id: row.get(1)?,
+        to_node_id: row.get(2)?,
+        kind: TraceCanvasEdgeKind::try_from(kind).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Text, Box::new(err))
+        })?,
+        label: row.get(4)?,
     })
 }

--- a/crates/cairn-store-sqlite/src/trace_canvas.rs
+++ b/crates/cairn-store-sqlite/src/trace_canvas.rs
@@ -1,0 +1,536 @@
+//! Store helpers for the task-trace canvas substrate.
+//!
+//! These methods are adapter-local scaffolding for issue #134's addendum.
+//! The cross-surface verb contract can promote them later once workflow
+//! materialization and hot-memory selection are settled.
+
+use rusqlite::{OptionalExtension, params};
+
+use crate::error::StoreError;
+use crate::store::{SqliteMemoryStore, current_unix_ms};
+
+/// Draft row for inserting or replaying a trace step.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TraceStepDraft {
+    /// Stable step id minted by the projector.
+    pub step_id: String,
+    /// Source trace id.
+    pub trace_id: String,
+    /// Session containing the step.
+    pub session_id: String,
+    /// Turn containing the step.
+    pub turn_id: String,
+    /// Optional tool-call id, when the step came from tool execution.
+    pub tool_call_id: Option<String>,
+    /// Event timestamp in Unix epoch milliseconds.
+    pub timestamp_ms: i64,
+    /// Optional tool name.
+    pub tool_name: Option<String>,
+    /// Body-free call summary.
+    pub call_summary: String,
+    /// Body-free result summary.
+    pub result_summary: String,
+    /// Optional result record reference for exact lookup.
+    pub result_ref: Option<String>,
+    /// Relative hot-memory salience score.
+    pub salience: f64,
+    /// How safely the step can be replaced by a summary.
+    pub replaceability_score: f64,
+    /// Optional projected canvas node id.
+    pub node_id: Option<String>,
+    /// Replay dedupe hash derived from body-free source material.
+    pub source_hash: String,
+}
+
+/// Stored trace-step row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TraceStepRow {
+    /// Stable step id.
+    pub step_id: String,
+    /// Source trace id.
+    pub trace_id: String,
+    /// Session containing the step.
+    pub session_id: String,
+    /// Turn containing the step.
+    pub turn_id: String,
+    /// Optional tool-call id.
+    pub tool_call_id: Option<String>,
+    /// Event timestamp in Unix epoch milliseconds.
+    pub timestamp_ms: i64,
+    /// Optional tool name.
+    pub tool_name: Option<String>,
+    /// Body-free call summary.
+    pub call_summary: String,
+    /// Body-free result summary.
+    pub result_summary: String,
+    /// Optional result record reference.
+    pub result_ref: Option<String>,
+    /// Relative hot-memory salience score.
+    pub salience: f64,
+    /// How safely the step can be replaced by a summary.
+    pub replaceability_score: f64,
+    /// Optional projected canvas node id.
+    pub node_id: Option<String>,
+    /// Replay dedupe hash.
+    pub source_hash: String,
+}
+
+/// Outcome of [`SqliteMemoryStore::upsert_trace_step`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct TraceStepUpsert {
+    /// Stored row, either newly inserted or pre-existing replay target.
+    pub row: TraceStepRow,
+    /// True when this call inserted the row.
+    pub inserted: bool,
+}
+
+/// Canvas lifecycle status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TraceCanvasStatus {
+    /// Canvas is still the current task context.
+    Active,
+    /// Canvas is completed.
+    Completed,
+    /// Canvas was abandoned.
+    Abandoned,
+}
+
+impl TraceCanvasStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Completed => "completed",
+            Self::Abandoned => "abandoned",
+        }
+    }
+}
+
+impl TryFrom<String> for TraceCanvasStatus {
+    type Error = StoreError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "active" => Ok(Self::Active),
+            "completed" => Ok(Self::Completed),
+            "abandoned" => Ok(Self::Abandoned),
+            _ => Err(StoreError::Invariant {
+                what: format!("unknown trace canvas status `{value}`"),
+            }),
+        }
+    }
+}
+
+/// Draft row for inserting or updating a task-trace canvas.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasDraft {
+    /// Stable canvas id.
+    pub canvas_id: String,
+    /// Session the canvas belongs to.
+    pub session_id: String,
+    /// Short canvas title.
+    pub title: String,
+    /// Current task goal.
+    pub goal: String,
+    /// Canvas lifecycle status.
+    pub status: TraceCanvasStatus,
+    /// Body-free current canvas summary.
+    pub summary: String,
+    /// Optional active node id.
+    pub active_node_id: Option<String>,
+    /// Byte budget for rendering this canvas into hot memory.
+    pub max_bytes: i64,
+}
+
+/// Stored task-trace canvas row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasRow {
+    /// Stable canvas id.
+    pub canvas_id: String,
+    /// Session the canvas belongs to.
+    pub session_id: String,
+    /// Short canvas title.
+    pub title: String,
+    /// Current task goal.
+    pub goal: String,
+    /// Canvas lifecycle status.
+    pub status: TraceCanvasStatus,
+    /// Body-free current canvas summary.
+    pub summary: String,
+    /// Optional active node id.
+    pub active_node_id: Option<String>,
+    /// Byte budget for rendering this canvas into hot memory.
+    pub max_bytes: i64,
+    /// Monotonic canvas version.
+    pub version: i64,
+}
+
+/// Draft row for inserting or updating a canvas node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasNodeDraft {
+    /// Stable node id.
+    pub node_id: String,
+    /// Parent canvas id.
+    pub canvas_id: String,
+    /// Short node label.
+    pub label: String,
+    /// Node status string constrained by the `SQLite` schema.
+    pub status: String,
+    /// Body-free node summary.
+    pub summary: String,
+    /// Node timestamp in Unix epoch milliseconds.
+    pub timestamp_ms: i64,
+    /// Source step ids supporting this node.
+    pub source_step_ids: Vec<String>,
+    /// Evidence record ids supporting this node.
+    pub evidence_record_ids: Vec<String>,
+}
+
+/// Stored canvas node row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasNodeRow {
+    /// Stable node id.
+    pub node_id: String,
+    /// Parent canvas id.
+    pub canvas_id: String,
+    /// Short node label.
+    pub label: String,
+    /// Node status string.
+    pub status: String,
+    /// Body-free node summary.
+    pub summary: String,
+    /// Node timestamp in Unix epoch milliseconds.
+    pub timestamp_ms: i64,
+    /// Source step ids supporting this node.
+    pub source_step_ids: Vec<String>,
+    /// Evidence record ids supporting this node.
+    pub evidence_record_ids: Vec<String>,
+}
+
+/// Active canvas plus its ordered nodes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceCanvasContext {
+    /// Active canvas row.
+    pub canvas: TraceCanvasRow,
+    /// Canvas nodes ordered by timestamp then id.
+    pub nodes: Vec<TraceCanvasNodeRow>,
+}
+
+impl SqliteMemoryStore {
+    /// Insert a trace step, returning the existing row on replay.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Worker`] on background-thread failure, or
+    /// [`StoreError::Sqlite`] / [`StoreError::Codec`] for storage errors.
+    pub async fn upsert_trace_step(
+        &self,
+        draft: TraceStepDraft,
+    ) -> Result<TraceStepUpsert, StoreError> {
+        let conn = self.require_conn("upsert_trace_step")?.clone();
+        let now_ms = current_unix_ms();
+        Ok(conn
+            .call(move |c| {
+                let inserted = c.execute(
+                    "INSERT OR IGNORE INTO trace_steps
+                    (step_id, trace_id, session_id, turn_id, tool_call_id, timestamp_ms,
+                     tool_name, call_summary, result_summary, result_ref, salience,
+                     replaceability_score, node_id, source_hash, created_at_ms, updated_at_ms)
+                 VALUES
+                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)",
+                    params![
+                        draft.step_id,
+                        draft.trace_id,
+                        draft.session_id,
+                        draft.turn_id,
+                        draft.tool_call_id,
+                        draft.timestamp_ms,
+                        draft.tool_name,
+                        draft.call_summary,
+                        draft.result_summary,
+                        draft.result_ref,
+                        draft.salience,
+                        draft.replaceability_score,
+                        draft.node_id,
+                        draft.source_hash,
+                        now_ms,
+                    ],
+                )? == 1;
+
+                let tool_call_key = draft.tool_call_id.as_deref().unwrap_or_default();
+                let row = c.query_row(
+                    "SELECT step_id, trace_id, session_id, turn_id, tool_call_id, timestamp_ms,
+                        tool_name, call_summary, result_summary, result_ref, salience,
+                        replaceability_score, node_id, source_hash
+                   FROM trace_steps
+                  WHERE source_hash = ?1
+                    AND COALESCE(tool_call_id, '') = ?2",
+                    params![draft.source_hash, tool_call_key],
+                    trace_step_from_row,
+                )?;
+
+                Ok(TraceStepUpsert { row, inserted })
+            })
+            .await?)
+    }
+
+    /// Find trace steps that produced or reference a result record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Worker`] on background-thread failure, or
+    /// [`StoreError::Sqlite`] for query errors.
+    pub async fn find_trace_steps_by_result_ref(
+        &self,
+        result_ref: &str,
+    ) -> Result<Vec<TraceStepRow>, StoreError> {
+        let conn = self.require_conn("find_trace_steps_by_result_ref")?.clone();
+        let result_ref = result_ref.to_owned();
+        Ok(conn
+            .call(move |c| {
+                let mut stmt = c.prepare_cached(
+                    "SELECT step_id, trace_id, session_id, turn_id, tool_call_id, timestamp_ms,
+                        tool_name, call_summary, result_summary, result_ref, salience,
+                        replaceability_score, node_id, source_hash
+                   FROM trace_steps
+                  WHERE result_ref = ?1
+                  ORDER BY timestamp_ms ASC, step_id ASC",
+                )?;
+                let rows: Result<Vec<_>, rusqlite::Error> =
+                    stmt.query_map([result_ref], trace_step_from_row)?.collect();
+                Ok(rows?)
+            })
+            .await?)
+    }
+
+    /// Insert or update a task-trace canvas.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Worker`] on background-thread failure, or
+    /// [`StoreError::Sqlite`] for storage errors.
+    pub async fn upsert_trace_canvas(
+        &self,
+        draft: TraceCanvasDraft,
+    ) -> Result<TraceCanvasRow, StoreError> {
+        let conn = self.require_conn("upsert_trace_canvas")?.clone();
+        let now_ms = current_unix_ms();
+        Ok(conn
+            .call(move |c| {
+                c.execute(
+                    "INSERT INTO trace_canvases
+                    (canvas_id, session_id, title, goal, status, summary,
+                     active_node_id, max_bytes, version, created_at_ms, updated_at_ms)
+                 VALUES
+                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, ?9, ?9)
+                 ON CONFLICT(canvas_id) DO UPDATE SET
+                    session_id = excluded.session_id,
+                    title = excluded.title,
+                    goal = excluded.goal,
+                    status = excluded.status,
+                    summary = excluded.summary,
+                    active_node_id = excluded.active_node_id,
+                    max_bytes = excluded.max_bytes,
+                    version = trace_canvases.version + 1,
+                    updated_at_ms = excluded.updated_at_ms",
+                    params![
+                        draft.canvas_id,
+                        draft.session_id,
+                        draft.title,
+                        draft.goal,
+                        draft.status.as_str(),
+                        draft.summary,
+                        draft.active_node_id,
+                        draft.max_bytes,
+                        now_ms,
+                    ],
+                )?;
+                Ok(trace_canvas_by_id(c, &draft.canvas_id)?)
+            })
+            .await?)
+    }
+
+    /// Insert or update a task-trace canvas node.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Worker`] on background-thread failure, or
+    /// [`StoreError::Sqlite`] / [`StoreError::Codec`] for storage errors.
+    pub async fn upsert_trace_canvas_node(
+        &self,
+        draft: TraceCanvasNodeDraft,
+    ) -> Result<TraceCanvasNodeRow, StoreError> {
+        let conn = self.require_conn("upsert_trace_canvas_node")?.clone();
+        let source_step_ids = serde_json::to_string(&draft.source_step_ids)?;
+        let evidence_record_ids = serde_json::to_string(&draft.evidence_record_ids)?;
+        Ok(conn
+            .call(move |c| {
+                c.execute(
+                    "INSERT INTO trace_canvas_nodes
+                    (node_id, canvas_id, label, status, summary, timestamp_ms,
+                     source_step_ids, evidence_record_ids)
+                 VALUES
+                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                 ON CONFLICT(node_id) DO UPDATE SET
+                    canvas_id = excluded.canvas_id,
+                    label = excluded.label,
+                    status = excluded.status,
+                    summary = excluded.summary,
+                    timestamp_ms = excluded.timestamp_ms,
+                    source_step_ids = excluded.source_step_ids,
+                    evidence_record_ids = excluded.evidence_record_ids",
+                    params![
+                        draft.node_id,
+                        draft.canvas_id,
+                        draft.label,
+                        draft.status,
+                        draft.summary,
+                        draft.timestamp_ms,
+                        source_step_ids,
+                        evidence_record_ids,
+                    ],
+                )?;
+                Ok(trace_canvas_node_by_id(c, &draft.node_id)?)
+            })
+            .await?)
+    }
+
+    /// Return the latest active trace canvas and its ordered nodes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Worker`] on background-thread failure, or
+    /// [`StoreError::Sqlite`] / [`StoreError::Codec`] for storage errors.
+    pub async fn active_trace_canvas_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<TraceCanvasContext>, StoreError> {
+        let conn = self
+            .require_conn("active_trace_canvas_for_session")?
+            .clone();
+        let session_id = session_id.to_owned();
+        Ok(conn
+            .call(move |c| {
+                let Some(canvas) = c
+                    .query_row(
+                        "SELECT canvas_id, session_id, title, goal, status, summary,
+                            active_node_id, max_bytes, version
+                       FROM trace_canvases
+                      WHERE session_id = ?1
+                        AND status = 'active'
+                      ORDER BY updated_at_ms DESC, canvas_id ASC
+                      LIMIT 1",
+                        [session_id],
+                        trace_canvas_from_row,
+                    )
+                    .optional()?
+                else {
+                    return Ok(None);
+                };
+
+                let mut stmt = c.prepare_cached(
+                    "SELECT node_id, canvas_id, label, status, summary, timestamp_ms,
+                        source_step_ids, evidence_record_ids
+                   FROM trace_canvas_nodes
+                  WHERE canvas_id = ?1
+                  ORDER BY timestamp_ms ASC, node_id ASC",
+                )?;
+                let nodes: Result<Vec<_>, rusqlite::Error> = stmt
+                    .query_map([canvas.canvas_id.as_str()], trace_canvas_node_from_row)?
+                    .collect();
+
+                Ok(Some(TraceCanvasContext {
+                    canvas,
+                    nodes: nodes?,
+                }))
+            })
+            .await?)
+    }
+}
+
+fn trace_step_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TraceStepRow> {
+    Ok(TraceStepRow {
+        step_id: row.get(0)?,
+        trace_id: row.get(1)?,
+        session_id: row.get(2)?,
+        turn_id: row.get(3)?,
+        tool_call_id: row.get(4)?,
+        timestamp_ms: row.get(5)?,
+        tool_name: row.get(6)?,
+        call_summary: row.get(7)?,
+        result_summary: row.get(8)?,
+        result_ref: row.get(9)?,
+        salience: row.get(10)?,
+        replaceability_score: row.get(11)?,
+        node_id: row.get(12)?,
+        source_hash: row.get(13)?,
+    })
+}
+
+fn trace_canvas_by_id(
+    c: &rusqlite::Connection,
+    canvas_id: &str,
+) -> rusqlite::Result<TraceCanvasRow> {
+    c.query_row(
+        "SELECT canvas_id, session_id, title, goal, status, summary,
+                active_node_id, max_bytes, version
+           FROM trace_canvases
+          WHERE canvas_id = ?1",
+        [canvas_id],
+        trace_canvas_from_row,
+    )
+}
+
+fn trace_canvas_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TraceCanvasRow> {
+    let status: String = row.get(4)?;
+    Ok(TraceCanvasRow {
+        canvas_id: row.get(0)?,
+        session_id: row.get(1)?,
+        title: row.get(2)?,
+        goal: row.get(3)?,
+        status: TraceCanvasStatus::try_from(status).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(err))
+        })?,
+        summary: row.get(5)?,
+        active_node_id: row.get(6)?,
+        max_bytes: row.get(7)?,
+        version: row.get(8)?,
+    })
+}
+
+fn trace_canvas_node_by_id(
+    c: &rusqlite::Connection,
+    node_id: &str,
+) -> rusqlite::Result<TraceCanvasNodeRow> {
+    c.query_row(
+        "SELECT node_id, canvas_id, label, status, summary, timestamp_ms,
+                source_step_ids, evidence_record_ids
+           FROM trace_canvas_nodes
+          WHERE node_id = ?1",
+        [node_id],
+        trace_canvas_node_from_row,
+    )
+}
+
+fn trace_canvas_node_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TraceCanvasNodeRow> {
+    let source_step_ids: String = row.get(6)?;
+    let evidence_record_ids: String = row.get(7)?;
+    Ok(TraceCanvasNodeRow {
+        node_id: row.get(0)?,
+        canvas_id: row.get(1)?,
+        label: row.get(2)?,
+        status: row.get(3)?,
+        summary: row.get(4)?,
+        timestamp_ms: row.get(5)?,
+        source_step_ids: serde_json::from_str(&source_step_ids).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Text, Box::new(err))
+        })?,
+        evidence_record_ids: serde_json::from_str(&evidence_record_ids).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, Box::new(err))
+        })?,
+    })
+}

--- a/crates/cairn-store-sqlite/src/trace_canvas.rs
+++ b/crates/cairn-store-sqlite/src/trace_canvas.rs
@@ -398,6 +398,36 @@ impl SqliteMemoryStore {
             .await?)
     }
 
+    /// Assign a persisted trace step to its materialized canvas node.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::NotInitialized`] when the store is unconnected,
+    /// [`StoreError::Worker`] on background-thread failure, or
+    /// [`StoreError::Sqlite`] for storage errors.
+    pub async fn assign_trace_step_node(
+        &self,
+        step_id: &str,
+        node_id: &str,
+    ) -> Result<(), StoreError> {
+        let conn = self.require_conn("assign_trace_step_node")?.clone();
+        let step_id = step_id.to_owned();
+        let node_id = node_id.to_owned();
+        let now_ms = current_unix_ms();
+        Ok(conn
+            .call(move |c| {
+                c.execute(
+                    "UPDATE trace_steps
+                        SET node_id = ?1,
+                            updated_at_ms = ?2
+                      WHERE step_id = ?3",
+                    params![node_id, now_ms, step_id],
+                )?;
+                Ok::<_, tokio_rusqlite::Error>(())
+            })
+            .await?)
+    }
+
     /// Insert or update a task-trace canvas.
     ///
     /// # Errors

--- a/crates/cairn-store-sqlite/src/verify.rs
+++ b/crates/cairn-store-sqlite/src/verify.rs
@@ -291,6 +291,20 @@ const EXPECTED_OBJECTS: &[(&str, &str)] = &[
     // dead-letter enumeration and per-kind last-success lookup.
     ("index", "workflow_jobs_dead_letter_idx"),
     ("index", "workflow_jobs_kind_completed_idx"),
+    // 0065_trace_canvas (issue #134 addendum): durable task-trace canvas
+    // substrate for projected steps, nodes, and edges.
+    ("table", "trace_canvases"),
+    ("index", "trace_canvases_session_idx"),
+    ("table", "trace_canvas_nodes"),
+    ("index", "trace_canvas_nodes_canvas_idx"),
+    ("table", "trace_canvas_edges"),
+    ("index", "trace_canvas_edges_unique_idx"),
+    ("index", "trace_canvas_edges_to_idx"),
+    ("table", "trace_steps"),
+    ("index", "trace_steps_replay_key_idx"),
+    ("index", "trace_steps_session_turn_idx"),
+    ("index", "trace_steps_node_idx"),
+    ("index", "trace_steps_result_ref_idx"),
 ];
 
 /// Identity registry objects share `cairn.db` but are owned by

--- a/crates/cairn-store-sqlite/tests/migrations.rs
+++ b/crates/cairn-store-sqlite/tests/migrations.rs
@@ -99,7 +99,7 @@ fn fresh_in_memory_opens_to_head() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 64);
+    assert_eq!(head, 66);
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn fresh_vault_opens_and_reopens_idempotent() {
             r.get(0)
         })
         .expect("query head");
-    assert_eq!(head, 64);
+    assert_eq!(head, 66);
 }
 
 #[test]

--- a/crates/cairn-store-sqlite/tests/trace_canvas_api.rs
+++ b/crates/cairn-store-sqlite/tests/trace_canvas_api.rs
@@ -163,6 +163,44 @@ async fn active_trace_canvas_context_returns_edges_in_stable_order() {
     assert_eq!(context.edges[1].label, None);
 }
 
+#[tokio::test]
+async fn trace_canvas_lint_snapshot_carries_steps_canvases_and_nodes() {
+    let store = open_in_memory().await.expect("open");
+    seed_canvas_with_two_nodes(&store).await;
+    store
+        .upsert_trace_step(TraceStepDraft {
+            step_id: "step-1".into(),
+            trace_id: "trace-1".into(),
+            session_id: "session-1".into(),
+            turn_id: "turn-1".into(),
+            tool_call_id: Some("tool-call-1".into()),
+            timestamp_ms: 100,
+            tool_name: Some("shell".into()),
+            call_summary: "run check".into(),
+            result_summary: "check passed".into(),
+            result_ref: Some("record-1".into()),
+            salience: 0.7,
+            replaceability_score: 0.2,
+            node_id: Some("node-1".into()),
+            source_hash: "source-hash-1".into(),
+        })
+        .await
+        .expect("insert step");
+
+    let snapshot = store
+        .trace_canvas_lint_snapshot()
+        .await
+        .expect("trace canvas lint snapshot");
+    assert_eq!(snapshot.steps.len(), 1);
+    assert_eq!(snapshot.steps[0].step_id, "step-1");
+    assert_eq!(snapshot.steps[0].node_id.as_deref(), Some("node-1"));
+    assert_eq!(snapshot.canvases.len(), 1);
+    assert_eq!(snapshot.canvases[0].canvas_id, "canvas-1");
+    assert_eq!(snapshot.nodes.len(), 2);
+    assert_eq!(snapshot.nodes[0].node_id, "node-1");
+    assert_eq!(snapshot.nodes[1].source_step_ids, vec!["step-2"]);
+}
+
 async fn seed_canvas_with_two_nodes(store: &cairn_store_sqlite::SqliteMemoryStore) {
     store
         .upsert_trace_canvas(TraceCanvasDraft {

--- a/crates/cairn-store-sqlite/tests/trace_canvas_api.rs
+++ b/crates/cairn-store-sqlite/tests/trace_canvas_api.rs
@@ -1,0 +1,120 @@
+//! Public store helpers for the task-trace canvas substrate.
+
+use cairn_store_sqlite::{
+    TraceCanvasDraft, TraceCanvasNodeDraft, TraceCanvasStatus, TraceStepDraft, open_in_memory,
+};
+
+#[tokio::test]
+async fn trace_step_upsert_is_replay_idempotent_and_result_ref_lookupable() {
+    let store = open_in_memory().await.expect("open");
+
+    let first = store
+        .upsert_trace_step(TraceStepDraft {
+            step_id: "step-1".into(),
+            trace_id: "trace-1".into(),
+            session_id: "session-1".into(),
+            turn_id: "turn-1".into(),
+            tool_call_id: Some("tool-call-1".into()),
+            timestamp_ms: 100,
+            tool_name: Some("shell".into()),
+            call_summary: "run check".into(),
+            result_summary: "check passed".into(),
+            result_ref: Some("record-1".into()),
+            salience: 0.7,
+            replaceability_score: 0.2,
+            node_id: None,
+            source_hash: "source-hash-1".into(),
+        })
+        .await
+        .expect("insert first step");
+
+    let replay = store
+        .upsert_trace_step(TraceStepDraft {
+            step_id: "step-2".into(),
+            trace_id: "trace-1".into(),
+            session_id: "session-1".into(),
+            turn_id: "turn-1".into(),
+            tool_call_id: Some("tool-call-1".into()),
+            timestamp_ms: 200,
+            tool_name: Some("shell".into()),
+            call_summary: "run check again".into(),
+            result_summary: "duplicate".into(),
+            result_ref: Some("record-1".into()),
+            salience: 0.1,
+            replaceability_score: 0.9,
+            node_id: None,
+            source_hash: "source-hash-1".into(),
+        })
+        .await
+        .expect("replay step");
+
+    assert!(first.inserted);
+    assert!(!replay.inserted);
+    assert_eq!(replay.row.step_id, "step-1");
+    assert_eq!(replay.row.call_summary, "run check");
+
+    let hits = store
+        .find_trace_steps_by_result_ref("record-1")
+        .await
+        .expect("lookup by result ref");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].step_id, "step-1");
+}
+
+#[tokio::test]
+async fn active_trace_canvas_context_returns_nodes_in_timestamp_order() {
+    let store = open_in_memory().await.expect("open");
+
+    store
+        .upsert_trace_canvas(TraceCanvasDraft {
+            canvas_id: "canvas-1".into(),
+            session_id: "session-1".into(),
+            title: "Ship issue".into(),
+            goal: "finish the current task".into(),
+            status: TraceCanvasStatus::Active,
+            summary: "working summary".into(),
+            active_node_id: None,
+            max_bytes: 4096,
+        })
+        .await
+        .expect("insert canvas");
+
+    store
+        .upsert_trace_canvas_node(TraceCanvasNodeDraft {
+            node_id: "node-2".into(),
+            canvas_id: "canvas-1".into(),
+            label: "Verify".into(),
+            status: "planned".into(),
+            summary: "verify the work".into(),
+            timestamp_ms: 20,
+            source_step_ids: vec!["step-2".into()],
+            evidence_record_ids: Vec::new(),
+        })
+        .await
+        .expect("insert later node");
+
+    store
+        .upsert_trace_canvas_node(TraceCanvasNodeDraft {
+            node_id: "node-1".into(),
+            canvas_id: "canvas-1".into(),
+            label: "Implement".into(),
+            status: "active".into(),
+            summary: "implement the slice".into(),
+            timestamp_ms: 10,
+            source_step_ids: vec!["step-1".into()],
+            evidence_record_ids: vec!["record-1".into()],
+        })
+        .await
+        .expect("insert earlier node");
+
+    let context = store
+        .active_trace_canvas_for_session("session-1")
+        .await
+        .expect("load active context")
+        .expect("context exists");
+
+    assert_eq!(context.canvas.canvas_id, "canvas-1");
+    assert_eq!(context.nodes.len(), 2);
+    assert_eq!(context.nodes[0].node_id, "node-1");
+    assert_eq!(context.nodes[1].node_id, "node-2");
+}

--- a/crates/cairn-store-sqlite/tests/trace_canvas_api.rs
+++ b/crates/cairn-store-sqlite/tests/trace_canvas_api.rs
@@ -1,7 +1,8 @@
 //! Public store helpers for the task-trace canvas substrate.
 
 use cairn_store_sqlite::{
-    TraceCanvasDraft, TraceCanvasNodeDraft, TraceCanvasStatus, TraceStepDraft, open_in_memory,
+    TraceCanvasDraft, TraceCanvasEdgeDraft, TraceCanvasEdgeKind, TraceCanvasNodeDraft,
+    TraceCanvasStatus, TraceStepDraft, open_in_memory,
 };
 
 #[tokio::test]
@@ -117,4 +118,91 @@ async fn active_trace_canvas_context_returns_nodes_in_timestamp_order() {
     assert_eq!(context.nodes.len(), 2);
     assert_eq!(context.nodes[0].node_id, "node-1");
     assert_eq!(context.nodes[1].node_id, "node-2");
+}
+
+#[tokio::test]
+async fn active_trace_canvas_context_returns_edges_in_stable_order() {
+    let store = open_in_memory().await.expect("open");
+    seed_canvas_with_two_nodes(&store).await;
+
+    store
+        .upsert_trace_canvas_edge(TraceCanvasEdgeDraft {
+            canvas_id: "canvas-1".into(),
+            from_node_id: "node-1".into(),
+            to_node_id: "node-2".into(),
+            kind: TraceCanvasEdgeKind::DependsOn,
+            label: Some("needs verification".into()),
+        })
+        .await
+        .expect("insert dependency edge");
+
+    store
+        .upsert_trace_canvas_edge(TraceCanvasEdgeDraft {
+            canvas_id: "canvas-1".into(),
+            from_node_id: "node-1".into(),
+            to_node_id: "node-2".into(),
+            kind: TraceCanvasEdgeKind::Supersedes,
+            label: None,
+        })
+        .await
+        .expect("insert supersedes edge");
+
+    let context = store
+        .active_trace_canvas_for_session("session-1")
+        .await
+        .expect("load active context")
+        .expect("context exists");
+
+    assert_eq!(context.edges.len(), 2);
+    assert_eq!(context.edges[0].kind, TraceCanvasEdgeKind::DependsOn);
+    assert_eq!(
+        context.edges[0].label.as_deref(),
+        Some("needs verification")
+    );
+    assert_eq!(context.edges[1].kind, TraceCanvasEdgeKind::Supersedes);
+    assert_eq!(context.edges[1].label, None);
+}
+
+async fn seed_canvas_with_two_nodes(store: &cairn_store_sqlite::SqliteMemoryStore) {
+    store
+        .upsert_trace_canvas(TraceCanvasDraft {
+            canvas_id: "canvas-1".into(),
+            session_id: "session-1".into(),
+            title: "Ship issue".into(),
+            goal: "finish the current task".into(),
+            status: TraceCanvasStatus::Active,
+            summary: "working summary".into(),
+            active_node_id: None,
+            max_bytes: 4096,
+        })
+        .await
+        .expect("insert canvas");
+
+    store
+        .upsert_trace_canvas_node(TraceCanvasNodeDraft {
+            node_id: "node-1".into(),
+            canvas_id: "canvas-1".into(),
+            label: "Implement".into(),
+            status: "active".into(),
+            summary: "implement the slice".into(),
+            timestamp_ms: 10,
+            source_step_ids: vec!["step-1".into()],
+            evidence_record_ids: vec!["record-1".into()],
+        })
+        .await
+        .expect("insert node 1");
+
+    store
+        .upsert_trace_canvas_node(TraceCanvasNodeDraft {
+            node_id: "node-2".into(),
+            canvas_id: "canvas-1".into(),
+            label: "Verify".into(),
+            status: "planned".into(),
+            summary: "verify the work".into(),
+            timestamp_ms: 20,
+            source_step_ids: vec!["step-2".into()],
+            evidence_record_ids: Vec::new(),
+        })
+        .await
+        .expect("insert node 2");
 }

--- a/crates/cairn-store-sqlite/tests/trace_canvas_api.rs
+++ b/crates/cairn-store-sqlite/tests/trace_canvas_api.rs
@@ -201,6 +201,30 @@ async fn trace_canvas_lint_snapshot_carries_steps_canvases_and_nodes() {
     assert_eq!(snapshot.nodes[1].source_step_ids, vec!["step-2"]);
 }
 
+#[tokio::test]
+async fn trace_canvas_projection_refresh_is_rebuildable_from_rows() {
+    let store = open_in_memory().await.expect("open");
+    seed_canvas_with_two_nodes(&store).await;
+
+    let projection = store
+        .refresh_trace_canvas_projection("canvas-1")
+        .await
+        .expect("refresh projection");
+    assert!(projection.markdown.contains("# Ship issue"));
+    assert!(projection.markdown.contains("Canvas: canvas-1"));
+    assert!(projection.markdown.contains("Source steps: step-1"));
+    assert!(projection.hash.len() >= 64);
+
+    let snapshot = store
+        .trace_canvas_lint_snapshot()
+        .await
+        .expect("lint snapshot");
+    assert_eq!(
+        snapshot.canvases[0].projection_markdown.as_deref(),
+        Some(projection.markdown.as_str())
+    );
+}
+
 async fn seed_canvas_with_two_nodes(store: &cairn_store_sqlite::SqliteMemoryStore) {
     store
         .upsert_trace_canvas(TraceCanvasDraft {

--- a/crates/cairn-store-sqlite/tests/trace_canvas_schema.rs
+++ b/crates/cairn-store-sqlite/tests/trace_canvas_schema.rs
@@ -1,0 +1,135 @@
+//! Schema-level guarantees for the task-trace canvas substrate.
+//!
+//! Issue #134's trace-canvas addendum extends the existing `capture_trace`
+//! record projection (brief §5.7, §7, §10) with durable step and graph
+//! tables. These tests pin the storage shape before workflow materialization
+//! starts depending on it.
+
+use cairn_store_sqlite::open_in_memory_sync as open_in_memory;
+use rusqlite::params;
+
+#[test]
+fn trace_canvas_tables_are_created() {
+    let conn = open_in_memory().expect("open");
+
+    for table in [
+        "trace_steps",
+        "trace_canvases",
+        "trace_canvas_nodes",
+        "trace_canvas_edges",
+    ] {
+        let exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM sqlite_schema
+                     WHERE type = 'table' AND name = ?1
+                )",
+                [table],
+                |row| row.get(0),
+            )
+            .expect("query sqlite_schema");
+        assert!(exists, "missing table {table}");
+    }
+}
+
+#[test]
+fn trace_steps_are_idempotent_by_source_hash_and_tool_call() {
+    let conn = open_in_memory().expect("open");
+    insert_trace_step(&conn, "step-1", Some("tool-call-1")).expect("insert first step");
+
+    let err = insert_trace_step(&conn, "step-2", Some("tool-call-1")).unwrap_err();
+    assert!(
+        format!("{err}").contains("UNIQUE"),
+        "expected duplicate source/tool key rejection, got: {err}"
+    );
+}
+
+#[test]
+fn trace_canvas_nodes_require_source_steps() {
+    let conn = open_in_memory().expect("open");
+    conn.execute(
+        "INSERT INTO trace_canvases
+            (canvas_id, session_id, title, goal, status, summary, created_at_ms, updated_at_ms)
+         VALUES
+            ('canvas-1', 'session-1', 'Plan', 'Finish task', 'active', 'summary', 1, 1)",
+        [],
+    )
+    .expect("insert canvas");
+
+    let err = conn
+        .execute(
+            "INSERT INTO trace_canvas_nodes
+                (node_id, canvas_id, label, status, summary, timestamp_ms,
+                 source_step_ids, evidence_record_ids)
+             VALUES
+                ('node-1', 'canvas-1', 'Node', 'active', 'summary', 1, '[]', '[]')",
+            [],
+        )
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("CHECK"),
+        "expected empty source-step rejection, got: {err}"
+    );
+}
+
+#[test]
+fn trace_canvas_edges_reject_unknown_kind() {
+    let conn = open_in_memory().expect("open");
+    conn.execute(
+        "INSERT INTO trace_canvases
+            (canvas_id, session_id, title, goal, status, summary, created_at_ms, updated_at_ms)
+         VALUES
+            ('canvas-1', 'session-1', 'Plan', 'Finish task', 'active', 'summary', 1, 1)",
+        [],
+    )
+    .expect("insert canvas");
+    insert_canvas_node(&conn, "node-1", "canvas-1").expect("insert node 1");
+    insert_canvas_node(&conn, "node-2", "canvas-1").expect("insert node 2");
+
+    let err = conn
+        .execute(
+            "INSERT INTO trace_canvas_edges
+                (canvas_id, from_node_id, to_node_id, kind, label)
+             VALUES
+                ('canvas-1', 'node-1', 'node-2', 'mystery', NULL)",
+            [],
+        )
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("CHECK"),
+        "expected edge-kind rejection, got: {err}"
+    );
+}
+
+fn insert_trace_step(
+    conn: &rusqlite::Connection,
+    step_id: &str,
+    tool_call_id: Option<&str>,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "INSERT INTO trace_steps
+            (step_id, trace_id, session_id, turn_id, tool_call_id, timestamp_ms,
+             tool_name, call_summary, result_summary, result_ref, salience,
+             replaceability_score, node_id, source_hash, created_at_ms, updated_at_ms)
+         VALUES
+            (?1, 'trace-1', 'session-1', 'turn-1', ?2, 1,
+             'shell', 'call', 'result', 'record-1', 0.5, 0.5, NULL,
+             'source-hash-1', 1, 1)",
+        params![step_id, tool_call_id],
+    )
+}
+
+fn insert_canvas_node(
+    conn: &rusqlite::Connection,
+    node_id: &str,
+    canvas_id: &str,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "INSERT INTO trace_canvas_nodes
+            (node_id, canvas_id, label, status, summary, timestamp_ms,
+             source_step_ids, evidence_record_ids)
+         VALUES
+            (?1, ?2, 'Node', 'active', 'summary', 1, '[\"step-1\"]', '[]')",
+        params![node_id, canvas_id],
+    )
+}

--- a/crates/cairn-workflows/src/lib.rs
+++ b/crates/cairn-workflows/src/lib.rs
@@ -54,8 +54,8 @@ pub use scheduler::{Clock, MockClock, Scheduler, SchedulerConfig, SystemClock};
 pub use sqlite_apply::SqliteFlushPlanApply;
 pub use sqlite_store::{SqliteJobStore, SqliteJobStoreInitError};
 pub use trace_canvas::{
-    TRACE_CANVAS_KIND, TraceCanvasHandler, TraceCanvasMaterializer, TraceCanvasPayload,
-    TraceCanvasProjection,
+    TRACE_CANVAS_KIND, TraceCanvasEnqueueDecision, TraceCanvasHandler, TraceCanvasMaterializer,
+    TraceCanvasPayload, TraceCanvasProjection, enqueue_trace_canvas_step,
 };
 pub use workflows::{
     ConsolidateWorkflow, ExpireWorkflow, PromoteWorkflow, ReflectionWorkflow, WorkflowPlanSource,

--- a/crates/cairn-workflows/src/lib.rs
+++ b/crates/cairn-workflows/src/lib.rs
@@ -53,7 +53,10 @@ pub use planners::{
 pub use scheduler::{Clock, MockClock, Scheduler, SchedulerConfig, SystemClock};
 pub use sqlite_apply::SqliteFlushPlanApply;
 pub use sqlite_store::{SqliteJobStore, SqliteJobStoreInitError};
-pub use trace_canvas::{TraceCanvasMaterializer, TraceCanvasProjection};
+pub use trace_canvas::{
+    TRACE_CANVAS_KIND, TraceCanvasHandler, TraceCanvasMaterializer, TraceCanvasPayload,
+    TraceCanvasProjection,
+};
 pub use workflows::{
     ConsolidateWorkflow, ExpireWorkflow, PromoteWorkflow, ReflectionWorkflow, WorkflowPlanSource,
 };

--- a/crates/cairn-workflows/src/lib.rs
+++ b/crates/cairn-workflows/src/lib.rs
@@ -20,6 +20,7 @@ pub mod scheduler;
 pub mod sqlite_apply;
 pub mod sqlite_store;
 pub mod synthetic;
+pub mod trace_canvas;
 pub mod workflows;
 
 #[cfg(test)]
@@ -52,6 +53,7 @@ pub use planners::{
 pub use scheduler::{Clock, MockClock, Scheduler, SchedulerConfig, SystemClock};
 pub use sqlite_apply::SqliteFlushPlanApply;
 pub use sqlite_store::{SqliteJobStore, SqliteJobStoreInitError};
+pub use trace_canvas::{TraceCanvasMaterializer, TraceCanvasProjection};
 pub use workflows::{
     ConsolidateWorkflow, ExpireWorkflow, PromoteWorkflow, ReflectionWorkflow, WorkflowPlanSource,
 };

--- a/crates/cairn-workflows/src/trace_canvas.rs
+++ b/crates/cairn-workflows/src/trace_canvas.rs
@@ -221,9 +221,12 @@ impl TraceCanvasMaterializer {
                 status: projection.node_status,
                 summary: projection.node_summary,
                 timestamp_ms,
-                source_step_ids: vec![step_id],
+                source_step_ids: vec![step_id.clone()],
                 evidence_record_ids: result_ref.into_iter().collect(),
             })
+            .await?;
+        self.store
+            .assign_trace_step_node(&step_id, &node_id)
             .await?;
 
         self.store

--- a/crates/cairn-workflows/src/trace_canvas.rs
+++ b/crates/cairn-workflows/src/trace_canvas.rs
@@ -1,0 +1,142 @@
+//! Workflow-facing task-trace canvas projection helper.
+//!
+//! This module is intentionally narrower than a scheduler handler: it provides
+//! the deterministic store mutation primitive that a capture/workflow path can
+//! call once jobs are wired.
+
+use std::sync::Arc;
+
+use cairn_store_sqlite::{
+    SqliteMemoryStore, StoreError, TraceCanvasContext, TraceCanvasDraft, TraceCanvasEdgeDraft,
+    TraceCanvasEdgeKind, TraceCanvasNodeDraft, TraceCanvasStatus, TraceStepDraft,
+};
+
+/// Deterministic projection input for one trace step.
+#[derive(Debug, Clone)]
+pub struct TraceCanvasProjection {
+    /// Trace step to persist.
+    pub step: TraceStepDraft,
+    /// Active canvas title to create or refresh.
+    pub canvas_title: String,
+    /// Active canvas goal to create or refresh.
+    pub canvas_goal: String,
+    /// Projected node label.
+    pub node_label: String,
+    /// Projected node status. Must satisfy the store schema domain.
+    pub node_status: String,
+    /// Projected node summary.
+    pub node_summary: String,
+}
+
+/// Store-backed task-trace canvas materializer.
+pub struct TraceCanvasMaterializer {
+    store: Arc<SqliteMemoryStore>,
+}
+
+impl TraceCanvasMaterializer {
+    /// Create a materializer backed by `store`.
+    #[must_use]
+    pub fn new(store: Arc<SqliteMemoryStore>) -> Self {
+        Self { store }
+    }
+
+    /// Project one trace step into the session's active task canvas.
+    ///
+    /// The method is idempotent for the trace step itself through
+    /// `SqliteMemoryStore::upsert_trace_step`. It refreshes the active canvas
+    /// row, upserts the projected node, and links the previous active node to
+    /// the new node with a `depends_on` edge when they differ.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError`] for store failures or schema-domain violations.
+    pub async fn project_step(
+        &self,
+        projection: TraceCanvasProjection,
+    ) -> Result<TraceCanvasContext, StoreError> {
+        let previous = self
+            .store
+            .active_trace_canvas_for_session(&projection.step.session_id)
+            .await?;
+        let previous_active_node = previous.and_then(|context| context.canvas.active_node_id);
+
+        let canvas_id = active_canvas_id(&projection.step.session_id);
+        let node_id = trace_node_id(&projection.step.step_id);
+        let result_ref = projection.step.result_ref.clone();
+        let step_id = projection.step.step_id.clone();
+        let session_id = projection.step.session_id.clone();
+        let context_session_id = session_id.clone();
+        let timestamp_ms = projection.step.timestamp_ms;
+        let canvas_title = projection.canvas_title;
+        let canvas_goal = projection.canvas_goal;
+
+        self.store
+            .upsert_trace_canvas(TraceCanvasDraft {
+                canvas_id: canvas_id.clone(),
+                session_id: session_id.clone(),
+                title: canvas_title.clone(),
+                goal: canvas_goal.clone(),
+                status: TraceCanvasStatus::Active,
+                summary: "Active task trace canvas.".to_owned(),
+                active_node_id: previous_active_node.clone(),
+                max_bytes: 8192,
+            })
+            .await?;
+
+        self.store.upsert_trace_step(projection.step).await?;
+        self.store
+            .upsert_trace_canvas_node(TraceCanvasNodeDraft {
+                node_id: node_id.clone(),
+                canvas_id: canvas_id.clone(),
+                label: projection.node_label,
+                status: projection.node_status,
+                summary: projection.node_summary,
+                timestamp_ms,
+                source_step_ids: vec![step_id],
+                evidence_record_ids: result_ref.into_iter().collect(),
+            })
+            .await?;
+
+        self.store
+            .upsert_trace_canvas(TraceCanvasDraft {
+                canvas_id: canvas_id.clone(),
+                session_id,
+                title: canvas_title,
+                goal: canvas_goal,
+                status: TraceCanvasStatus::Active,
+                summary: "Active task trace canvas.".to_owned(),
+                active_node_id: Some(node_id.clone()),
+                max_bytes: 8192,
+            })
+            .await?;
+
+        if let Some(previous_node_id) = previous_active_node
+            && previous_node_id != node_id
+        {
+            self.store
+                .upsert_trace_canvas_edge(TraceCanvasEdgeDraft {
+                    canvas_id,
+                    from_node_id: previous_node_id,
+                    to_node_id: node_id,
+                    kind: TraceCanvasEdgeKind::DependsOn,
+                    label: None,
+                })
+                .await?;
+        }
+
+        self.store
+            .active_trace_canvas_for_session(&context_session_id)
+            .await?
+            .ok_or_else(|| StoreError::Invariant {
+                what: "trace canvas projection did not leave an active context".into(),
+            })
+    }
+}
+
+fn active_canvas_id(session_id: &str) -> String {
+    format!("trace-canvas:{session_id}:active")
+}
+
+fn trace_node_id(step_id: &str) -> String {
+    format!("trace-node:{step_id}")
+}

--- a/crates/cairn-workflows/src/trace_canvas.rs
+++ b/crates/cairn-workflows/src/trace_canvas.rs
@@ -6,13 +6,21 @@
 
 use std::sync::Arc;
 
+use cairn_core::contract::job_store::{FailureClass, JobKind, JobPayload};
 use cairn_store_sqlite::{
     SqliteMemoryStore, StoreError, TraceCanvasContext, TraceCanvasDraft, TraceCanvasEdgeDraft,
     TraceCanvasEdgeKind, TraceCanvasNodeDraft, TraceCanvasStatus, TraceStepDraft,
 };
+use serde::{Deserialize, Serialize};
+
+use crate::scheduler::{HandlerOutcome, JobHandler};
+
+/// The `JobKind` discriminator stored in `workflow_jobs.kind`.
+pub const TRACE_CANVAS_KIND: &str = "trace_canvas.materialize_step";
 
 /// Deterministic projection input for one trace step.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TraceCanvasProjection {
     /// Trace step to persist.
     pub step: TraceStepDraft,
@@ -28,9 +36,83 @@ pub struct TraceCanvasProjection {
     pub node_summary: String,
 }
 
+/// One enqueued trace-canvas materialization request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TraceCanvasPayload {
+    /// Projection to apply.
+    pub projection: TraceCanvasProjection,
+}
+
+impl TraceCanvasPayload {
+    /// Recommended `EnqueueRequest::queue_key` for this payload.
+    #[must_use]
+    pub fn recommended_queue_key(&self) -> String {
+        format!("trace-canvas:{}", self.projection.step.session_id)
+    }
+
+    /// Serialize to `JobPayload`.
+    ///
+    /// # Errors
+    /// JSON encoding failure (effectively unreachable for this struct).
+    pub fn to_bytes(&self) -> Result<JobPayload, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+
+    /// Deserialize from `JobPayload`.
+    ///
+    /// # Errors
+    /// JSON decoding failure.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
+    }
+}
+
 /// Store-backed task-trace canvas materializer.
 pub struct TraceCanvasMaterializer {
     store: Arc<SqliteMemoryStore>,
+}
+
+/// Scheduler handler for task-trace canvas materialization jobs.
+pub struct TraceCanvasHandler {
+    materializer: TraceCanvasMaterializer,
+}
+
+impl TraceCanvasHandler {
+    /// Create a handler backed by `store`.
+    #[must_use]
+    pub fn new(store: Arc<SqliteMemoryStore>) -> Self {
+        Self {
+            materializer: TraceCanvasMaterializer::new(store),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl JobHandler for TraceCanvasHandler {
+    fn kind(&self) -> JobKind {
+        JobKind::new(TRACE_CANVAS_KIND)
+    }
+
+    async fn handle(&self, payload_bytes: &JobPayload) -> HandlerOutcome {
+        let payload = match TraceCanvasPayload::from_bytes(payload_bytes) {
+            Ok(payload) => payload,
+            Err(err) => {
+                return HandlerOutcome::Permanent {
+                    reason: format!("trace canvas payload decode failed: {err}"),
+                    class: FailureClass::Validation,
+                };
+            }
+        };
+
+        match self.materializer.project_step(payload.projection).await {
+            Ok(_) => HandlerOutcome::Done,
+            Err(err) => HandlerOutcome::Retry {
+                reason: err.to_string(),
+                class: FailureClass::Transient,
+            },
+        }
+    }
 }
 
 impl TraceCanvasMaterializer {

--- a/crates/cairn-workflows/src/trace_canvas.rs
+++ b/crates/cairn-workflows/src/trace_canvas.rs
@@ -6,7 +6,9 @@
 
 use std::sync::Arc;
 
-use cairn_core::contract::job_store::{FailureClass, JobKind, JobPayload};
+use cairn_core::contract::job_store::{
+    EnqueueRequest, FailureClass, JobId, JobKind, JobPayload, JobStore, JobStoreError, RetryPolicy,
+};
 use cairn_store_sqlite::{
     SqliteMemoryStore, StoreError, TraceCanvasContext, TraceCanvasDraft, TraceCanvasEdgeDraft,
     TraceCanvasEdgeKind, TraceCanvasNodeDraft, TraceCanvasStatus, TraceStepDraft,
@@ -44,6 +46,17 @@ pub struct TraceCanvasPayload {
     pub projection: TraceCanvasProjection,
 }
 
+/// Outcome of a trace-canvas materialization enqueue attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TraceCanvasEnqueueDecision {
+    /// A materialization job was accepted, or an existing matching job
+    /// already covers the same step.
+    Enqueued {
+        /// Stable job id for the materialization request.
+        job_id: JobId,
+    },
+}
+
 impl TraceCanvasPayload {
     /// Recommended `EnqueueRequest::queue_key` for this payload.
     #[must_use]
@@ -65,6 +78,40 @@ impl TraceCanvasPayload {
     /// JSON decoding failure.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
         serde_json::from_slice(bytes)
+    }
+}
+
+/// Enqueue one trace-step materialization job.
+///
+/// The request is idempotent on `step_id`: replaying a capture batch will hit
+/// the job-store dedupe constraint and report the same [`TraceCanvasEnqueueDecision`].
+///
+/// # Errors
+/// Returns [`JobStoreError::Backend`] on store I/O or payload encoding failures.
+pub async fn enqueue_trace_canvas_step(
+    store: &dyn JobStore,
+    payload: TraceCanvasPayload,
+    now_ms: i64,
+) -> Result<TraceCanvasEnqueueDecision, JobStoreError> {
+    let job_id = JobId::new(format!("trace-canvas:{}", payload.projection.step.step_id));
+    let dedupe_key = payload.projection.step.step_id.clone();
+    let req = EnqueueRequest {
+        job_id: job_id.clone(),
+        kind: JobKind::new(TRACE_CANVAS_KIND),
+        payload: payload
+            .to_bytes()
+            .map_err(|e| JobStoreError::Backend(e.to_string()))?,
+        queue_key: Some(payload.recommended_queue_key()),
+        dedupe_key: Some(dedupe_key),
+        not_before_ms: now_ms,
+        retry: RetryPolicy::DEFAULT,
+    };
+
+    match store.enqueue(req).await {
+        Ok(()) | Err(JobStoreError::DuplicateDedupeKey { .. }) => {
+            Ok(TraceCanvasEnqueueDecision::Enqueued { job_id })
+        }
+        Err(err) => Err(err),
     }
 }
 

--- a/crates/cairn-workflows/src/trace_canvas.rs
+++ b/crates/cairn-workflows/src/trace_canvas.rs
@@ -244,7 +244,7 @@ impl TraceCanvasMaterializer {
         {
             self.store
                 .upsert_trace_canvas_edge(TraceCanvasEdgeDraft {
-                    canvas_id,
+                    canvas_id: canvas_id.clone(),
                     from_node_id: previous_node_id,
                     to_node_id: node_id,
                     kind: TraceCanvasEdgeKind::DependsOn,
@@ -252,6 +252,10 @@ impl TraceCanvasMaterializer {
                 })
                 .await?;
         }
+
+        self.store
+            .refresh_trace_canvas_projection(&canvas_id)
+            .await?;
 
         self.store
             .active_trace_canvas_for_session(&context_session_id)

--- a/crates/cairn-workflows/tests/trace_canvas_materializer.rs
+++ b/crates/cairn-workflows/tests/trace_canvas_materializer.rs
@@ -46,6 +46,35 @@ async fn materializer_creates_active_canvas_node_and_step() {
 }
 
 #[tokio::test]
+async fn materializer_refreshes_markdown_projection_cache() {
+    let store = Arc::new(open_in_memory().await.expect("open"));
+    let materializer = TraceCanvasMaterializer::new(Arc::clone(&store));
+
+    materializer
+        .project_step(TraceCanvasProjection {
+            step: step("step-1", "turn-1", 100, Some("record-1")),
+            canvas_title: "Current task".into(),
+            canvas_goal: "finish issue 134".into(),
+            node_label: "Run check".into(),
+            node_status: "completed".into(),
+            node_summary: "The focused check passed.".into(),
+        })
+        .await
+        .expect("project step");
+
+    let snapshot = store
+        .trace_canvas_lint_snapshot()
+        .await
+        .expect("lint snapshot");
+    let projection = snapshot.canvases[0]
+        .projection_markdown
+        .as_deref()
+        .expect("projection cache");
+    assert!(projection.contains("Canvas: trace-canvas:session-1:active"));
+    assert!(projection.contains("Source steps: step-1"));
+}
+
+#[tokio::test]
 async fn materializer_links_previous_active_node_to_new_node() {
     let store = Arc::new(open_in_memory().await.expect("open"));
     let materializer = TraceCanvasMaterializer::new(Arc::clone(&store));

--- a/crates/cairn-workflows/tests/trace_canvas_materializer.rs
+++ b/crates/cairn-workflows/tests/trace_canvas_materializer.rs
@@ -3,7 +3,11 @@
 use std::sync::Arc;
 
 use cairn_store_sqlite::{TraceCanvasEdgeKind, TraceStepDraft, open_in_memory};
-use cairn_workflows::{TraceCanvasMaterializer, TraceCanvasProjection};
+use cairn_workflows::{
+    TRACE_CANVAS_KIND, TraceCanvasHandler, TraceCanvasMaterializer, TraceCanvasPayload,
+    TraceCanvasProjection,
+    scheduler::{HandlerOutcome, JobHandler},
+};
 
 #[tokio::test]
 async fn materializer_creates_active_canvas_node_and_step() {
@@ -78,6 +82,42 @@ async fn materializer_links_previous_active_node_to_new_node() {
     assert_eq!(context.edges[0].from_node_id, "trace-node:step-1");
     assert_eq!(context.edges[0].to_node_id, "trace-node:step-2");
     assert_eq!(context.edges[0].kind, TraceCanvasEdgeKind::DependsOn);
+}
+
+#[tokio::test]
+async fn handler_decodes_payload_and_materializes_context() {
+    let store = Arc::new(open_in_memory().await.expect("open"));
+    let handler = TraceCanvasHandler::new(Arc::clone(&store));
+    assert_eq!(
+        handler.kind(),
+        cairn_core::contract::job_store::JobKind::new(TRACE_CANVAS_KIND)
+    );
+
+    let payload = TraceCanvasPayload {
+        projection: TraceCanvasProjection {
+            step: step("step-1", "turn-1", 100, Some("record-1")),
+            canvas_title: "Current task".into(),
+            canvas_goal: "finish issue 134".into(),
+            node_label: "Run check".into(),
+            node_status: "completed".into(),
+            node_summary: "The focused check passed.".into(),
+        },
+    };
+
+    let outcome = handler
+        .handle(&payload.to_bytes().expect("encode payload"))
+        .await;
+    assert_eq!(outcome, HandlerOutcome::Done);
+
+    let context = store
+        .active_trace_canvas_for_session("session-1")
+        .await
+        .expect("load context")
+        .expect("context exists");
+    assert_eq!(
+        context.canvas.active_node_id.as_deref(),
+        Some("trace-node:step-1")
+    );
 }
 
 fn step(

--- a/crates/cairn-workflows/tests/trace_canvas_materializer.rs
+++ b/crates/cairn-workflows/tests/trace_canvas_materializer.rs
@@ -75,6 +75,33 @@ async fn materializer_refreshes_markdown_projection_cache() {
 }
 
 #[tokio::test]
+async fn materializer_backfills_trace_step_node_assignment() {
+    let store = Arc::new(open_in_memory().await.expect("open"));
+    let materializer = TraceCanvasMaterializer::new(Arc::clone(&store));
+
+    materializer
+        .project_step(TraceCanvasProjection {
+            step: step("step-1", "turn-1", 100, Some("record-1")),
+            canvas_title: "Current task".into(),
+            canvas_goal: "finish issue 134".into(),
+            node_label: "Run check".into(),
+            node_status: "completed".into(),
+            node_summary: "The focused check passed.".into(),
+        })
+        .await
+        .expect("project step");
+
+    let snapshot = store
+        .trace_canvas_lint_snapshot()
+        .await
+        .expect("lint snapshot");
+    assert_eq!(
+        snapshot.steps[0].node_id.as_deref(),
+        Some("trace-node:step-1")
+    );
+}
+
+#[tokio::test]
 async fn materializer_links_previous_active_node_to_new_node() {
     let store = Arc::new(open_in_memory().await.expect("open"));
     let materializer = TraceCanvasMaterializer::new(Arc::clone(&store));

--- a/crates/cairn-workflows/tests/trace_canvas_materializer.rs
+++ b/crates/cairn-workflows/tests/trace_canvas_materializer.rs
@@ -2,10 +2,11 @@
 
 use std::sync::Arc;
 
+use cairn_core::contract::job_store::JobStore;
 use cairn_store_sqlite::{TraceCanvasEdgeKind, TraceStepDraft, open_in_memory};
 use cairn_workflows::{
-    TRACE_CANVAS_KIND, TraceCanvasHandler, TraceCanvasMaterializer, TraceCanvasPayload,
-    TraceCanvasProjection,
+    SqliteJobStore, TRACE_CANVAS_KIND, TraceCanvasEnqueueDecision, TraceCanvasHandler,
+    TraceCanvasMaterializer, TraceCanvasPayload, TraceCanvasProjection, enqueue_trace_canvas_step,
     scheduler::{HandlerOutcome, JobHandler},
 };
 
@@ -117,6 +118,58 @@ async fn handler_decodes_payload_and_materializes_context() {
     assert_eq!(
         context.canvas.active_node_id.as_deref(),
         Some("trace-node:step-1")
+    );
+}
+
+#[tokio::test]
+async fn enqueue_trace_canvas_step_is_idempotent_and_serializes_payload() {
+    let conn = rusqlite::Connection::open_in_memory().expect("conn");
+    cairn_workflows::sqlite_store::install_for_tests(&conn);
+    let jobs = SqliteJobStore::new(conn).expect("job store");
+    let payload = TraceCanvasPayload {
+        projection: TraceCanvasProjection {
+            step: step("step-1", "turn-1", 100, Some("record-1")),
+            canvas_title: "Current task".into(),
+            canvas_goal: "finish issue 134".into(),
+            node_label: "Run check".into(),
+            node_status: "completed".into(),
+            node_summary: "The focused check passed.".into(),
+        },
+    };
+
+    let first = enqueue_trace_canvas_step(&jobs, payload.clone(), 1234)
+        .await
+        .expect("first enqueue");
+    let second = enqueue_trace_canvas_step(&jobs, payload.clone(), 1234)
+        .await
+        .expect("second enqueue dedupes");
+    assert_eq!(first, second);
+    assert_eq!(
+        first,
+        TraceCanvasEnqueueDecision::Enqueued {
+            job_id: cairn_core::contract::job_store::JobId::new("trace-canvas:step-1".to_owned())
+        }
+    );
+
+    let leased = jobs
+        .lease_specific(
+            &cairn_core::contract::job_store::JobId::new("trace-canvas:step-1".to_owned()),
+            &cairn_core::contract::job_store::JobKind::new(TRACE_CANVAS_KIND),
+            "worker",
+            1235,
+            30_000,
+        )
+        .await
+        .expect("lease")
+        .expect("job queued");
+    assert_eq!(leased.job_id.as_str(), "trace-canvas:step-1");
+    assert_eq!(
+        TraceCanvasPayload::from_bytes(&leased.payload)
+            .expect("decode")
+            .projection
+            .step
+            .step_id,
+        "step-1"
     );
 }
 

--- a/crates/cairn-workflows/tests/trace_canvas_materializer.rs
+++ b/crates/cairn-workflows/tests/trace_canvas_materializer.rs
@@ -1,0 +1,105 @@
+//! Workflow-facing projection helper for task-trace canvases.
+
+use std::sync::Arc;
+
+use cairn_store_sqlite::{TraceCanvasEdgeKind, TraceStepDraft, open_in_memory};
+use cairn_workflows::{TraceCanvasMaterializer, TraceCanvasProjection};
+
+#[tokio::test]
+async fn materializer_creates_active_canvas_node_and_step() {
+    let store = Arc::new(open_in_memory().await.expect("open"));
+    let materializer = TraceCanvasMaterializer::new(Arc::clone(&store));
+
+    let context = materializer
+        .project_step(TraceCanvasProjection {
+            step: step("step-1", "turn-1", 100, Some("record-1")),
+            canvas_title: "Current task".into(),
+            canvas_goal: "finish issue 134".into(),
+            node_label: "Run check".into(),
+            node_status: "completed".into(),
+            node_summary: "The focused check passed.".into(),
+        })
+        .await
+        .expect("project step");
+
+    assert_eq!(context.canvas.canvas_id, "trace-canvas:session-1:active");
+    assert_eq!(
+        context.canvas.active_node_id.as_deref(),
+        Some("trace-node:step-1")
+    );
+    assert_eq!(context.nodes.len(), 1);
+    assert_eq!(context.nodes[0].source_step_ids, vec!["step-1"]);
+    assert_eq!(context.nodes[0].evidence_record_ids, vec!["record-1"]);
+    assert!(context.edges.is_empty());
+
+    let steps = store
+        .find_trace_steps_by_result_ref("record-1")
+        .await
+        .expect("lookup result ref");
+    assert_eq!(steps.len(), 1);
+    assert_eq!(steps[0].step_id, "step-1");
+}
+
+#[tokio::test]
+async fn materializer_links_previous_active_node_to_new_node() {
+    let store = Arc::new(open_in_memory().await.expect("open"));
+    let materializer = TraceCanvasMaterializer::new(Arc::clone(&store));
+
+    materializer
+        .project_step(TraceCanvasProjection {
+            step: step("step-1", "turn-1", 100, None),
+            canvas_title: "Current task".into(),
+            canvas_goal: "finish issue 134".into(),
+            node_label: "Implement".into(),
+            node_status: "completed".into(),
+            node_summary: "Implementation landed.".into(),
+        })
+        .await
+        .expect("project first step");
+
+    let context = materializer
+        .project_step(TraceCanvasProjection {
+            step: step("step-2", "turn-2", 200, Some("record-2")),
+            canvas_title: "Current task".into(),
+            canvas_goal: "finish issue 134".into(),
+            node_label: "Verify".into(),
+            node_status: "active".into(),
+            node_summary: "Verification is running.".into(),
+        })
+        .await
+        .expect("project second step");
+
+    assert_eq!(
+        context.canvas.active_node_id.as_deref(),
+        Some("trace-node:step-2")
+    );
+    assert_eq!(context.nodes.len(), 2);
+    assert_eq!(context.edges.len(), 1);
+    assert_eq!(context.edges[0].from_node_id, "trace-node:step-1");
+    assert_eq!(context.edges[0].to_node_id, "trace-node:step-2");
+    assert_eq!(context.edges[0].kind, TraceCanvasEdgeKind::DependsOn);
+}
+
+fn step(
+    step_id: &str,
+    turn_id: &str,
+    timestamp_ms: i64,
+    result_ref: Option<&str>,
+) -> TraceStepDraft {
+    TraceStepDraft {
+        step_id: step_id.into(),
+        trace_id: "trace-1".into(),
+        session_id: "session-1".into(),
+        turn_id: turn_id.into(),
+        tool_call_id: Some(format!("tool-call-{step_id}")),
+        timestamp_ms,
+        tool_name: Some("shell".into()),
+        call_summary: "run command".into(),
+        result_summary: "command completed".into(),
+        result_ref: result_ref.map(Into::into),
+        salience: 0.5,
+        replaceability_score: 0.5,
+        node_id: None,
+        source_hash: format!("source-hash-{step_id}"),
+    }
+}

--- a/docs/superpowers/plans/2026-05-16-issue-134-tree-aware-read-windows.md
+++ b/docs/superpowers/plans/2026-05-16-issue-134-tree-aware-read-windows.md
@@ -1,0 +1,1055 @@
+# Issue 134 Tree-Aware Read Windows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a reusable tree-aware read-window planner and wire it into the first read surfaces for issue #134.
+
+**Architecture:** `cairn-core` owns pure planning over `SessionTree` and pre-authorized records. `cairn-cli` loads authorized records from SQLite, calls the planner, and emits existing response shapes plus body-free policy/debug metadata. SQLite remains persistence-only and no public `cairn.sessiontree.v1` verbs are advertised.
+
+**Tech Stack:** Rust 2024, `cairn-core` pure domain module, `cairn-cli` verb wiring, `SqliteMemoryStore` session-tree methods, `cargo nextest`, existing generated `cairn.mcp.v1` envelope types.
+
+---
+
+## File Structure
+
+- Create: `crates/cairn-core/src/domain/tree_read_window.rs`
+  - Pure input/output types and deterministic planner.
+  - No adapter imports, no async, no filesystem.
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+  - Export planner types.
+- Modify: `crates/cairn-cli/src/verbs/retrieve.rs`
+  - Hydrate tree metadata for `retrieve --session`, load authorized records by planned session ids, use selected records, and append `tree.*` policy traces.
+- Modify: `crates/cairn-cli/src/verbs/assemble_hot.rs`
+  - Use the planner to expand session-scoped `user_signal` loading and add safe `--explain` tree choice notes through existing debug/policy trace surfaces.
+- Modify: `crates/cairn-cli/src/verbs/summarize.rs`
+  - Reuse the planner when summarize source records share one session id and tree metadata is available.
+- Test: unit tests inside `crates/cairn-core/src/domain/tree_read_window.rs`
+  - Pure planner behavior.
+- Test: existing CLI integration tests under `crates/cairn-cli/tests/`
+  - `retrieve --session` tree fixture and `assemble_hot --session --explain` metadata fixture if current helpers make this practical without broad fixture rewrites.
+
+---
+
+### Task 1: Add Core Planner Types
+
+**Files:**
+- Create: `crates/cairn-core/src/domain/tree_read_window.rs`
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+
+- [ ] **Step 1: Write the failing flat-session compatibility test**
+
+Add this test module to the new file first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::session_tree::SessionTree;
+    use crate::domain::{RecordId, SessionId};
+
+    fn sid(raw: &str) -> SessionId {
+        SessionId::parse(raw).expect("valid session id")
+    }
+
+    fn rid(raw: &str) -> RecordId {
+        RecordId::parse(raw).expect("valid record id")
+    }
+
+    fn item(session_id: &str, turn_id: &str, record_id: &str, body: &str) -> TreeReadRecord {
+        TreeReadRecord {
+            session_id: sid(session_id),
+            turn_id: Some(turn_id.to_owned()),
+            record_id: rid(record_id),
+            body: body.to_owned(),
+        }
+    }
+
+    #[test]
+    fn flat_session_selects_branch_local_records_in_turn_order() {
+        let root = sid("root");
+        let tree = SessionTree::flat(root.clone());
+        let records = vec![
+            item("root", "turn-2", "01JTS6R4J70000000000000001", "second"),
+            item("root", "turn-1", "01JTS6R4J70000000000000002", "first"),
+        ];
+
+        let window = plan_tree_read_window(TreeReadWindowInput {
+            tree: &tree,
+            target_session: &root,
+            records: &records,
+            budget_bytes: 1024,
+        })
+        .expect("plan window");
+
+        assert_eq!(window.ancestry_path, vec![root]);
+        assert_eq!(
+            window
+                .selected_records
+                .iter()
+                .map(|r| r.body.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "second"]
+        );
+        assert!(!window.budget.trimmed);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-core flat_session_selects_branch_local_records_in_turn_order
+```
+
+Expected: compile failure because `tree_read_window`, `TreeReadRecord`, `TreeReadWindowInput`, and `plan_tree_read_window` do not exist yet.
+
+- [ ] **Step 3: Add the minimal planner API**
+
+Create `crates/cairn-core/src/domain/tree_read_window.rs`:
+
+```rust
+//! Pure tree-aware read-window planning for session reads.
+//!
+//! Brief refs: §5.7 Sessions are trees, §7 Hot Memory. This module is pure:
+//! callers pre-authorize records and hydrate [`SessionTree`] before planning.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::domain::{RecordId, SessionId, SessionTree, SessionTreeError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TreeReadSegmentKind {
+    BranchLocal,
+    AncestorContext,
+    MergeSummary,
+    SiblingSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeReadRecord {
+    pub session_id: SessionId,
+    pub turn_id: Option<String>,
+    pub record_id: RecordId,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TreeBudgetReport {
+    pub budget_bytes: usize,
+    pub records_in: usize,
+    pub records_out: usize,
+    pub skipped_for_budget: usize,
+    pub trimmed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeReadSelection {
+    pub kind: TreeReadSegmentKind,
+    pub record: TreeReadRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreeReadWindow {
+    pub ancestry_path: Vec<SessionId>,
+    pub selected_records: Vec<TreeReadRecord>,
+    pub selections: Vec<TreeReadSelection>,
+    pub sibling_sessions: Vec<SessionId>,
+    pub merge_notes: Vec<String>,
+    pub budget: TreeBudgetReport,
+}
+
+pub struct TreeReadWindowInput<'a> {
+    pub tree: &'a SessionTree,
+    pub target_session: &'a SessionId,
+    pub records: &'a [TreeReadRecord],
+    pub budget_bytes: usize,
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum TreeReadWindowError {
+    #[error(transparent)]
+    SessionTree(#[from] SessionTreeError),
+}
+
+pub fn plan_tree_read_window(
+    input: TreeReadWindowInput<'_>,
+) -> Result<TreeReadWindow, TreeReadWindowError> {
+    let ancestry_path = input.tree.lineage(input.target_session)?;
+    let ancestry = ancestry_path.iter().cloned().collect::<BTreeSet<_>>();
+    let mut selected = input
+        .records
+        .iter()
+        .filter(|record| ancestry.contains(&record.session_id))
+        .map(|record| TreeReadSelection {
+            kind: if &record.session_id == input.target_session {
+                TreeReadSegmentKind::BranchLocal
+            } else {
+                TreeReadSegmentKind::AncestorContext
+            },
+            record: record.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    selected.sort_by(compare_selection);
+    let records_in = selected.len();
+    let selected = trim_selections(selected, input.budget_bytes);
+    let records_out = selected.len();
+    let selected_records = selected.iter().map(|s| s.record.clone()).collect();
+
+    Ok(TreeReadWindow {
+        ancestry_path,
+        selected_records,
+        selections: selected,
+        sibling_sessions: siblings(input.tree, input.target_session)?,
+        merge_notes: merge_notes(input.tree, input.target_session),
+        budget: TreeBudgetReport {
+            budget_bytes: input.budget_bytes,
+            records_in,
+            records_out,
+            skipped_for_budget: records_in.saturating_sub(records_out),
+            trimmed: records_out < records_in,
+        },
+    })
+}
+
+fn compare_selection(a: &TreeReadSelection, b: &TreeReadSelection) -> std::cmp::Ordering {
+    a.kind
+        .cmp(&b.kind)
+        .then_with(|| a.record.session_id.cmp(&b.record.session_id))
+        .then_with(|| a.record.turn_id.cmp(&b.record.turn_id))
+        .then_with(|| a.record.record_id.cmp(&b.record.record_id))
+}
+
+fn trim_selections(
+    selections: Vec<TreeReadSelection>,
+    budget_bytes: usize,
+) -> Vec<TreeReadSelection> {
+    let mut used = 0usize;
+    let mut out = Vec::with_capacity(selections.len());
+    for selection in selections {
+        let len = selection.record.body.len();
+        if used.saturating_add(len) <= budget_bytes {
+            used = used.saturating_add(len);
+            out.push(selection);
+        }
+    }
+    out
+}
+
+fn siblings(
+    tree: &SessionTree,
+    target: &SessionId,
+) -> Result<Vec<SessionId>, TreeReadWindowError> {
+    let Some(parent) = tree.parent(target)? else {
+        return Ok(Vec::new());
+    };
+    let mut siblings = tree
+        .children(&parent.session_id)?
+        .into_iter()
+        .filter(|candidate| candidate != target)
+        .collect::<Vec<_>>();
+    siblings.sort();
+    Ok(siblings)
+}
+
+fn merge_notes(tree: &SessionTree, target: &SessionId) -> Vec<String> {
+    let mut notes = tree
+        .merges()
+        .iter()
+        .filter(|merge| &merge.source == target || &merge.destination == target)
+        .map(|merge| {
+            format!(
+                "source={} destination={} applied_at={}",
+                merge.source.as_str(),
+                merge.destination.as_str(),
+                merge.applied_at_turn_id
+            )
+        })
+        .collect::<Vec<_>>();
+    notes.sort();
+    notes
+}
+```
+
+Add the module export in `crates/cairn-core/src/domain/mod.rs`:
+
+```rust
+pub mod tree_read_window;
+
+pub use tree_read_window::{
+    TreeBudgetReport, TreeReadRecord, TreeReadSegmentKind, TreeReadSelection, TreeReadWindow,
+    TreeReadWindowError, TreeReadWindowInput, plan_tree_read_window,
+};
+```
+
+Remove unused imports if the compiler reports them.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p cairn-core flat_session_selects_branch_local_records_in_turn_order
+```
+
+Expected: one matching test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/tree_read_window.rs crates/cairn-core/src/domain/mod.rs
+git commit -m "feat(core): add tree read window planner"
+```
+
+---
+
+### Task 2: Add Lineage, Sibling, Merge, and Budget Tests
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/tree_read_window.rs`
+
+- [ ] **Step 1: Write failing tests for tree behavior**
+
+Append these tests to the existing test module:
+
+```rust
+#[test]
+fn branch_session_includes_ancestor_then_branch_local_records() {
+    let root = sid("root");
+    let branch = sid("branch");
+    let mut tree = SessionTree::flat(root.clone());
+    tree.fork(&root, branch.clone(), "turn-2").expect("fork");
+    let records = vec![
+        item("branch", "turn-3", "01JTS6R4J70000000000000003", "branch"),
+        item("root", "turn-1", "01JTS6R4J70000000000000004", "ancestor"),
+    ];
+
+    let window = plan_tree_read_window(TreeReadWindowInput {
+        tree: &tree,
+        target_session: &branch,
+        records: &records,
+        budget_bytes: 1024,
+    })
+    .expect("plan window");
+
+    assert_eq!(window.ancestry_path, vec![root, branch]);
+    assert_eq!(
+        window
+            .selections
+            .iter()
+            .map(|s| (s.kind, s.record.body.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (TreeReadSegmentKind::BranchLocal, "branch"),
+            (TreeReadSegmentKind::AncestorContext, "ancestor"),
+        ]
+    );
+}
+
+#[test]
+fn sibling_and_merge_metadata_are_body_free_and_sorted() {
+    let root = sid("root");
+    let branch_a = sid("branch-a");
+    let branch_b = sid("branch-b");
+    let mut tree = SessionTree::flat(root.clone());
+    tree.fork(&root, branch_b.clone(), "turn-2").expect("fork b");
+    tree.fork(&root, branch_a.clone(), "turn-2").expect("fork a");
+    tree.record_merge(
+        branch_a.clone(),
+        root.clone(),
+        crate::domain::MergeStrategy::ControlledSplice {
+            first_turn_id: "turn-3".to_owned(),
+            last_turn_id: "turn-4".to_owned(),
+        },
+        "turn-5",
+    )
+    .expect("merge");
+
+    let window = plan_tree_read_window(TreeReadWindowInput {
+        tree: &tree,
+        target_session: &branch_a,
+        records: &[],
+        budget_bytes: 1024,
+    })
+    .expect("plan window");
+
+    assert_eq!(window.sibling_sessions, vec![branch_b]);
+    assert_eq!(window.merge_notes.len(), 1);
+    assert!(window.merge_notes[0].contains("applied_at=turn-5"));
+    assert!(!window.merge_notes[0].contains("branch body"));
+}
+
+#[test]
+fn budget_trimming_is_deterministic_and_preserves_priority_order() {
+    let root = sid("root");
+    let branch = sid("branch");
+    let mut tree = SessionTree::flat(root.clone());
+    tree.fork(&root, branch.clone(), "turn-2").expect("fork");
+    let records = vec![
+        item("root", "turn-1", "01JTS6R4J70000000000000005", "ancestor-long"),
+        item("branch", "turn-3", "01JTS6R4J70000000000000006", "branch"),
+    ];
+
+    let window = plan_tree_read_window(TreeReadWindowInput {
+        tree: &tree,
+        target_session: &branch,
+        records: &records,
+        budget_bytes: "branch".len(),
+    })
+    .expect("plan window");
+
+    assert_eq!(
+        window.selected_records.iter().map(|r| r.body.as_str()).collect::<Vec<_>>(),
+        vec!["branch"]
+    );
+    assert!(window.budget.trimmed);
+    assert_eq!(window.budget.skipped_for_budget, 1);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify failures where behavior is incomplete**
+
+Run:
+
+```bash
+cargo test -p cairn-core tree_read_window
+```
+
+Expected before implementation adjustments: at least one assertion fails if Task 1 sorted ancestor before branch-local or did not trim by priority. If all pass because Task 1 already implemented these semantics, continue and treat this as the red check for currently covered behavior.
+
+- [ ] **Step 3: Adjust planner ordering and trim behavior if needed**
+
+Ensure `compare_selection` keeps priority order:
+
+```rust
+fn compare_selection(a: &TreeReadSelection, b: &TreeReadSelection) -> std::cmp::Ordering {
+    a.kind
+        .cmp(&b.kind)
+        .then_with(|| a.record.session_id.cmp(&b.record.session_id))
+        .then_with(|| a.record.turn_id.cmp(&b.record.turn_id))
+        .then_with(|| a.record.record_id.cmp(&b.record.record_id))
+}
+```
+
+Ensure the enum declaration order stays:
+
+```rust
+pub enum TreeReadSegmentKind {
+    BranchLocal,
+    AncestorContext,
+    MergeSummary,
+    SiblingSummary,
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p cairn-core tree_read_window
+```
+
+Expected: all `tree_read_window` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-core/src/domain/tree_read_window.rs
+git commit -m "test(core): cover tree read window semantics"
+```
+
+---
+
+### Task 3: Wire Tree Windows Into `retrieve --session`
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/retrieve.rs`
+
+- [ ] **Step 1: Write the failing CLI-local unit test**
+
+Add a `#[cfg(test)] mod tree_window_tests` near the bottom of `retrieve.rs` with a focused helper test that does not require a full CLI process:
+
+```rust
+#[cfg(test)]
+mod tree_window_tests {
+    use super::*;
+    use cairn_core::domain::{RecordId, SessionId, TreeReadRecord};
+
+    fn sid(raw: &str) -> SessionId {
+        SessionId::parse(raw).expect("valid session id")
+    }
+
+    fn rid(raw: &str) -> RecordId {
+        RecordId::parse(raw).expect("valid record id")
+    }
+
+    #[test]
+    fn tree_records_from_memory_records_preserve_trace_turn_ids() {
+        let mut record = cairn_core::domain::record::tests_export::sample_record();
+        record.id = rid("01JTS6R4J70000000000000007");
+        record.scope.session_id = Some("branch".to_owned());
+        record.body = "body".to_owned();
+        record.extra_frontmatter.insert(
+            "trace".to_owned(),
+            serde_json::json!({ "turn_id": "turn-9" }),
+        );
+
+        let got = tree_read_records_from_memory_records(&[record]);
+
+        assert_eq!(
+            got,
+            vec![TreeReadRecord {
+                session_id: sid("branch"),
+                turn_id: Some("turn-9".to_owned()),
+                record_id: rid("01JTS6R4J70000000000000007"),
+                body: "body".to_owned(),
+            }]
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-cli tree_records_from_memory_records_preserve_trace_turn_ids
+```
+
+Expected: compile failure because `tree_read_records_from_memory_records` does not exist.
+
+- [ ] **Step 3: Add conversion and policy-trace helpers**
+
+In `retrieve.rs`, import the planner types:
+
+```rust
+use cairn_core::domain::{
+    Identity, MemoryKind, MemoryRecord, RecordId, ScopeTuple, SessionId, TreeBudgetReport,
+    TreeReadRecord, TreeReadWindow,
+};
+```
+
+Add helpers:
+
+```rust
+fn tree_read_records_from_memory_records(records: &[MemoryRecord]) -> Vec<TreeReadRecord> {
+    records
+        .iter()
+        .filter_map(|record| {
+            let session_id = record.scope.session_id.as_ref()?;
+            let session_id = SessionId::parse(session_id.clone()).ok()?;
+            Some(TreeReadRecord {
+                session_id,
+                turn_id: trace_turn_id(record),
+                record_id: record.id.clone(),
+                body: record.body.clone(),
+            })
+        })
+        .collect()
+}
+
+fn tree_trace_entries(window: &TreeReadWindow) -> Vec<ResponsePolicyTrace> {
+    vec![
+        ResponsePolicyTrace {
+            detail: Some(format!(
+                "path={} selected_records={} skipped_for_budget={}",
+                window
+                    .ancestry_path
+                    .iter()
+                    .map(|id| id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(">"),
+                window.budget.records_out,
+                window.budget.skipped_for_budget,
+            )),
+            gate: "tree.lineage".to_owned(),
+            result: ResponsePolicyTraceResult::Pass,
+        },
+        ResponsePolicyTrace {
+            detail: Some(format!("siblings={}", window.sibling_sessions.len())),
+            gate: "tree.sibling_context".to_owned(),
+            result: ResponsePolicyTraceResult::Pass,
+        },
+        ResponsePolicyTrace {
+            detail: Some(format!("merges={}", window.merge_notes.len())),
+            gate: "tree.merge_context".to_owned(),
+            result: ResponsePolicyTraceResult::Pass,
+        },
+    ]
+}
+```
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p cairn-cli tree_records_from_memory_records_preserve_trace_turn_ids
+```
+
+Expected: the test passes.
+
+- [ ] **Step 5: Wire `retrieve_session` to load lineage records and plan**
+
+Inside `retrieve_session`, after parsing `order` and `start`, replace the single-session load with a tree-aware path:
+
+```rust
+let target_session_id = match SessionId::parse(session_id.clone()) {
+    Ok(id) => id,
+    Err(e) => return super::signed::rejected_from_domain(ResponseVerb::Retrieve, e),
+};
+let tree = match store.get_session_tree(&target_session_id).await {
+    Ok(tree) => tree,
+    Err(e) if e.to_string().contains("capability unavailable") => None,
+    Err(e) => return super::signed::aborted(ResponseVerb::Retrieve, format!("session tree: {e}")),
+};
+
+let mut records = if let Some(tree) = tree.as_ref() {
+    let lineage = match tree.lineage(&target_session_id) {
+        Ok(lineage) => lineage,
+        Err(e) => return super::signed::aborted(ResponseVerb::Retrieve, format!("session tree: {e}")),
+    };
+    let mut out = Vec::new();
+    for lineage_session in lineage {
+        let mut session_args = scoped_list_args(auth);
+        if let Some(scope) = &mut session_args.scope {
+            scope.session_id = Some(lineage_session.as_str().to_owned());
+        }
+        match list_records(store, session_args).await {
+            Ok(mut page_records) => out.append(&mut page_records),
+            Err(resp) => return resp,
+        }
+    }
+    out
+} else {
+    let mut args = scoped_list_args(auth);
+    if let Some(scope) = &mut args.scope {
+        scope.session_id = Some(session_id.clone());
+    }
+    match list_records(store, args).await {
+        Ok(records) => records,
+        Err(resp) => return resp,
+    }
+};
+```
+
+Before grouping, apply the planner when `tree.is_some()`:
+
+```rust
+let mut tree_trace = Vec::new();
+if let Some(tree) = tree.as_ref() {
+    let tree_records = tree_read_records_from_memory_records(&records);
+    match cairn_core::domain::plan_tree_read_window(cairn_core::domain::TreeReadWindowInput {
+        tree,
+        target_session: &target_session_id,
+        records: &tree_records,
+        budget_bytes: read_budget_chars,
+    }) {
+        Ok(window) => {
+            let selected_ids = window
+                .selected_records
+                .iter()
+                .map(|record| record.record_id.clone())
+                .collect::<std::collections::BTreeSet<_>>();
+            records.retain(|record| selected_ids.contains(&record.id));
+            tree_trace = tree_trace_entries(&window);
+        }
+        Err(e) => {
+            return super::signed::aborted(
+                ResponseVerb::Retrieve,
+                format!("tree read window: {e}"),
+            );
+        }
+    }
+} else {
+    records.retain(|record| record.scope.session_id.as_deref() == Some(session_id.as_str()));
+}
+```
+
+Thread `tree_trace` into `committed_after_access` by adding an optional `extra_trace` parameter, or append it after building the response:
+
+```rust
+let mut resp = committed_after_access(...).await;
+resp.policy_trace.extend(tree_trace);
+resp
+```
+
+- [ ] **Step 6: Run retrieve tests**
+
+Run:
+
+```bash
+cargo test -p cairn-cli retrieve_session
+```
+
+Expected: tests compile and any matching retrieve session tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/retrieve.rs
+git commit -m "feat(cli): plan tree-aware session retrieval"
+```
+
+---
+
+### Task 4: Add Retrieve Window Response Coverage
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/retrieve.rs`
+
+- [ ] **Step 1: Write a failing response-shaping test**
+
+Extend the `tree_window_tests` module from Task 3:
+
+```rust
+#[test]
+fn tree_trace_entries_explain_path_without_record_bodies() {
+    let root = sid("root");
+    let branch = sid("branch");
+    let mut tree = cairn_core::domain::SessionTree::flat(root.clone());
+    tree.fork(&root, branch.clone(), "turn-2").expect("fork");
+    let records = vec![
+        TreeReadRecord {
+            session_id: root.clone(),
+            turn_id: Some("turn-1".to_owned()),
+            record_id: rid("01JTS6R4J70000000000000008"),
+            body: "ancestor secret body".to_owned(),
+        },
+        TreeReadRecord {
+            session_id: branch.clone(),
+            turn_id: Some("turn-3".to_owned()),
+            record_id: rid("01JTS6R4J70000000000000009"),
+            body: "branch secret body".to_owned(),
+        },
+    ];
+    let window = cairn_core::domain::plan_tree_read_window(
+        cairn_core::domain::TreeReadWindowInput {
+            tree: &tree,
+            target_session: &branch,
+            records: &records,
+            budget_bytes: 1024,
+        },
+    )
+    .expect("window");
+
+    let entries = tree_trace_entries(&window);
+
+    assert!(entries.iter().any(|entry| entry.gate == "tree.lineage"));
+    let joined = entries
+        .iter()
+        .filter_map(|entry| entry.detail.as_deref())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(joined.contains("path=root>branch"));
+    assert!(!joined.contains("secret body"));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-cli tree_trace_entries_explain_path_without_record_bodies
+```
+
+Expected: compile failure if Task 3 did not expose `tree_trace_entries`; otherwise failure if the detail leaks record body text or omits the lineage path.
+
+- [ ] **Step 3: Update `tree_trace_entries` if needed**
+
+Ensure the lineage detail uses only session ids and counts:
+
+```rust
+detail: Some(format!(
+    "path={} selected_records={} skipped_for_budget={}",
+    window
+        .ancestry_path
+        .iter()
+        .map(|id| id.as_str())
+        .collect::<Vec<_>>()
+        .join(">"),
+    window.budget.records_out,
+    window.budget.skipped_for_budget,
+)),
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p cairn-cli tree_trace_entries_explain_path_without_record_bodies
+```
+
+Expected: test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/retrieve.rs
+git commit -m "test(cli): cover tree-aware retrieve metadata"
+```
+
+---
+
+### Task 5: Reuse Planner For Session-Scoped Hot Memory
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/assemble_hot.rs`
+
+- [ ] **Step 1: Write failing helper test**
+
+Add a test module near the bottom of `assemble_hot.rs`:
+
+```rust
+#[cfg(test)]
+mod tree_hot_tests {
+    use super::*;
+
+    #[test]
+    fn tree_policy_detail_is_metadata_only() {
+        let detail = tree_policy_detail(2, 1, 3);
+        assert_eq!(detail, "path_sessions=2 siblings=1 merges=3");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-cli tree_policy_detail_is_metadata_only
+```
+
+Expected: compile failure because `tree_policy_detail` does not exist.
+
+- [ ] **Step 3: Add metadata helper and planner-backed session expansion**
+
+Add:
+
+```rust
+fn tree_policy_detail(path_sessions: usize, siblings: usize, merges: usize) -> String {
+    format!("path_sessions={path_sessions} siblings={siblings} merges={merges}")
+}
+```
+
+In `load_records_for_kinds`, when `session_id.is_some()` and `kind == MemoryKind::UserSignal`, hydrate `get_session_tree`, compute lineage, and query user-signal records for each lineage session. Keep the existing single-session path for capability-unavailable stores.
+
+The new branch should preserve authorization by calling existing `list_records_for_visibility` for each lineage session rather than directly querying the DB.
+
+- [ ] **Step 4: Append policy trace metadata**
+
+In `read_policy_trace` or immediately after `load_hot_bodies`, append a `ResponsePolicyTrace` when tree metadata was used:
+
+```rust
+ResponsePolicyTrace {
+    detail: Some(tree_policy_detail(path_sessions, siblings, merges)),
+    gate: "tree.branch_context".to_owned(),
+    result: ResponsePolicyTraceResult::Pass,
+}
+```
+
+Do not include raw record bodies, turn text, or unauthorized ids in the detail.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+cargo test -p cairn-cli tree_policy_detail_is_metadata_only
+cargo test -p cairn-cli assemble_hot
+```
+
+Expected: focused helper test and existing assemble-hot tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/assemble_hot.rs
+git commit -m "feat(cli): add tree context to hot memory reads"
+```
+
+---
+
+### Task 6: Reuse Planner For Summarize Source Selection
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/summarize.rs`
+
+- [ ] **Step 1: Inspect current summarize source loading**
+
+Run:
+
+```bash
+sed -n '1,260p' crates/cairn-cli/src/verbs/summarize.rs
+```
+
+Confirm where source `MemoryRecord` values are loaded before
+`cairn_core::verbs::summarize::render_summary_data`.
+
+- [ ] **Step 2: Write failing helper test**
+
+Add a local unit test in `summarize.rs` for a helper that extracts one common session id:
+
+```rust
+#[cfg(test)]
+mod tree_summary_tests {
+    use super::*;
+
+    #[test]
+    fn common_session_id_requires_all_records_to_match() {
+        let mut a = cairn_core::domain::record::tests_export::sample_record();
+        let mut b = cairn_core::domain::record::tests_export::sample_record();
+        a.scope.session_id = Some("session-a".to_owned());
+        b.scope.session_id = Some("session-a".to_owned());
+        assert_eq!(common_session_id(&[a.clone(), b]).as_deref(), Some("session-a"));
+
+        let mut c = a;
+        c.scope.session_id = Some("session-c".to_owned());
+        assert!(common_session_id(&[c]).is_some());
+    }
+}
+```
+
+If the desired behavior is "all records match or no tree planning", add a second assertion with two different session ids returning `None`:
+
+```rust
+let mut d = cairn_core::domain::record::tests_export::sample_record();
+d.scope.session_id = Some("session-d".to_owned());
+assert!(common_session_id(&[c, d]).is_none());
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p cairn-cli common_session_id_requires_all_records_to_match
+```
+
+Expected: compile failure because `common_session_id` does not exist.
+
+- [ ] **Step 4: Add helper and planner use**
+
+Add:
+
+```rust
+fn common_session_id(records: &[MemoryRecord]) -> Option<String> {
+    let mut ids = records
+        .iter()
+        .filter_map(|record| record.scope.session_id.as_deref());
+    let first = ids.next()?.to_owned();
+    ids.all(|id| id == first).then_some(first)
+}
+```
+
+After source records are authorized and loaded, if `common_session_id` returns a session id and `get_session_tree` succeeds, run `plan_tree_read_window` with those records converted to `TreeReadRecord`. Retain only selected record ids before calling `render_summary_data`.
+
+If `get_session_tree` returns capability unavailable, keep existing behavior. If it returns malformed tree metadata, abort the summarize response.
+
+- [ ] **Step 5: Run summarize tests**
+
+Run:
+
+```bash
+cargo test -p cairn-cli common_session_id_requires_all_records_to_match
+cargo test -p cairn-cli summarize
+```
+
+Expected: focused helper and existing summarize tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-cli/src/verbs/summarize.rs
+git commit -m "feat(cli): apply tree windows to summarize"
+```
+
+---
+
+### Task 7: Targeted Verification
+
+**Files:**
+- No source changes unless verification exposes a defect.
+
+- [ ] **Step 1: Run core planner tests**
+
+Run:
+
+```bash
+cargo test -p cairn-core tree_read_window
+```
+
+Expected: all tree-read-window tests pass.
+
+- [ ] **Step 2: Run session-tree store tests**
+
+Run:
+
+```bash
+cargo test -p cairn-store-sqlite sessions
+```
+
+Expected: existing #133 session tests pass.
+
+- [ ] **Step 3: Run CLI focused tests**
+
+Run:
+
+```bash
+cargo test -p cairn-cli retrieve
+cargo test -p cairn-cli assemble_hot
+cargo test -p cairn-cli summarize
+```
+
+Expected: focused CLI tests pass.
+
+- [ ] **Step 4: Run workspace check**
+
+Run:
+
+```bash
+cargo check --workspace --all-targets --locked
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 5: Run core boundary check**
+
+Run:
+
+```bash
+./scripts/check-core-boundary.sh
+```
+
+Expected: exit code 0 and no `cairn-core` dependency violations.
+
+- [ ] **Step 6: Commit verification fixes if any**
+
+If any command fails, fix only the defect exposed by that command and rerun the failing command. Commit the fix:
+
+```bash
+git add <changed-files>
+git commit -m "fix: stabilize tree-aware read windows"
+```
+
+---
+
+## Plan Self-Review
+
+- Spec coverage: Tasks 1-2 implement the pure planner, Task 3-4 cover `retrieve`, Task 5 covers `assemble_hot`, Task 6 covers `summarize`, Task 7 covers verification.
+- Trace canvas remains out of scope and has no storage/workflow tasks here.
+- No IDL change is planned. If implementation proves existing metadata surfaces are insufficient, stop and write a small IDL amendment plan before touching generated code.
+- TDD order is explicit for every behavior-changing task.

--- a/docs/superpowers/plans/2026-05-16-issue-134-tree-aware-read-windows.md
+++ b/docs/superpowers/plans/2026-05-16-issue-134-tree-aware-read-windows.md
@@ -36,7 +36,7 @@
 - Create: `crates/cairn-core/src/domain/tree_read_window.rs`
 - Modify: `crates/cairn-core/src/domain/mod.rs`
 
-- [ ] **Step 1: Write the failing flat-session compatibility test**
+- [x] **Step 1: Write the failing flat-session compatibility test**
 
 Add this test module to the new file first:
 
@@ -95,7 +95,7 @@ mod tests {
 }
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run:
 
@@ -105,7 +105,7 @@ cargo test -p cairn-core flat_session_selects_branch_local_records_in_turn_order
 
 Expected: compile failure because `tree_read_window`, `TreeReadRecord`, `TreeReadWindowInput`, and `plan_tree_read_window` do not exist yet.
 
-- [ ] **Step 3: Add the minimal planner API**
+- [x] **Step 3: Add the minimal planner API**
 
 Create `crates/cairn-core/src/domain/tree_read_window.rs`:
 
@@ -292,7 +292,7 @@ pub use tree_read_window::{
 
 Remove unused imports if the compiler reports them.
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 Run:
 
@@ -302,7 +302,7 @@ cargo test -p cairn-core flat_session_selects_branch_local_records_in_turn_order
 
 Expected: one matching test passes.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add crates/cairn-core/src/domain/tree_read_window.rs crates/cairn-core/src/domain/mod.rs
@@ -316,7 +316,7 @@ git commit -m "feat(core): add tree read window planner"
 **Files:**
 - Modify: `crates/cairn-core/src/domain/tree_read_window.rs`
 
-- [ ] **Step 1: Write failing tests for tree behavior**
+- [x] **Step 1: Write failing tests for tree behavior**
 
 Append these tests to the existing test module:
 
@@ -415,7 +415,7 @@ fn budget_trimming_is_deterministic_and_preserves_priority_order() {
 }
 ```
 
-- [ ] **Step 2: Run the tests to verify failures where behavior is incomplete**
+- [x] **Step 2: Run the tests to verify failures where behavior is incomplete**
 
 Run:
 
@@ -425,7 +425,7 @@ cargo test -p cairn-core tree_read_window
 
 Expected before implementation adjustments: at least one assertion fails if Task 1 sorted ancestor before branch-local or did not trim by priority. If all pass because Task 1 already implemented these semantics, continue and treat this as the red check for currently covered behavior.
 
-- [ ] **Step 3: Adjust planner ordering and trim behavior if needed**
+- [x] **Step 3: Adjust planner ordering and trim behavior if needed**
 
 Ensure `compare_selection` keeps priority order:
 
@@ -450,7 +450,7 @@ pub enum TreeReadSegmentKind {
 }
 ```
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [x] **Step 4: Run the tests to verify they pass**
 
 Run:
 
@@ -460,7 +460,7 @@ cargo test -p cairn-core tree_read_window
 
 Expected: all `tree_read_window` tests pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add crates/cairn-core/src/domain/tree_read_window.rs
@@ -474,7 +474,7 @@ git commit -m "test(core): cover tree read window semantics"
 **Files:**
 - Modify: `crates/cairn-cli/src/verbs/retrieve.rs`
 
-- [ ] **Step 1: Write the failing CLI-local unit test**
+- [x] **Step 1: Write the failing CLI-local unit test**
 
 Add a `#[cfg(test)] mod tree_window_tests` near the bottom of `retrieve.rs` with a focused helper test that does not require a full CLI process:
 
@@ -518,7 +518,7 @@ mod tree_window_tests {
 }
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run:
 
@@ -528,7 +528,7 @@ cargo test -p cairn-cli tree_records_from_memory_records_preserve_trace_turn_ids
 
 Expected: compile failure because `tree_read_records_from_memory_records` does not exist.
 
-- [ ] **Step 3: Add conversion and policy-trace helpers**
+- [x] **Step 3: Add conversion and policy-trace helpers**
 
 In `retrieve.rs`, import the planner types:
 
@@ -589,7 +589,7 @@ fn tree_trace_entries(window: &TreeReadWindow) -> Vec<ResponsePolicyTrace> {
 }
 ```
 
-- [ ] **Step 4: Run the focused test to verify it passes**
+- [x] **Step 4: Run the focused test to verify it passes**
 
 Run:
 
@@ -599,7 +599,7 @@ cargo test -p cairn-cli tree_records_from_memory_records_preserve_trace_turn_ids
 
 Expected: the test passes.
 
-- [ ] **Step 5: Wire `retrieve_session` to load lineage records and plan**
+- [x] **Step 5: Wire `retrieve_session` to load lineage records and plan**
 
 Inside `retrieve_session`, after parsing `order` and `start`, replace the single-session load with a tree-aware path:
 
@@ -684,7 +684,7 @@ resp.policy_trace.extend(tree_trace);
 resp
 ```
 
-- [ ] **Step 6: Run retrieve tests**
+- [x] **Step 6: Run retrieve tests**
 
 Run:
 
@@ -694,7 +694,7 @@ cargo test -p cairn-cli retrieve_session
 
 Expected: tests compile and any matching retrieve session tests pass.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add crates/cairn-cli/src/verbs/retrieve.rs
@@ -708,7 +708,7 @@ git commit -m "feat(cli): plan tree-aware session retrieval"
 **Files:**
 - Modify: `crates/cairn-cli/src/verbs/retrieve.rs`
 
-- [ ] **Step 1: Write a failing response-shaping test**
+- [x] **Step 1: Write a failing response-shaping test**
 
 Extend the `tree_window_tests` module from Task 3:
 
@@ -756,7 +756,7 @@ fn tree_trace_entries_explain_path_without_record_bodies() {
 }
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run:
 
@@ -766,7 +766,7 @@ cargo test -p cairn-cli tree_trace_entries_explain_path_without_record_bodies
 
 Expected: compile failure if Task 3 did not expose `tree_trace_entries`; otherwise failure if the detail leaks record body text or omits the lineage path.
 
-- [ ] **Step 3: Update `tree_trace_entries` if needed**
+- [x] **Step 3: Update `tree_trace_entries` if needed**
 
 Ensure the lineage detail uses only session ids and counts:
 
@@ -784,7 +784,7 @@ detail: Some(format!(
 )),
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 Run:
 
@@ -794,7 +794,7 @@ cargo test -p cairn-cli tree_trace_entries_explain_path_without_record_bodies
 
 Expected: test passes.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add crates/cairn-cli/src/verbs/retrieve.rs
@@ -808,7 +808,7 @@ git commit -m "test(cli): cover tree-aware retrieve metadata"
 **Files:**
 - Modify: `crates/cairn-cli/src/verbs/assemble_hot.rs`
 
-- [ ] **Step 1: Write failing helper test**
+- [x] **Step 1: Write failing helper test**
 
 Add a test module near the bottom of `assemble_hot.rs`:
 
@@ -825,7 +825,7 @@ mod tree_hot_tests {
 }
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run:
 
@@ -835,7 +835,7 @@ cargo test -p cairn-cli tree_policy_detail_is_metadata_only
 
 Expected: compile failure because `tree_policy_detail` does not exist.
 
-- [ ] **Step 3: Add metadata helper and planner-backed session expansion**
+- [x] **Step 3: Add metadata helper and planner-backed session expansion**
 
 Add:
 
@@ -849,7 +849,7 @@ In `load_records_for_kinds`, when `session_id.is_some()` and `kind == MemoryKind
 
 The new branch should preserve authorization by calling existing `list_records_for_visibility` for each lineage session rather than directly querying the DB.
 
-- [ ] **Step 4: Append policy trace metadata**
+- [x] **Step 4: Append policy trace metadata**
 
 In `read_policy_trace` or immediately after `load_hot_bodies`, append a `ResponsePolicyTrace` when tree metadata was used:
 
@@ -863,7 +863,7 @@ ResponsePolicyTrace {
 
 Do not include raw record bodies, turn text, or unauthorized ids in the detail.
 
-- [ ] **Step 5: Run focused tests**
+- [x] **Step 5: Run focused tests**
 
 Run:
 
@@ -874,7 +874,7 @@ cargo test -p cairn-cli assemble_hot
 
 Expected: focused helper test and existing assemble-hot tests pass.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add crates/cairn-cli/src/verbs/assemble_hot.rs
@@ -888,7 +888,7 @@ git commit -m "feat(cli): add tree context to hot memory reads"
 **Files:**
 - Modify: `crates/cairn-cli/src/verbs/summarize.rs`
 
-- [ ] **Step 1: Inspect current summarize source loading**
+- [x] **Step 1: Inspect current summarize source loading**
 
 Run:
 
@@ -899,7 +899,7 @@ sed -n '1,260p' crates/cairn-cli/src/verbs/summarize.rs
 Confirm where source `MemoryRecord` values are loaded before
 `cairn_core::verbs::summarize::render_summary_data`.
 
-- [ ] **Step 2: Write failing helper test**
+- [x] **Step 2: Write failing helper test**
 
 Add a local unit test in `summarize.rs` for a helper that extracts one common session id:
 
@@ -931,7 +931,7 @@ d.scope.session_id = Some("session-d".to_owned());
 assert!(common_session_id(&[c, d]).is_none());
 ```
 
-- [ ] **Step 3: Run the test to verify it fails**
+- [x] **Step 3: Run the test to verify it fails**
 
 Run:
 
@@ -941,7 +941,7 @@ cargo test -p cairn-cli common_session_id_requires_all_records_to_match
 
 Expected: compile failure because `common_session_id` does not exist.
 
-- [ ] **Step 4: Add helper and planner use**
+- [x] **Step 4: Add helper and planner use**
 
 Add:
 
@@ -959,7 +959,7 @@ After source records are authorized and loaded, if `common_session_id` returns a
 
 If `get_session_tree` returns capability unavailable, keep existing behavior. If it returns malformed tree metadata, abort the summarize response.
 
-- [ ] **Step 5: Run summarize tests**
+- [x] **Step 5: Run summarize tests**
 
 Run:
 
@@ -970,7 +970,7 @@ cargo test -p cairn-cli summarize
 
 Expected: focused helper and existing summarize tests pass.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add crates/cairn-cli/src/verbs/summarize.rs
@@ -984,7 +984,7 @@ git commit -m "feat(cli): apply tree windows to summarize"
 **Files:**
 - No source changes unless verification exposes a defect.
 
-- [ ] **Step 1: Run core planner tests**
+- [x] **Step 1: Run core planner tests**
 
 Run:
 
@@ -994,7 +994,7 @@ cargo test -p cairn-core tree_read_window
 
 Expected: all tree-read-window tests pass.
 
-- [ ] **Step 2: Run session-tree store tests**
+- [x] **Step 2: Run session-tree store tests**
 
 Run:
 
@@ -1004,7 +1004,7 @@ cargo test -p cairn-store-sqlite sessions
 
 Expected: existing #133 session tests pass.
 
-- [ ] **Step 3: Run CLI focused tests**
+- [x] **Step 3: Run CLI focused tests**
 
 Run:
 
@@ -1016,7 +1016,7 @@ cargo test -p cairn-cli summarize
 
 Expected: focused CLI tests pass.
 
-- [ ] **Step 4: Run workspace check**
+- [x] **Step 4: Run workspace check**
 
 Run:
 
@@ -1026,7 +1026,7 @@ cargo check --workspace --all-targets --locked
 
 Expected: exit code 0.
 
-- [ ] **Step 5: Run core boundary check**
+- [x] **Step 5: Run core boundary check**
 
 Run:
 
@@ -1036,7 +1036,7 @@ Run:
 
 Expected: exit code 0 and no `cairn-core` dependency violations.
 
-- [ ] **Step 6: Commit verification fixes if any**
+- [x] **Step 6: Commit verification fixes if any**
 
 If any command fails, fix only the defect exposed by that command and rerun the failing command. Commit the fix:
 
@@ -1053,3 +1053,27 @@ git commit -m "fix: stabilize tree-aware read windows"
 - Trace canvas remains out of scope and has no storage/workflow tasks here.
 - No IDL change is planned. If implementation proves existing metadata surfaces are insufficient, stop and write a small IDL amendment plan before touching generated code.
 - TDD order is explicit for every behavior-changing task.
+
+## Execution Notes
+
+Completed on branch `codex/issue-134-tree-hot-memory`.
+
+Final verification:
+
+```bash
+cargo fmt --all --check
+cargo clippy -p cairn-cli --all-targets --locked -- -D warnings
+cargo test -p cairn-cli assemble_hot --locked
+cargo test -p cairn-cli summarize --locked
+cargo check --workspace --all-targets --locked
+./scripts/check-core-boundary.sh
+cargo run -p cairn-idl --bin cairn-codegen --locked -- --check
+cargo nextest run --workspace --locked --no-fail-fast
+cargo test --doc --workspace --locked
+```
+
+Results:
+
+- `cargo nextest`: 4,634 passed, 19 skipped.
+- `cairn-codegen --check`: clean, 74 generated files matched.
+- Doctests passed across the workspace.

--- a/docs/superpowers/specs/2026-05-16-issue-134-tree-aware-read-windows-design.md
+++ b/docs/superpowers/specs/2026-05-16-issue-134-tree-aware-read-windows-design.md
@@ -1,0 +1,238 @@
+# Design — issue #134 tree-aware read windows
+
+**Status:** Approved for planning (brainstorm 2026-05-16).
+**Issue:** [#134](https://github.com/windoliver/cairn/issues/134).
+**Parent epic:** [#30](https://github.com/windoliver/cairn/issues/30).
+**Brief refs:** §5.7 Sessions are trees, §7 Hot Memory, §8.0 core verbs.
+
+## 1. Goal
+
+Implement the first issue #134 slice: a reusable, deterministic tree-aware
+read-window planner for `retrieve`, `summarize`, and `assemble_hot`.
+
+The planner consumes the session-tree substrate from #133 and makes a branch
+session readable as a path through the tree, not as an isolated flat log. The
+same planned window is reused by all three read surfaces so ancestry, branch
+locality, sibling/merge explanations, and budget trimming are consistent.
+
+## 2. Non-goals
+
+- New `cairn.sessiontree.v1` public verbs. Those remain governed by #30 and
+  capability discovery.
+- Task-trace canvas persistence or workflows (`trace_step`, `trace_canvas`,
+  canvas markdown projection). The issue addendum is valid, but it should land
+  after tree-aware read windows are stable.
+- New LLM summarization behavior. This slice keeps P0 deterministic summary
+  generation and only changes which authorized records enter the summary.
+- GUI session-tree visualization. That belongs to #135.
+- Direct DB mutation outside the existing session-tree substrate. This is a
+  read-path feature.
+
+## 3. Current base
+
+`origin/main` already contains #133:
+
+- `cairn_core::domain::session_tree` with `SessionTree`, `SessionParent`,
+  lineage, children, subtree preorder, and merge validation.
+- SQLite migration `0062_session_tree.sql` with `session_tree_nodes` and
+  `session_tree_merges`.
+- `SqliteMemoryStore::get_session_tree`, `record_session_fork`,
+  `record_session_clone`, `record_session_tool_spawn`, and
+  `record_session_merge`.
+- Compatibility behavior: legacy flat sessions hydrate as one-node trees.
+
+The read surfaces are already real:
+
+- `cairn retrieve --session` loads records by `scope.session_id`, groups by
+  turn, applies include flags, and trims to `search.max_snippet_chars_per_page`.
+- `cairn summarize` renders deterministic P0 rollups from authorized records.
+- `cairn assemble_hot --session` uses the session id today for recent
+  `user_signal` records and cache keys, with segment-aware hot-prefix output.
+
+## 4. Approach
+
+Add a pure planner in `cairn-core`:
+
+```text
+SessionTree + target session + per-session record groups + budget policy
+  -> TreeReadWindow
+       ancestry_path
+       selected_segments
+       sibling_summaries
+       merge_summaries
+       deterministic trim report
+       explanation strings / metadata
+```
+
+Adapters remain responsible for storage and authorization. The CLI loads only
+authorized records from `MemoryStore`, then passes those records plus hydrated
+`SessionTree` metadata into core. Core never queries SQLite or reads the
+filesystem.
+
+This mirrors the existing design rule: `cairn-core` owns pure behavior;
+`cairn-store-sqlite` persists; `cairn-cli` wires adapters into the verb layer.
+
+## 5. Window Semantics
+
+### 5.1 Target and lineage
+
+For `target_session = S`, the planner resolves:
+
+1. `ancestry_path`: `root -> ... -> S`, inclusive.
+2. `branch_local`: records whose `scope.session_id == S`.
+3. `ancestor_context`: records from ancestors before the child branch boundary
+   when turn ids are available. If the branch boundary is `"latest"` or the
+   source data lacks turn ids, ancestor records are included as bounded summary
+   context rather than pretending to know an exact cutoff.
+4. `sibling_context`: sibling branch metadata only by default, plus compact
+   sibling summaries when they fit the budget and are justified by a merge or
+   explicit sibling relation.
+5. `merge_context`: merge events where either `source == S` or
+   `destination == S`, represented as compact explanatory context. A
+   `reasoning_summary` merge cites `summary_record_id`; a
+   `controlled_splice` merge cites the spliced turn range.
+
+Legacy one-node trees produce the same flat session behavior as today.
+
+### 5.2 Segment kinds
+
+The planner classifies selected material into stable segment kinds:
+
+| Segment kind | Purpose | Default priority |
+|---|---|---:|
+| `branch_local` | Direct target-session turns/records | 0 |
+| `ancestor_context` | Required lineage context up to branch point | 1 |
+| `merge_summary` | Explicit merge explanations and cited summaries | 2 |
+| `sibling_summary` | Compact sibling branch context | 3 |
+
+Lower priority numbers survive trimming first. Ties are broken by
+`session_id`, then `turn_id`, then `record_id`, all ascending. This makes
+budget trimming deterministic across platforms and runs.
+
+### 5.3 Budget trimming
+
+The planner trims in two passes:
+
+1. **Segment pass:** reserve room for `branch_local` first, then add ancestor,
+   merge, and sibling segments while budget remains.
+2. **Record pass:** within each segment, trim record bodies at UTF-8-safe byte
+   boundaries using the existing style of budget handling. Record ordering is
+   stable before trimming, so repeated runs with unchanged inputs emit the
+   same window.
+
+The output includes a `TreeBudgetReport` with:
+
+- budget bytes/chars requested by the caller,
+- selected and skipped segment counts,
+- selected and skipped record counts,
+- `skipped_for_budget` by segment kind,
+- whether sibling or merge context was omitted.
+
+## 6. Verb Integration
+
+### 6.1 `retrieve --session`
+
+`retrieve --session <id>` becomes tree-aware when
+`MemoryStore::get_session_tree` succeeds for that session:
+
+1. Load and authorize records for every session on the target lineage plus
+   relevant sibling/merge summary record ids.
+2. Build a `TreeReadWindow`.
+3. Flatten the selected records back into the existing `DataSession.items`
+   shape so old clients keep working.
+4. Add branch/path choices to the existing response policy trace, using
+   metadata-only details. Do not leak unauthorized sibling ids or record ids.
+
+If the store returns capability unavailable for session trees, retrieve keeps
+the existing flat behavior. If the store has tree metadata but it is invalid,
+the verb aborts rather than silently downgrading.
+
+### 6.2 `summarize`
+
+When summary inputs contain session/turn records with a common session id, the
+CLI should use the same tree planner before rendering deterministic summary
+data. The summary digest and facts still cite the selected source record ids;
+records skipped for tree budget are not cited.
+
+This keeps P0 offline and deterministic: the only change is source selection.
+
+### 6.3 `assemble_hot --session`
+
+`assemble_hot --session <id>` should be able to include compact current-branch
+context when configured source material exists. This slice does not add a new
+`HotRecipeStep`, because `cairn.mcp.v1` freezes the enum. Instead:
+
+- tree-aware session context is folded into existing session-scoped sources
+  where they already exist, starting with `recent_user_signal`;
+- debug/explain output gets metadata-only branch choice notes where the current
+  wire shape can carry them safely;
+- a future `cairn.mcp.v2` can add a dedicated `current_task_context` or
+  `session_tree_context` recipe step.
+
+The hot prefix must still respect `HotMemoryConfig.max_bytes`, explicit
+`--budget`, and #288 segment validation.
+
+## 7. Response Metadata
+
+The current `cairn.mcp.v1` retrieve/session and assemble-hot response shapes
+are tight. This slice should avoid a broad schema churn unless implementation
+proves it necessary.
+
+Preferred metadata path:
+
+- use `policy_trace` for retrieve tree choices:
+  `tree.lineage`, `tree.branch_local`, `tree.merge_context`,
+  `tree.sibling_context`, `tree.budget`;
+- use `assemble_hot.debug` for hot-prefix tree choices only when `--explain`
+  is set;
+- keep metadata body-free and authorization-safe.
+
+If a typed wire addition becomes necessary, it must be minimal, generated from
+IDL, and codegen must be rerun in the same PR.
+
+## 8. Error Semantics
+
+| Condition | Behavior |
+|---|---|
+| Legacy flat session | Existing flat output. |
+| Store lacks session-tree capability | Existing flat output, no branch metadata. |
+| Requested session missing | Existing authorized empty/not-found behavior. |
+| Tree metadata malformed | `aborted`, because branch semantics cannot be trusted. |
+| Unauthorized ancestor/sibling record | Excluded before planning; no id leakage. |
+| Sibling/merge context over budget | Omitted with metadata-only explanation. |
+
+This preserves fail-closed behavior where capability is explicitly advertised
+or metadata exists, while keeping older adapters compatible.
+
+## 9. Tests
+
+Use TDD. The first implementation plan must start with failing tests for:
+
+- pure `TreeReadWindow` lineage and branch-local ordering,
+- deterministic budget trimming with sibling and merge context,
+- legacy flat-session compatibility,
+- malformed tree abort behavior at the CLI/store boundary,
+- `retrieve --session` fixture showing ancestry plus branch-local context,
+- `assemble_hot --session --explain` showing safe branch-choice metadata when
+  available.
+
+Targeted verification for the branch:
+
+```bash
+cargo nextest run -p cairn-core tree_read_window
+cargo nextest run -p cairn-store-sqlite sessions
+cargo nextest run -p cairn-cli retrieve assemble_hot
+cargo check --workspace --all-targets --locked
+./scripts/check-core-boundary.sh
+```
+
+Before PR, run the full checklist from `AGENTS.md` that is relevant to changed
+IDL/docs/generated code.
+
+## 10. Deferred Trace Canvas
+
+The task-trace canvas addendum should become a follow-up design and PR after
+this read-window slice lands. It needs new storage tables, workflow locking,
+projection rebuild, lint checks, metrics, and exact retrieve keys. Mixing that
+with tree-aware read-window selection would make it difficult to review and
+hard to recover if one half needs redesign.

--- a/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
+++ b/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
@@ -33,15 +33,16 @@ and links the previous active node to the new node with a deterministic
 `depends_on` edge.
 
 The same module exposes `TraceCanvasPayload` and `TraceCanvasHandler` under
-`trace_canvas.materialize_step` so the scheduler can dispatch materialization
-jobs once capture enqueueing lands.
+`trace_canvas.materialize_step`, plus an idempotent enqueue helper. The
+`capture_trace` path now queues body-free tool-step materialization jobs after
+successful turn commits when a `JobStore` is available.
 
 ## Non-Goals
 
-This slice does not implement workflow materialization, hot-memory selection,
-lint checks, metric emission, exact retrieval keys, or search ranking changes.
-Those build on the schema and adapter-local helpers once the storage invariants
-are pinned.
+This slice does not implement hot-memory selection, lint checks, metric
+emission, exact retrieval keys, or search ranking changes. Those build on the
+schema, adapter-local helpers, and queued canvas materialization path once the
+storage invariants are pinned.
 
 ## Invariants
 

--- a/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
+++ b/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
@@ -26,6 +26,12 @@ workflow slice:
 - canvas, node, and edge upserts
 - active canvas context reads with deterministic node and edge ordering
 
+The workflows crate now adds a narrow `TraceCanvasMaterializer` helper that
+projects one trace step into the session's active canvas. It creates the active
+canvas if needed, writes the step and node, advances the active node pointer,
+and links the previous active node to the new node with a deterministic
+`depends_on` edge.
+
 ## Non-Goals
 
 This slice does not implement workflow materialization, hot-memory selection,

--- a/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
+++ b/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
@@ -11,18 +11,27 @@ brief sections that govern this area:
 - §10 Continuous Learning: projection and consolidation should be workflow
   driven, not ad hoc in read paths.
 
-The slice adds only the durable SQLite substrate:
+The slice adds the durable `SQLite` substrate:
 
 - `trace_steps`
 - `trace_canvases`
 - `trace_canvas_nodes`
 - `trace_canvas_edges`
 
+It also exposes adapter-local `SqliteMemoryStore` helpers for the next
+workflow slice:
+
+- idempotent trace-step upsert keyed by `(source_hash, tool_call_id)`
+- exact result-reference lookup for trace steps
+- canvas and node upserts
+- active canvas context reads with deterministic node ordering
+
 ## Non-Goals
 
 This slice does not implement workflow materialization, hot-memory selection,
 lint checks, metric emission, exact retrieval keys, or search ranking changes.
-Those build on the schema once the storage invariants are pinned.
+Those build on the schema and adapter-local helpers once the storage invariants
+are pinned.
 
 ## Invariants
 

--- a/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
+++ b/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
@@ -7,7 +7,8 @@ issue #134, after the tree-aware read-window work landed. It follows the design
 brief sections that govern this area:
 
 - §5.7 Sessions are trees: canvas context must remain session and branch aware.
-- §7 Hot Memory: canvas summaries will later feed the current-task segment.
+- §7 Hot Memory: canvas summaries feed the current-task portion of the hot
+  prefix through the existing v1 `recent_user_signal` recipe step.
 - §10 Continuous Learning: projection and consolidation should be workflow
   driven, not ad hoc in read paths.
 
@@ -37,11 +38,16 @@ The same module exposes `TraceCanvasPayload` and `TraceCanvasHandler` under
 `capture_trace` path now queues body-free tool-step materialization jobs after
 successful turn commits when a `JobStore` is available.
 
+`assemble_hot --session` reads the active trace canvas, when present, and
+renders a compact body-free `Current Task` section inside the existing
+`recent_user_signal` step. This keeps v1 wire compatibility while making
+materialized canvas state available at session start/resume.
+
 ## Non-Goals
 
-This slice does not implement hot-memory selection, lint checks, metric
-emission, exact retrieval keys, or search ranking changes. Those build on the
-schema, adapter-local helpers, and queued canvas materialization path once the
+This slice does not implement lint checks, metric emission, exact retrieval
+keys, or search ranking changes. Those build on the schema, adapter-local
+helpers, queued canvas materialization path, and hot-prefix rendering once the
 storage invariants are pinned.
 
 ## Invariants

--- a/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
+++ b/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
@@ -32,6 +32,10 @@ canvas if needed, writes the step and node, advances the active node pointer,
 and links the previous active node to the new node with a deterministic
 `depends_on` edge.
 
+The same module exposes `TraceCanvasPayload` and `TraceCanvasHandler` under
+`trace_canvas.materialize_step` so the scheduler can dispatch materialization
+jobs once capture enqueueing lands.
+
 ## Non-Goals
 
 This slice does not implement workflow materialization, hot-memory selection,

--- a/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
+++ b/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
@@ -1,0 +1,34 @@
+# Issue #134 Task-Trace Canvas Foundation
+
+## Scope
+
+This is the first implementation slice for the task-trace canvas addendum on
+issue #134, after the tree-aware read-window work landed. It follows the design
+brief sections that govern this area:
+
+- §5.7 Sessions are trees: canvas context must remain session and branch aware.
+- §7 Hot Memory: canvas summaries will later feed the current-task segment.
+- §10 Continuous Learning: projection and consolidation should be workflow
+  driven, not ad hoc in read paths.
+
+The slice adds only the durable SQLite substrate:
+
+- `trace_steps`
+- `trace_canvases`
+- `trace_canvas_nodes`
+- `trace_canvas_edges`
+
+## Non-Goals
+
+This slice does not implement workflow materialization, hot-memory selection,
+lint checks, metric emission, exact retrieval keys, or search ranking changes.
+Those build on the schema once the storage invariants are pinned.
+
+## Invariants
+
+- Trace-step replay is idempotent on `(source_hash, tool_call_id)`, with
+  missing tool-call IDs normalized by the unique expression index.
+- Canvas nodes must cite at least one source step.
+- Canvas edge kinds are closed and validated by the database.
+- Result references have a dedicated lookup index for later exact retrieve
+  paths.

--- a/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
+++ b/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
@@ -43,12 +43,16 @@ renders a compact body-free `Current Task` section inside the existing
 `recent_user_signal` step. This keeps v1 wire compatibility while making
 materialized canvas state available at session start/resume.
 
+`retrieve` now probes the trace-step `result_ref` index for returned records
+and emits body-free `trace_canvas.result_ref` policy metadata when exact
+trace-step links exist. The response shape stays unchanged.
+
 ## Non-Goals
 
-This slice does not implement lint checks, metric emission, exact retrieval
-keys, or search ranking changes. Those build on the schema, adapter-local
-helpers, queued canvas materialization path, and hot-prefix rendering once the
-storage invariants are pinned.
+This slice does not implement lint checks, metric emission, or search ranking
+changes. Those build on the schema, adapter-local helpers, queued canvas
+materialization path, hot-prefix rendering, and exact result-ref metadata once
+the storage invariants are pinned.
 
 ## Invariants
 

--- a/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
+++ b/docs/superpowers/specs/2026-05-17-issue-134-task-trace-canvas-foundation.md
@@ -23,8 +23,8 @@ workflow slice:
 
 - idempotent trace-step upsert keyed by `(source_hash, tool_call_id)`
 - exact result-reference lookup for trace steps
-- canvas and node upserts
-- active canvas context reads with deterministic node ordering
+- canvas, node, and edge upserts
+- active canvas context reads with deterministic node and edge ordering
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary

Adds the issue #134 trace-canvas substrate and threads it through hot-memory assembly so active task context can be included in `assemble_hot` via the existing `recent_user_signal` recipe path.

This includes:

- durable trace canvas, node, edge, step, and projection storage in SQLite
- trace-canvas materialization workflow support
- active trace-canvas rendering in `assemble_hot`, including compact fallback when budgets are tight
- retrieve-hint rendering for trace steps and result refs
- trace-canvas lint checks for broken result refs, missing/cross-canvas active nodes, and projection drift
- cache-key hardening so old clipped hot-prefix cache entries are not replayed after assembly semantics change
- body-free trace-canvas render metrics

## Why

The branch implements tree-aware task context for hot memory without adding a new wire verb. The key bug fixed near the end was that small-budget trace-canvas sections could be clipped and then cached, causing later requests to replay incomplete `# Current Task` sections or truncated retrieve hints.

## Validation

Fresh automated checks run before publishing:

- `cargo build -p cairn-cli --locked`
- Prior session verification also ran:
  - `cargo fmt --all --check`
  - `cargo clippy -p cairn-core -p cairn-cli --all-targets --locked -- -D warnings`
  - `cargo test -p cairn-core cache_key_hash_includes_assembly_semantics_version --locked`
  - `cargo test -p cairn-cli trace_canvas --locked`
  - `cargo build -p cairn-cli --locked`

Manual e2e on fresh vault `/tmp/cairn-manual-e2e.cUps0o`:

- bootstrapped a new vault and seeded identity through real `cairn ingest`
- seeded trace-canvas rows in the real migrated SQLite DB
- `assemble_hot --session ... --budget 100`: committed, 47 bytes, no partial `# Current` fragment
- `assemble_hot --session ... --budget 4096`: committed, 581 bytes, active canvas, active node, and complete retrieve hints present
- repeated `4096` run: same prefix, cache path stable
- no-session assemble: no session canvas leakage
- cross-session assemble: only the cross-session active canvas rendered
- empty session id rejected with `InvalidArgs`, process code `64`
- budget sweep `48, 120, 180, 240, 320, 800, 900, 1000, 1200, 1500, 2000`: all under budget; low budgets omitted the task section rather than clipping; `1000+` rendered complete compact hints
- `lint --json`: flagged the deliberately broken `result_ref` and cross-canvas active node, and did not flag the valid active node
- metrics assertion confirmed `trace_canvas_rendered` events did not leak node summary body text

## Notes

The branch is currently ahead of `main` but also behind it; I did not rebase as part of this publish step.

## Issue Closure

Closes #134. The blocking dependency #133 is already closed, and this PR covers the original tree-aware retrieve/summarize/assemble_hot scope plus the task-trace canvas addendum acceptance path.