### PR TITLE
[codex] Add local telemetry for verbs and search

### DIFF
--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -218,17 +218,17 @@ fn search_mode(sub: &ArgMatches) -> Option<&str> {
     sub.get_one::<String>("mode").map(String::as_str)
 }
 
-fn retrieve_mode(sub: &ArgMatches) -> Option<&'static str> {
+fn retrieve_mode(sub: &ArgMatches) -> &'static str {
     if sub.contains_id("profile") && sub.get_flag("profile") {
-        Some("profile")
+        "profile"
     } else if sub.contains_id("session_id") && sub.get_one::<String>("session_id").is_some() {
-        Some("session")
+        "session"
     } else if sub.contains_id("path") && sub.get_one::<String>("path").is_some() {
-        Some("folder")
+        "folder"
     } else if sub.contains_id("scope") && sub.get_one::<String>("scope").is_some() {
-        Some("scope")
+        "scope"
     } else {
-        Some("record")
+        "record"
     }
 }
 
@@ -393,7 +393,7 @@ fn main() -> ExitCode {
                 let metric_config = config.clone();
                 observed_cli_verb(
                     "retrieve",
-                    retrieve_mode(sub),
+                    Some(retrieve_mode(sub)),
                     &metric_root,
                     &metric_config,
                     || verbs::retrieve::run(sub, vault_root, config),

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -8,6 +8,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::time::Instant;
 
 use cairn_cli::{
     command, doctor, hooks, identity, import, nexus_cli, plugins, repair, setup, verbs,
@@ -149,6 +150,108 @@ fn subcommand_needs_vault_guard(subcommand: Option<(&str, &ArgMatches)>) -> bool
     )
 }
 
+fn exit_status_name(code: ExitCode) -> &'static str {
+    if code == ExitCode::SUCCESS {
+        "committed"
+    } else {
+        "aborted"
+    }
+}
+
+fn observed_cli_verb<F>(
+    verb: &'static str,
+    mode: Option<&str>,
+    vault_root: &Path,
+    config: &cairn_core::config::CairnConfig,
+    run: F,
+) -> ExitCode
+where
+    F: FnOnce() -> ExitCode,
+{
+    let start = Instant::now();
+    let code = if config.observability.enabled && config.observability.local_traces {
+        let span = tracing::info_span!(
+            "cairn.verb",
+            surface = "cli",
+            verb,
+            mode = mode.unwrap_or(""),
+            request_id = tracing::field::Empty
+        );
+        let _guard = span.enter();
+        run()
+    } else {
+        run()
+    };
+    let latency_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let error = (code != ExitCode::SUCCESS).then_some("nonzero_exit");
+    cairn_cli::metrics::emit_verb_invocation_sync(
+        vault_root,
+        config,
+        verb,
+        mode,
+        exit_status_name(code),
+        latency_ms,
+        error,
+    );
+    code
+}
+
+fn ingest_mode(sub: &ArgMatches) -> Option<&'static str> {
+    if sub.get_one::<std::path::PathBuf>("recording").is_some() {
+        Some("recording")
+    } else if sub.get_one::<std::path::PathBuf>("jsonl").is_some() {
+        Some("jsonl")
+    } else if sub.get_one::<std::path::PathBuf>("folder").is_some() {
+        Some("folder")
+    } else if sub.get_one::<std::path::PathBuf>("file").is_some() {
+        Some("file")
+    } else if sub.contains_id("url") && sub.get_one::<String>("url").is_some() {
+        Some("url")
+    } else if sub.contains_id("body") && sub.get_one::<String>("body").is_some() {
+        Some("body")
+    } else {
+        None
+    }
+}
+
+fn search_mode(sub: &ArgMatches) -> Option<&str> {
+    sub.get_one::<String>("mode").map(String::as_str)
+}
+
+fn retrieve_mode(sub: &ArgMatches) -> Option<&'static str> {
+    if sub.contains_id("profile") && sub.get_flag("profile") {
+        Some("profile")
+    } else if sub.contains_id("session_id") && sub.get_one::<String>("session_id").is_some() {
+        Some("session")
+    } else if sub.contains_id("path") && sub.get_one::<String>("path").is_some() {
+        Some("folder")
+    } else if sub.contains_id("scope") && sub.get_one::<String>("scope").is_some() {
+        Some("scope")
+    } else {
+        Some("record")
+    }
+}
+
+fn forget_mode(sub: &ArgMatches) -> Option<&'static str> {
+    if sub.contains_id("session_id") && sub.get_one::<String>("session_id").is_some() {
+        Some("session")
+    } else if sub.contains_id("record_id") && sub.get_one::<String>("record_id").is_some() {
+        Some("record")
+    } else if sub.contains_id("scope") && sub.get_one::<String>("scope").is_some() {
+        Some("scope")
+    } else {
+        None
+    }
+}
+
+fn screen_mode(sub: &ArgMatches) -> Option<&str> {
+    sub.subcommand_name()
+}
+
+fn sensor_mode(sub: &ArgMatches) -> Option<&str> {
+    sub.subcommand_name()
+}
+
 #[allow(clippy::too_many_lines)] // top-level dispatch table; per-subcommand splits would scatter the verb wiring without untangling anything.
 fn main() -> ExitCode {
     let matches = match command::build_command().try_get_matches() {
@@ -251,25 +354,61 @@ fn main() -> ExitCode {
 
     match matches.subcommand() {
         Some(("ingest", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
-            Ok((vault_root, _source, config)) => verbs::ingest::run(sub, vault_root, config),
+            Ok((vault_root, _source, config)) => {
+                let metric_root = vault_root.clone();
+                let metric_config = config.clone();
+                observed_cli_verb(
+                    "ingest",
+                    ingest_mode(sub),
+                    &metric_root,
+                    &metric_config,
+                    || verbs::ingest::run(sub, vault_root, config),
+                )
+            }
             Err(code) => code,
         },
         Some(("search", sub)) => match resolve_vault_or_cwd(explicit_vault.as_deref()) {
             // search has its own internal vault-binding gate, so the
             // resolution source doesn't change behaviour here — it only
             // needs the resolved path.
-            Ok((vault_root, _source)) => verbs::search::run(sub, vault_root),
+            Ok((vault_root, _source)) => {
+                let config = cairn_cli::config::load(
+                    &vault_root,
+                    &cairn_cli::config::CliOverrides::default(),
+                )
+                .unwrap_or_default();
+                let metric_root = vault_root.clone();
+                observed_cli_verb("search", search_mode(sub), &metric_root, &config, || {
+                    verbs::search::run(sub, vault_root)
+                })
+            }
             Err(e) => {
                 eprintln!("cairn search: vault resolution error — {e:#}");
                 ExitCode::from(78) // EX_CONFIG
             }
         },
         Some(("retrieve", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
-            Ok((vault_root, _source, config)) => verbs::retrieve::run(sub, vault_root, config),
+            Ok((vault_root, _source, config)) => {
+                let metric_root = vault_root.clone();
+                let metric_config = config.clone();
+                observed_cli_verb(
+                    "retrieve",
+                    retrieve_mode(sub),
+                    &metric_root,
+                    &metric_config,
+                    || verbs::retrieve::run(sub, vault_root, config),
+                )
+            }
             Err(code) => code,
         },
         Some(("summarize", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
-            Ok((vault_root, _source, config)) => verbs::summarize::run(sub, vault_root, config),
+            Ok((vault_root, _source, config)) => {
+                let metric_root = vault_root.clone();
+                let metric_config = config.clone();
+                observed_cli_verb("summarize", None, &metric_root, &metric_config, || {
+                    verbs::summarize::run(sub, vault_root, config)
+                })
+            }
             Err(code) => code,
         },
         Some(("assemble_hot", sub)) => run_assemble_hot(sub, explicit_vault.as_deref()),
@@ -299,7 +438,11 @@ fn main() -> ExitCode {
                 ) {
                     rc
                 } else {
-                    verbs::capture_trace::run(sub, vault_root, config)
+                    let metric_root = vault_root.clone();
+                    let metric_config = config.clone();
+                    observed_cli_verb("capture_trace", None, &metric_root, &metric_config, || {
+                        verbs::capture_trace::run(sub, vault_root, config)
+                    })
                 }
             }
             Err(code) => code,
@@ -312,7 +455,15 @@ fn main() -> ExitCode {
             if verbs::forget::requires_vault_context(sub) {
                 match resolve_vault_and_config(explicit_vault.as_deref()) {
                     Ok((vault_root, _source, config)) => {
-                        verbs::forget::run(sub, vault_root, config)
+                        let metric_root = vault_root.clone();
+                        let metric_config = config.clone();
+                        observed_cli_verb(
+                            "forget",
+                            forget_mode(sub),
+                            &metric_root,
+                            &metric_config,
+                            || verbs::forget::run(sub, vault_root, config),
+                        )
                     }
                     Err(code) => code,
                 }
@@ -324,7 +475,12 @@ fn main() -> ExitCode {
         Some(("hook", sub)) => hooks::run(sub),
         Some(("status", sub)) => run_status(sub, explicit_vault.as_deref()),
         Some(("screen", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
-            Ok((vault_root, _source, config)) => verbs::screen::run(sub, &vault_root, &config),
+            Ok((vault_root, _source, config)) => {
+                let metric_root = vault_root.clone();
+                observed_cli_verb("screen", screen_mode(sub), &metric_root, &config, || {
+                    verbs::screen::run(sub, &vault_root, &config)
+                })
+            }
             Err(code) => code,
         },
         Some(("sensor", sub)) => match resolve_vault_and_config(explicit_vault.as_deref()) {
@@ -332,7 +488,15 @@ fn main() -> ExitCode {
                 if let Some(code) = enforce_vault_binding("sensor", &vault_root) {
                     code
                 } else {
-                    verbs::sensor::run(sub, &vault_root, config)
+                    let metric_root = vault_root.clone();
+                    let metric_config = config.clone();
+                    observed_cli_verb(
+                        "sensor",
+                        sensor_mode(sub),
+                        &metric_root,
+                        &metric_config,
+                        || verbs::sensor::run(sub, &vault_root, config),
+                    )
                 }
             }
             Err(code) => code,
@@ -730,7 +894,11 @@ fn run_assemble_hot(sub: &ArgMatches, explicit_vault: Option<&str>) -> ExitCode 
                 return ExitCode::from(78); // EX_CONFIG
             }
         };
-    verbs::assemble_hot::run(sub, vault_root, config)
+    let metric_root = vault_root.clone();
+    let metric_config = config.clone();
+    observed_cli_verb("assemble_hot", None, &metric_root, &metric_config, || {
+        verbs::assemble_hot::run(sub, vault_root, config)
+    })
 }
 
 fn run_admin(matches: &ArgMatches, explicit_vault: Option<&str>) -> ExitCode {

--- a/crates/cairn-cli/src/metrics.rs
+++ b/crates/cairn-cli/src/metrics.rs
@@ -5,9 +5,12 @@
 //! `cached_assemble` verb) swallows them with a `tracing::warn!`. Brief
 //! §15: a missing line is preferable to a broken `assemble_hot`.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use cairn_core::config::CairnConfig;
 use cairn_core::contract::metrics::{MetricsError, MetricsSink};
 use cairn_core::domain::metrics::MetricEvent;
 use tokio::io::AsyncWriteExt;
@@ -58,6 +61,63 @@ impl MetricsSink for JsonlMetricsSink {
         guard.write_all(&line).await?;
         guard.flush().await?;
         Ok(())
+    }
+}
+
+/// Current wall-clock millis since UNIX epoch.
+#[must_use]
+pub fn now_ms() -> i64 {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0_u128, |duration| duration.as_millis());
+    i64::try_from(millis).unwrap_or(i64::MAX)
+}
+
+/// Append one local metric synchronously. Used by the thin CLI
+/// dispatch layer, which cannot await while returning an `ExitCode`.
+///
+/// # Errors
+/// Returns filesystem or serialization errors.
+pub fn append_local_event_sync(vault_root: &Path, event: &MetricEvent) -> anyhow::Result<()> {
+    let path = vault_root.join(".cairn").join("metrics.jsonl");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    serde_json::to_writer(&mut file, event)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Emit a body-free verb invocation metric when local metrics are enabled.
+pub fn emit_verb_invocation_sync(
+    vault_root: &Path,
+    config: &CairnConfig,
+    verb: &str,
+    mode: Option<&str>,
+    status: &str,
+    latency_ms: u64,
+    error: Option<&str>,
+) {
+    if !config.observability.enabled || !config.observability.local_metrics {
+        return;
+    }
+    let event = MetricEvent::VerbInvocation {
+        ts_ms: now_ms(),
+        verb: verb.to_owned(),
+        surface: "cli".to_owned(),
+        mode: mode.map(str::to_owned),
+        status: status.to_owned(),
+        latency_ms,
+        error: error.map(str::to_owned),
+        budget_used_ratio: None,
+        degradation_state: Some("none".to_owned()),
+    };
+    if let Err(err) = append_local_event_sync(vault_root, &event) {
+        tracing::warn!(error = %err, verb, "verb metric emit failed");
     }
 }
 

--- a/crates/cairn-cli/src/verbs/admin_reindex.rs
+++ b/crates/cairn-cli/src/verbs/admin_reindex.rs
@@ -7,8 +7,10 @@
 use std::path::Path;
 use std::process::ExitCode;
 use std::sync::Arc;
+use std::time::Instant;
 
 use cairn_core::config::CairnConfig;
+use cairn_core::domain::metrics::MetricEvent;
 use clap::ArgMatches;
 use serde::Serialize;
 
@@ -98,7 +100,7 @@ pub fn run(sub: &ArgMatches, vault_root: &Path, config: &CairnConfig) -> ExitCod
 
     if from_db {
         return rt.block_on(async move {
-            run_rebuild_from_db_async(&db_path, &models_root, kind, json).await
+            run_rebuild_from_db_async(vault_root, &db_path, &models_root, kind, json, config).await
         });
     }
 
@@ -235,12 +237,15 @@ async fn run_reindex_async(
 
 #[allow(clippy::too_many_lines)]
 async fn run_rebuild_from_db_async(
+    vault_root: &Path,
     db_path: &Path,
     models_root: &Path,
     kind: cairn_core::config::EmbeddingModelKind,
     json: bool,
+    config: &CairnConfig,
 ) -> ExitCode {
     use anyhow::Context as _;
+    let started = Instant::now();
 
     // Load embedder (CPU-bound). CAIRN_MOCK_EMBEDDER=1 bypasses disk load for tests.
     let embedder: Arc<dyn cairn_embeddings_local::EmbeddingModel> =
@@ -265,6 +270,14 @@ async fn run_rebuild_from_db_async(
         match cairn_store_sqlite::open_with_embedder(db_path, Some(Arc::clone(&embedder))).await {
             Ok(s) => s,
             Err(e) => {
+                emit_projection_rebuild_metric(
+                    vault_root,
+                    config,
+                    started,
+                    "aborted",
+                    0,
+                    Some("store_open"),
+                );
                 return bail(
                     json,
                     "admin reindex",
@@ -276,6 +289,14 @@ async fn run_rebuild_from_db_async(
         };
 
     let Some(raw_conn) = store.raw_conn_for_admin() else {
+        emit_projection_rebuild_metric(
+            vault_root,
+            config,
+            started,
+            "aborted",
+            0,
+            Some("store_unavailable"),
+        );
         return bail(
             json,
             "admin reindex",
@@ -290,6 +311,14 @@ async fn run_rebuild_from_db_async(
     let stats = match cairn_store_sqlite::rebuild_from_db(Arc::clone(&conn)).await {
         Ok(s) => s,
         Err(e) => {
+            emit_projection_rebuild_metric(
+                vault_root,
+                config,
+                started,
+                "aborted",
+                0,
+                Some("rebuild_from_db"),
+            );
             return bail(
                 json,
                 "admin reindex",
@@ -316,6 +345,14 @@ async fn run_rebuild_from_db_async(
                 }
             }
             Err(e) => {
+                emit_projection_rebuild_metric(
+                    vault_root,
+                    config,
+                    started,
+                    "aborted",
+                    stats.fts_rebuilt,
+                    Some("drain_once"),
+                );
                 return bail(
                     json,
                     "admin reindex",
@@ -326,6 +363,15 @@ async fn run_rebuild_from_db_async(
             }
         }
     }
+
+    emit_projection_rebuild_metric(
+        vault_root,
+        config,
+        started,
+        "committed",
+        stats.fts_rebuilt,
+        None,
+    );
 
     let out = RebuildOutput {
         fts_rebuilt: stats.fts_rebuilt,
@@ -346,4 +392,32 @@ async fn run_rebuild_from_db_async(
         );
     }
     ExitCode::SUCCESS
+}
+
+fn emit_projection_rebuild_metric(
+    vault_root: &Path,
+    config: &CairnConfig,
+    started: Instant,
+    status: &str,
+    records_rebuilt: u64,
+    error: Option<&str>,
+) {
+    if !config.observability.enabled || !config.observability.local_metrics {
+        return;
+    }
+    let latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let event = MetricEvent::ProjectionRebuild {
+        ts_ms: crate::metrics::now_ms(),
+        projection: "sqlite.from_db".to_owned(),
+        status: status.to_owned(),
+        latency_ms,
+        records_rebuilt,
+        queue_lag_ms: 0,
+        retry_count: 0,
+        error: error.map(str::to_owned),
+        degradation_state: Some("none".to_owned()),
+    };
+    if let Err(err) = crate::metrics::append_local_event_sync(vault_root, &event) {
+        tracing::warn!(error = %err, "projection rebuild metric emit failed");
+    }
 }

--- a/crates/cairn-cli/src/verbs/screen.rs
+++ b/crates/cairn-cli/src/verbs/screen.rs
@@ -179,17 +179,22 @@ fn emit_post_capture_drop(err: &CaptureEventBuildError, json: bool) -> ExitCode 
         ),
     };
     if json {
-        emit_json(&serde_json::json!({
-            "status": "dropped",
-            "sensor": "screen",
-            "reason": reason,
-            "error": error,
-            "artifact_created": false,
-        }));
+        emit_json(&post_capture_drop_payload(reason, error));
     } else {
         eprintln!("cairn screen capture: failed to build capture event: {error}");
     }
     code
+}
+
+fn post_capture_drop_payload(reason: &str, error: &str) -> serde_json::Value {
+    serde_json::json!({
+        "status": "dropped",
+        "sensor": "screen",
+        "reason": reason,
+        "error": error,
+        "artifact_created": true,
+        "artifact_removed": true,
+    })
 }
 
 fn emit_skipped_capture(
@@ -285,7 +290,7 @@ fn emit_artifact_cleanup_failed_metric(
     vault_root: &Path,
     config: &CairnConfig,
     observed_bytes: u64,
-    err: &ScreenError,
+    _err: &ScreenError,
     started: Instant,
 ) {
     emit_screen_sensor_metric(
@@ -294,7 +299,7 @@ fn emit_artifact_cleanup_failed_metric(
         ScreenSensorMetric {
             status: "dropped",
             error: Some("artifact_cleanup_failed".to_owned()),
-            degradation_state: Some(screen_error_degradation_state(err).to_owned()),
+            degradation_state: Some("cleanup_failed".to_owned()),
             started,
             observed_bytes,
             budget_bytes: Some(screen_text_budget_bytes(config)),
@@ -309,9 +314,10 @@ fn cleanup_failed_payload(skip: ScreenCaptureSkip, err: &ScreenError) -> serde_j
         "reason": "artifact_cleanup_failed",
         "skip_reason": skip.reason.as_str(),
         "artifact_created": skip.artifact_created,
+        "artifact_removed": false,
         "observed_bytes": skip.observed_bytes,
         "error": screen_error_metric_class(err),
-        "degradation_state": screen_error_degradation_state(err),
+        "degradation_state": "cleanup_failed",
     })
 }
 
@@ -322,8 +328,9 @@ fn post_capture_cleanup_failed_payload(err: &ScreenError) -> serde_json::Value {
         "reason": "artifact_cleanup_failed",
         "skip_reason": "post_capture_validation_failed",
         "artifact_created": true,
+        "artifact_removed": false,
         "error": screen_error_metric_class(err),
-        "degradation_state": screen_error_degradation_state(err),
+        "degradation_state": "cleanup_failed",
     })
 }
 
@@ -865,9 +872,34 @@ mod tests {
         assert_eq!(payload["reason"], "artifact_cleanup_failed");
         assert_eq!(payload["skip_reason"], "privacy_filtered");
         assert_eq!(payload["artifact_created"], true);
+        assert_eq!(payload["artifact_removed"], false);
         assert_eq!(payload["observed_bytes"], 321);
         assert_eq!(payload["error"], "capture_failed");
-        assert_eq!(payload["degradation_state"], "backend_unavailable");
+        assert_eq!(payload["degradation_state"], "cleanup_failed");
+        assert!(!payload.to_string().contains("super-secret"));
+    }
+
+    #[test]
+    fn post_capture_cleanup_failure_payload_uses_cleanup_state() {
+        let payload = post_capture_cleanup_failed_payload(&ScreenError::CaptureFailed(
+            "failed to remove dropped screen capture".to_owned(),
+        ));
+
+        assert_eq!(payload["reason"], "artifact_cleanup_failed");
+        assert_eq!(payload["artifact_created"], true);
+        assert_eq!(payload["artifact_removed"], false);
+        assert_eq!(payload["error"], "capture_failed");
+        assert_eq!(payload["degradation_state"], "cleanup_failed");
+    }
+
+    #[test]
+    fn post_capture_drop_payload_reports_created_then_removed_artifact() {
+        let payload = post_capture_drop_payload("policy_rejected", "policy_rejected");
+
+        assert_eq!(payload["status"], "dropped");
+        assert_eq!(payload["reason"], "policy_rejected");
+        assert_eq!(payload["artifact_created"], true);
+        assert_eq!(payload["artifact_removed"], true);
     }
 
     #[test]
@@ -881,5 +913,44 @@ mod tests {
         assert_eq!(payload["reason"], "permission_missing");
         assert_eq!(payload["error"], "permission_missing");
         assert_eq!(payload["degradation_state"], "permission_missing");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn captured_receipt_json_cleanup_failure_leaves_artifact_and_metrics_cleanup_state() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let vault = tempfile::tempdir().expect("tempdir");
+        let output_dir = vault.path().join("captures");
+        std::fs::create_dir(&output_dir).expect("create output directory");
+        let output_path = output_dir.join("screen.png");
+        std::fs::write(&output_path, b"fake-png").expect("write fake capture");
+        std::fs::set_permissions(&output_dir, std::fs::Permissions::from_mode(0o500))
+            .expect("make output directory non-writable");
+        let config = screen_config_with_text_budget(1024);
+        let mut observation = observation_with_secret_text();
+        observation.captured_at = "not-a-timestamp".to_owned();
+        let receipt = ScreenCaptureReceipt {
+            output_path: output_path.clone(),
+            width: 10,
+            height: 20,
+            observation,
+        };
+
+        let code = emit_captured_receipt(vault.path(), &config, &receipt, Instant::now(), true);
+        std::fs::set_permissions(&output_dir, std::fs::Permissions::from_mode(0o700))
+            .expect("restore directory permissions");
+
+        assert_eq!(code, ExitCode::from(69));
+        assert!(output_path.exists());
+        let metrics = std::fs::read_to_string(vault.path().join(".cairn/metrics.jsonl"))
+            .expect("metrics file");
+        let metric = metrics
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("metric json"))
+            .find(|row| row["error"] == "artifact_cleanup_failed")
+            .expect("artifact cleanup metric");
+        assert_eq!(metric["error"], "artifact_cleanup_failed");
+        assert_eq!(metric["degradation_state"], "cleanup_failed");
     }
 }

--- a/crates/cairn-cli/src/verbs/screen.rs
+++ b/crates/cairn-cli/src/verbs/screen.rs
@@ -2,17 +2,20 @@
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::time::Instant;
 
 use cairn_core::config::CairnConfig;
 use cairn_core::domain::{
     BudgetObservation, CaptureEvent, CaptureEventId, LocalSensorName, SensorGateReason,
-    SourceFamily,
+    SourceFamily, metrics::MetricEvent,
 };
 use cairn_sensors_local::screen::{
-    ScreenDegradationCode, ScreenError, ScreenEventObservation, ScreenObservation,
-    capture_png_snapshot_configured,
+    ScreenCaptureOutcome, ScreenCaptureReceipt, ScreenCaptureSkip, ScreenDegradationCode,
+    ScreenError, ScreenEventObservation, ScreenObservation,
+    capture_png_snapshot_outcome_configured, screen_observation_budgeted_payload_bytes,
+    screen_observation_observed_bytes,
 };
-use cairn_sensors_local::{EmitOutcome, LocalSensorConfig, SensorSettings};
+use cairn_sensors_local::{DropReason, EmitOutcome, LocalSensorConfig, SensorKind, SensorSettings};
 use clap::{Arg, ArgAction, ArgMatches};
 
 use crate::sensor_gate::{
@@ -77,57 +80,273 @@ fn run_capture(sub: &ArgMatches, vault_root: &Path, config: &CairnConfig) -> Exi
         }
         return exit_code_for_gate_reason(reason);
     }
-    match capture_png_snapshot_configured(&config.sensors.screen, output_path) {
-        Ok(Some(receipt)) => {
-            let capture_event = match capture_event_for_observation(receipt.observation.clone()) {
-                Ok(event) => event,
-                Err(err) => {
-                    eprintln!("cairn screen capture: failed to build capture event: {err}");
-                    return ExitCode::from(70);
-                }
-            };
-            if json {
-                emit_json(&serde_json::json!({
-                    "status": "captured",
-                    "output_path": receipt.output_path,
-                    "width": receipt.width,
-                    "height": receipt.height,
-                    "backend": format!("{:?}", receipt.observation.backend).to_ascii_lowercase(),
-                    "ocr_engine": format!("{:?}", receipt.observation.ocr_engine).to_ascii_lowercase(),
-                    "sensor_label": receipt.observation.sensor_label,
-                    "captured_at": receipt.observation.captured_at,
-                    "app": receipt.observation.app,
-                    "window_title": receipt.observation.window_title,
-                    "url": receipt.observation.url,
-                    "ocr_text_bytes": receipt.observation.text.len(),
-                    "bounding_boxes_count": receipt.observation.bounding_boxes.len(),
-                    "capture_event": capture_event,
-                }));
-            } else {
-                println!(
-                    "captured {} ({}x{}, app={}, ocr_bytes={})",
-                    receipt.output_path.display(),
-                    receipt.width,
-                    receipt.height,
-                    receipt.observation.app,
-                    receipt.observation.text.len()
-                );
-            }
-            ExitCode::SUCCESS
+    let started = Instant::now();
+    match capture_png_snapshot_outcome_configured(&config.sensors.screen, output_path) {
+        Ok(ScreenCaptureOutcome::Captured(receipt)) => {
+            emit_captured_receipt(vault_root, config, &receipt, started, json)
         }
-        Ok(None) => {
-            if config.sensors.screen.enabled {
-                eprintln!("cairn screen capture: skipped by screen allow_apps policy");
-            } else {
-                eprintln!("cairn screen capture: screen sensor is disabled in config");
-            }
-            ExitCode::from(78)
+        Ok(ScreenCaptureOutcome::Skipped(skip)) => {
+            emit_skipped_capture(vault_root, config, skip, started, json)
         }
-        Err(err) => {
-            eprintln!("cairn screen capture: {err}");
-            exit_code_for_screen_error(&err)
+        Ok(ScreenCaptureOutcome::CleanupFailed { skip, error }) => {
+            emit_cleanup_failed_capture(vault_root, config, skip, &error, started, json)
         }
+        Err(err) => emit_failed_capture(vault_root, config, &err, started, json),
     }
+}
+
+fn emit_captured_receipt(
+    vault_root: &Path,
+    config: &CairnConfig,
+    receipt: &ScreenCaptureReceipt,
+    started: Instant,
+    json: bool,
+) -> ExitCode {
+    let capture_event = match capture_event_for_observation(
+        vault_root,
+        config,
+        receipt.observation.clone(),
+        started,
+    ) {
+        Ok(event) => event,
+        Err(err) => {
+            if let Err(cleanup_err) = remove_screen_capture_artifact(&receipt.output_path) {
+                emit_artifact_cleanup_failed_metric(
+                    vault_root,
+                    config,
+                    screen_observation_observed_bytes(&receipt.observation),
+                    &cleanup_err,
+                    started,
+                );
+                if json {
+                    emit_json(&post_capture_cleanup_failed_payload(&cleanup_err));
+                } else {
+                    eprintln!(
+                        "cairn screen capture: failed to build capture event: {err}; failed to remove capture artifact: {cleanup_err}"
+                    );
+                }
+                return exit_code_for_screen_error(&cleanup_err);
+            }
+            return emit_post_capture_drop(&err, json);
+        }
+    };
+    if json {
+        emit_json(&serde_json::json!({
+            "status": "captured",
+            "output_path": receipt.output_path,
+            "width": receipt.width,
+            "height": receipt.height,
+            "backend": format!("{:?}", receipt.observation.backend).to_ascii_lowercase(),
+            "ocr_engine": format!("{:?}", receipt.observation.ocr_engine).to_ascii_lowercase(),
+            "sensor_label": receipt.observation.sensor_label,
+            "captured_at": receipt.observation.captured_at,
+            "app": receipt.observation.app,
+            "window_title": receipt.observation.window_title,
+            "url": receipt.observation.url,
+            "ocr_text_bytes": receipt.observation.text.len(),
+            "bounding_boxes_count": receipt.observation.bounding_boxes.len(),
+            "capture_event": capture_event,
+        }));
+    } else {
+        println!(
+            "captured {} ({}x{}, app={}, ocr_bytes={})",
+            receipt.output_path.display(),
+            receipt.width,
+            receipt.height,
+            receipt.observation.app,
+            receipt.observation.text.len()
+        );
+    }
+    ExitCode::SUCCESS
+}
+
+fn emit_post_capture_drop(err: &CaptureEventBuildError, json: bool) -> ExitCode {
+    let (reason, error, code) = match err {
+        CaptureEventBuildError::Dropped(DropReason::PolicyRejected(_)) => {
+            ("policy_rejected", "policy_rejected", ExitCode::from(78))
+        }
+        CaptureEventBuildError::Dropped(DropReason::BudgetExceeded) => {
+            ("budget_exceeded", "budget_exceeded", ExitCode::from(77))
+        }
+        CaptureEventBuildError::Dropped(DropReason::Disabled) => {
+            ("disabled", "disabled", ExitCode::from(78))
+        }
+        CaptureEventBuildError::Dropped(DropReason::MalformedObservation(_))
+        | CaptureEventBuildError::BuildFailed(_) => (
+            "post_capture_validation_failed",
+            "validation_failed",
+            ExitCode::from(70),
+        ),
+    };
+    if json {
+        emit_json(&serde_json::json!({
+            "status": "dropped",
+            "sensor": "screen",
+            "reason": reason,
+            "error": error,
+            "artifact_created": false,
+        }));
+    } else {
+        eprintln!("cairn screen capture: failed to build capture event: {error}");
+    }
+    code
+}
+
+fn emit_skipped_capture(
+    vault_root: &Path,
+    config: &CairnConfig,
+    skip: ScreenCaptureSkip,
+    started: Instant,
+    json: bool,
+) -> ExitCode {
+    let outcome = EmitOutcome::Dropped {
+        sensor: SensorKind::Screen,
+        reason: skip.reason.drop_reason(),
+    };
+    emit_screen_sensor_outcome_metric(
+        vault_root,
+        config,
+        &outcome,
+        started,
+        skip.observed_bytes,
+        Some(screen_text_budget_bytes(config)),
+    );
+    if json {
+        emit_json(&serde_json::json!({
+            "status": "dropped",
+            "sensor": "screen",
+            "reason": skip.reason.as_str(),
+        }));
+    } else {
+        eprintln!("cairn screen capture: {}", skip.reason.message());
+    }
+    ExitCode::from(78)
+}
+
+fn emit_failed_capture(
+    vault_root: &Path,
+    config: &CairnConfig,
+    err: &ScreenError,
+    started: Instant,
+    json: bool,
+) -> ExitCode {
+    emit_screen_sensor_metric(
+        vault_root,
+        config,
+        ScreenSensorMetric {
+            status: "dropped",
+            error: Some(screen_error_metric_class(err).to_owned()),
+            degradation_state: Some(screen_error_degradation_state(err).to_owned()),
+            started,
+            observed_bytes: 0,
+            budget_bytes: Some(screen_text_budget_bytes(config)),
+        },
+    );
+    if json {
+        emit_json(&screen_error_payload(err));
+    } else {
+        eprintln!("cairn screen capture: {err}");
+    }
+    exit_code_for_screen_error(err)
+}
+
+fn emit_cleanup_failed_capture(
+    vault_root: &Path,
+    config: &CairnConfig,
+    skip: ScreenCaptureSkip,
+    err: &ScreenError,
+    started: Instant,
+    json: bool,
+) -> ExitCode {
+    emit_screen_sensor_metric(
+        vault_root,
+        config,
+        ScreenSensorMetric {
+            status: "dropped",
+            error: Some("artifact_cleanup_failed".to_owned()),
+            degradation_state: Some("cleanup_failed".to_owned()),
+            started,
+            observed_bytes: skip.observed_bytes,
+            budget_bytes: Some(screen_text_budget_bytes(config)),
+        },
+    );
+    if json {
+        emit_json(&cleanup_failed_payload(skip, err));
+    } else {
+        eprintln!(
+            "cairn screen capture: {} but failed to remove capture artifact: {err}",
+            skip.reason.message()
+        );
+    }
+    exit_code_for_screen_error(err)
+}
+
+fn emit_artifact_cleanup_failed_metric(
+    vault_root: &Path,
+    config: &CairnConfig,
+    observed_bytes: u64,
+    err: &ScreenError,
+    started: Instant,
+) {
+    emit_screen_sensor_metric(
+        vault_root,
+        config,
+        ScreenSensorMetric {
+            status: "dropped",
+            error: Some("artifact_cleanup_failed".to_owned()),
+            degradation_state: Some(screen_error_degradation_state(err).to_owned()),
+            started,
+            observed_bytes,
+            budget_bytes: Some(screen_text_budget_bytes(config)),
+        },
+    );
+}
+
+fn cleanup_failed_payload(skip: ScreenCaptureSkip, err: &ScreenError) -> serde_json::Value {
+    serde_json::json!({
+        "status": "dropped",
+        "sensor": "screen",
+        "reason": "artifact_cleanup_failed",
+        "skip_reason": skip.reason.as_str(),
+        "artifact_created": skip.artifact_created,
+        "observed_bytes": skip.observed_bytes,
+        "error": screen_error_metric_class(err),
+        "degradation_state": screen_error_degradation_state(err),
+    })
+}
+
+fn post_capture_cleanup_failed_payload(err: &ScreenError) -> serde_json::Value {
+    serde_json::json!({
+        "status": "dropped",
+        "sensor": "screen",
+        "reason": "artifact_cleanup_failed",
+        "skip_reason": "post_capture_validation_failed",
+        "artifact_created": true,
+        "error": screen_error_metric_class(err),
+        "degradation_state": screen_error_degradation_state(err),
+    })
+}
+
+fn screen_error_payload(err: &ScreenError) -> serde_json::Value {
+    serde_json::json!({
+        "status": "error",
+        "sensor": "screen",
+        "reason": screen_error_metric_class(err),
+        "error": screen_error_metric_class(err),
+        "degradation_state": screen_error_degradation_state(err),
+    })
+}
+
+fn remove_screen_capture_artifact(output_path: &Path) -> Result<(), ScreenError> {
+    if !output_path.exists() {
+        return Ok(());
+    }
+    std::fs::remove_file(output_path).map_err(|err| {
+        ScreenError::CaptureFailed(format!(
+            "failed to remove dropped screen capture {}: {err}",
+            output_path.display()
+        ))
+    })
 }
 
 fn enforce_screen_sensor_gate(
@@ -190,16 +409,157 @@ fn exit_code_for_gate_reason(reason: SensorGateReason) -> ExitCode {
     }
 }
 
-fn capture_event_for_observation(observation: ScreenObservation) -> Result<CaptureEvent, String> {
-    let event_id = CaptureEventId::parse(new_operation_id().0).map_err(|err| err.to_string())?;
-    let event_observation = ScreenEventObservation::from_observation(event_id, observation, None)
-        .map_err(|err| err.to_string())?;
-    let mut local_config = LocalSensorConfig::all_disabled();
-    local_config.screen = SensorSettings::enabled();
+fn screen_text_budget_bytes(config: &CairnConfig) -> u64 {
+    u64::from(config.sensors.screen.budget.max_text_bytes_per_event)
+}
 
-    match cairn_sensors_local::screen::emit(&local_config, event_observation) {
+#[derive(Debug)]
+enum CaptureEventBuildError {
+    Dropped(DropReason),
+    BuildFailed(String),
+}
+
+impl std::fmt::Display for CaptureEventBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Dropped(reason) => write!(f, "{reason:?}"),
+            Self::BuildFailed(err) => f.write_str(err),
+        }
+    }
+}
+
+fn capture_event_for_observation(
+    vault_root: &Path,
+    config: &CairnConfig,
+    observation: ScreenObservation,
+    started: Instant,
+) -> Result<CaptureEvent, CaptureEventBuildError> {
+    let event_id = CaptureEventId::parse(new_operation_id().0)
+        .map_err(|err| CaptureEventBuildError::BuildFailed(err.to_string()))?;
+    let observed_bytes = screen_observation_budgeted_payload_bytes(&observation).map_or_else(
+        |_| screen_observation_observed_bytes(&observation),
+        |bytes| u64::try_from(bytes).unwrap_or(u64::MAX),
+    );
+    let budget_bytes = Some(screen_text_budget_bytes(config));
+    let Ok(event_observation) =
+        ScreenEventObservation::from_observation(event_id, observation, None)
+    else {
+        let outcome = EmitOutcome::Dropped {
+            sensor: SensorKind::Screen,
+            reason: DropReason::MalformedObservation("invalid_timestamp".to_owned()),
+        };
+        emit_screen_sensor_outcome_metric(
+            vault_root,
+            config,
+            &outcome,
+            started,
+            observed_bytes,
+            budget_bytes,
+        );
+        return Err(CaptureEventBuildError::Dropped(
+            DropReason::MalformedObservation("invalid_timestamp".to_owned()),
+        ));
+    };
+    let mut local_config = LocalSensorConfig::from_core(&config.sensors);
+    local_config.screen = SensorSettings::enabled();
+    let outcome = cairn_sensors_local::screen::emit(&local_config, event_observation);
+    emit_screen_sensor_outcome_metric(
+        vault_root,
+        config,
+        &outcome,
+        started,
+        observed_bytes,
+        budget_bytes,
+    );
+
+    match outcome {
         EmitOutcome::Emitted(event) => Ok(event),
-        EmitOutcome::Dropped { reason, .. } => Err(format!("{reason:?}")),
+        EmitOutcome::Dropped { reason, .. } => Err(CaptureEventBuildError::Dropped(reason)),
+    }
+}
+
+fn emit_screen_sensor_outcome_metric(
+    vault_root: &Path,
+    config: &CairnConfig,
+    outcome: &EmitOutcome,
+    started: Instant,
+    observed_bytes: u64,
+    budget_bytes: Option<u64>,
+) {
+    if !config.observability.enabled || !config.observability.local_metrics {
+        return;
+    }
+    let latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let event = outcome.metric_event(
+        crate::metrics::now_ms(),
+        latency_ms,
+        observed_bytes,
+        budget_bytes,
+    );
+    if let Err(err) = crate::metrics::append_local_event_sync(vault_root, &event) {
+        tracing::warn!(error = %err, "screen sensor metric emit failed");
+    }
+}
+
+struct ScreenSensorMetric {
+    status: &'static str,
+    error: Option<String>,
+    degradation_state: Option<String>,
+    started: Instant,
+    observed_bytes: u64,
+    budget_bytes: Option<u64>,
+}
+
+fn emit_screen_sensor_metric(vault_root: &Path, config: &CairnConfig, metric: ScreenSensorMetric) {
+    if !config.observability.enabled || !config.observability.local_metrics {
+        return;
+    }
+    let latency_ms = u64::try_from(metric.started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let budget_used_ratio = metric
+        .budget_bytes
+        .and_then(|budget| screen_budget_ratio(metric.observed_bytes, budget));
+    let event = MetricEvent::SensorEmission {
+        ts_ms: crate::metrics::now_ms(),
+        sensor: SensorKind::Screen.as_str().to_owned(),
+        status: metric.status.to_owned(),
+        latency_ms,
+        bytes: metric.observed_bytes,
+        budget_bytes: metric.budget_bytes,
+        budget_used_ratio,
+        error: metric.error,
+        degradation_state: metric.degradation_state,
+    };
+    if let Err(err) = crate::metrics::append_local_event_sync(vault_root, &event) {
+        tracing::warn!(error = %err, "screen sensor metric emit failed");
+    }
+}
+
+fn screen_budget_ratio(bytes: u64, budget: u64) -> Option<f64> {
+    if budget == 0 {
+        return None;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    Some(bytes as f64 / budget as f64)
+}
+
+fn screen_error_metric_class(err: &ScreenError) -> &'static str {
+    match err {
+        ScreenError::Unavailable(ScreenDegradationCode::PermissionMissing) => "permission_missing",
+        ScreenError::Unavailable(ScreenDegradationCode::Disabled) => "disabled",
+        ScreenError::Unavailable(ScreenDegradationCode::BackendUnavailable) => {
+            "backend_unavailable"
+        }
+        ScreenError::Unavailable(ScreenDegradationCode::Degraded) => "degraded",
+        ScreenError::CaptureFailed(_) => "capture_failed",
+    }
+}
+
+fn screen_error_degradation_state(err: &ScreenError) -> &'static str {
+    match err.code() {
+        ScreenDegradationCode::PermissionMissing => "permission_missing",
+        ScreenDegradationCode::Disabled => "disabled",
+        ScreenDegradationCode::BackendUnavailable => "backend_unavailable",
+        ScreenDegradationCode::Degraded => "degraded",
     }
 }
 
@@ -210,5 +570,316 @@ fn exit_code_for_screen_error(err: &ScreenError) -> ExitCode {
         ScreenDegradationCode::BackendUnavailable | ScreenDegradationCode::Degraded => {
             ExitCode::from(69)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cairn_core::config::{ScreenBackend, ScreenOcrEngine};
+    use cairn_sensors_local::screen::{BoundingBox, ResolvedScreenOcrEngine, XCAP_SENSOR_LABEL};
+
+    fn observation_with_secret_text() -> ScreenObservation {
+        ScreenObservation {
+            text: "screen body with password=super-secret".to_owned(),
+            app: "Code".to_owned(),
+            window_title: "Telemetry Review".to_owned(),
+            url: Some("file:///tmp/secret.md".to_owned()),
+            bounding_boxes: vec![BoundingBox {
+                x: 1,
+                y: 2,
+                width: 3,
+                height: 4,
+            }],
+            captured_at: "2026-05-20T08:00:00Z".to_owned(),
+            sensor_label: XCAP_SENSOR_LABEL.to_owned(),
+            backend: ScreenBackend::Xcap,
+            ocr_engine: ResolvedScreenOcrEngine::Tesseract,
+        }
+    }
+
+    fn screen_config_with_text_budget(max_text_bytes: u32) -> CairnConfig {
+        let mut config = CairnConfig::default();
+        config.sensors.screen.enabled = true;
+        config.sensors.screen.ocr.engine = ScreenOcrEngine::Tesseract;
+        config.sensors.screen.budget.max_text_bytes_per_event = max_text_bytes;
+        config
+    }
+
+    fn first_sensor_metric(vault: &Path) -> serde_json::Value {
+        let metrics =
+            std::fs::read_to_string(vault.join(".cairn/metrics.jsonl")).expect("metrics file");
+        metrics
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("metric json"))
+            .find(|row| row["event"] == "sensor_emission")
+            .expect("sensor emission metric")
+    }
+
+    #[test]
+    fn screen_capture_event_emits_body_free_sensor_metric() {
+        let vault = tempfile::tempdir().expect("tempdir");
+        let payload_len = u32::try_from(
+            screen_observation_budgeted_payload_bytes(&observation_with_secret_text())
+                .expect("payload bytes"),
+        )
+        .expect("payload len fits u32");
+        let config = screen_config_with_text_budget(payload_len);
+
+        let event = capture_event_for_observation(
+            vault.path(),
+            &config,
+            observation_with_secret_text(),
+            Instant::now(),
+        )
+        .expect("screen capture event");
+        assert_eq!(event.source_family, SourceFamily::Screen);
+
+        let metrics = std::fs::read_to_string(vault.path().join(".cairn/metrics.jsonl"))
+            .expect("metrics file");
+        let metric = first_sensor_metric(vault.path());
+        assert_eq!(metric["sensor"], "screen");
+        assert_eq!(metric["status"], "emitted");
+        assert_eq!(metric["bytes"], u64::from(payload_len));
+        assert_eq!(metric["budget_bytes"], u64::from(payload_len));
+        assert!(metric["latency_ms"].as_u64().is_some());
+        assert!(
+            !metrics.contains("password=super-secret")
+                && !metrics.contains("screen body")
+                && !metrics.contains("secret.md"),
+            "screen sensor metric must not export payload fields: {metrics}"
+        );
+    }
+
+    #[test]
+    fn screen_capture_event_emits_when_payload_exceeds_configured_budget() {
+        let vault = tempfile::tempdir().expect("tempdir");
+        let config = screen_config_with_text_budget(1);
+
+        let event = capture_event_for_observation(
+            vault.path(),
+            &config,
+            observation_with_secret_text(),
+            Instant::now(),
+        )
+        .expect("diagnostic capture event should not fail on metric budget");
+        assert_eq!(event.source_family, SourceFamily::Screen);
+
+        let metric = first_sensor_metric(vault.path());
+        assert_eq!(metric["sensor"], "screen");
+        assert_eq!(metric["status"], "emitted");
+        assert!(metric["bytes"].as_u64().expect("metric bytes") > 1);
+        assert_eq!(metric["budget_bytes"], 1);
+        assert!(metric["budget_used_ratio"].as_f64().expect("budget ratio") > 1.0);
+    }
+
+    #[test]
+    fn screen_capture_event_metric_uses_capture_start_latency() {
+        let vault = tempfile::tempdir().expect("tempdir");
+        let payload_len = u32::try_from(
+            screen_observation_budgeted_payload_bytes(&observation_with_secret_text())
+                .expect("payload bytes"),
+        )
+        .expect("payload len fits u32");
+        let config = screen_config_with_text_budget(payload_len);
+        let started = Instant::now()
+            .checked_sub(std::time::Duration::from_millis(25))
+            .expect("instant can move back for test");
+
+        capture_event_for_observation(
+            vault.path(),
+            &config,
+            observation_with_secret_text(),
+            started,
+        )
+        .expect("screen capture event");
+
+        let metric = first_sensor_metric(vault.path());
+        assert!(metric["latency_ms"].as_u64().expect("latency") >= 25);
+    }
+
+    #[test]
+    fn screen_capture_event_emits_malformed_timestamp_metric() {
+        let vault = tempfile::tempdir().expect("tempdir");
+        let config = screen_config_with_text_budget(1024);
+        let mut observation = observation_with_secret_text();
+        observation.captured_at = "not-a-timestamp".to_owned();
+
+        let err = capture_event_for_observation(vault.path(), &config, observation, Instant::now())
+            .expect_err("screen event should reject malformed timestamp");
+        assert!(
+            err.to_string().contains("invalid_timestamp"),
+            "expected timestamp failure, got {err}"
+        );
+
+        let metric = first_sensor_metric(vault.path());
+        assert_eq!(metric["sensor"], "screen");
+        assert_eq!(metric["status"], "dropped");
+        assert_eq!(metric["error"], "malformed_observation");
+        assert_eq!(metric["budget_bytes"], 1024);
+    }
+
+    #[test]
+    fn captured_receipt_validation_failure_removes_artifact() {
+        let vault = tempfile::tempdir().expect("tempdir");
+        let output_path = vault.path().join("screen.png");
+        std::fs::write(&output_path, b"fake-png").expect("write fake capture");
+        let config = screen_config_with_text_budget(1024);
+        let mut observation = observation_with_secret_text();
+        observation.captured_at = "not-a-timestamp".to_owned();
+        let receipt = ScreenCaptureReceipt {
+            output_path: output_path.clone(),
+            width: 10,
+            height: 20,
+            observation,
+        };
+
+        let code = emit_captured_receipt(vault.path(), &config, &receipt, Instant::now(), false);
+
+        assert_eq!(code, ExitCode::from(70));
+        assert!(!output_path.exists());
+    }
+
+    #[test]
+    fn captured_receipt_policy_rejection_removes_artifact_as_drop() {
+        let vault = tempfile::tempdir().expect("tempdir");
+        let output_path = vault.path().join("screen.png");
+        std::fs::write(&output_path, b"fake-png").expect("write fake capture");
+        let config = screen_config_with_text_budget(4096);
+        let mut observation = observation_with_secret_text();
+        observation.text = "-----BEGIN PRIVATE KEY-----\nsecret".to_owned();
+        let receipt = ScreenCaptureReceipt {
+            output_path: output_path.clone(),
+            width: 10,
+            height: 20,
+            observation,
+        };
+
+        let code = emit_captured_receipt(vault.path(), &config, &receipt, Instant::now(), true);
+
+        assert_eq!(code, ExitCode::from(78));
+        assert!(!output_path.exists());
+        let metric = first_sensor_metric(vault.path());
+        assert_eq!(metric["status"], "dropped");
+        assert_eq!(metric["error"], "policy_rejected");
+    }
+
+    #[test]
+    fn screen_capture_skip_emits_body_free_privacy_metric() {
+        let vault = tempfile::tempdir().expect("tempdir");
+        let config = screen_config_with_text_budget(1024);
+        let outcome = EmitOutcome::Dropped {
+            sensor: SensorKind::Screen,
+            reason: DropReason::PolicyRejected("privacy_filtered".to_owned()),
+        };
+
+        emit_screen_sensor_outcome_metric(
+            vault.path(),
+            &config,
+            &outcome,
+            Instant::now(),
+            73,
+            Some(screen_text_budget_bytes(&config)),
+        );
+
+        let metrics = std::fs::read_to_string(vault.path().join(".cairn/metrics.jsonl"))
+            .expect("metrics file");
+        let metric = first_sensor_metric(vault.path());
+        assert_eq!(metric["sensor"], "screen");
+        assert_eq!(metric["status"], "dropped");
+        assert_eq!(metric["error"], "policy_rejected");
+        assert_eq!(metric["bytes"], 73);
+        assert_eq!(metric["budget_bytes"], 1024);
+        assert!(
+            !metrics.contains("privacy_filtered"),
+            "privacy metric must not export internal reason details: {metrics}"
+        );
+    }
+
+    #[test]
+    fn screen_capture_failure_emits_runtime_failure_metric() {
+        let vault = tempfile::tempdir().expect("tempdir");
+        let config = screen_config_with_text_budget(1024);
+
+        let code = emit_failed_capture(
+            vault.path(),
+            &config,
+            &ScreenError::Unavailable(ScreenDegradationCode::PermissionMissing),
+            Instant::now(),
+            false,
+        );
+        assert_eq!(code, ExitCode::from(77));
+
+        let metric = first_sensor_metric(vault.path());
+        assert_eq!(metric["sensor"], "screen");
+        assert_eq!(metric["status"], "dropped");
+        assert_eq!(metric["error"], "permission_missing");
+        assert_eq!(metric["degradation_state"], "permission_missing");
+        assert_eq!(metric["budget_bytes"], 1024);
+    }
+
+    #[test]
+    fn screen_capture_cleanup_failure_preserves_skip_bytes_metric() {
+        let vault = tempfile::tempdir().expect("tempdir");
+        let config = screen_config_with_text_budget(1024);
+        let skip = ScreenCaptureSkip {
+            reason: cairn_sensors_local::screen::ScreenCaptureSkipReason::PrivacyFiltered,
+            observed_bytes: 321,
+            artifact_created: true,
+        };
+
+        let code = emit_cleanup_failed_capture(
+            vault.path(),
+            &config,
+            skip,
+            &ScreenError::CaptureFailed("failed to remove dropped screen capture".to_owned()),
+            Instant::now(),
+            false,
+        );
+        assert_eq!(code, ExitCode::from(69));
+
+        let metric = first_sensor_metric(vault.path());
+        assert_eq!(metric["sensor"], "screen");
+        assert_eq!(metric["status"], "dropped");
+        assert_eq!(metric["error"], "artifact_cleanup_failed");
+        assert_eq!(metric["degradation_state"], "cleanup_failed");
+        assert_eq!(metric["bytes"], 321);
+        assert_eq!(metric["budget_bytes"], 1024);
+    }
+
+    #[test]
+    fn cleanup_failure_payload_is_structured_for_json_callers() {
+        let skip = ScreenCaptureSkip {
+            reason: cairn_sensors_local::screen::ScreenCaptureSkipReason::PrivacyFiltered,
+            observed_bytes: 321,
+            artifact_created: true,
+        };
+
+        let payload = cleanup_failed_payload(
+            skip,
+            &ScreenError::CaptureFailed("failed to remove dropped screen capture".to_owned()),
+        );
+
+        assert_eq!(payload["status"], "dropped");
+        assert_eq!(payload["sensor"], "screen");
+        assert_eq!(payload["reason"], "artifact_cleanup_failed");
+        assert_eq!(payload["skip_reason"], "privacy_filtered");
+        assert_eq!(payload["artifact_created"], true);
+        assert_eq!(payload["observed_bytes"], 321);
+        assert_eq!(payload["error"], "capture_failed");
+        assert_eq!(payload["degradation_state"], "backend_unavailable");
+    }
+
+    #[test]
+    fn runtime_error_payload_is_structured_for_json_callers() {
+        let payload = screen_error_payload(&ScreenError::Unavailable(
+            ScreenDegradationCode::PermissionMissing,
+        ));
+
+        assert_eq!(payload["status"], "error");
+        assert_eq!(payload["sensor"], "screen");
+        assert_eq!(payload["reason"], "permission_missing");
+        assert_eq!(payload["error"], "permission_missing");
+        assert_eq!(payload["degradation_state"], "permission_missing");
     }
 }

--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -10,11 +10,12 @@
 use std::collections::HashMap;
 use std::process::ExitCode;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use cairn_core::config::{EmbeddingProvider, StoreKind};
 use cairn_core::contract::memory_store::MemoryStore;
 use cairn_core::domain::filter::validate_filter;
+use cairn_core::domain::metrics::MetricEvent;
 use cairn_core::domain::projection::ProjectionTarget;
 use cairn_core::generated::envelope::ResponseVerb;
 use cairn_core::generated::verbs::search::{SearchArgsFilters, SearchArgsMode};
@@ -44,6 +45,16 @@ enum SearchMode {
     Keyword,
     Semantic,
     Hybrid,
+}
+
+impl SearchMode {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Keyword => "keyword",
+            Self::Semantic => "semantic",
+            Self::Hybrid => "hybrid",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -287,6 +298,7 @@ async fn run_async(
     let provider_ready = super::embedding_provider_ready(&config, model_present, Some(&vault_root));
     let caps = config.capabilities(provider_ready);
     let provider = config.search.default_provider;
+    let search_started = Instant::now();
 
     // CLI-side capability gate — fires BEFORE embedder resolution so an
     // unadvertised mode (e.g. `--mode semantic` against a vault without
@@ -385,11 +397,21 @@ async fn run_async(
     match cairn_core::verbs::search::run(&store, &config, &caps, request).await {
         Ok(outcome) => {
             match bm25s_scores(&store, &config, &outcome, &query_text, limit, bm25s_mode).await {
-                Ok(scores) => render_outcome(&outcome, json, mode, scores.as_ref()),
+                Ok(scores) => {
+                    emit_search_metric(&vault_root, &config, mode, search_started, &outcome, None);
+                    render_outcome(&outcome, json, mode, scores.as_ref())
+                }
                 Err(err) => emit_bm25s_unavailable(json, &err),
             }
         }
         Err(cairn_core::verbs::search::SearchError::CapabilityUnavailable { capability }) => {
+            emit_search_metric_error(
+                &vault_root,
+                &config,
+                mode,
+                search_started,
+                "capability_unavailable",
+            );
             let resp = capability_unavailable_response(ResponseVerb::Search, capability);
             if json {
                 emit_json(&resp);
@@ -407,6 +429,7 @@ async fn run_async(
             ExitCode::from(69) // EX_UNAVAILABLE
         }
         Err(cairn_core::verbs::search::SearchError::InvalidArgs { reason }) => {
+            emit_search_metric_error(&vault_root, &config, mode, search_started, "invalid_args");
             let resp = invalid_args_response(ResponseVerb::Search, "args", &reason);
             if json {
                 emit_json(&resp);
@@ -421,6 +444,7 @@ async fn run_async(
             ExitCode::from(64) // EX_USAGE
         }
         Err(cairn_core::verbs::search::SearchError::InvalidFilter { reason }) => {
+            emit_search_metric_error(&vault_root, &config, mode, search_started, "invalid_filter");
             let resp = invalid_filter_response(ResponseVerb::Search, &reason, Some("filters"));
             if json {
                 emit_json(&resp);
@@ -435,6 +459,7 @@ async fn run_async(
             ExitCode::from(64) // EX_USAGE
         }
         Err(e) => {
+            emit_search_metric_error(&vault_root, &config, mode, search_started, "internal");
             let msg = format!("{e}");
             let resp = internal_error_response(ResponseVerb::Search, &msg);
             if json {
@@ -600,6 +625,60 @@ fn required_or_skip<T>(mode: Bm25sMode, reason: String) -> Result<Option<T>, Bm2
         Err(Bm25sUnavailable { reason })
     } else {
         Ok(None)
+    }
+}
+
+fn emit_search_metric(
+    vault_root: &std::path::Path,
+    config: &cairn_core::config::CairnConfig,
+    mode: SearchMode,
+    started: Instant,
+    outcome: &cairn_core::verbs::search::SearchOutcome,
+    error: Option<&str>,
+) {
+    if !config.observability.enabled || !config.observability.local_metrics {
+        return;
+    }
+    let latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let degradation_state = if outcome.degraded_legs.is_empty() {
+        "none"
+    } else {
+        "partial"
+    };
+    let event = MetricEvent::SearchCompleted {
+        ts_ms: crate::metrics::now_ms(),
+        mode: mode.as_str().to_owned(),
+        hit_count: u32::try_from(outcome.candidates.len()).unwrap_or(u32::MAX),
+        latency_ms,
+        degradation_state: degradation_state.to_owned(),
+        error: error.map(str::to_owned),
+    };
+    if let Err(err) = crate::metrics::append_local_event_sync(vault_root, &event) {
+        tracing::warn!(error = %err, "search metric emit failed");
+    }
+}
+
+fn emit_search_metric_error(
+    vault_root: &std::path::Path,
+    config: &cairn_core::config::CairnConfig,
+    mode: SearchMode,
+    started: Instant,
+    error: &str,
+) {
+    if !config.observability.enabled || !config.observability.local_metrics {
+        return;
+    }
+    let latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+    let event = MetricEvent::SearchCompleted {
+        ts_ms: crate::metrics::now_ms(),
+        mode: mode.as_str().to_owned(),
+        hit_count: 0,
+        latency_ms,
+        degradation_state: "failed".to_owned(),
+        error: Some(error.to_owned()),
+    };
+    if let Err(err) = crate::metrics::append_local_event_sync(vault_root, &event) {
+        tracing::warn!(error = %err, "search metric emit failed");
     }
 }
 

--- a/crates/cairn-cli/tests/admin_reindex_from_db.rs
+++ b/crates/cairn-cli/tests/admin_reindex_from_db.rs
@@ -65,6 +65,25 @@ async fn rebuild_from_db_snapshot() {
         "expected at least 3 records drained (embedded); got: {stdout}"
     );
 
+    let metrics = std::fs::read_to_string(root.join(".cairn/metrics.jsonl"))
+        .expect("projection rebuild metric file");
+    let projection_metric = metrics
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("metric json"))
+        .find(|row| row["event"] == "projection_rebuild")
+        .expect("projection_rebuild metric");
+    assert_eq!(projection_metric["projection"], "sqlite.from_db");
+    assert_eq!(projection_metric["status"], "committed");
+    assert_eq!(projection_metric["records_rebuilt"], 3);
+    assert!(projection_metric["latency_ms"].as_u64().is_some());
+    assert_eq!(projection_metric["retry_count"], 0);
+    assert_eq!(projection_metric["queue_lag_ms"], 0);
+    assert_eq!(projection_metric["error"], serde_json::Value::Null);
+    assert!(
+        !metrics.contains("alpha") && !metrics.contains("bravo") && !metrics.contains("charlie"),
+        "projection metric must not export record bodies: {metrics}"
+    );
+
     insta::assert_snapshot!("admin_reindex_from_db", stdout);
     drop(dir);
 }

--- a/crates/cairn-cli/tests/folder_ingest.rs
+++ b/crates/cairn-cli/tests/folder_ingest.rs
@@ -64,9 +64,18 @@ fn folder_ingest_keyword_dry_run_json_succeeds_without_writes() {
 
     assert_eq!(out.status.code(), Some(0), "exit: {:?}", out.status);
     assert!(
-        !dir.path().join(".cairn").exists(),
-        "dry-run must not create vault state"
+        !dir.path().join(".cairn/cairn.db").exists(),
+        "dry-run must not create the store"
     );
+    assert!(
+        !dir.path().join(".cairn/cache").exists(),
+        "dry-run must not create extraction cache state"
+    );
+    let metrics = std::fs::read_to_string(dir.path().join(".cairn/metrics.jsonl"))
+        .expect("read dry-run verb metric");
+    assert!(metrics.contains("\"event\":\"verb_invocation\""));
+    assert!(metrics.contains("\"verb\":\"ingest\""));
+    assert!(metrics.contains("\"mode\":\"folder\""));
     let v = json_stdout(&out);
     for field in [
         "cached",

--- a/crates/cairn-cli/tests/hot_prefix_cache_e2e.rs
+++ b/crates/cairn-cli/tests/hot_prefix_cache_e2e.rs
@@ -51,6 +51,14 @@ fn assemble_hot(vault: &Path) {
     );
 }
 
+fn hot_prefix_metrics(content: &str) -> Vec<serde_json::Value> {
+    content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|metric| metric["event"] == "hot_prefix_assembled")
+        .collect()
+}
+
 #[test]
 fn assemble_hot_writes_one_metrics_line_per_call() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -62,9 +70,9 @@ fn assemble_hot_writes_one_metrics_line_per_call() {
     // First call → cache miss → 1 line.
     assemble_hot(dir.path());
     let content1 = std::fs::read_to_string(&metrics_path).expect("read metrics #1");
-    assert_eq!(content1.lines().count(), 1, "after 1 call");
-    let line1: serde_json::Value =
-        serde_json::from_str(content1.lines().next().unwrap()).expect("parse #1");
+    let metrics1 = hot_prefix_metrics(&content1);
+    assert_eq!(metrics1.len(), 1, "after 1 call: {content1}");
+    let line1 = &metrics1[0];
     assert_eq!(line1["event"], "hot_prefix_assembled");
     assert_eq!(
         line1["cache_hit"], false,
@@ -74,9 +82,9 @@ fn assemble_hot_writes_one_metrics_line_per_call() {
     // Second call → cache hit → 2 lines, last line cache_hit: true.
     assemble_hot(dir.path());
     let content2 = std::fs::read_to_string(&metrics_path).expect("read metrics #2");
-    let all_lines: Vec<&str> = content2.lines().collect();
-    assert_eq!(all_lines.len(), 2, "after 2 calls");
-    let line2: serde_json::Value = serde_json::from_str(all_lines[1]).expect("parse #2");
+    let metrics2 = hot_prefix_metrics(&content2);
+    assert_eq!(metrics2.len(), 2, "after 2 calls: {content2}");
+    let line2 = &metrics2[1];
     assert_eq!(line2["event"], "hot_prefix_assembled");
     assert_eq!(
         line2["cache_hit"], true,
@@ -117,15 +125,15 @@ fn watermark_bump_invalidates_cache_across_cli_calls() {
     assemble_hot(dir.path());
 
     let content = std::fs::read_to_string(&metrics_path).expect("read metrics");
-    let lines: Vec<&str> = content.lines().collect();
+    let metrics = hot_prefix_metrics(&content);
     assert_eq!(
-        lines.len(),
+        metrics.len(),
         3,
-        "expected 3 metric lines, got {}: {content}",
-        lines.len()
+        "expected 3 hot-prefix metric lines, got {}: {content}",
+        metrics.len()
     );
 
-    let last: serde_json::Value = serde_json::from_str(lines[2]).expect("parse last");
+    let last = &metrics[2];
     assert_eq!(
         last["cache_hit"], false,
         "watermark bump must invalidate the cache; last metric line: {last}"

--- a/crates/cairn-cli/tests/hot_prefix_latency_smoke.rs
+++ b/crates/cairn-cli/tests/hot_prefix_latency_smoke.rs
@@ -65,12 +65,13 @@ fn assemble_hot_p95_meets_slo_on_fixture_vault() {
     let mut latencies: Vec<u64> = content
         .lines()
         .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .filter(|v| v["event"] == "hot_prefix_assembled")
         .filter_map(|v| v["latency_ms"].as_u64())
         .collect();
 
     assert!(
         latencies.len() >= 10,
-        "expected >=10 metric events; got {} in {content:?}",
+        "expected >=10 hot-prefix metric events; got {} in {content:?}",
         latencies.len()
     );
 

--- a/crates/cairn-cli/tests/ingest_pipeline_e2e.rs
+++ b/crates/cairn-cli/tests/ingest_pipeline_e2e.rs
@@ -86,6 +86,17 @@ fn keyword_search_hits(vault: &Path, query: &str) -> Vec<serde_json::Value> {
         .clone()
 }
 
+fn assert_ingest_metric_is_body_free(vault: &Path, forbidden: &str, status: &str) {
+    let metrics = fs::read_to_string(vault.join(".cairn/metrics.jsonl")).expect("read metrics");
+    assert!(metrics.contains("\"event\":\"verb_invocation\""));
+    assert!(metrics.contains("\"verb\":\"ingest\""));
+    assert!(metrics.contains(&format!("\"status\":\"{status}\"")));
+    assert!(
+        !metrics.contains(forbidden),
+        "verb metric must not leak body text: {metrics}"
+    );
+}
+
 #[test]
 fn ingest_body_commits_record_through_signed_store() {
     let vault = tempfile::tempdir().expect("temp vault");
@@ -129,10 +140,7 @@ fn ingest_body_commits_record_through_signed_store() {
     let record_id = response["data"]["record_id"]
         .as_str()
         .expect("record_id is string");
-    assert!(
-        !vault.path().join(".cairn/metrics.jsonl").exists(),
-        "signed ingest path should not write the legacy metrics sidecar"
-    );
+    assert_ingest_metric_is_body_free(vault.path(), body, "committed");
 
     let record = active_record_json(vault.path(), record_id);
     assert_eq!(record["id"], record_id);
@@ -178,10 +186,7 @@ fn ingest_rejects_invented_kind_before_store_dispatch() {
     );
     assert_eq!(response["policy_trace"][0]["gate"], "scope_check");
     assert_eq!(response["policy_trace"][0]["result"], "error");
-    assert!(
-        !vault.path().join(".cairn/metrics.jsonl").exists(),
-        "invalid taxonomy should reject before metric append"
-    );
+    assert_ingest_metric_is_body_free(vault.path(), "invented taxonomy value", "aborted");
 }
 
 #[test]
@@ -227,10 +232,7 @@ fn ingest_file_runs_signed_pipeline_without_leaking_file_body() {
         .as_str()
         .expect("record_id is string");
 
-    assert!(
-        !vault.path().join(".cairn/metrics.jsonl").exists(),
-        "signed ingest path should not write the legacy metrics sidecar"
-    );
+    assert_ingest_metric_is_body_free(vault.path(), "Body marker", "committed");
     let record = active_record_json(vault.path(), record_id);
     assert_eq!(record["kind"], "user");
     assert_eq!(

--- a/crates/cairn-cli/tests/telemetry.rs
+++ b/crates/cairn-cli/tests/telemetry.rs
@@ -1,0 +1,141 @@
+//! Telemetry fixture tests for issue #116.
+
+use std::process::Command;
+
+fn cli() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cairn"));
+    cmd.env_remove("CAIRN_VAULT");
+    cmd
+}
+
+fn bootstrap_vault(vault: &std::path::Path) {
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: vault.to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+}
+
+#[test]
+fn local_verb_metric_is_body_free_by_default() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+
+    let secret = "very secret body text";
+    let out = cli()
+        .current_dir(vault.path())
+        .args(["ingest", "--kind", "reference", "--body", secret, "--json"])
+        .output()
+        .expect("cairn ingest");
+    assert!(
+        out.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let metrics =
+        std::fs::read_to_string(vault.path().join(".cairn/metrics.jsonl")).expect("read metrics");
+    assert!(metrics.contains("\"event\":\"verb_invocation\""));
+    assert!(metrics.contains("\"verb\":\"ingest\""));
+    assert!(metrics.contains("\"status\":\"committed\""));
+    assert!(metrics.contains("\"mode\":\"body\""));
+    assert!(!metrics.contains(secret));
+    assert!(!metrics.contains("\"body\":"));
+    assert!(!metrics.contains("body_text"));
+}
+
+#[test]
+fn local_verb_metric_records_file_mode_without_panicking() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let source = vault.path().join("note.md");
+    std::fs::write(&source, "file body text").expect("write source");
+
+    let out = cli()
+        .current_dir(vault.path())
+        .args([
+            "ingest",
+            "--kind",
+            "reference",
+            "--file",
+            source.to_str().expect("utf8 path"),
+            "--json",
+        ])
+        .output()
+        .expect("cairn ingest");
+    assert!(
+        out.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let metrics =
+        std::fs::read_to_string(vault.path().join(".cairn/metrics.jsonl")).expect("read metrics");
+    assert!(metrics.contains("\"event\":\"verb_invocation\""));
+    assert!(metrics.contains("\"verb\":\"ingest\""));
+    assert!(metrics.contains("\"mode\":\"file\""));
+    assert!(!metrics.contains("file body text"));
+}
+
+#[test]
+fn forget_record_mode_does_not_panic() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+
+    let out = cli()
+        .current_dir(vault.path())
+        .args(["forget", "--record", "01ARZ3NDEKTSV4RRFFQ69G5FAV", "--json"])
+        .output()
+        .expect("cairn forget");
+
+    assert_ne!(
+        out.status.code(),
+        Some(101),
+        "forget telemetry mode detection must not panic\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let metrics =
+        std::fs::read_to_string(vault.path().join(".cairn/metrics.jsonl")).expect("read metrics");
+    assert!(metrics.contains("\"event\":\"verb_invocation\""));
+    assert!(metrics.contains("\"verb\":\"forget\""));
+    assert!(metrics.contains("\"mode\":\"record\""));
+}
+
+#[test]
+fn local_verb_metrics_can_be_disabled() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    std::fs::write(
+        vault.path().join(".cairn/config.yaml"),
+        "observability:\n  enabled: false\n",
+    )
+    .expect("write config");
+
+    let out = cli()
+        .current_dir(vault.path())
+        .args([
+            "ingest",
+            "--kind",
+            "reference",
+            "--body",
+            "not exported",
+            "--json",
+        ])
+        .output()
+        .expect("cairn ingest");
+    assert!(
+        out.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let metrics_path = vault.path().join(".cairn/metrics.jsonl");
+    if metrics_path.exists() {
+        let metrics = std::fs::read_to_string(metrics_path).expect("read metrics");
+        assert!(!metrics.contains("\"event\":\"verb_invocation\""));
+    }
+}

--- a/crates/cairn-core/src/config/mod.rs
+++ b/crates/cairn-core/src/config/mod.rs
@@ -178,6 +178,10 @@ pub enum ObservabilityExporter {
 /// Local-first observability configuration (§15, §19 v0.2).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "user-facing config uses independent feature toggles"
+)]
 pub struct ObservabilityConfig {
     /// Master switch for spans and metrics.
     pub enabled: bool,

--- a/crates/cairn-core/src/config/mod.rs
+++ b/crates/cairn-core/src/config/mod.rs
@@ -158,6 +158,52 @@ pub enum ConfigError {
         /// Stringified `DomainError::MalformedScope` body.
         message: String,
     },
+    /// OTLP export was requested without an endpoint.
+    #[error("observability.exporter = otlp requires observability.endpoint")]
+    MissingObservabilityEndpoint,
+}
+
+/// Optional telemetry exporter for traces/metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ObservabilityExporter {
+    /// No network exporter. Default local-only mode.
+    #[default]
+    None,
+    /// OTLP exporter. Requires `observability.endpoint`.
+    Otlp,
+}
+
+/// Local-first observability configuration (§15, §19 v0.2).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ObservabilityConfig {
+    /// Master switch for spans and metrics.
+    pub enabled: bool,
+    /// Append body-free events to `.cairn/metrics.jsonl`.
+    pub local_metrics: bool,
+    /// Emit structured `tracing` spans/events without network export.
+    pub local_traces: bool,
+    /// Optional external exporter, disabled by default.
+    pub exporter: ObservabilityExporter,
+    /// Exporter endpoint such as an OTLP collector URL.
+    pub endpoint: Option<String>,
+    /// Keep sensitive record fields out of exported telemetry.
+    pub redact_sensitive_fields: bool,
+}
+
+impl Default for ObservabilityConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            local_metrics: true,
+            local_traces: true,
+            exporter: ObservabilityExporter::None,
+            endpoint: None,
+            redact_sensitive_fields: true,
+        }
+    }
 }
 
 /// Vault storage tier (§3.1).
@@ -541,6 +587,9 @@ pub struct CairnConfig {
     pub pipeline: PipelineConfig,
     /// MCP transport configuration (issue #190).
     pub mcp: McpConfig,
+    /// Local-first observability and exporter configuration (§15, §19 v0.2).
+    #[serde(default)]
+    pub observability: ObservabilityConfig,
     /// Rolling-summary consolidation workflow configuration (brief §5.3, §10.0).
     #[serde(default)]
     pub consolidation: ConsolidationConfig,
@@ -1852,6 +1901,16 @@ impl CairnConfig {
         self.evaluation
             .validate()
             .map_err(|source| ConfigError::InvalidEvaluation { source })?;
+
+        if self.observability.exporter == ObservabilityExporter::Otlp
+            && self
+                .observability
+                .endpoint
+                .as_ref()
+                .is_none_or(|endpoint| endpoint.trim().is_empty())
+        {
+            return Err(ConfigError::MissingObservabilityEndpoint);
+        }
 
         Ok(())
     }
@@ -3180,6 +3239,24 @@ rerank_topk: 20
         // Default: single_tenant = false, principal = None — cleanly valid.
         let cfg = CairnConfig::default();
         cfg.validate_mcp().expect("default config is valid");
+    }
+
+    #[test]
+    fn observability_defaults_are_local_only() {
+        let cfg = CairnConfig::default();
+        assert!(cfg.observability.enabled);
+        assert!(cfg.observability.local_metrics);
+        assert!(cfg.observability.local_traces);
+        assert_eq!(cfg.observability.exporter, ObservabilityExporter::None);
+        assert!(cfg.observability.redact_sensitive_fields);
+    }
+
+    #[test]
+    fn validate_rejects_otlp_exporter_without_endpoint() {
+        let mut cfg = CairnConfig::default();
+        cfg.observability.exporter = ObservabilityExporter::Otlp;
+        let err = cfg.validate().unwrap_err();
+        assert!(matches!(err, ConfigError::MissingObservabilityEndpoint));
     }
 
     proptest! {

--- a/crates/cairn-core/src/config/snapshots/cairn_core__config__tests__default_config_snapshot.snap
+++ b/crates/cairn-core/src/config/snapshots/cairn_core__config__tests__default_config_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cairn-core/src/config/mod.rs
+assertion_line: 2729
 expression: json
 ---
 {
@@ -212,6 +213,14 @@ expression: json
     "stdio": {
       "single_tenant": false
     }
+  },
+  "observability": {
+    "enabled": true,
+    "local_metrics": true,
+    "local_traces": true,
+    "exporter": "none",
+    "endpoint": null,
+    "redact_sensitive_fields": true
   },
   "consolidation": {
     "enabled": true,

--- a/crates/cairn-core/src/domain/metrics.rs
+++ b/crates/cairn-core/src/domain/metrics.rs
@@ -57,6 +57,30 @@ pub enum MetricEvent {
         /// Body-free error class when the search did not commit.
         error: Option<String>,
     },
+    /// Emitted by local sensors after an observation is accepted or
+    /// dropped. Payload bodies, OCR text, transcripts, command output,
+    /// file paths, and raw policy messages are deliberately omitted.
+    #[serde(rename = "sensor_emission")]
+    SensorEmission {
+        /// Wall-clock millis since UNIX epoch.
+        ts_ms: i64,
+        /// Sensor family (`hook`, `terminal`, `clipboard`, ...).
+        sensor: String,
+        /// Response status (`emitted` or `dropped`).
+        status: String,
+        /// Wall-clock latency observed by the sensor surface.
+        latency_ms: u64,
+        /// Sanitized or observed payload size used for budget accounting.
+        bytes: u64,
+        /// Configured sensor byte budget when known.
+        budget_bytes: Option<u64>,
+        /// `bytes / budget_bytes` when a non-zero budget is known.
+        budget_used_ratio: Option<f64>,
+        /// Body-free error class when the observation was dropped.
+        error: Option<String>,
+        /// Degradation state such as `none` or `partial`.
+        degradation_state: Option<String>,
+    },
     /// Emitted for record WAL operations after finalization.
     #[serde(rename = "wal_apply")]
     WalApply {
@@ -97,6 +121,31 @@ pub enum MetricEvent {
         cache_hit: bool,
         /// Snapshot of every source-class watermark at assembly time.
         watermarks: SourceWatermarks,
+    },
+    /// Emitted after an administrative projection rebuild, such as
+    /// `cairn admin reindex --from-db`. Record bodies and projection
+    /// payloads are omitted; only aggregate SRE dimensions are exported.
+    #[serde(rename = "projection_rebuild")]
+    ProjectionRebuild {
+        /// Wall-clock millis since UNIX epoch.
+        ts_ms: i64,
+        /// Projection or rebuild path (`sqlite.from_db`, ...).
+        projection: String,
+        /// Final rebuild status (`committed` or `aborted`).
+        status: String,
+        /// Wall-clock latency observed by the caller.
+        latency_ms: u64,
+        /// Number of projection rows rebuilt when known.
+        records_rebuilt: u64,
+        /// Queue lag in milliseconds when known; zero is the local
+        /// unknown/no-lag sentinel for immediate admin rebuilds.
+        queue_lag_ms: i64,
+        /// Retry count observed by the caller.
+        retry_count: u32,
+        /// Body-free error class when status is not committed.
+        error: Option<String>,
+        /// Degradation state such as `none` or `partial`.
+        degradation_state: Option<String>,
     },
     /// Emitted when an active task-trace canvas is rendered into the
     /// hot-memory current-task section. The payload is intentionally
@@ -405,5 +454,57 @@ mod tests {
         assert!(json.contains("\"budget_used_ratio\":0.25"));
         assert!(!json.contains("secret"));
         assert!(!json.contains("body_text"));
+    }
+
+    #[test]
+    fn sensor_emission_metric_is_body_free_and_exposes_budget() {
+        let event = MetricEvent::SensorEmission {
+            ts_ms: 1,
+            sensor: "clipboard".into(),
+            status: "dropped".into(),
+            latency_ms: 7,
+            bytes: 64,
+            budget_bytes: Some(1024),
+            budget_used_ratio: Some(0.0625),
+            error: Some("privacy_denied".into()),
+            degradation_state: Some("none".into()),
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert!(json.contains("\"event\":\"sensor_emission\""));
+        assert!(json.contains("\"latency_ms\":7"));
+        assert!(json.contains("\"budget_used_ratio\":0.0625"));
+        assert!(!json.contains("copied secret text"));
+        assert!(!json.contains("body"));
+    }
+
+    #[test]
+    fn projection_rebuild_metric_exposes_queue_and_retry_fields() {
+        let event = MetricEvent::ProjectionRebuild {
+            ts_ms: 1,
+            projection: "sqlite.from_db".into(),
+            status: "committed".into(),
+            latency_ms: 123,
+            records_rebuilt: 3,
+            queue_lag_ms: 42,
+            retry_count: 0,
+            error: None,
+            degradation_state: Some("none".into()),
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert!(json.contains("\"event\":\"projection_rebuild\""));
+        assert!(json.contains("\"queue_lag_ms\":42"));
+        assert!(json.contains("\"retry_count\":0"));
+        let back: MetricEvent = serde_json::from_str(&json).expect("deserialize");
+        match back {
+            MetricEvent::ProjectionRebuild {
+                records_rebuilt,
+                queue_lag_ms,
+                ..
+            } => {
+                assert_eq!(records_rebuilt, 3);
+                assert_eq!(queue_lag_ms, 42);
+            }
+            _ => panic!("expected ProjectionRebuild"),
+        }
     }
 }

--- a/crates/cairn-core/src/domain/metrics.rs
+++ b/crates/cairn-core/src/domain/metrics.rs
@@ -14,6 +14,66 @@ use crate::domain::hot_prefix::SourceWatermarks;
 #[serde(tag = "event")]
 #[non_exhaustive]
 pub enum MetricEvent {
+    /// Emitted once per observed verb invocation. The payload is
+    /// intentionally body-free: it records dimensions needed for SRE
+    /// dashboards without carrying query text, record bodies, snippets,
+    /// source paths, or raw error messages.
+    #[serde(rename = "verb_invocation")]
+    VerbInvocation {
+        /// Wall-clock millis since UNIX epoch.
+        ts_ms: i64,
+        /// Verb name (`ingest`, `search`, `assemble_hot`, ...).
+        verb: String,
+        /// Surface that handled the verb (`cli`, `mcp`, `sdk`).
+        surface: String,
+        /// Body-free mode/classification such as `keyword`, `hybrid`,
+        /// or `record`.
+        mode: Option<String>,
+        /// Response status (`committed`, `aborted`, `rejected`).
+        status: String,
+        /// Wall-clock latency observed by the surface.
+        latency_ms: u64,
+        /// Body-free error class when status is not committed.
+        error: Option<String>,
+        /// Budget usage ratio when the verb has an explicit budget.
+        budget_used_ratio: Option<f64>,
+        /// Degradation state such as `none` or `partial`.
+        degradation_state: Option<String>,
+    },
+    /// Emitted for local search modes after a response is produced.
+    /// Query text and snippets are deliberately omitted.
+    #[serde(rename = "search_completed")]
+    SearchCompleted {
+        /// Wall-clock millis since UNIX epoch.
+        ts_ms: i64,
+        /// Search mode (`keyword`, `semantic`, `hybrid`).
+        mode: String,
+        /// Number of hits returned to the caller.
+        hit_count: u32,
+        /// Response latency in milliseconds.
+        latency_ms: u64,
+        /// Degradation state such as `none` or `partial`.
+        degradation_state: String,
+        /// Body-free error class when the search did not commit.
+        error: Option<String>,
+    },
+    /// Emitted for record WAL operations after finalization.
+    #[serde(rename = "wal_apply")]
+    WalApply {
+        /// Wall-clock millis since UNIX epoch.
+        ts_ms: i64,
+        /// WAL kind (`upsert`, `forget_record`, `expire`).
+        kind: String,
+        /// Operation id.
+        operation_id: String,
+        /// Final WAL state (`committed`, `aborted`, ...).
+        state: String,
+        /// Apply latency in milliseconds.
+        latency_ms: u64,
+        /// Retry count observed by the caller. Record WAL applies are
+        /// single-pass today, so this is currently zero.
+        retry_count: u32,
+    },
     /// Emitted exactly once per `assemble_hot` call.
     #[serde(rename = "hot_prefix_assembled")]
     HotPrefixAssembled {
@@ -324,5 +384,26 @@ mod tests {
             }
             _ => panic!("expected WorkflowJobFailed"),
         }
+    }
+
+    #[test]
+    fn verb_invocation_metric_is_body_free() {
+        let event = MetricEvent::VerbInvocation {
+            ts_ms: 1,
+            verb: "ingest".into(),
+            surface: "cli".into(),
+            mode: Some("body".into()),
+            status: "committed".into(),
+            latency_ms: 12,
+            error: None,
+            budget_used_ratio: Some(0.25),
+            degradation_state: Some("none".into()),
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert!(json.contains("\"event\":\"verb_invocation\""));
+        assert!(json.contains("\"verb\":\"ingest\""));
+        assert!(json.contains("\"budget_used_ratio\":0.25"));
+        assert!(!json.contains("secret"));
+        assert!(!json.contains("body_text"));
     }
 }

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -7,8 +7,10 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    io::Write,
     path::{Path, PathBuf},
     sync::Arc,
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 use rmcp::{
@@ -23,7 +25,7 @@ use rmcp::{
 use cairn_core::config::CairnConfig;
 use cairn_core::contract::memory_store::{ListArgs, MemoryStore};
 use cairn_core::domain::{
-    MemoryKind, MemoryRecord, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+    MemoryKind, MemoryRecord, MemoryVisibility, Rfc3339Timestamp, ScopeTuple, metrics::MetricEvent,
 };
 use cairn_core::generated::envelope::{ResponseData, ResponseVerb};
 use cairn_core::generated::verbs::assemble_hot::{AssembleHotArgs, HotMemoryDebug};
@@ -31,6 +33,7 @@ use cairn_core::mcp_auth::{McpAuthContext, McpGraphAvailability, McpTransport};
 
 use cairn_store_sqlite::SqliteMemoryStore;
 use cairn_store_sqlite::entity_graph::queries::GraphQueries;
+use tracing::Instrument;
 
 use crate::generated::TOOLS;
 
@@ -704,117 +707,208 @@ impl ServerHandler for CairnMcpHandler {
         let name = request.name.clone();
         let arguments = request.arguments.clone();
         let request_id = context.id.to_string();
+        let metric_vault_root = self.vault_root.clone();
+        let metric_config = self.config.clone();
 
         async move {
-            // Prelude tool routing (`handshake`) — accept the call iff
-            // (a) the tool name is in PRELUDE_TOOLS, AND
-            // (b) a sqlite store is wired, AND
-            // (c) `REPLAY_CHALLENGE_WIRED` is true (read at dispatch time
-            //     so a future PR that flips the flag does not need to
-            //     touch this branch).
-            // The wired/unwired gate lives inside `prelude_tools::dispatch`
-            // so production and direct unit-test entry points share one
-            // implementation.
-            if crate::prelude_tools::is_prelude_tool(name.as_ref()) {
-                return Ok(crate::prelude_tools::dispatch(
-                    name.as_ref(),
-                    arguments,
-                    self.sqlite_store.clone(),
-                    cairn_core::status::wiring::REPLAY_CHALLENGE_WIRED,
-                )
-                .await);
-            }
-
-            // Graph tool routing — single-pass resolution, no TOCTOU.
-            if crate::graph_tools::GRAPH_TOOLS
-                .iter()
-                .any(|d| d.name == name.as_ref())
-            {
-                let ctx = self.auth_context_for(&request_id);
-                let Ok(req) = self.materialize_graph_request(&ctx) else {
-                    return Ok(capability_unavailable_result(&name));
-                };
-                let queries = GraphQueries::new(req.store, req.allowed, req.now_ms);
-                return Ok(crate::graph_tools::dispatch(&queries, &name, arguments).await);
-            }
-
-            if crate::coord_tools::is_coord_tool(name.as_ref()) {
-                if !crate::coord_tools::runtime_ready(&self.build_status_response().capabilities) {
-                    return Ok(capability_unavailable_result(&name));
+            let verb_name = name.to_string();
+            let started = Instant::now();
+            let call = async {
+                // Prelude tool routing (`handshake`) — accept the call iff
+                // (a) the tool name is in PRELUDE_TOOLS, AND
+                // (b) a sqlite store is wired, AND
+                // (c) `REPLAY_CHALLENGE_WIRED` is true (read at dispatch time
+                //     so a future PR that flips the flag does not need to
+                //     touch this branch).
+                // The wired/unwired gate lives inside `prelude_tools::dispatch`
+                // so production and direct unit-test entry points share one
+                // implementation.
+                if crate::prelude_tools::is_prelude_tool(name.as_ref()) {
+                    return Ok(crate::prelude_tools::dispatch(
+                        name.as_ref(),
+                        arguments,
+                        self.sqlite_store.clone(),
+                        cairn_core::status::wiring::REPLAY_CHALLENGE_WIRED,
+                    )
+                    .await);
                 }
-                return Ok(crate::coord_tools::dispatch(&name, arguments));
-            }
 
-            let request_verb = crate::verb_envelope::core_verb_for_tool(name.as_ref());
-            let store = self.store.clone();
-            let sqlite_store = self.sqlite_store.clone();
-            let scope = self.scope.clone();
-            let vault_root = self.vault_root.clone();
-            let principal = self.principal.clone();
-            let config = self.config.clone();
-
-            let Some(request_verb) = request_verb else {
-                return Ok(CallToolResult::error(vec![Content::text(format!(
-                    "cairn: unknown verb '{name}'. Available verbs: {}",
-                    TOOLS.iter().map(|d| d.name).collect::<Vec<_>>().join(", ")
-                ))]));
-            };
-
-            let typed_args = match crate::verb_envelope::parse_args(request_verb, arguments) {
-                Ok(args) => args,
-                Err(response) => {
-                    return Ok(crate::verb_envelope::call_result_from_response(&response));
+                // Graph tool routing — single-pass resolution, no TOCTOU.
+                if crate::graph_tools::GRAPH_TOOLS
+                    .iter()
+                    .any(|d| d.name == name.as_ref())
+                {
+                    let ctx = self.auth_context_for(&request_id);
+                    let Ok(req) = self.materialize_graph_request(&ctx) else {
+                        return Ok(capability_unavailable_result(&name));
+                    };
+                    let queries = GraphQueries::new(req.store, req.allowed, req.now_ms);
+                    return Ok(crate::graph_tools::dispatch(&queries, &name, arguments).await);
                 }
-            };
 
-            if name.as_ref() == "search"
-                && let Some(store) = store
-            {
-                let cairn_core::generated::envelope::RequestArgs::Search(args) = typed_args else {
-                    let response = crate::verb_envelope::invalid_args_response(
-                        crate::verb_envelope::response_verb(request_verb),
-                        "args",
-                        "expected search arguments",
-                    );
-                    return Ok(crate::verb_envelope::call_result_from_response(&response));
-                };
-                return Ok(handle_search(store, config, args).await);
-            }
-
-            if name.as_ref() == "assemble_hot"
-                && let (Some(sqlite_store), Some(scope), Some(vault_root)) =
-                    (sqlite_store, scope, vault_root)
-            {
-                let cairn_core::generated::envelope::RequestArgs::AssembleHot(args) = typed_args
-                else {
-                    let response = crate::verb_envelope::invalid_args_response(
-                        crate::verb_envelope::response_verb(request_verb),
-                        "args",
-                        "expected assemble_hot arguments",
-                    );
-                    return Ok(crate::verb_envelope::call_result_from_response(&response));
-                };
-                let ctx = McpAuthContext::new(&principal, &request_id);
-                let allowed_scopes = match scope.allowed_scopes(&ctx) {
-                    Ok(scopes) if !scopes.is_empty() => scopes,
-                    Ok(_) | Err(_) => {
+                if crate::coord_tools::is_coord_tool(name.as_ref()) {
+                    if !crate::coord_tools::runtime_ready(
+                        &self.build_status_response().capabilities,
+                    ) {
                         return Ok(capability_unavailable_result(&name));
                     }
-                };
-                return Ok(handle_assemble_hot(
-                    sqlite_store,
-                    vault_root,
-                    config,
-                    principal,
-                    allowed_scopes,
-                    args,
-                )
-                .await);
-            }
+                    return Ok(crate::coord_tools::dispatch(&name, arguments));
+                }
 
-            Ok(dispatch_stub(&name))
+                let request_verb = crate::verb_envelope::core_verb_for_tool(name.as_ref());
+                let store = self.store.clone();
+                let sqlite_store = self.sqlite_store.clone();
+                let scope = self.scope.clone();
+                let vault_root = self.vault_root.clone();
+                let principal = self.principal.clone();
+                let config = self.config.clone();
+
+                let Some(request_verb) = request_verb else {
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "cairn: unknown verb '{name}'. Available verbs: {}",
+                        TOOLS.iter().map(|d| d.name).collect::<Vec<_>>().join(", ")
+                    ))]));
+                };
+
+                let typed_args = match crate::verb_envelope::parse_args(request_verb, arguments) {
+                    Ok(args) => args,
+                    Err(response) => {
+                        return Ok(crate::verb_envelope::call_result_from_response(&response));
+                    }
+                };
+
+                if name.as_ref() == "search"
+                    && let Some(store) = store
+                {
+                    let cairn_core::generated::envelope::RequestArgs::Search(args) = typed_args
+                    else {
+                        let response = crate::verb_envelope::invalid_args_response(
+                            crate::verb_envelope::response_verb(request_verb),
+                            "args",
+                            "expected search arguments",
+                        );
+                        return Ok(crate::verb_envelope::call_result_from_response(&response));
+                    };
+                    return Ok(handle_search(store, config, args).await);
+                }
+
+                if name.as_ref() == "assemble_hot"
+                    && let (Some(sqlite_store), Some(scope), Some(vault_root)) =
+                        (sqlite_store, scope, vault_root)
+                {
+                    let cairn_core::generated::envelope::RequestArgs::AssembleHot(args) =
+                        typed_args
+                    else {
+                        let response = crate::verb_envelope::invalid_args_response(
+                            crate::verb_envelope::response_verb(request_verb),
+                            "args",
+                            "expected assemble_hot arguments",
+                        );
+                        return Ok(crate::verb_envelope::call_result_from_response(&response));
+                    };
+                    let ctx = McpAuthContext::new(&principal, &request_id);
+                    let allowed_scopes = match scope.allowed_scopes(&ctx) {
+                        Ok(scopes) if !scopes.is_empty() => scopes,
+                        Ok(_) | Err(_) => {
+                            return Ok(capability_unavailable_result(&name));
+                        }
+                    };
+                    return Ok(handle_assemble_hot(
+                        sqlite_store,
+                        vault_root,
+                        config,
+                        principal,
+                        allowed_scopes,
+                        args,
+                    )
+                    .await);
+                }
+
+                Ok(dispatch_stub(&name))
+            };
+            let result = if metric_config.observability.enabled
+                && metric_config.observability.local_traces
+            {
+                let span = tracing::info_span!(
+                    "cairn.verb",
+                    surface = "mcp",
+                    verb = %verb_name,
+                    mode = tracing::field::Empty,
+                    request_id = %request_id
+                );
+                call.instrument(span).await
+            } else {
+                call.await
+            };
+
+            emit_mcp_verb_invocation_sync(
+                metric_vault_root.as_deref(),
+                &metric_config,
+                &verb_name,
+                &result,
+                u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            );
+            result
         }
     }
+}
+
+fn emit_mcp_verb_invocation_sync(
+    vault_root: Option<&Path>,
+    config: &CairnConfig,
+    verb: &str,
+    result: &Result<CallToolResult, rmcp::ErrorData>,
+    latency_ms: u64,
+) {
+    if !config.observability.enabled || !config.observability.local_metrics {
+        return;
+    }
+    let Some(vault_root) = vault_root else {
+        return;
+    };
+    let (status, error) = match result {
+        Ok(result) if result.is_error.unwrap_or(false) => ("rejected", Some("tool_error")),
+        Ok(_) => ("committed", None),
+        Err(_) => ("aborted", Some("protocol_error")),
+    };
+    let event = MetricEvent::VerbInvocation {
+        ts_ms: current_time_ms(),
+        verb: verb.to_owned(),
+        surface: "mcp".to_owned(),
+        mode: None,
+        status: status.to_owned(),
+        latency_ms,
+        error: error.map(str::to_owned),
+        budget_used_ratio: None,
+        degradation_state: Some("none".to_owned()),
+    };
+    if let Err(err) = append_local_metric_sync(vault_root, &event) {
+        tracing::warn!(error = %err, verb, "mcp verb metric emit failed");
+    }
+}
+
+fn append_local_metric_sync(
+    vault_root: &Path,
+    event: &MetricEvent,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let path = vault_root.join(".cairn").join("metrics.jsonl");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    serde_json::to_writer(&mut file, event)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn current_time_ms() -> i64 {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0_u128, |duration| duration.as_millis());
+    i64::try_from(millis).unwrap_or(i64::MAX)
 }
 
 /// Dispatch `assemble_hot` against a wired `SQLite` store and vault root.

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -698,6 +698,10 @@ impl ServerHandler for CairnMcpHandler {
     /// and a store is wired, dispatches through
     /// [`cairn_core::verbs::search::run`]. All other verbs (or `"search"` with
     /// no store wired) fall back to [`dispatch_stub`].
+    #[allow(
+        clippy::too_many_lines,
+        reason = "central MCP dispatch table keeps tool routing auditable"
+    )]
     fn call_tool(
         &self,
         request: CallToolRequestParams,

--- a/crates/cairn-mcp/tests/assemble_hot_tool.rs
+++ b/crates/cairn-mcp/tests/assemble_hot_tool.rs
@@ -104,4 +104,21 @@ async fn wired_assemble_hot_returns_committed_prefix() {
     );
     assert!(envelope["data"]["bytes"].as_u64().expect("bytes") <= 64);
     assert!(envelope["data"]["segments"].is_array());
+
+    let metrics =
+        std::fs::read_to_string(vault.path().join(".cairn/metrics.jsonl")).expect("metrics file");
+    assert!(
+        metrics.lines().any(|line| {
+            let event: serde_json::Value = serde_json::from_str(line).expect("metric JSON");
+            event["event"] == "verb_invocation"
+                && event["surface"] == "mcp"
+                && event["verb"] == "assemble_hot"
+                && event["status"] == "committed"
+        }),
+        "assemble_hot MCP call should emit a committed verb metric: {metrics}"
+    );
+    assert!(
+        !metrics.contains("mcp purpose text"),
+        "metric output must not include source body text: {metrics}"
+    );
 }

--- a/crates/cairn-mcp/tests/relay_integration.rs
+++ b/crates/cairn-mcp/tests/relay_integration.rs
@@ -109,7 +109,7 @@ async fn serve_with_relay_completes_initialize_handshake() {
     let (mut client_read_half, server_output) = tokio::io::duplex(65_536);
 
     let _server_task = tokio::spawn(async move {
-        serve_stdio_with_store_io(
+        Box::pin(serve_stdio_with_store_io(
             store_dyn,
             f.store,
             scope,
@@ -117,7 +117,7 @@ async fn serve_with_relay_completes_initialize_handshake() {
             principal,
             server_input,
             server_output,
-        )
+        ))
         .await
         .ok();
     });
@@ -160,7 +160,7 @@ async fn serve_with_relay_tools_list_includes_graph_tools() {
     let (mut client_read_half, server_output) = tokio::io::duplex(65_536);
 
     let _server_task = tokio::spawn(async move {
-        serve_stdio_with_store_io(
+        Box::pin(serve_stdio_with_store_io(
             store_dyn,
             f.store,
             scope,
@@ -168,7 +168,7 @@ async fn serve_with_relay_tools_list_includes_graph_tools() {
             principal,
             server_input,
             server_output,
-        )
+        ))
         .await
         .ok();
     });

--- a/crates/cairn-sensors-local/src/outcome.rs
+++ b/crates/cairn-sensors-local/src/outcome.rs
@@ -1,6 +1,6 @@
 //! Local sensor emission outcomes.
 
-use cairn_core::domain::{CaptureEvent, SourceFamily};
+use cairn_core::domain::{CaptureEvent, SourceFamily, metrics::MetricEvent};
 
 /// Local sensor family handled by this adapter crate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -33,6 +33,19 @@ impl SensorKind {
             _ => None,
         }
     }
+
+    /// Stable label used in telemetry dimensions.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Hook => "hook",
+            Self::Ide => "ide",
+            Self::Terminal => "terminal",
+            Self::Clipboard => "clipboard",
+            Self::Voice => "voice",
+            Self::Screen => "screen",
+        }
+    }
 }
 
 /// Reason an observation produced no event.
@@ -46,6 +59,19 @@ pub enum DropReason {
     PolicyRejected(String),
     /// Observation was malformed or failed core capture validation.
     MalformedObservation(String),
+}
+
+impl DropReason {
+    /// Body-free error class suitable for metrics and traces.
+    #[must_use]
+    pub const fn as_metric_error(&self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::BudgetExceeded => "budget_exceeded",
+            Self::PolicyRejected(_) => "policy_rejected",
+            Self::MalformedObservation(_) => "malformed_observation",
+        }
+    }
 }
 
 /// Result of trying to emit one local sensor event.
@@ -91,5 +117,83 @@ impl EmitOutcome {
             Self::Emitted(_) => None,
             Self::Dropped { reason, .. } => Some(reason),
         }
+    }
+
+    /// Build a body-free metric event for this sensor outcome.
+    #[must_use]
+    pub fn metric_event(
+        &self,
+        ts_ms: i64,
+        latency_ms: u64,
+        bytes: u64,
+        budget_bytes: Option<u64>,
+    ) -> MetricEvent {
+        let budget_used_ratio = budget_bytes.and_then(|budget| budget_ratio(bytes, budget));
+        let sensor = self
+            .sensor()
+            .map_or("unknown", SensorKind::as_str)
+            .to_owned();
+        let (status, error) = match self {
+            Self::Emitted(_) => ("emitted", None),
+            Self::Dropped { reason, .. } => ("dropped", Some(reason.as_metric_error().to_owned())),
+        };
+
+        MetricEvent::SensorEmission {
+            ts_ms,
+            sensor,
+            status: status.to_owned(),
+            latency_ms,
+            bytes,
+            budget_bytes,
+            budget_used_ratio,
+            error,
+            degradation_state: Some("none".to_owned()),
+        }
+    }
+}
+
+fn budget_ratio(bytes: u64, budget: u64) -> Option<f64> {
+    if budget == 0 {
+        return None;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    Some(bytes as f64 / budget as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use cairn_core::domain::metrics::MetricEvent;
+
+    use super::{DropReason, EmitOutcome, SensorKind};
+
+    #[test]
+    fn dropped_outcome_builds_body_free_sensor_metric() {
+        let outcome = EmitOutcome::Dropped {
+            sensor: SensorKind::Clipboard,
+            reason: DropReason::PolicyRejected("private key block".to_owned()),
+        };
+
+        let metric = outcome.metric_event(10, 7, 64, Some(1_024));
+        let MetricEvent::SensorEmission {
+            sensor,
+            status,
+            latency_ms,
+            bytes,
+            budget_bytes,
+            budget_used_ratio,
+            error,
+            ..
+        } = metric
+        else {
+            panic!("expected SensorEmission");
+        };
+
+        assert_eq!(sensor, "clipboard");
+        assert_eq!(status, "dropped");
+        assert_eq!(latency_ms, 7);
+        assert_eq!(bytes, 64);
+        assert_eq!(budget_bytes, Some(1_024));
+        assert_eq!(budget_used_ratio, Some(0.0625));
+        assert_eq!(error.as_deref(), Some("policy_rejected"));
     }
 }

--- a/crates/cairn-sensors-local/src/screen.rs
+++ b/crates/cairn-sensors-local/src/screen.rs
@@ -275,6 +275,113 @@ pub struct ScreenCaptureReceipt {
     pub observation: ScreenObservation,
 }
 
+/// Body-free reason a configured screen capture produced no artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenCaptureSkipReason {
+    /// Screen capture is disabled in config.
+    Disabled,
+    /// The focused application did not match `allow_apps`.
+    AllowList,
+    /// Password-field or OCR-off privacy filtering dropped the artifact.
+    PrivacyFiltered,
+    /// A screen policy rejected the captured observation.
+    PolicyRejected,
+}
+
+impl ScreenCaptureSkipReason {
+    /// Convert to a local sensor drop reason for telemetry.
+    #[must_use]
+    pub fn drop_reason(self) -> DropReason {
+        match self {
+            Self::Disabled => DropReason::Disabled,
+            Self::AllowList => DropReason::PolicyRejected("allow_apps".to_owned()),
+            Self::PrivacyFiltered => DropReason::PolicyRejected("privacy_filtered".to_owned()),
+            Self::PolicyRejected => DropReason::PolicyRejected("policy_rejected".to_owned()),
+        }
+    }
+
+    /// Stable CLI/API reason string.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::AllowList => "allow_apps",
+            Self::PrivacyFiltered => "privacy_filtered",
+            Self::PolicyRejected => "policy_rejected",
+        }
+    }
+
+    /// Human-facing description that does not expose captured content.
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::Disabled => "screen sensor is disabled in config",
+            Self::AllowList => "skipped by screen allow_apps policy",
+            Self::PrivacyFiltered => "dropped by screen privacy filter",
+            Self::PolicyRejected => "dropped by screen policy",
+        }
+    }
+}
+
+/// Body-free skip details for a screen PNG capture attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenCaptureSkip {
+    /// Stable skip reason.
+    pub reason: ScreenCaptureSkipReason,
+    /// Body-free count of bytes observed before the skip.
+    pub observed_bytes: u64,
+    /// Whether a capture artifact was created before the skip decision.
+    pub artifact_created: bool,
+}
+
+impl ScreenCaptureSkip {
+    const fn before_capture(reason: ScreenCaptureSkipReason) -> Self {
+        Self {
+            reason,
+            observed_bytes: 0,
+            artifact_created: false,
+        }
+    }
+
+    fn after_capture(reason: ScreenCaptureSkipReason, observation: &ScreenObservation) -> Self {
+        Self {
+            reason,
+            observed_bytes: screen_observation_observed_bytes(observation),
+            artifact_created: true,
+        }
+    }
+}
+
+/// Result of a configured screen PNG capture attempt.
+// Keep the receipt by value because callers immediately match on this
+// short-lived runtime boundary result.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScreenCaptureOutcome {
+    /// Capture produced a PNG receipt.
+    Captured(ScreenCaptureReceipt),
+    /// Capture was intentionally skipped before returning an artifact.
+    Skipped(ScreenCaptureSkip),
+    /// Capture was skipped after an artifact was written, but cleanup failed.
+    CleanupFailed {
+        /// Skip context that led to artifact cleanup.
+        skip: ScreenCaptureSkip,
+        /// Cleanup failure.
+        error: ScreenError,
+    },
+}
+
+impl ScreenCaptureOutcome {
+    /// Convert to the legacy optional receipt shape while preserving cleanup failures.
+    pub fn into_result_receipt(self) -> Result<Option<ScreenCaptureReceipt>, ScreenError> {
+        match self {
+            Self::Captured(receipt) => Ok(Some(receipt)),
+            Self::Skipped(_) => Ok(None),
+            Self::CleanupFailed { error, .. } => Err(error),
+        }
+    }
+}
+
 #[cfg(any(test, feature = "screenpipe-runtime"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ScreenpipeFrameCapture {
@@ -284,7 +391,7 @@ struct ScreenpipeFrameCapture {
 }
 
 /// Errors emitted by the screen runtime boundary.
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum ScreenError {
     /// Capture is unavailable for the current configuration.
     #[error("screen capture unavailable: {0:?}")]
@@ -367,27 +474,6 @@ pub fn emit(config: &LocalSensorConfig, observation: ScreenEventObservation) -> 
         };
     }
 
-    let raw_len = observation
-        .observation
-        .text
-        .len()
-        .saturating_add(observation.observation.app.len())
-        .saturating_add(observation.observation.window_title.len())
-        .saturating_add(observation.observation.url.as_ref().map_or(0, String::len))
-        .saturating_add(
-            observation
-                .observation
-                .bounding_boxes
-                .len()
-                .saturating_mul(std::mem::size_of::<BoundingBox>()),
-        );
-    if !config.screen.budget.allows(1, raw_len) {
-        return EmitOutcome::Dropped {
-            sensor: SensorKind::Screen,
-            reason: DropReason::BudgetExceeded,
-        };
-    }
-
     if observation.observation.app.trim().is_empty() {
         return EmitOutcome::Dropped {
             sensor: SensorKind::Screen,
@@ -431,6 +517,13 @@ pub fn emit(config: &LocalSensorConfig, observation: ScreenEventObservation) -> 
             };
         }
     };
+
+    if !config.screen.budget.allows(1, sanitized_payload.len()) {
+        return EmitOutcome::Dropped {
+            sensor: SensorKind::Screen,
+            reason: DropReason::BudgetExceeded,
+        };
+    }
 
     let payload = CapturePayload::Screen {
         app: observation.observation.app,
@@ -486,6 +579,45 @@ fn sanitize_screen_text(text: &str) -> Result<String, DropReason> {
         PolicyAction::Sanitized(text) => Ok(text),
         PolicyAction::Rejected(reason) => Err(DropReason::PolicyRejected(reason)),
     }
+}
+
+/// Return the sanitized payload byte count used for screen budget enforcement.
+///
+/// # Errors
+/// Returns [`DropReason`] when local privacy policy rejects a field, or
+/// [`serde_json::Error`] if payload serialization fails.
+pub fn screen_observation_budgeted_payload_bytes(
+    observation: &ScreenObservation,
+) -> Result<usize, DropReason> {
+    let sanitized = sanitize_screen_fields(observation)?;
+    raw_payload_bytes(
+        observation,
+        &sanitized.text,
+        &sanitized.window_title,
+        sanitized.url.as_deref(),
+    )
+    .map(|bytes| bytes.len())
+    .map_err(|err| {
+        DropReason::MalformedObservation(format!("screen payload serialization failed: {err}"))
+    })
+}
+
+/// Return a body-free count of raw screen observation bytes.
+#[must_use]
+pub fn screen_observation_observed_bytes(observation: &ScreenObservation) -> u64 {
+    let string_bytes = observation
+        .text
+        .len()
+        .saturating_add(observation.app.len())
+        .saturating_add(observation.window_title.len())
+        .saturating_add(observation.url.as_ref().map_or(0, String::len))
+        .saturating_add(observation.captured_at.len())
+        .saturating_add(observation.sensor_label.len());
+    let box_bytes = observation
+        .bounding_boxes
+        .len()
+        .saturating_mul(std::mem::size_of::<BoundingBox>());
+    u64::try_from(string_bytes.saturating_add(box_bytes)).unwrap_or(u64::MAX)
 }
 
 fn raw_payload_bytes(
@@ -791,14 +923,16 @@ where
     B: ScreenCaptureRuntime,
     P: ScreenPolicy,
 {
-    /// Capture a single PNG snapshot, returning `None` when disabled or filtered out.
-    pub fn capture_png_snapshot(
+    /// Capture a single PNG snapshot with a structured skip outcome.
+    pub fn capture_png_snapshot_outcome(
         &self,
         config: &ScreenSensorConfig,
         output_path: &Path,
-    ) -> Result<Option<ScreenCaptureReceipt>, ScreenError> {
+    ) -> Result<ScreenCaptureOutcome, ScreenError> {
         if !config.enabled {
-            return Ok(None);
+            return Ok(ScreenCaptureOutcome::Skipped(
+                ScreenCaptureSkip::before_capture(ScreenCaptureSkipReason::Disabled),
+            ));
         }
 
         let probe = self.backend.probe(config);
@@ -816,25 +950,66 @@ where
                 .as_ref()
                 .is_some_and(|app| config.allow_apps.contains(app))
         {
-            return Ok(None);
+            return Ok(ScreenCaptureOutcome::Skipped(
+                ScreenCaptureSkip::before_capture(ScreenCaptureSkipReason::AllowList),
+            ));
         }
 
         self.admit_frame(config.budget.max_frames_per_minute)?;
 
         let mut receipt = self.backend.capture_png_snapshot(config, output_path)?;
         if !config.allow_apps.is_empty() && !config.allow_apps.contains(&receipt.observation.app) {
-            return Ok(None);
+            let skip = ScreenCaptureSkip::after_capture(
+                ScreenCaptureSkipReason::AllowList,
+                &receipt.observation,
+            );
+            if let Err(error) = remove_capture_artifact(&receipt.output_path) {
+                return Ok(ScreenCaptureOutcome::CleanupFailed { skip, error });
+            }
+            return Ok(ScreenCaptureOutcome::Skipped(skip));
         }
         if should_drop_capture_artifact(config, &receipt.observation) {
-            remove_capture_artifact(&receipt.output_path)?;
-            return Ok(None);
+            let skip = ScreenCaptureSkip::after_capture(
+                ScreenCaptureSkipReason::PrivacyFiltered,
+                &receipt.observation,
+            );
+            if let Err(error) = remove_capture_artifact(&receipt.output_path) {
+                return Ok(ScreenCaptureOutcome::CleanupFailed { skip, error });
+            }
+            return Ok(ScreenCaptureOutcome::Skipped(skip));
         }
         truncate_text_to_budget(
             &mut receipt.observation.text,
             config.budget.max_text_bytes_per_event,
         );
-        receipt.observation = self.policy.apply(receipt.observation)?;
-        Ok(Some(receipt))
+        let pre_policy_observation = receipt.observation;
+        receipt.observation = match self.policy.apply(pre_policy_observation.clone()) {
+            Ok(observation) => observation,
+            Err(error) => {
+                let skip = ScreenCaptureSkip::after_capture(
+                    ScreenCaptureSkipReason::PolicyRejected,
+                    &pre_policy_observation,
+                );
+                if let Err(cleanup_error) = remove_capture_artifact(&receipt.output_path) {
+                    return Ok(ScreenCaptureOutcome::CleanupFailed {
+                        skip,
+                        error: cleanup_error,
+                    });
+                }
+                return Err(error);
+            }
+        };
+        Ok(ScreenCaptureOutcome::Captured(receipt))
+    }
+
+    /// Capture a single PNG snapshot, returning `None` when disabled or filtered out.
+    pub fn capture_png_snapshot(
+        &self,
+        config: &ScreenSensorConfig,
+        output_path: &Path,
+    ) -> Result<Option<ScreenCaptureReceipt>, ScreenError> {
+        self.capture_png_snapshot_outcome(config, output_path)?
+            .into_result_receipt()
     }
 }
 
@@ -898,21 +1073,29 @@ pub fn capture_png_snapshot_configured(
     config: &ScreenSensorConfig,
     output_path: &Path,
 ) -> Result<Option<ScreenCaptureReceipt>, ScreenError> {
+    capture_png_snapshot_outcome_configured(config, output_path)?.into_result_receipt()
+}
+
+/// Capture a PNG snapshot through configured backends with structured skip reasons.
+pub fn capture_png_snapshot_outcome_configured(
+    config: &ScreenSensorConfig,
+    output_path: &Path,
+) -> Result<ScreenCaptureOutcome, ScreenError> {
     match config.backend {
         ScreenBackend::Xcap => ScreenSensor::with_frame_budget(
             XcapBackendRuntime,
             NoopScreenPolicy,
             configured_frame_budget(ScreenBackend::Xcap),
         )
-        .capture_png_snapshot(config, output_path),
+        .capture_png_snapshot_outcome(config, output_path),
         ScreenBackend::Screenpipe => {
             let primary = ScreenSensor::with_frame_budget(
                 ScreenpipeBackendRuntime,
                 NoopScreenPolicy,
                 configured_frame_budget(ScreenBackend::Screenpipe),
             );
-            match primary.capture_png_snapshot(config, output_path) {
-                Ok(receipt) => Ok(receipt),
+            match primary.capture_png_snapshot_outcome(config, output_path) {
+                Ok(outcome) => Ok(outcome),
                 Err(err) if can_fallback_from_screenpipe(&err) => {
                     let mut fallback_config = config.clone();
                     fallback_config.backend = ScreenBackend::Xcap;
@@ -921,7 +1104,7 @@ pub fn capture_png_snapshot_configured(
                         NoopScreenPolicy,
                         configured_frame_budget(ScreenBackend::Xcap),
                     )
-                    .capture_png_snapshot(&fallback_config, output_path)
+                    .capture_png_snapshot_outcome(&fallback_config, output_path)
                 }
                 Err(err) => Err(err),
             }
@@ -1946,6 +2129,12 @@ mod tests {
         config
     }
 
+    fn screen_local_config_with_byte_budget(max_bytes: usize) -> LocalSensorConfig {
+        let mut config = screen_enabled_local_config();
+        config.screen.budget.max_bytes = Some(max_bytes);
+        config
+    }
+
     fn payload_hash(bytes: &[u8]) -> String {
         format!("sha256:{:x}", Sha256::digest(bytes))
     }
@@ -2014,6 +2203,52 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[derive(Clone)]
+    struct CleanupFailingBackend {
+        probe: ScreenProbe,
+        observation: ScreenObservation,
+    }
+
+    #[cfg(unix)]
+    impl ScreenBackendRuntime for CleanupFailingBackend {
+        fn probe(&self, _config: &ScreenSensorConfig) -> ScreenProbe {
+            self.probe.clone()
+        }
+
+        fn capture_snapshot(
+            &self,
+            _config: &ScreenSensorConfig,
+        ) -> Result<ScreenObservation, ScreenError> {
+            Ok(self.observation.clone())
+        }
+    }
+
+    #[cfg(unix)]
+    impl ScreenCaptureRuntime for CleanupFailingBackend {
+        fn capture_png_snapshot(
+            &self,
+            _config: &ScreenSensorConfig,
+            output_path: &std::path::Path,
+        ) -> Result<ScreenCaptureReceipt, ScreenError> {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            std::fs::write(output_path, b"fake-png")
+                .map_err(|err| ScreenError::CaptureFailed(err.to_string()))?;
+            let parent = output_path
+                .parent()
+                .expect("test output path has parent directory");
+            std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o500))
+                .map_err(|err| ScreenError::CaptureFailed(err.to_string()))?;
+            Ok(ScreenCaptureReceipt {
+                output_path: output_path.to_path_buf(),
+                width: 10,
+                height: 20,
+                observation: self.observation.clone(),
+            })
+        }
+    }
+
     #[test]
     fn fake_backend_writes_png_receipt_and_metadata() {
         let backend = FakeBackend {
@@ -2065,6 +2300,75 @@ mod tests {
 
         assert!(result.is_none());
         assert!(!output_path.exists());
+    }
+
+    #[test]
+    fn png_capture_outcome_distinguishes_privacy_filtered_skip() {
+        let backend = FakeBackend {
+            probe: fake_probe(),
+            observation: fake_observation("password=abc123"),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("snapshot.png");
+        let sensor = ScreenSensor::new(backend, NoopScreenPolicy);
+
+        let outcome = sensor
+            .capture_png_snapshot_outcome(&enabled_config(), &output_path)
+            .unwrap();
+
+        let ScreenCaptureOutcome::Skipped(skip) = outcome else {
+            panic!("expected privacy skip");
+        };
+        assert_eq!(skip.reason, ScreenCaptureSkipReason::PrivacyFiltered);
+        assert!(skip.artifact_created);
+        assert!(skip.observed_bytes > 0);
+        assert!(!output_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn png_capture_cleanup_failure_preserves_privacy_skip_context() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let backend = CleanupFailingBackend {
+            probe: fake_probe(),
+            observation: fake_observation("password=abc123"),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("snapshot.png");
+        let sensor = ScreenSensor::new(backend, NoopScreenPolicy);
+
+        let outcome = sensor
+            .capture_png_snapshot_outcome(&enabled_config(), &output_path)
+            .unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let ScreenCaptureOutcome::CleanupFailed { skip, error } = outcome else {
+            panic!("expected cleanup failure");
+        };
+        assert_eq!(skip.reason, ScreenCaptureSkipReason::PrivacyFiltered);
+        assert!(skip.artifact_created);
+        assert!(skip.observed_bytes > 0);
+        assert!(matches!(error, ScreenError::CaptureFailed(_)));
+        assert!(output_path.exists());
+    }
+
+    #[test]
+    fn cleanup_failure_conversion_preserves_error() {
+        let skip = ScreenCaptureSkip {
+            reason: ScreenCaptureSkipReason::PrivacyFiltered,
+            observed_bytes: 42,
+            artifact_created: true,
+        };
+        let outcome = ScreenCaptureOutcome::CleanupFailed {
+            skip,
+            error: ScreenError::CaptureFailed("cleanup failed".to_owned()),
+        };
+
+        let err = outcome
+            .into_result_receipt()
+            .expect_err("cleanup failure must not become None");
+        assert_eq!(err, ScreenError::CaptureFailed("cleanup failed".to_owned()));
     }
 
     #[test]
@@ -2150,8 +2454,10 @@ mod tests {
     fn allow_list_drops_unlisted_apps() {
         let mut config = enabled_config();
         config.allow_apps = vec!["Terminal".to_owned()];
+        let mut probe = fake_probe();
+        probe.focused_app = Some("Terminal".to_owned());
         let backend = FakeBackend {
-            probe: fake_probe(),
+            probe,
             observation: fake_observation("meeting notes"),
         };
         let sensor = ScreenSensor::new(backend, NoopScreenPolicy);
@@ -2159,6 +2465,33 @@ mod tests {
         let result = sensor.capture_snapshot(&config).unwrap();
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn png_capture_outcome_distinguishes_allow_list_skip() {
+        let mut config = enabled_config();
+        config.allow_apps = vec!["Terminal".to_owned()];
+        let mut probe = fake_probe();
+        probe.focused_app = Some("Terminal".to_owned());
+        let backend = FakeBackend {
+            probe,
+            observation: fake_observation("meeting notes"),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("snapshot.png");
+        let sensor = ScreenSensor::new(backend, NoopScreenPolicy);
+
+        let outcome = sensor
+            .capture_png_snapshot_outcome(&config, &output_path)
+            .unwrap();
+
+        let ScreenCaptureOutcome::Skipped(skip) = outcome else {
+            panic!("expected allow-list skip");
+        };
+        assert_eq!(skip.reason, ScreenCaptureSkipReason::AllowList);
+        assert!(skip.artifact_created);
+        assert!(skip.observed_bytes > 0);
+        assert!(!output_path.exists());
     }
 
     #[test]
@@ -2307,6 +2640,27 @@ mod tests {
     }
 
     #[test]
+    fn rejecting_policy_removes_png_artifact() {
+        let backend = FakeBackend {
+            probe: fake_probe(),
+            observation: fake_observation("meeting notes"),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("snapshot.png");
+        let sensor = ScreenSensor::new(backend, RejectingPolicy);
+
+        let err = sensor
+            .capture_png_snapshot_outcome(&enabled_config(), &output_path)
+            .unwrap_err();
+
+        assert_eq!(
+            err,
+            ScreenError::CaptureFailed("rejected by policy".to_owned())
+        );
+        assert!(!output_path.exists());
+    }
+
+    #[test]
     fn screen_observation_emits_valid_capture_event() {
         let outcome = emit(
             &screen_enabled_local_config(),
@@ -2344,6 +2698,32 @@ mod tests {
         event
             .validate_for_capture()
             .expect("screen event validates");
+    }
+
+    #[test]
+    fn screen_emit_budgets_sanitized_payload_not_only_ocr_text() {
+        let mut observation = fake_observation("ok");
+        observation.window_title = "w".repeat(512);
+        let payload_bytes =
+            screen_observation_budgeted_payload_bytes(&observation).expect("payload bytes");
+
+        let outcome = emit(
+            &screen_local_config_with_byte_budget(payload_bytes - 1),
+            ScreenEventObservation {
+                event_id: event_id(),
+                captured_at: captured_at(),
+                observation,
+                refs: None,
+            },
+        );
+
+        assert_eq!(
+            outcome,
+            EmitOutcome::Dropped {
+                sensor: SensorKind::Screen,
+                reason: DropReason::BudgetExceeded,
+            }
+        );
     }
 
     #[test]

--- a/crates/cairn-store-sqlite/src/record_wal/expire.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/expire.rs
@@ -1,6 +1,7 @@
 //! Public expire apply through record WAL.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use cairn_core::domain::{ScopeTuple, TargetId};
 use cairn_core::wal::{OpState, WalKind, graph_for};
@@ -18,6 +19,7 @@ pub(crate) async fn apply_expire(
     store: &SqliteMemoryStore,
     target: &TargetId,
 ) -> Result<(), StoreError> {
+    let started = Instant::now();
     let conn = Arc::clone(store.require_conn("expire")?);
     let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
         what: "expire requires daemon incarnation".to_owned(),
@@ -68,6 +70,14 @@ pub(crate) async fn apply_expire(
         Ok::<_, tokio_rusqlite::Error>(())
     })
     .await?;
+    tracing::info!(
+        wal.kind = WalKind::Expire.as_str(),
+        operation_id = op_id.as_str(),
+        state = OpState::Committed.as_str(),
+        latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        retry_count = 0_u32,
+        "record WAL apply complete"
+    );
     Ok(())
 }
 

--- a/crates/cairn-store-sqlite/src/record_wal/forget.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/forget.rs
@@ -1,6 +1,7 @@
 //! Public record-level forget apply through record WAL.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use cairn_core::domain::{RecordId, ScopeTuple, TargetId};
 use cairn_core::wal::{OpState, OperationId, WalKind, graph_for};
@@ -42,6 +43,7 @@ pub(crate) async fn apply_forget_record(
     store: &SqliteMemoryStore,
     record_id: &RecordId,
 ) -> Result<ForgetOutcome, StoreError> {
+    let started = Instant::now();
     let conn = Arc::clone(store.require_conn("forget_record")?);
     let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
         what: "forget_record requires daemon incarnation".to_owned(),
@@ -119,6 +121,15 @@ pub(crate) async fn apply_forget_record(
     })
     .await
     .map_err(unpack_worker_err)?;
+
+    tracing::info!(
+        wal.kind = WalKind::ForgetRecord.as_str(),
+        operation_id = op_id.as_str(),
+        state = OpState::Committed.as_str(),
+        latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        retry_count = 0_u32,
+        "record WAL apply complete"
+    );
 
     Ok(ForgetOutcome {
         deleted_count: u64::try_from(target.record_ids.len()).unwrap_or(u64::MAX),

--- a/crates/cairn-store-sqlite/src/record_wal/upsert.rs
+++ b/crates/cairn-store-sqlite/src/record_wal/upsert.rs
@@ -1,6 +1,7 @@
 //! Public upsert apply through record WAL.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use cairn_core::contract::memory_store::UpsertOutcome;
 use cairn_core::domain::{BodyHash, MemoryRecord, RecordId};
@@ -22,6 +23,7 @@ pub(crate) async fn apply_upsert(
     record: &MemoryRecord,
     embed: StoredEmbedOutcome,
 ) -> Result<UpsertOutcome, StoreError> {
+    let started = Instant::now();
     let conn = Arc::clone(store.require_conn("upsert")?);
     let incarnation = store.incarnation().cloned().ok_or(StoreError::Invariant {
         what: "upsert requires daemon incarnation".to_owned(),
@@ -97,6 +99,15 @@ pub(crate) async fn apply_upsert(
         Ok::<_, tokio_rusqlite::Error>(())
     })
     .await?;
+
+    tracing::info!(
+        wal.kind = WalKind::Upsert.as_str(),
+        operation_id = op_id.as_str(),
+        state = OpState::Committed.as_str(),
+        latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        retry_count = 0_u32,
+        "record WAL apply complete"
+    );
 
     Ok(UpsertOutcome {
         record_id: RecordId::parse(planned_for_outcome.outcome_record_id.clone()).map_err(|e| {

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_custom_store.snap
@@ -248,6 +248,14 @@ expression: "&c"
       "single_tenant": false
     }
   },
+  "observability": {
+    "enabled": true,
+    "local_metrics": true,
+    "local_traces": true,
+    "exporter": "none",
+    "endpoint": null,
+    "redact_sensitive_fields": true
+  },
   "consolidation": {
     "enabled": true,
     "window_size_turns": 8,

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_llm_enabled.snap
@@ -226,6 +226,14 @@ expression: "&c"
       "single_tenant": false
     }
   },
+  "observability": {
+    "enabled": true,
+    "local_metrics": true,
+    "local_traces": true,
+    "exporter": "none",
+    "endpoint": null,
+    "redact_sensitive_fields": true
+  },
   "consolidation": {
     "enabled": true,
     "window_size_turns": 8,

--- a/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
+++ b/crates/cairn-test-fixtures/tests/snapshots/schema_fixtures__config_p0_defaults.snap
@@ -213,6 +213,14 @@ expression: "&c"
       "single_tenant": false
     }
   },
+  "observability": {
+    "enabled": true,
+    "local_metrics": true,
+    "local_traces": true,
+    "exporter": "none",
+    "endpoint": null,
+    "redact_sensitive_fields": true
+  },
   "consolidation": {
     "enabled": true,
     "window_size_turns": 8,

--- a/docs/site/src/reference/generated/config-defaults.md
+++ b/docs/site/src/reference/generated/config-defaults.md
@@ -164,6 +164,13 @@ pipeline:
 mcp:
   stdio:
     single_tenant: false
+observability:
+  enabled: true
+  local_metrics: true
+  local_traces: true
+  exporter: none
+  endpoint: null
+  redact_sensitive_fields: true
 consolidation:
   enabled: true
   window_size_turns: 8


### PR DESCRIPTION
## Summary

Completes local-first observability coverage for issue #116:

- Adds `observability` config with local-only defaults and OTLP endpoint validation.
- Adds body-free metric events for CLI/MCP verb invocations, search completion, WAL apply, workflow jobs, sensor emissions, hot-memory assembly, trace-canvas rendering, and projection rebuilds.
- Instruments CLI verb dispatch, CLI search modes, MCP tool calls, SQLite record WAL apply, workflow scheduler jobs, local sensor outcome metrics, and `admin reindex --from-db` projection rebuild telemetry.
- Keeps `.cairn/metrics.jsonl` local by default with config-based disable behavior; exporter config remains opt-in and validation-gated.
- Extends redaction/local exporter coverage so exported metrics omit record bodies, queries, snippets, file contents, sensor payloads, projection bodies, and screen capture text/artifacts.
- Hardens screen sensor telemetry so emitted, skipped, failed, cleanup-failed, and post-capture policy-drop paths produce body-free metrics/JSON and clean up dropped screenshot artifacts.

Fixes #116. GitHub recognizes this closing reference, so issue #116 will close automatically when this PR merges.

## Validation

Automated checks:

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p cairn-core metric`
- `cargo test -p cairn-sensors-local outcome::tests::dropped_outcome_builds_body_free_sensor_metric`
- `cargo test -p cairn-cli --test admin_reindex_from_db rebuild_from_db_snapshot`
- `cargo test -p cairn-cli --test telemetry`
- `cargo test -p cairn-mcp --test assemble_hot_tool`
- `cargo test -p cairn-core observability_defaults_are_local_only`
- `cargo test -p cairn-core validate_rejects_otlp_exporter_without_endpoint`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`

Review-loop focused checks:

- `cargo test -p cairn-cli --lib verbs::screen::tests`
- `cargo test -p cairn-sensors-local screen::tests::rejecting_policy`
- `cargo test -p cairn-sensors-local screen::tests::png_capture`
- `cargo test -p cairn-sensors-local screen::tests::screen_emit_budgets_sanitized_payload_not_only_ocr_text`
- `cargo clippy -p cairn-cli --lib --locked -- -D warnings`
- `cargo clippy -p cairn-sensors-local --lib --locked -- -D warnings`

Manual E2E checks with `target/debug/cairn` and temporary vaults:

- `ingest --body` emits body-free verb metric.
- `ingest --file` emits `mode:"file"` without leaking file contents.
- `search --mode keyword` emits `search_completed` and body-free verb metric without query leakage.
- `forget --record` and `retrieve --folder` mode-classification corner cases do not panic.
- `observability.local_metrics: false` suppresses local metric rows.
- `observability.local_traces: false` still permits local metrics.
- `observability.exporter: otlp` without endpoint fails config validation.
- Wired MCP stdio (`single_tenant = true` with principal) emits a body-free `surface:"mcp"` verb metric for `assemble_hot`.
- `admin reindex --from-db --json` rebuilds projections and emits a body-free `projection_rebuild` JSONL metric.
- Fresh rebuilt-binary screen E2E passed 20/20 on temporary vaults: no-consent pre-capture denial writes no PNG and records `pre_capture` privacy metric; consented real `xcap` capture writes a PNG and body-free `sensor_emission`; `allow_apps` post-capture drop removes the PNG and emits body-free dropped telemetry; `local_metrics: false` and `observability.enabled: false` suppress screen `sensor_emission`; `ingest --body` remains body-free.

Review-loop result:

- Initial adversarial review loop ran through round 10/10; all reported blockers were fixed or converted into tests before push.
- Follow-up review-loop requested up to 10 rounds passed on round 4/10; fixed cleanup JSON lifecycle consistency, cleanup-specific degradation state, and retained-artifact reporting.
- Skipped one non-actionable legacy API compatibility finding after verifying `HEAD~1` already returned an error on cleanup failure through `remove_capture_artifact(...)?`.
- GitHub Actions passed on head commit `bc3a4580` after rerunning one noisy Ubuntu latency gate job.

## Note

Bare `cairn --vault <path> mcp` without single-tenant config remains on the legacy unwired MCP path by design; the wired MCP metric path requires the existing `[mcp.stdio] single_tenant = true` opt-in.

