### PR TITLE
feat(cli): add agent skill pack installer

### DIFF
--- a/crates/cairn-cli/src/command.rs
+++ b/crates/cairn-cli/src/command.rs
@@ -249,12 +249,26 @@ fn skill_subcommand() -> clap::Command {
                 .arg(
                     clap::Arg::new("harness")
                         .long("harness")
-                        .required(true)
                         .value_name("HARNESS")
                         .value_parser(clap::builder::EnumValueParser::<skill::Harness>::new())
                         .help(
                             "Target harness (claude-code, codex, gemini, opencode, cursor, custom)",
                         ),
+                )
+                .arg(
+                    clap::Arg::new("agent")
+                        .long("agent")
+                        .value_name("AGENT")
+                        .value_parser(clap::builder::EnumValueParser::<skill::Agent>::new())
+                        .conflicts_with_all(["harness", "all"])
+                        .help("Write generated agent integration files (claude-code, codex, kiro, cursor)"),
+                )
+                .arg(
+                    clap::Arg::new("all")
+                        .long("all")
+                        .action(clap::ArgAction::SetTrue)
+                        .conflicts_with_all(["harness", "agent"])
+                        .help("Write generated integration files for all supported agents"),
                 )
                 .arg(
                     clap::Arg::new("target-dir")
@@ -273,6 +287,11 @@ fn skill_subcommand() -> clap::Command {
                         .long("json")
                         .action(clap::ArgAction::SetTrue)
                         .help("Emit JSON receipt instead of human-readable output"),
+                )
+                .group(
+                    clap::ArgGroup::new("skill-install-target")
+                        .args(["harness", "agent", "all"])
+                        .required(true),
                 ),
         )
 }

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -1097,11 +1097,6 @@ fn run_setup_claude_code_remove(
 }
 
 fn run_skill_install(matches: &ArgMatches) -> ExitCode {
-    let harness = matches
-        .get_one::<cairn_cli::skill::Harness>("harness")
-        .expect("invariant: --harness is required by clap")
-        .clone();
-
     let target_dir = if let Some(path) = matches.get_one::<String>("target-dir") {
         std::path::PathBuf::from(path)
     } else {
@@ -1116,6 +1111,64 @@ fn run_skill_install(matches: &ArgMatches) -> ExitCode {
 
     let force = matches.get_flag("force");
     let json = matches.get_flag("json");
+
+    if matches.get_flag("all")
+        || matches
+            .get_one::<cairn_cli::skill::Agent>("agent")
+            .is_some()
+    {
+        let agents = if matches.get_flag("all") {
+            cairn_cli::skill::Agent::ALL.to_vec()
+        } else {
+            vec![
+                *matches
+                    .get_one::<cairn_cli::skill::Agent>("agent")
+                    .expect("invariant: skill-install-target requires --agent when present"),
+            ]
+        };
+        let harness = agents
+            .first()
+            .map(agent_default_harness)
+            .unwrap_or(cairn_cli::skill::Harness::ClaudeCode);
+        let project_dir = match std::env::current_dir() {
+            Ok(path) => path,
+            Err(e) => {
+                eprintln!("cairn skill install: failed to resolve current directory - {e}");
+                return ExitCode::from(69);
+            }
+        };
+        let opts = cairn_cli::skill::AgentInstallOpts {
+            target_dir,
+            project_dir,
+            agents,
+            harness,
+            force,
+        };
+
+        return match cairn_cli::skill::install_agent_pack(&opts) {
+            Ok(receipt) => {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&receipt)
+                            .expect("invariant: AgentInstallReceipt is always serializable")
+                    );
+                } else {
+                    println!("{}", cairn_cli::skill::render_agent_human(&receipt));
+                }
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("cairn skill install: {e:#}");
+                ExitCode::from(74)
+            }
+        };
+    }
+
+    let harness = matches
+        .get_one::<cairn_cli::skill::Harness>("harness")
+        .expect("invariant: skill-install-target requires --harness without --agent/--all")
+        .clone();
 
     let opts = cairn_cli::skill::InstallOpts {
         target_dir,
@@ -1140,6 +1193,15 @@ fn run_skill_install(matches: &ArgMatches) -> ExitCode {
             eprintln!("cairn skill install: {e:#}");
             ExitCode::from(74) // EX_IOERR
         }
+    }
+}
+
+fn agent_default_harness(agent: &cairn_cli::skill::Agent) -> cairn_cli::skill::Harness {
+    match agent {
+        cairn_cli::skill::Agent::ClaudeCode => cairn_cli::skill::Harness::ClaudeCode,
+        cairn_cli::skill::Agent::Codex => cairn_cli::skill::Harness::Codex,
+        cairn_cli::skill::Agent::Kiro => cairn_cli::skill::Harness::Custom,
+        cairn_cli::skill::Agent::Cursor => cairn_cli::skill::Harness::Cursor,
     }
 }
 

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -1128,8 +1128,8 @@ fn run_skill_install(matches: &ArgMatches) -> ExitCode {
         };
         let harness = agents
             .first()
-            .map(agent_default_harness)
-            .unwrap_or(cairn_cli::skill::Harness::ClaudeCode);
+            .copied()
+            .map_or(cairn_cli::skill::Harness::ClaudeCode, agent_default_harness);
         let project_dir = match std::env::current_dir() {
             Ok(path) => path,
             Err(e) => {
@@ -1196,7 +1196,7 @@ fn run_skill_install(matches: &ArgMatches) -> ExitCode {
     }
 }
 
-fn agent_default_harness(agent: &cairn_cli::skill::Agent) -> cairn_cli::skill::Harness {
+fn agent_default_harness(agent: cairn_cli::skill::Agent) -> cairn_cli::skill::Harness {
     match agent {
         cairn_cli::skill::Agent::ClaudeCode => cairn_cli::skill::Harness::ClaudeCode,
         cairn_cli::skill::Agent::Codex => cairn_cli::skill::Harness::Codex,

--- a/crates/cairn-cli/src/skill.rs
+++ b/crates/cairn-cli/src/skill.rs
@@ -66,6 +66,8 @@ impl Agent {
 
 const AGENT_BLOCK_BEGIN: &str = "<!-- BEGIN CAIRN AGENT SKILL -->";
 const AGENT_BLOCK_END: &str = "<!-- END CAIRN AGENT SKILL -->";
+const SESSION_START_HOOK_COMMAND: &str =
+    "cairn ingest --folder . --mode keyword >/tmp/cairn-session-start.log 2>&1 &";
 
 fn render_agent_markdown_block(agent: Agent) -> String {
     format!(
@@ -665,6 +667,14 @@ fn install_claude_code_integration(
         &render_agent_markdown_block(Agent::ClaudeCode),
         &mut receipt,
     )?;
+    for (name, content) in claude_slash_commands() {
+        write_generated_guarded_file(
+            &project_dir.join(".claude/commands").join(name),
+            content,
+            force,
+            &mut receipt,
+        )?;
+    }
     Ok(receipt)
 }
 
@@ -711,8 +721,76 @@ fn install_cursor_integration(
         force,
         &mut receipt,
     )?;
+    write_guarded_markdown(
+        &project_dir.join(".cursorrules"),
+        &render_agent_markdown_block(Agent::Cursor),
+        &mut receipt,
+    )?;
     Ok(receipt)
 }
+
+fn claude_slash_commands() -> [(&'static str, &'static str); 4] {
+    [
+        ("remember.md", CLAUDE_REMEMBER_COMMAND),
+        ("forget.md", CLAUDE_FORGET_COMMAND),
+        ("recall.md", CLAUDE_RECALL_COMMAND),
+        ("graph.md", CLAUDE_GRAPH_COMMAND),
+    ]
+}
+
+const CLAUDE_REMEMBER_COMMAND: &str = r#"---
+description: Remember durable project context in Cairn
+argument-hint: <memory>
+---
+
+<!-- BEGIN CAIRN AGENT SKILL -->
+Store the user's provided memory in Cairn.
+
+Run:
+`cairn ingest --kind user --body "$ARGUMENTS"`
+<!-- END CAIRN AGENT SKILL -->
+"#;
+
+const CLAUDE_FORGET_COMMAND: &str = r#"---
+description: Forget a Cairn record after explicit confirmation
+argument-hint: <record-id>
+---
+
+<!-- BEGIN CAIRN AGENT SKILL -->
+Confirm the user wants to forget the named Cairn record, then run:
+
+`cairn forget --record "$ARGUMENTS"`
+<!-- END CAIRN AGENT SKILL -->
+"#;
+
+const CLAUDE_RECALL_COMMAND: &str = r#"---
+description: Search and retrieve relevant Cairn memory
+argument-hint: <query>
+---
+
+<!-- BEGIN CAIRN AGENT SKILL -->
+Search Cairn for relevant memory, then retrieve exact records when needed.
+
+Start with:
+`cairn search --mode keyword "$ARGUMENTS"`
+
+Then run:
+`cairn retrieve <record-id>`
+<!-- END CAIRN AGENT SKILL -->
+"#;
+
+const CLAUDE_GRAPH_COMMAND: &str = r#"---
+description: Explore non-obvious Cairn graph connections
+argument-hint: <entity-ids>
+---
+
+<!-- BEGIN CAIRN AGENT SKILL -->
+Use the MCP graph tools for non-obvious connections between known entity ids.
+
+Prefer `graph.surprising_connections` when comparing multiple entities.
+Do not use graph tools for ordinary file reads or code execution.
+<!-- END CAIRN AGENT SKILL -->
+"#;
 
 impl AgentIntegrationReceipt {
     fn new(agent: Agent) -> Self {
@@ -761,7 +839,7 @@ fn merged_claude_hooks(existing: Option<serde_json::Value>) -> serde_json::Value
         "SessionStart".to_owned(),
         serde_json::json!([
             {
-                "command": "cairn ingest --folder . --mode keyword"
+                "command": SESSION_START_HOOK_COMMAND
             }
         ]),
     );
@@ -1112,6 +1190,70 @@ mod tests {
         assert!(project.join(".kiro/steering/cairn.md").exists());
         assert!(project.join(".cursor/rules/cairn.mdc").exists());
         assert_eq!(receipt.integrations.len(), 4);
+    }
+
+    #[test]
+    fn install_agent_pack_claude_writes_slash_commands_and_background_hook() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).expect("project dir");
+        let target = tmp.path().join("skills/cairn");
+
+        install_agent_pack(&AgentInstallOpts {
+            target_dir: target,
+            project_dir: project.clone(),
+            agents: vec![Agent::ClaudeCode],
+            harness: Harness::ClaudeCode,
+            force: false,
+        })
+        .expect("install Claude Code agent pack");
+
+        let settings: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(project.join(".claude/settings.json")).expect("settings"),
+        )
+        .expect("settings json");
+        let command = settings["hooks"]["SessionStart"][0]["command"]
+            .as_str()
+            .expect("SessionStart command");
+        assert!(command.contains("cairn ingest --folder . --mode keyword"));
+        assert!(
+            command.trim_end().ends_with('&'),
+            "session-start hook should run in the background: {command}"
+        );
+
+        let commands = project.join(".claude/commands");
+        let remember =
+            std::fs::read_to_string(commands.join("remember.md")).expect("remember command");
+        let forget = std::fs::read_to_string(commands.join("forget.md")).expect("forget command");
+        let recall = std::fs::read_to_string(commands.join("recall.md")).expect("recall command");
+        let graph = std::fs::read_to_string(commands.join("graph.md")).expect("graph command");
+        assert!(remember.contains("cairn ingest"));
+        assert!(forget.contains("cairn forget"));
+        assert!(recall.contains("cairn retrieve"));
+        assert!(graph.contains("graph.surprising_connections"));
+    }
+
+    #[test]
+    fn install_agent_pack_cursor_writes_modern_and_legacy_rules() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).expect("project dir");
+        let target = tmp.path().join("skills/cairn");
+
+        install_agent_pack(&AgentInstallOpts {
+            target_dir: target,
+            project_dir: project.clone(),
+            agents: vec![Agent::Cursor],
+            harness: Harness::Cursor,
+            force: false,
+        })
+        .expect("install Cursor agent pack");
+
+        assert!(project.join(".cursor/rules/cairn.mdc").exists());
+        let cursorrules =
+            std::fs::read_to_string(project.join(".cursorrules")).expect(".cursorrules");
+        assert!(cursorrules.contains("<!-- BEGIN CAIRN AGENT SKILL -->"));
+        assert!(cursorrules.contains("cairn ingest --folder . --mode keyword"));
     }
 
     #[test]

--- a/crates/cairn-cli/src/skill.rs
+++ b/crates/cairn-cli/src/skill.rs
@@ -857,15 +857,44 @@ fn merged_claude_hooks(existing: Option<serde_json::Value>) -> serde_json::Value
     let mut hooks = existing
         .and_then(|value| value.as_object().cloned())
         .unwrap_or_default();
-    hooks.insert(
-        "SessionStart".to_owned(),
-        serde_json::json!([
+    let cairn_hook = serde_json::json!({"command": SESSION_START_HOOK_COMMAND});
+    match hooks.remove("SessionStart") {
+        Some(serde_json::Value::Array(mut session_start)) => {
+            if !session_start
+                .iter()
+                .any(|hook| hook_contains_command(hook, SESSION_START_HOOK_COMMAND))
             {
-                "command": SESSION_START_HOOK_COMMAND
+                session_start.push(cairn_hook);
             }
-        ]),
-    );
+            hooks.insert(
+                "SessionStart".to_owned(),
+                serde_json::Value::Array(session_start),
+            );
+        }
+        Some(existing_session_start) => {
+            hooks.insert(
+                "SessionStart".to_owned(),
+                serde_json::json!([existing_session_start, cairn_hook]),
+            );
+        }
+        None => {
+            hooks.insert("SessionStart".to_owned(), serde_json::json!([cairn_hook]));
+        }
+    }
     serde_json::Value::Object(hooks)
+}
+
+fn hook_contains_command(value: &serde_json::Value, command: &str) -> bool {
+    match value {
+        serde_json::Value::String(s) => s == command,
+        serde_json::Value::Array(values) => values
+            .iter()
+            .any(|value| hook_contains_command(value, command)),
+        serde_json::Value::Object(map) => map
+            .values()
+            .any(|value| hook_contains_command(value, command)),
+        _ => false,
+    }
 }
 
 fn write_guarded_markdown(
@@ -1306,6 +1335,28 @@ mod tests {
         );
         let rendered = serde_json::to_string(&merged).expect("json");
         assert!(rendered.contains("cairn ingest --folder . --mode keyword"));
+    }
+
+    #[test]
+    fn claude_settings_merge_preserves_existing_session_start_hooks() {
+        let existing = serde_json::json!({
+            "hooks": {
+                "SessionStart": [{"command": "echo existing"}],
+                "Stop": [{"command": "echo stop"}]
+            }
+        });
+        let merged = merge_claude_settings(existing).expect("merge settings");
+
+        let session_start = merged["hooks"]["SessionStart"]
+            .as_array()
+            .expect("SessionStart hooks array");
+        assert_eq!(session_start[0]["command"], "echo existing");
+        assert!(
+            session_start
+                .iter()
+                .any(|hook| hook["command"] == SESSION_START_HOOK_COMMAND)
+        );
+        assert_eq!(merged["hooks"]["Stop"][0]["command"], "echo stop");
     }
 
     #[test]

--- a/crates/cairn-cli/src/skill.rs
+++ b/crates/cairn-cli/src/skill.rs
@@ -24,6 +24,94 @@ pub enum Harness {
     Custom,
 }
 
+/// Agents with first-slice generated skill-pack integrations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum Agent {
+    /// Claude Code project integration.
+    #[value(name = "claude-code")]
+    ClaudeCode,
+    /// Codex/OpenCode project instructions.
+    Codex,
+    /// Kiro always-included steering file.
+    Kiro,
+    /// Cursor always-applied rule file.
+    Cursor,
+}
+
+impl Agent {
+    /// First-slice agents in deterministic receipt order.
+    pub const ALL: [Self; 4] = [Self::ClaudeCode, Self::Codex, Self::Kiro, Self::Cursor];
+
+    /// Compatibility mapping from the older issue #68 harness flag.
+    #[must_use]
+    pub const fn from_harness(harness: &Harness) -> Option<Self> {
+        match harness {
+            Harness::ClaudeCode => Some(Self::ClaudeCode),
+            Harness::Codex => Some(Self::Codex),
+            Harness::Cursor => Some(Self::Cursor),
+            Harness::Gemini | Harness::Opencode | Harness::Custom => None,
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "Claude Code",
+            Self::Codex => "Codex / OpenCode",
+            Self::Kiro => "Kiro",
+            Self::Cursor => "Cursor",
+        }
+    }
+}
+
+const AGENT_BLOCK_BEGIN: &str = "<!-- BEGIN CAIRN AGENT SKILL -->";
+const AGENT_BLOCK_END: &str = "<!-- END CAIRN AGENT SKILL -->";
+
+fn render_agent_markdown_block(agent: Agent) -> String {
+    format!(
+        "{AGENT_BLOCK_BEGIN}\n\
+         ## Cairn Memory Layer ({label})\n\n\
+         Cairn is the persistent memory and knowledge-graph layer for this project.\n\n\
+         - Use Cairn when persistent memory, recall from previous sessions, or graph-aware connections would help.\n\
+         - Do not use Cairn tools for ordinary file reads or code execution.\n\
+         - Prefer exact `cairn search` / `cairn retrieve` paths when the user names a known record or concept; use graph exploration only for non-obvious connections.\n\
+         - At session start, run `cairn ingest --folder . --mode keyword` in the project root.\n\
+         - Use `cairn assemble_hot` when you need a hot-memory prefix for the current session.\n\
+         - `/remember` maps to `cairn ingest`; `/forget` maps to `cairn forget` after explicit user confirmation.\n\
+         {AGENT_BLOCK_END}\n",
+        label = agent.label()
+    )
+}
+
+fn upsert_guarded_markdown(existing: &str, block: &str) -> String {
+    if let Some(start) = existing.find(AGENT_BLOCK_BEGIN)
+        && let Some(end_rel) = existing[start..].find(AGENT_BLOCK_END)
+    {
+        let end = start + end_rel + AGENT_BLOCK_END.len();
+        let mut out = String::new();
+        out.push_str(&existing[..start]);
+        out.push_str(block.trim_end());
+        out.push('\n');
+        out.push_str(&existing[end..]);
+        return ensure_trailing_newline(out);
+    }
+
+    let mut out = ensure_trailing_newline(existing.to_owned());
+    if !out.trim().is_empty() {
+        out.push('\n');
+    }
+    out.push_str(block.trim_end());
+    out.push('\n');
+    out
+}
+
+fn ensure_trailing_newline(mut text: String) -> String {
+    if !text.is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text
+}
+
 /// Returns the harness-specific registration hint for the actual install path.
 ///
 /// The hint uses `target_dir` so that `--target-dir` installs produce a hint
@@ -84,6 +172,43 @@ pub struct InstallReceipt {
     pub files_skipped: Vec<PathBuf>,
     /// Harness-specific registration hint for the user.
     pub registration_hint: String,
+}
+
+/// Options for installing the skill bundle plus generated agent integrations.
+#[derive(Debug, Clone)]
+pub struct AgentInstallOpts {
+    /// Target directory for the shared Cairn skill bundle.
+    pub target_dir: PathBuf,
+    /// Project directory where harness integration files are written.
+    pub project_dir: PathBuf,
+    /// Agents to write integrations for.
+    pub agents: Vec<Agent>,
+    /// Compatibility harness used for the shared bundle registration hint.
+    pub harness: Harness,
+    /// If `true`, overwrite generated files even if the version matches.
+    pub force: bool,
+}
+
+/// Result of a skill bundle plus agent integration install.
+#[derive(Debug, serde::Serialize)]
+pub struct AgentInstallReceipt {
+    /// Receipt from the shared skill bundle install.
+    pub bundle: InstallReceipt,
+    /// Per-agent generated integration writes.
+    pub integrations: Vec<AgentIntegrationReceipt>,
+}
+
+/// Files written for one generated agent integration.
+#[derive(Debug, serde::Serialize)]
+pub struct AgentIntegrationReceipt {
+    /// Agent integration that was installed.
+    pub agent: Agent,
+    /// New files created during the integration write.
+    pub files_created: Vec<PathBuf>,
+    /// Existing files updated during the integration write.
+    pub files_updated: Vec<PathBuf>,
+    /// Files left unchanged because generated content already matched.
+    pub files_skipped: Vec<PathBuf>,
 }
 
 /// Resolves the default install directory (`~/.cairn/skills/cairn/`).
@@ -484,6 +609,227 @@ pub fn install(opts: &InstallOpts) -> Result<InstallReceipt> {
     })
 }
 
+/// Install the Cairn skill bundle and generated agent integration files.
+///
+/// # Errors
+/// Returns an error if the shared bundle install fails, an integration file
+/// cannot be read or written, or a JSON integration file is malformed.
+pub fn install_agent_pack(opts: &AgentInstallOpts) -> Result<AgentInstallReceipt> {
+    let bundle = install(&InstallOpts {
+        target_dir: opts.target_dir.clone(),
+        harness: opts.harness.clone(),
+        force: opts.force,
+    })?;
+    let project_dir = if opts.project_dir.is_absolute() {
+        opts.project_dir.components().collect::<PathBuf>()
+    } else {
+        std::env::current_dir()
+            .context("resolving current directory for project path")?
+            .join(&opts.project_dir)
+            .components()
+            .collect::<PathBuf>()
+    };
+
+    let mut integrations = Vec::new();
+    for agent in &opts.agents {
+        integrations.push(match agent {
+            Agent::ClaudeCode => install_claude_code_integration(&project_dir, opts.force)?,
+            Agent::Codex => install_codex_integration(&project_dir)?,
+            Agent::Kiro => install_kiro_integration(&project_dir, opts.force)?,
+            Agent::Cursor => install_cursor_integration(&project_dir, opts.force)?,
+        });
+    }
+
+    Ok(AgentInstallReceipt {
+        bundle,
+        integrations,
+    })
+}
+
+fn install_claude_code_integration(
+    project_dir: &std::path::Path,
+    force: bool,
+) -> Result<AgentIntegrationReceipt> {
+    let mut receipt = AgentIntegrationReceipt::new(Agent::ClaudeCode);
+    let settings_path = project_dir.join(".claude/settings.json");
+    let existing = read_json_or_empty(&settings_path)?;
+    let merged = merge_claude_settings(existing)?;
+    let settings = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&merged).context("serializing Claude Code settings JSON")?
+    );
+    write_if_changed(&settings_path, &settings, force, &mut receipt)?;
+
+    write_guarded_markdown(
+        &project_dir.join("CLAUDE.md"),
+        &render_agent_markdown_block(Agent::ClaudeCode),
+        &mut receipt,
+    )?;
+    Ok(receipt)
+}
+
+fn install_codex_integration(project_dir: &std::path::Path) -> Result<AgentIntegrationReceipt> {
+    let mut receipt = AgentIntegrationReceipt::new(Agent::Codex);
+    write_guarded_markdown(
+        &project_dir.join("AGENTS.md"),
+        &render_agent_markdown_block(Agent::Codex),
+        &mut receipt,
+    )?;
+    Ok(receipt)
+}
+
+fn install_kiro_integration(
+    project_dir: &std::path::Path,
+    force: bool,
+) -> Result<AgentIntegrationReceipt> {
+    let mut receipt = AgentIntegrationReceipt::new(Agent::Kiro);
+    let content = format!(
+        "---\ninclusion: always\n---\n\n{}",
+        render_agent_markdown_block(Agent::Kiro)
+    );
+    write_generated_guarded_file(
+        &project_dir.join(".kiro/steering/cairn.md"),
+        &content,
+        force,
+        &mut receipt,
+    )?;
+    Ok(receipt)
+}
+
+fn install_cursor_integration(
+    project_dir: &std::path::Path,
+    force: bool,
+) -> Result<AgentIntegrationReceipt> {
+    let mut receipt = AgentIntegrationReceipt::new(Agent::Cursor);
+    let content = format!(
+        "---\nalwaysApply: true\n---\n\n{}",
+        render_agent_markdown_block(Agent::Cursor)
+    );
+    write_generated_guarded_file(
+        &project_dir.join(".cursor/rules/cairn.mdc"),
+        &content,
+        force,
+        &mut receipt,
+    )?;
+    Ok(receipt)
+}
+
+impl AgentIntegrationReceipt {
+    fn new(agent: Agent) -> Self {
+        Self {
+            agent,
+            files_created: Vec::new(),
+            files_updated: Vec::new(),
+            files_skipped: Vec::new(),
+        }
+    }
+}
+
+fn read_json_or_empty(path: &std::path::Path) -> Result<serde_json::Value> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => serde_json::from_str(&content)
+            .with_context(|| format!("parsing JSON from {}", path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(serde_json::json!({})),
+        Err(e) => Err(anyhow::Error::from(e).context(format!("reading {}", path.display()))),
+    }
+}
+
+fn merge_claude_settings(mut value: serde_json::Value) -> Result<serde_json::Value> {
+    let root = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Claude Code settings root must be a JSON object"))?;
+    let servers = root
+        .entry("mcpServers")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Claude Code mcpServers must be a JSON object"))?;
+    servers.insert(
+        "cairn".to_owned(),
+        serde_json::json!({"command": "cairn", "args": ["mcp"]}),
+    );
+
+    let hooks = root.remove("hooks");
+    root.insert("hooks".to_owned(), merged_claude_hooks(hooks));
+    Ok(value)
+}
+
+fn merged_claude_hooks(existing: Option<serde_json::Value>) -> serde_json::Value {
+    let mut hooks = existing
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    hooks.insert(
+        "SessionStart".to_owned(),
+        serde_json::json!([
+            {
+                "command": "cairn ingest --folder . --mode keyword"
+            }
+        ]),
+    );
+    serde_json::Value::Object(hooks)
+}
+
+fn write_guarded_markdown(
+    path: &std::path::Path,
+    block: &str,
+    receipt: &mut AgentIntegrationReceipt,
+) -> Result<()> {
+    let existing = read_optional_string(path)?;
+    let updated = upsert_guarded_markdown(existing.as_deref().unwrap_or(""), block);
+    write_if_changed(path, &updated, false, receipt)
+}
+
+fn write_generated_guarded_file(
+    path: &std::path::Path,
+    content: &str,
+    force: bool,
+    receipt: &mut AgentIntegrationReceipt,
+) -> Result<()> {
+    if !force
+        && let Some(existing) = read_optional_string(path)?
+        && !existing.contains(AGENT_BLOCK_BEGIN)
+        && existing.trim() != content.trim()
+    {
+        anyhow::bail!(
+            "{} exists without a Cairn guard; pass --force to overwrite it",
+            path.display()
+        );
+    }
+    write_if_changed(path, content, force, receipt)
+}
+
+fn write_if_changed(
+    path: &std::path::Path,
+    content: &str,
+    force: bool,
+    receipt: &mut AgentIntegrationReceipt,
+) -> Result<()> {
+    let existing = read_optional_string(path)?;
+    if !force && existing.as_deref() == Some(content) {
+        receipt.files_skipped.push(path.to_path_buf());
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
+    }
+    std::fs::write(path, content).with_context(|| format!("writing {}", path.display()))?;
+    if existing.is_some() {
+        receipt.files_updated.push(path.to_path_buf());
+    } else {
+        receipt.files_created.push(path.to_path_buf());
+    }
+    Ok(())
+}
+
+fn read_optional_string(path: &std::path::Path) -> Result<Option<String>> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(anyhow::Error::from(e).context(format!("reading {}", path.display()))),
+    }
+}
+
 /// Renders a human-readable summary of an install receipt.
 #[must_use]
 pub fn render_human(receipt: &InstallReceipt) -> String {
@@ -523,6 +869,26 @@ pub fn render_human(receipt: &InstallReceipt) -> String {
         }
     }
 
+    lines.join("\n")
+}
+
+/// Renders a human-readable summary of an agent-pack install receipt.
+#[must_use]
+pub fn render_agent_human(receipt: &AgentInstallReceipt) -> String {
+    let mut lines = vec![render_human(&receipt.bundle)];
+    for integration in &receipt.integrations {
+        lines.push(String::new());
+        lines.push(format!("{} integration:", integration.agent.label()));
+        for path in &integration.files_created {
+            lines.push(format!("  {}  [created]", path.display()));
+        }
+        for path in &integration.files_updated {
+            lines.push(format!("  {}  [updated]", path.display()));
+        }
+        for path in &integration.files_skipped {
+            lines.push(format!("  {}  [skipped]", path.display()));
+        }
+    }
     lines.join("\n")
 }
 
@@ -617,6 +983,167 @@ mod tests {
                 "hint for {harness:?} should mention '{expected_fragment}' — got: {hint:?}"
             );
         }
+    }
+
+    #[test]
+    fn agent_values_render_expected_fragments() {
+        assert_eq!(
+            Agent::ClaudeCode
+                .to_possible_value()
+                .expect("possible value")
+                .get_name(),
+            "claude-code"
+        );
+        assert_eq!(
+            Agent::Codex
+                .to_possible_value()
+                .expect("possible value")
+                .get_name(),
+            "codex"
+        );
+        assert_eq!(
+            Agent::Kiro
+                .to_possible_value()
+                .expect("possible value")
+                .get_name(),
+            "kiro"
+        );
+        assert_eq!(
+            Agent::Cursor
+                .to_possible_value()
+                .expect("possible value")
+                .get_name(),
+            "cursor"
+        );
+
+        let block = render_agent_markdown_block(Agent::Codex);
+        assert!(block.contains("<!-- BEGIN CAIRN AGENT SKILL -->"));
+        assert!(block.contains("cairn ingest --folder . --mode keyword"));
+        assert!(
+            block.contains("Do not use Cairn tools for ordinary file reads or code execution.")
+        );
+        assert!(block.contains("/remember"));
+        assert!(block.contains("/forget"));
+    }
+
+    #[test]
+    fn harness_maps_to_first_slice_agent_when_supported() {
+        assert_eq!(
+            Agent::from_harness(&Harness::ClaudeCode),
+            Some(Agent::ClaudeCode)
+        );
+        assert_eq!(Agent::from_harness(&Harness::Codex), Some(Agent::Codex));
+        assert_eq!(Agent::from_harness(&Harness::Cursor), Some(Agent::Cursor));
+        assert_eq!(Agent::from_harness(&Harness::Gemini), None);
+        assert_eq!(Agent::from_harness(&Harness::Opencode), None);
+        assert_eq!(Agent::from_harness(&Harness::Custom), None);
+    }
+
+    #[test]
+    fn guarded_markdown_appends_to_user_content() {
+        let original = "# Existing\n\nKeep me.\n";
+        let block = render_agent_markdown_block(Agent::Codex);
+        let updated = upsert_guarded_markdown(original, &block);
+
+        assert!(updated.starts_with(original));
+        assert!(updated.contains("<!-- BEGIN CAIRN AGENT SKILL -->"));
+        assert!(updated.ends_with('\n'));
+    }
+
+    #[test]
+    fn guarded_markdown_replaces_existing_block_once() {
+        let old = "# Existing\n\n<!-- BEGIN CAIRN AGENT SKILL -->\nold\n<!-- END CAIRN AGENT SKILL -->\n\nTail\n";
+        let block = render_agent_markdown_block(Agent::Codex);
+        let updated = upsert_guarded_markdown(old, &block);
+
+        assert!(updated.contains("# Existing"));
+        assert!(updated.contains("Tail"));
+        assert!(!updated.contains("\nold\n"));
+        assert_eq!(
+            updated.matches("<!-- BEGIN CAIRN AGENT SKILL -->").count(),
+            1
+        );
+    }
+
+    #[test]
+    fn install_agent_pack_codex_writes_agents_md_and_bundle() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).expect("project dir");
+        std::fs::write(project.join("AGENTS.md"), "# Project\n").expect("seed agents");
+        let target = tmp.path().join("skills/cairn");
+
+        let receipt = install_agent_pack(&AgentInstallOpts {
+            target_dir: target.clone(),
+            project_dir: project.clone(),
+            agents: vec![Agent::Codex],
+            harness: Harness::Codex,
+            force: false,
+        })
+        .expect("install codex agent pack");
+
+        assert!(target.join("SKILL.md").exists());
+        let agents = std::fs::read_to_string(project.join("AGENTS.md")).expect("read agents");
+        assert!(agents.contains("# Project"));
+        assert!(agents.contains("<!-- BEGIN CAIRN AGENT SKILL -->"));
+        assert_eq!(receipt.integrations.len(), 1);
+        assert_eq!(receipt.integrations[0].agent, Agent::Codex);
+    }
+
+    #[test]
+    fn install_agent_pack_all_writes_first_slice_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().join("project");
+        std::fs::create_dir_all(&project).expect("project dir");
+        let target = tmp.path().join("skills/cairn");
+
+        let receipt = install_agent_pack(&AgentInstallOpts {
+            target_dir: target,
+            project_dir: project.clone(),
+            agents: Agent::ALL.to_vec(),
+            harness: Harness::ClaudeCode,
+            force: false,
+        })
+        .expect("install all agent packs");
+
+        assert!(project.join(".claude/settings.json").exists());
+        assert!(project.join("CLAUDE.md").exists());
+        assert!(project.join("AGENTS.md").exists());
+        assert!(project.join(".kiro/steering/cairn.md").exists());
+        assert!(project.join(".cursor/rules/cairn.mdc").exists());
+        assert_eq!(receipt.integrations.len(), 4);
+    }
+
+    #[test]
+    fn claude_settings_merge_preserves_unrelated_keys() {
+        let existing = serde_json::json!({
+            "theme": "dark",
+            "mcpServers": {
+                "other": {"command": "other", "args": []}
+            }
+        });
+        let merged = merge_claude_settings(existing).expect("merge settings");
+
+        assert_eq!(merged["theme"], "dark");
+        assert_eq!(merged["mcpServers"]["other"]["command"], "other");
+        assert_eq!(merged["mcpServers"]["cairn"]["command"], "cairn");
+        assert_eq!(
+            merged["mcpServers"]["cairn"]["args"],
+            serde_json::json!(["mcp"])
+        );
+        let rendered = serde_json::to_string(&merged).expect("json");
+        assert!(rendered.contains("cairn ingest --folder . --mode keyword"));
+    }
+
+    #[test]
+    fn agent_markdown_block_snapshot() {
+        insta::assert_snapshot!(render_agent_markdown_block(Agent::Codex));
+    }
+
+    #[test]
+    fn claude_settings_snapshot() {
+        let merged = merge_claude_settings(serde_json::json!({})).expect("merge");
+        insta::assert_json_snapshot!(merged);
     }
 
     // Task 7: idempotency and version-same skip tests

--- a/crates/cairn-cli/src/skill.rs
+++ b/crates/cairn-cli/src/skill.rs
@@ -662,6 +662,15 @@ fn install_claude_code_integration(
     );
     write_if_changed(&settings_path, &settings, force, &mut receipt)?;
 
+    let project_mcp_path = project_dir.join(".mcp.json");
+    let existing_mcp = read_json_or_empty(&project_mcp_path)?;
+    let merged_mcp = merge_project_mcp_json(existing_mcp)?;
+    let project_mcp = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&merged_mcp).context("serializing project MCP JSON")?
+    );
+    write_if_changed(&project_mcp_path, &project_mcp, force, &mut receipt)?;
+
     write_guarded_markdown(
         &project_dir.join("CLAUDE.md"),
         &render_agent_markdown_block(Agent::ClaudeCode),
@@ -816,19 +825,32 @@ fn merge_claude_settings(mut value: serde_json::Value) -> Result<serde_json::Val
     let root = value
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("Claude Code settings root must be a JSON object"))?;
-    let servers = root
-        .entry("mcpServers")
-        .or_insert_with(|| serde_json::json!({}))
-        .as_object_mut()
-        .ok_or_else(|| anyhow::anyhow!("Claude Code mcpServers must be a JSON object"))?;
-    servers.insert(
-        "cairn".to_owned(),
-        serde_json::json!({"command": "cairn", "args": ["mcp"]}),
-    );
+    insert_cairn_mcp_server(root)?;
 
     let hooks = root.remove("hooks");
     root.insert("hooks".to_owned(), merged_claude_hooks(hooks));
     Ok(value)
+}
+
+fn merge_project_mcp_json(mut value: serde_json::Value) -> Result<serde_json::Value> {
+    let root = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("project .mcp.json root must be a JSON object"))?;
+    insert_cairn_mcp_server(root)?;
+    Ok(value)
+}
+
+fn insert_cairn_mcp_server(root: &mut serde_json::Map<String, serde_json::Value>) -> Result<()> {
+    let servers = root
+        .entry("mcpServers")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("mcpServers must be a JSON object"))?;
+    servers.insert(
+        "cairn".to_owned(),
+        serde_json::json!({"command": "cairn", "args": ["mcp"]}),
+    );
+    Ok(())
 }
 
 fn merged_claude_hooks(existing: Option<serde_json::Value>) -> serde_json::Value {
@@ -1212,6 +1234,15 @@ mod tests {
             &std::fs::read_to_string(project.join(".claude/settings.json")).expect("settings"),
         )
         .expect("settings json");
+        let mcp: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).expect("mcp"))
+                .expect("mcp json");
+        assert_eq!(mcp["mcpServers"]["cairn"]["command"], "cairn");
+        assert_eq!(
+            mcp["mcpServers"]["cairn"]["args"],
+            serde_json::json!(["mcp"])
+        );
+
         let command = settings["hooks"]["SessionStart"][0]["command"]
             .as_str()
             .expect("SessionStart command");

--- a/crates/cairn-cli/src/skill.rs
+++ b/crates/cairn-cli/src/skill.rs
@@ -788,7 +788,7 @@ Then run:
 <!-- END CAIRN AGENT SKILL -->
 "#;
 
-const CLAUDE_GRAPH_COMMAND: &str = r#"---
+const CLAUDE_GRAPH_COMMAND: &str = r"---
 description: Explore non-obvious Cairn graph connections
 argument-hint: <entity-ids>
 ---
@@ -799,7 +799,7 @@ Use the MCP graph tools for non-obvious connections between known entity ids.
 Prefer `graph.surprising_connections` when comparing multiple entities.
 Do not use graph tools for ordinary file reads or code execution.
 <!-- END CAIRN AGENT SKILL -->
-"#;
+";
 
 impl AgentIntegrationReceipt {
     fn new(agent: Agent) -> Self {

--- a/crates/cairn-cli/src/snapshots/cairn_cli__skill__tests__agent_markdown_block_snapshot.snap
+++ b/crates/cairn-cli/src/snapshots/cairn_cli__skill__tests__agent_markdown_block_snapshot.snap
@@ -1,0 +1,16 @@
+---
+source: crates/cairn-cli/src/skill.rs
+expression: "render_agent_markdown_block(Agent::Codex)"
+---
+<!-- BEGIN CAIRN AGENT SKILL -->
+## Cairn Memory Layer (Codex / OpenCode)
+
+Cairn is the persistent memory and knowledge-graph layer for this project.
+
+- Use Cairn when persistent memory, recall from previous sessions, or graph-aware connections would help.
+- Do not use Cairn tools for ordinary file reads or code execution.
+- Prefer exact `cairn search` / `cairn retrieve` paths when the user names a known record or concept; use graph exploration only for non-obvious connections.
+- At session start, run `cairn ingest --folder . --mode keyword` in the project root.
+- Use `cairn assemble_hot` when you need a hot-memory prefix for the current session.
+- `/remember` maps to `cairn ingest`; `/forget` maps to `cairn forget` after explicit user confirmation.
+<!-- END CAIRN AGENT SKILL -->

--- a/crates/cairn-cli/src/snapshots/cairn_cli__skill__tests__claude_settings_snapshot.snap
+++ b/crates/cairn-cli/src/snapshots/cairn_cli__skill__tests__claude_settings_snapshot.snap
@@ -6,7 +6,7 @@ expression: merged
   "hooks": {
     "SessionStart": [
       {
-        "command": "cairn ingest --folder . --mode keyword"
+        "command": "cairn ingest --folder . --mode keyword >/tmp/cairn-session-start.log 2>&1 &"
       }
     ]
   },

--- a/crates/cairn-cli/src/snapshots/cairn_cli__skill__tests__claude_settings_snapshot.snap
+++ b/crates/cairn-cli/src/snapshots/cairn_cli__skill__tests__claude_settings_snapshot.snap
@@ -1,0 +1,21 @@
+---
+source: crates/cairn-cli/src/skill.rs
+expression: merged
+---
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "command": "cairn ingest --folder . --mode keyword"
+      }
+    ]
+  },
+  "mcpServers": {
+    "cairn": {
+      "args": [
+        "mcp"
+      ],
+      "command": "cairn"
+    }
+  }
+}

--- a/crates/cairn-cli/tests/skill_agent_pack.rs
+++ b/crates/cairn-cli/tests/skill_agent_pack.rs
@@ -1,0 +1,48 @@
+//! CLI coverage for `cairn skill install --agent` and `--all`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn skill_install_agent_codex_writes_agents_md() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let target = tmp.path().join("skills/cairn");
+
+    Command::cargo_bin("cairn")
+        .expect("binary")
+        .current_dir(&project)
+        .args(["skill", "install", "--agent", "codex", "--target-dir"])
+        .arg(&target)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Codex"));
+
+    let agents = std::fs::read_to_string(project.join("AGENTS.md")).expect("AGENTS.md");
+    assert!(agents.contains("cairn ingest --folder . --mode keyword"));
+}
+
+#[test]
+fn skill_install_all_json_reports_integrations() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let target = tmp.path().join("skills/cairn");
+
+    let output = Command::cargo_bin("cairn")
+        .expect("binary")
+        .current_dir(&project)
+        .args(["skill", "install", "--all", "--json", "--target-dir"])
+        .arg(&target)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("json output");
+    assert_eq!(
+        json["integrations"].as_array().expect("integrations").len(),
+        4
+    );
+}

--- a/crates/cairn-mcp/src/graph_tools.rs
+++ b/crates/cairn-mcp/src/graph_tools.rs
@@ -165,32 +165,47 @@ pub static GRAPH_TOOLS: &[GraphToolDecl] = &[
     tool!(
         "graph.query",
         "BFS/DFS from a seed entity within hop and token budget. \
-         Discovered nodes are returned id-only to avoid cross-scope name leaks.",
+         Discovered nodes are returned id-only to avoid cross-scope name leaks. \
+         Use when you need to find connections between concepts. \
+         Do NOT use for file reads or code execution. \
+         Prefer `search` over `query_graph` when you have exact record IDs.",
         QueryGraphArgs
     ),
     tool!(
         "graph.get_entity",
         "Look up an entity by id (returns {id, edge_count}) or name \
-         (returns {id, echoed_name, edge_count}).",
+         (returns {id, echoed_name, edge_count}). \
+         Use when you need to resolve a graph concept before traversal. \
+         Do NOT use for file reads or code execution. \
+         Prefer `search` over `query_graph` when you have exact record IDs.",
         GetEntityArgs
     ),
     tool!(
         "graph.get_neighbors",
         "Return one-hop in-scope edges incident to the given id. Optional \
-         relation and min_confidence filters.",
+         relation and min_confidence filters. \
+         Use when you need immediate graph relationships around a known entity. \
+         Do NOT use for file reads or code execution. \
+         Prefer `search` over `query_graph` when you have exact record IDs.",
         GetNeighborsArgs
     ),
     tool!(
         "graph.timeline",
         "Return all currently-visible edges for an entity ordered by valid_at. \
          include_history and include_expired flags opt into broader windows; \
-         scope filter is unconditional.",
+         scope filter is unconditional. \
+         Use when you need time-ordered graph context for a known entity. \
+         Do NOT use for file reads or code execution. \
+         Prefer `search` over `query_graph` when you have exact record IDs.",
         TimelineArgs
     ),
     tool!(
         "graph.surprising_connections",
         "Score in-scope edges between input entities; cross-scope (relative \
-         to the modal records.scope) gets a 2× confidence bonus.",
+         to the modal records.scope) gets a 2x confidence bonus. \
+         Use when you need to find connections between concepts. \
+         Do NOT use for file reads or code execution. \
+         Prefer `search` over `query_graph` when you have exact record IDs.",
         SurprisingArgs
     ),
 ];

--- a/crates/cairn-mcp/tests/graph_tools_manifest.rs
+++ b/crates/cairn-mcp/tests/graph_tools_manifest.rs
@@ -29,6 +29,32 @@ fn graph_tools_registry_lists_five_tools() {
 }
 
 #[test]
+fn graph_tool_descriptions_include_invocation_discipline() {
+    for decl in GRAPH_TOOLS {
+        assert!(
+            decl.description.contains("Use when"),
+            "{} description must include a positive trigger: {}",
+            decl.name,
+            decl.description
+        );
+        assert!(
+            decl.description
+                .contains("Do NOT use for file reads or code execution"),
+            "{} description must include a negative trigger: {}",
+            decl.name,
+            decl.description
+        );
+        assert!(
+            decl.description
+                .contains("Prefer `search` over `query_graph` when you have exact record IDs"),
+            "{} description must include the search exclusivity hint: {}",
+            decl.name,
+            decl.description
+        );
+    }
+}
+
+#[test]
 fn get_entity_args_rejects_both_id_and_name() {
     let v = serde_json::json!({"id": "x", "name": "y"});
     assert!(serde_json::from_value::<GetEntityArgs>(v).is_err());

--- a/docs/site/src/reference/generated/commands/skill-install.md
+++ b/docs/site/src/reference/generated/commands/skill-install.md
@@ -9,7 +9,7 @@ Install the Cairn skill bundle into the harness skill directory (§18.d)
 ```text
 Install the Cairn skill bundle into the harness skill directory (§18.d)
 
-Usage: cairn skill install [OPTIONS] --harness <HARNESS>
+Usage: cairn skill install [OPTIONS] <--harness <HARNESS>|--agent <AGENT>|--all>
 
 Options:
       --harness <HARNESS>
@@ -26,6 +26,18 @@ Options:
 
       --vault <NAME_OR_PATH>
           Active vault: name from registry or filesystem path (overrides CAIRN_VAULT)
+
+      --agent <AGENT>
+          Write generated agent integration files (claude-code, codex, kiro, cursor)
+
+          Possible values:
+          - claude-code: Claude Code project integration
+          - codex:       Codex/OpenCode project instructions
+          - kiro:        Kiro always-included steering file
+          - cursor:      Cursor always-applied rule file
+
+      --all
+          Write generated integration files for all supported agents
 
       --target-dir <PATH>
           Override the default install path (~/.cairn/skills/cairn/)

--- a/docs/superpowers/plans/2026-05-19-issue-193-agent-skill-pack.md
+++ b/docs/superpowers/plans/2026-05-19-issue-193-agent-skill-pack.md
@@ -1,0 +1,567 @@
+# Issue 193 Agent Skill-Pack Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-slice `cairn skill install --agent ...` and `--all` support that writes idempotent harness integration files for Claude Code, Codex, Kiro, and Cursor.
+
+**Architecture:** Preserve the existing issue #68 bundle installer as `skill::install`. Add a second `skill::install_agent_pack` wrapper that calls the bundle installer once, then writes guarded markdown and generated JSON integration files in the current project directory. Keep all new behavior in `crates/cairn-cli/src/skill.rs` and CLI argument plumbing in `command.rs`/`main.rs`.
+
+**Tech Stack:** Rust 2024, clap `ValueEnum`, serde/serde_json, tempfile and insta for existing tests.
+
+---
+
+### Task 1: Agent Types And Rendered Fragments
+
+**Files:**
+- Modify: `crates/cairn-cli/src/skill.rs`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Add these tests inside the existing `#[cfg(test)] mod tests` in `crates/cairn-cli/src/skill.rs`:
+
+```rust
+#[test]
+fn agent_values_render_expected_fragments() {
+    assert_eq!(Agent::ClaudeCode.to_possible_value().unwrap().get_name(), "claude-code");
+    assert_eq!(Agent::Codex.to_possible_value().unwrap().get_name(), "codex");
+    assert_eq!(Agent::Kiro.to_possible_value().unwrap().get_name(), "kiro");
+    assert_eq!(Agent::Cursor.to_possible_value().unwrap().get_name(), "cursor");
+
+    let block = render_agent_markdown_block(Agent::Codex);
+    assert!(block.contains("<!-- BEGIN CAIRN AGENT SKILL -->"));
+    assert!(block.contains("cairn ingest --folder . --mode keyword"));
+    assert!(block.contains("Do not use Cairn tools for ordinary file reads or code execution."));
+    assert!(block.contains("/remember"));
+    assert!(block.contains("/forget"));
+}
+
+#[test]
+fn harness_maps_to_first_slice_agent_when_supported() {
+    assert_eq!(Agent::from_harness(&Harness::ClaudeCode), Some(Agent::ClaudeCode));
+    assert_eq!(Agent::from_harness(&Harness::Codex), Some(Agent::Codex));
+    assert_eq!(Agent::from_harness(&Harness::Cursor), Some(Agent::Cursor));
+    assert_eq!(Agent::from_harness(&Harness::Gemini), None);
+    assert_eq!(Agent::from_harness(&Harness::Opencode), None);
+    assert_eq!(Agent::from_harness(&Harness::Custom), None);
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p cairn-cli skill::tests::agent_values_render_expected_fragments skill::tests::harness_maps_to_first_slice_agent_when_supported
+```
+
+Expected: compile failure because `Agent`, `from_harness`, and `render_agent_markdown_block` do not exist.
+
+- [ ] **Step 3: Implement minimal agent type and renderer**
+
+In `crates/cairn-cli/src/skill.rs`, add:
+
+```rust
+/// Agents with first-slice generated skill-pack integrations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum Agent {
+    /// Claude Code project integration.
+    #[value(name = "claude-code")]
+    ClaudeCode,
+    /// Codex/OpenCode project instructions.
+    Codex,
+    /// Kiro always-included steering file.
+    Kiro,
+    /// Cursor always-applied rule file.
+    Cursor,
+}
+
+impl Agent {
+    /// First-slice agents in deterministic receipt order.
+    pub const ALL: [Self; 4] = [Self::ClaudeCode, Self::Codex, Self::Kiro, Self::Cursor];
+
+    /// Compatibility mapping from the older issue #68 harness flag.
+    #[must_use]
+    pub const fn from_harness(harness: &Harness) -> Option<Self> {
+        match harness {
+            Harness::ClaudeCode => Some(Self::ClaudeCode),
+            Harness::Codex => Some(Self::Codex),
+            Harness::Cursor => Some(Self::Cursor),
+            Harness::Gemini | Harness::Opencode | Harness::Custom => None,
+        }
+    }
+}
+```
+
+Add `render_agent_markdown_block(agent: Agent) -> String` that returns a guarded markdown block containing the shared guidance and an agent-specific heading.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p cairn-cli skill::tests::agent_values_render_expected_fragments skill::tests::harness_maps_to_first_slice_agent_when_supported
+```
+
+Expected: both tests pass.
+
+---
+
+### Task 2: Guarded Markdown Updates
+
+**Files:**
+- Modify: `crates/cairn-cli/src/skill.rs`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Add tests:
+
+```rust
+#[test]
+fn guarded_markdown_appends_to_user_content() {
+    let original = "# Existing\n\nKeep me.\n";
+    let block = render_agent_markdown_block(Agent::Codex);
+    let updated = upsert_guarded_markdown(original, &block);
+
+    assert!(updated.starts_with(original));
+    assert!(updated.contains("<!-- BEGIN CAIRN AGENT SKILL -->"));
+    assert!(updated.ends_with('\n'));
+}
+
+#[test]
+fn guarded_markdown_replaces_existing_block_once() {
+    let old = "# Existing\n\n<!-- BEGIN CAIRN AGENT SKILL -->\nold\n<!-- END CAIRN AGENT SKILL -->\n\nTail\n";
+    let block = render_agent_markdown_block(Agent::Codex);
+    let updated = upsert_guarded_markdown(old, &block);
+
+    assert!(updated.contains("# Existing"));
+    assert!(updated.contains("Tail"));
+    assert!(!updated.contains("\nold\n"));
+    assert_eq!(updated.matches("<!-- BEGIN CAIRN AGENT SKILL -->").count(), 1);
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p cairn-cli skill::tests::guarded_markdown_appends_to_user_content skill::tests::guarded_markdown_replaces_existing_block_once
+```
+
+Expected: compile failure because `upsert_guarded_markdown` does not exist.
+
+- [ ] **Step 3: Implement guarded updater**
+
+Add constants:
+
+```rust
+const AGENT_BLOCK_BEGIN: &str = "<!-- BEGIN CAIRN AGENT SKILL -->";
+const AGENT_BLOCK_END: &str = "<!-- END CAIRN AGENT SKILL -->";
+```
+
+Add:
+
+```rust
+fn upsert_guarded_markdown(existing: &str, block: &str) -> String {
+    if let Some(start) = existing.find(AGENT_BLOCK_BEGIN)
+        && let Some(end_rel) = existing[start..].find(AGENT_BLOCK_END)
+    {
+        let end = start + end_rel + AGENT_BLOCK_END.len();
+        let mut out = String::new();
+        out.push_str(&existing[..start]);
+        out.push_str(block.trim_end());
+        out.push('\n');
+        out.push_str(&existing[end..]);
+        return ensure_trailing_newline(out);
+    }
+
+    let mut out = ensure_trailing_newline(existing.to_owned());
+    if !out.trim().is_empty() {
+        out.push('\n');
+    }
+    out.push_str(block.trim_end());
+    out.push('\n');
+    out
+}
+
+fn ensure_trailing_newline(mut text: String) -> String {
+    if !text.is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text
+}
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p cairn-cli skill::tests::guarded_markdown_appends_to_user_content skill::tests::guarded_markdown_replaces_existing_block_once
+```
+
+Expected: both tests pass.
+
+---
+
+### Task 3: Integration Writers
+
+**Files:**
+- Modify: `crates/cairn-cli/src/skill.rs`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Add tests:
+
+```rust
+#[test]
+fn install_agent_pack_codex_writes_agents_md_and_bundle() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("project dir");
+    std::fs::write(project.join("AGENTS.md"), "# Project\n").expect("seed agents");
+    let target = tmp.path().join("skills/cairn");
+
+    let receipt = install_agent_pack(&AgentInstallOpts {
+        target_dir: target.clone(),
+        project_dir: project.clone(),
+        agents: vec![Agent::Codex],
+        harness: Harness::Codex,
+        force: false,
+    })
+    .expect("install codex agent pack");
+
+    assert!(target.join("SKILL.md").exists());
+    let agents = std::fs::read_to_string(project.join("AGENTS.md")).expect("read agents");
+    assert!(agents.contains("# Project"));
+    assert!(agents.contains("<!-- BEGIN CAIRN AGENT SKILL -->"));
+    assert_eq!(receipt.integrations.len(), 1);
+    assert_eq!(receipt.integrations[0].agent, Agent::Codex);
+}
+
+#[test]
+fn install_agent_pack_all_writes_first_slice_files() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let target = tmp.path().join("skills/cairn");
+
+    let receipt = install_agent_pack(&AgentInstallOpts {
+        target_dir: target,
+        project_dir: project.clone(),
+        agents: Agent::ALL.to_vec(),
+        harness: Harness::ClaudeCode,
+        force: false,
+    })
+    .expect("install all agent packs");
+
+    assert!(project.join(".claude/settings.json").exists());
+    assert!(project.join("CLAUDE.md").exists());
+    assert!(project.join("AGENTS.md").exists());
+    assert!(project.join(".kiro/steering/cairn.md").exists());
+    assert!(project.join(".cursor/rules/cairn.mdc").exists());
+    assert_eq!(receipt.integrations.len(), 4);
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p cairn-cli skill::tests::install_agent_pack_codex_writes_agents_md_and_bundle skill::tests::install_agent_pack_all_writes_first_slice_files
+```
+
+Expected: compile failure because `AgentInstallOpts`, `install_agent_pack`, and integration receipt types do not exist.
+
+- [ ] **Step 3: Implement agent install receipt and writers**
+
+Add public structs:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct AgentInstallOpts {
+    pub target_dir: PathBuf,
+    pub project_dir: PathBuf,
+    pub agents: Vec<Agent>,
+    pub harness: Harness,
+    pub force: bool,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct AgentInstallReceipt {
+    pub bundle: InstallReceipt,
+    pub integrations: Vec<AgentIntegrationReceipt>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct AgentIntegrationReceipt {
+    pub agent: Agent,
+    pub files_created: Vec<PathBuf>,
+    pub files_updated: Vec<PathBuf>,
+    pub files_skipped: Vec<PathBuf>,
+}
+```
+
+Implement `install_agent_pack` by calling existing `install`, then dispatching to:
+
+- `install_claude_code_integration`
+- `install_codex_integration`
+- `install_kiro_integration`
+- `install_cursor_integration`
+
+Each writer should use `read_to_string` with empty fallback for missing files,
+compare final content with existing content, and write only when changed.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p cairn-cli skill::tests::install_agent_pack_codex_writes_agents_md_and_bundle skill::tests::install_agent_pack_all_writes_first_slice_files
+```
+
+Expected: both tests pass.
+
+---
+
+### Task 4: Claude Settings JSON Merge
+
+**Files:**
+- Modify: `crates/cairn-cli/src/skill.rs`
+
+- [ ] **Step 1: Write failing unit test**
+
+Add:
+
+```rust
+#[test]
+fn claude_settings_merge_preserves_unrelated_keys() {
+    let existing = serde_json::json!({
+        "theme": "dark",
+        "mcpServers": {
+            "other": {"command": "other", "args": []}
+        }
+    });
+    let merged = merge_claude_settings(existing).expect("merge settings");
+
+    assert_eq!(merged["theme"], "dark");
+    assert_eq!(merged["mcpServers"]["other"]["command"], "other");
+    assert_eq!(merged["mcpServers"]["cairn"]["command"], "cairn");
+    assert_eq!(merged["mcpServers"]["cairn"]["args"], serde_json::json!(["mcp"]));
+    let rendered = serde_json::to_string(&merged).expect("json");
+    assert!(rendered.contains("cairn ingest --folder . --mode keyword"));
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cargo test -p cairn-cli skill::tests::claude_settings_merge_preserves_unrelated_keys
+```
+
+Expected: compile failure because `merge_claude_settings` does not exist.
+
+- [ ] **Step 3: Implement JSON merge**
+
+Implement:
+
+```rust
+fn merge_claude_settings(mut value: serde_json::Value) -> Result<serde_json::Value> {
+    let root = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Claude Code settings root must be a JSON object"))?;
+    let servers = root
+        .entry("mcpServers")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Claude Code mcpServers must be a JSON object"))?;
+    servers.insert("cairn".to_owned(), serde_json::json!({"command": "cairn", "args": ["mcp"]}));
+    root.insert("hooks".to_owned(), merged_hooks(root.get("hooks").cloned()));
+    Ok(value)
+}
+```
+
+`merged_hooks` should return a JSON value containing a `SessionStart` command with
+`cairn ingest --folder . --mode keyword` while preserving existing hook keys when
+they are an object.
+
+- [ ] **Step 4: Run test to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p cairn-cli skill::tests::claude_settings_merge_preserves_unrelated_keys
+```
+
+Expected: test passes.
+
+---
+
+### Task 5: CLI Plumbing
+
+**Files:**
+- Modify: `crates/cairn-cli/src/command.rs`
+- Modify: `crates/cairn-cli/src/main.rs`
+- Test: `crates/cairn-cli/tests/skill_agent_pack.rs`
+
+- [ ] **Step 1: Write failing CLI integration tests**
+
+Create `crates/cairn-cli/tests/skill_agent_pack.rs` with tests that run the binary from a temp project:
+
+```rust
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn skill_install_agent_codex_writes_agents_md() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let target = tmp.path().join("skills/cairn");
+
+    Command::cargo_bin("cairn")
+        .expect("binary")
+        .current_dir(&project)
+        .args(["skill", "install", "--agent", "codex", "--target-dir"])
+        .arg(&target)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Codex"));
+
+    let agents = std::fs::read_to_string(project.join("AGENTS.md")).expect("AGENTS.md");
+    assert!(agents.contains("cairn ingest --folder . --mode keyword"));
+}
+
+#[test]
+fn skill_install_all_json_reports_integrations() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let target = tmp.path().join("skills/cairn");
+
+    let output = Command::cargo_bin("cairn")
+        .expect("binary")
+        .current_dir(&project)
+        .args(["skill", "install", "--all", "--json", "--target-dir"])
+        .arg(&target)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).expect("json output");
+    assert_eq!(json["integrations"].as_array().expect("integrations").len(), 4);
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p cairn-cli --test skill_agent_pack
+```
+
+Expected: clap rejects `--agent`/`--all`.
+
+- [ ] **Step 3: Add CLI args and dispatch**
+
+In `command.rs`, make `--harness` optional and add:
+
+```rust
+.arg(
+    clap::Arg::new("agent")
+        .long("agent")
+        .value_name("AGENT")
+        .value_parser(clap::builder::EnumValueParser::<skill::Agent>::new())
+        .conflicts_with_all(["harness", "all"])
+)
+.arg(
+    clap::Arg::new("all")
+        .long("all")
+        .action(clap::ArgAction::SetTrue)
+        .conflicts_with_all(["harness", "agent"])
+)
+.group(
+    clap::ArgGroup::new("skill-install-target")
+        .args(["harness", "agent", "all"])
+        .required(true)
+)
+```
+
+In `main.rs`, update `run_skill_install`:
+
+- If `--agent`, call `skill::install_agent_pack`.
+- If `--all`, call `skill::install_agent_pack` with `Agent::ALL`.
+- If `--harness` maps to an `Agent`, call `install_agent_pack`; otherwise call existing `install`.
+- Print `render_agent_human` for agent receipts.
+
+- [ ] **Step 4: Run CLI tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p cairn-cli --test skill_agent_pack
+```
+
+Expected: both tests pass.
+
+---
+
+### Task 6: Snapshots And Focused Verification
+
+**Files:**
+- Modify: `crates/cairn-cli/src/skill.rs`
+- Generated snapshots under `crates/cairn-cli/src/snapshots/` or existing insta snapshot location
+
+- [ ] **Step 1: Add snapshot tests**
+
+Add:
+
+```rust
+#[test]
+fn agent_markdown_block_snapshot() {
+    insta::assert_snapshot!(render_agent_markdown_block(Agent::Codex));
+}
+
+#[test]
+fn claude_settings_snapshot() {
+    let merged = merge_claude_settings(serde_json::json!({})).expect("merge");
+    insta::assert_json_snapshot!(merged);
+}
+```
+
+- [ ] **Step 2: Run snapshots**
+
+Run:
+
+```bash
+INSTA_UPDATE=always cargo test -p cairn-cli agent_markdown_block_snapshot claude_settings_snapshot
+```
+
+Expected: tests pass and snapshots are written.
+
+- [ ] **Step 3: Run focused verification**
+
+Run:
+
+```bash
+cargo test -p cairn-cli skill::tests::
+cargo test -p cairn-cli --test skill_agent_pack
+cargo fmt --check
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 4: Commit implementation**
+
+Run:
+
+```bash
+git add crates/cairn-cli/src/skill.rs crates/cairn-cli/src/command.rs crates/cairn-cli/src/main.rs crates/cairn-cli/tests/skill_agent_pack.rs docs/superpowers/specs/2026-05-19-issue-193-agent-skill-pack-design.md docs/superpowers/plans/2026-05-19-issue-193-agent-skill-pack.md
+git commit -m "feat: add agent skill-pack install"
+```

--- a/docs/superpowers/specs/2026-05-19-issue-193-agent-skill-pack-design.md
+++ b/docs/superpowers/specs/2026-05-19-issue-193-agent-skill-pack-design.md
@@ -1,0 +1,263 @@
+# Design: issue #193 agent skill-pack install
+
+**Issue:** [#193](https://github.com/windoliver/cairn/issues/193)
+**Design source:** `CLAUDE.md` section 8.0 and design brief sections 4, 8.0, 9.3, and 11
+**Date:** 2026-05-19
+**Status:** approved for first implementation slice
+
+---
+
+## Summary
+
+Extend `cairn skill install` from a skill-bundle writer into an agent integration
+writer. The first implementation slice writes deterministic, idempotent harness
+files for Claude Code, Codex/OpenCode, Kiro, and Cursor while preserving the
+existing `--harness` install behavior from issue #68.
+
+The installed integration advertises Cairn as a memory and knowledge layer,
+registers or describes the MCP server where the harness supports it, and gives
+each harness a session-start instruction to run:
+
+```bash
+cairn ingest --folder . --mode keyword
+```
+
+The hook is represented as a generated command or instruction only. Runtime
+nonblocking execution is owned by the harness and the existing Cairn CLI surfaces.
+
+---
+
+## Scope
+
+### In scope
+
+- Add `cairn skill install --agent <agent>` for:
+  - `claude-code`
+  - `codex`
+  - `kiro`
+  - `cursor`
+- Add `cairn skill install --all`.
+- Keep `cairn skill install --harness <harness>` working as a compatibility alias.
+- Write generated harness files without overwriting unrelated user content.
+- Use guarded Cairn blocks in markdown-like files.
+- Emit stable JSON and human receipts that list skill bundle writes and agent
+  integration writes.
+- Add snapshot/unit tests for generated fragments and idempotency.
+
+### Out of scope
+
+- Running `claude mcp list` from tests.
+- Proving background execution semantics inside Claude Code, Codex, Kiro, or Cursor.
+- Adding new hook runtime commands beyond the existing `cairn hook` and verb CLI.
+- Implementing `surprising_connections` if the MCP graph traversal tool is not
+  already available.
+- Changing `cairn setup claude-code`; this install path may reuse its JSON helper
+  patterns but must not replace it.
+
+---
+
+## CLI Shape
+
+`cairn skill install` accepts these options:
+
+```bash
+cairn skill install --agent claude-code
+cairn skill install --agent codex
+cairn skill install --agent kiro
+cairn skill install --agent cursor
+cairn skill install --all
+cairn skill install --harness claude-code
+```
+
+Rules:
+
+- `--agent` and `--all` are mutually exclusive.
+- `--harness` remains accepted and maps to `--agent` for known overlapping
+  values.
+- `custom`, `gemini`, and `opencode` remain valid compatibility harnesses for
+  the skill bundle and registration hint, but are not part of the first #193
+  integration writer unless passed through `--harness`.
+- `--target-dir`, `--force`, and `--json` keep their current meanings.
+- The default project directory for generated harness files is the current
+  working directory.
+
+---
+
+## Generated Content
+
+### Shared Cairn guidance
+
+Every generated agent-facing snippet includes:
+
+- One sentence explaining Cairn's role.
+- Positive trigger: use Cairn when persistent memory, recall, or graph-aware
+  connections are needed.
+- Negative trigger: do not use Cairn tools for ordinary file reads or code
+  execution.
+- Exclusivity hint: prefer exact search/retrieve paths when the user names a
+  known record or concept; use graph exploration only for non-obvious
+  connections.
+- Session-start instruction: run `cairn ingest --folder . --mode keyword`.
+- Hot context instruction: use `cairn assemble_hot` to build a memory prefix
+  when the harness supports context preambles.
+
+Generated markdown blocks use this guard:
+
+```markdown
+<!-- BEGIN CAIRN AGENT SKILL -->
+...
+<!-- END CAIRN AGENT SKILL -->
+```
+
+Reinstall replaces only the guarded block. If the file has user content outside
+the block, it is preserved byte-for-byte.
+
+### Claude Code
+
+Files:
+
+- `.claude/settings.json`
+- `CLAUDE.md`
+
+Behavior:
+
+- Merge a `mcpServers.cairn` entry with `command: "cairn"` and
+  `args: ["mcp"]`.
+- Merge a session-start hook command that invokes
+  `cairn ingest --folder . --mode keyword`.
+- Append or replace the guarded Cairn block in `CLAUDE.md`.
+- Preserve unrelated JSON keys and unrelated markdown content.
+
+### Codex / OpenCode
+
+Files:
+
+- `AGENTS.md`
+
+Behavior:
+
+- Append or replace the guarded Cairn block.
+- Include the session-start command as an instruction because Codex hook file
+  formats are not stable in this repository yet.
+
+### Kiro
+
+Files:
+
+- `.kiro/steering/cairn.md`
+
+Behavior:
+
+- Write a deterministic steering file with frontmatter:
+
+```markdown
+---
+inclusion: always
+---
+```
+
+- Include the shared Cairn guidance after the frontmatter.
+- Treat the file as generated; `--force` may overwrite it, otherwise reinstall
+  only rewrites it when it already contains the Cairn guard.
+
+### Cursor
+
+Files:
+
+- `.cursor/rules/cairn.mdc`
+
+Behavior:
+
+- Write a deterministic rule file with frontmatter:
+
+```markdown
+---
+alwaysApply: true
+---
+```
+
+- Include the shared Cairn guidance after the frontmatter.
+- Do not mutate legacy `.cursorrules` in the first slice; the human output may
+  mention the modern `.cursor/rules/cairn.mdc` path.
+
+---
+
+## Data Flow
+
+```text
+cairn skill install --agent claude-code
+  -> install or refresh ~/.cairn/skills/cairn
+  -> resolve project directory from cwd
+  -> render Claude Code integration fragments
+  -> merge JSON and guarded markdown blocks
+  -> return receipt with files_created, files_skipped, and integrations
+```
+
+`--all` repeats the integration render/write phase for each first-slice agent
+after installing the shared skill bundle once.
+
+---
+
+## Error Handling
+
+- Invalid combinations such as `--agent codex --all` fail with clap usage errors.
+- Malformed JSON in `.claude/settings.json` fails closed and does not rewrite the
+  file.
+- Existing Kiro/Cursor generated files without the Cairn guard are treated as
+  user-owned unless `--force` is passed.
+- File system write failures return the existing `EX_IOERR` path.
+- No network or LLM configuration is required.
+
+---
+
+## Testing
+
+Unit tests in `crates/cairn-cli/src/skill.rs` cover:
+
+- Agent enum parsing and compatibility mapping from `Harness`.
+- Guarded markdown insertion into an absent file, a user-authored file, and a
+  file with an existing Cairn block.
+- Claude settings JSON merge that preserves unrelated keys.
+- Kiro and Cursor generated-file idempotency.
+- `--all` receipt includes all first-slice agents.
+
+Snapshot tests cover:
+
+- Shared Cairn markdown block.
+- Claude settings fragment.
+- Kiro steering file.
+- Cursor rule file.
+- Human and JSON receipts after a first install.
+
+CLI integration tests cover:
+
+- `cairn skill install --agent codex --target-dir <tmp>` creates `AGENTS.md`
+  in the current project directory and the skill bundle in `<tmp>`.
+- `cairn skill install --all --json` reports every generated integration.
+
+---
+
+## Acceptance Mapping
+
+- Correct `settings.json` and `CLAUDE.md` without overwriting existing content:
+  covered by the Claude merge and guarded-block tests.
+- MCP registration intent: `mcpServers.cairn` is written; external
+  `claude mcp list` verification remains manual.
+- Session-start hook: generated command uses
+  `cairn ingest --folder . --mode keyword`.
+- Slash commands: first slice documents `/remember` and `/forget` mappings in
+  generated guidance; native slash-command files can land separately if the
+  harness path is confirmed.
+- Offline behavior: generated hook uses keyword mode only.
+- Stable snapshots: fragment and receipt snapshots pin output.
+
+---
+
+## Invariants
+
+- CLI remains ground truth; generated skill files are wrappers over `cairn`
+  commands.
+- Core remains untouched; all work lives in `cairn-cli` install helpers and tests.
+- Harness-specific logic stays in CLI adapter code, not `cairn-core`.
+- Generated writes are idempotent and preserve user-authored content outside
+  explicit Cairn-owned regions.


### PR DESCRIPTION
## Summary
- add `cairn skill install --agent <claude-code|codex|kiro|cursor>` and `--all`
- generate guarded agent guidance files for Claude Code, Codex/OpenCode, Kiro, and Cursor
- write Claude Code settings, project `.mcp.json`, slash commands, and a background session-start hook
- add MCP graph-tool trigger/negative/exclusivity descriptions and focused tests/snapshots

Closes #193.

## Verification
- `cargo test -p cairn-cli install_agent_pack`
- `cargo test -p cairn-cli --test skill_agent_pack`
- `cargo test -p cairn-mcp graph_tool_descriptions_include_invocation_discipline`
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p cairn-cli --test skill_agent_pack`
- manual e2e in throwaway projects: fresh `--all` install, generated Claude/Codex/Kiro/Cursor files, existing-content preservation, idempotent reinstall, guarded-file conflict handling, invalid JSON handling, CLI arg conflicts
- manual e2e: generated `SessionStart` hook ran `cairn ingest --folder . --mode keyword` in the background with isolated vault/home
- manual e2e: `/remember` equivalent committed via `cairn ingest`; `/forget` equivalent produced a dry-run plan
- `cairn doctor claude-code` verified generated MCP config, binary resolution, MCP startup, and `status` call; the separate all-five-hooks doctor stage remains outside this skill-pack path because this PR installs the issue #193 session-start ingest hook
- throwaway project: `claude mcp list` reports `cairn: cairn mcp - ✓ Connected` with `target/debug` on `PATH`
- throwaway fresh clone: `cairn ingest --folder . --mode keyword --json` completed successfully
