### PR TITLE
[codex] Surface semantic degraded search flag

### DIFF
--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -589,8 +589,9 @@ fn degraded_leg_to_idl(
 
     let reason_to_idl = |r: DegradationReason| match r {
         DegradationReason::CapabilityUnavailable => DegradedLegEntryReason::CapabilityUnavailable,
-        DegradationReason::TransientProviderOutage => DegradedLegEntryReason::Timeout,
-        DegradationReason::DeadlineExceeded => DegradedLegEntryReason::Timeout,
+        DegradationReason::TransientProviderOutage | DegradationReason::DeadlineExceeded => {
+            DegradedLegEntryReason::Timeout
+        }
         _ => DegradedLegEntryReason::SqlError,
     };
     let source_to_idl = |s: GraphSource| match s {

--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -876,7 +876,11 @@ async fn resolve_local_embedder(
     // and need deterministic, offline query embedding.
     if std::env::var("CAIRN_MOCK_EMBEDDER").as_deref() == Ok("1") {
         let embedder: Arc<dyn EmbeddingModel> =
-            Arc::new(cairn_embeddings_local::MockEmbedder::new(kind));
+            if std::env::var("CAIRN_MOCK_EMBEDDER_FAIL").as_deref() == Ok("network") {
+                Arc::new(NetworkFailingMockEmbedder { kind })
+            } else {
+                Arc::new(cairn_embeddings_local::MockEmbedder::new(kind))
+            };
         return Ok(embedder);
     }
 
@@ -889,6 +893,33 @@ async fn resolve_local_embedder(
         .map_err(|e| EmbedderInitError::Internal {
             msg: format!("{e:#}"),
         })
+}
+
+struct NetworkFailingMockEmbedder {
+    kind: cairn_core::config::EmbeddingModelKind,
+}
+
+impl EmbeddingModel for NetworkFailingMockEmbedder {
+    fn kind(&self) -> cairn_core::config::EmbeddingModelKind {
+        self.kind
+    }
+
+    fn dim(&self) -> usize {
+        self.kind.dim()
+    }
+
+    fn embed_document(
+        &self,
+        text: &str,
+    ) -> Result<Vec<f32>, cairn_embeddings_local::EmbeddingError> {
+        Ok(cairn_embeddings_local::mock_vector(text))
+    }
+
+    fn embed_query(&self, _text: &str) -> Result<Vec<f32>, cairn_embeddings_local::EmbeddingError> {
+        Err(cairn_embeddings_local::EmbeddingError::Network(
+            "mock semantic provider outage".to_owned(),
+        ))
+    }
 }
 
 #[cfg(feature = "openai")]

--- a/crates/cairn-cli/src/verbs/search.rs
+++ b/crates/cairn-cli/src/verbs/search.rs
@@ -280,7 +280,9 @@ async fn run_async(
         _ => None,
     };
     if let Some(capability) = mode_capability {
-        let resp = capability_unavailable_response(ResponseVerb::Search, capability);
+        let hint = openai_provider_unavailable_hint(&config, mode);
+        let resp =
+            capability_unavailable_response_with_hint(ResponseVerb::Search, capability, hint);
         if json {
             emit_json(&resp);
         } else {
@@ -290,7 +292,7 @@ async fn run_async(
                 &format!("capability unavailable: {capability}"),
                 &resp.operation_id,
             );
-            if let Some(hint) = cairn_core::status::remediation_for(capability) {
+            if let Some(hint) = hint.or_else(|| cairn_core::status::remediation_for(capability)) {
                 eprintln!("  hint: {hint}");
             }
         }
@@ -559,6 +561,7 @@ fn outcome_envelope(
             .map(|items| to_wire_exclusions(items)),
         score_explain,
         degraded_legs,
+        semantic_degraded: outcome.semantic_degraded.then_some(true),
     };
 
     Response {
@@ -586,6 +589,7 @@ fn degraded_leg_to_idl(
 
     let reason_to_idl = |r: DegradationReason| match r {
         DegradationReason::CapabilityUnavailable => DegradedLegEntryReason::CapabilityUnavailable,
+        DegradationReason::TransientProviderOutage => DegradedLegEntryReason::Timeout,
         DegradationReason::DeadlineExceeded => DegradedLegEntryReason::Timeout,
         _ => DegradedLegEntryReason::SqlError,
     };
@@ -741,6 +745,36 @@ fn openai_feature_gate(provider: EmbeddingProvider, json: bool) -> Option<ExitCo
             eprintln!("  hint: {FEATURE_HINT}");
         }
         Some(ExitCode::from(69)) // EX_UNAVAILABLE
+    }
+}
+
+fn openai_provider_unavailable_hint(
+    config: &cairn_core::config::CairnConfig,
+    mode: SearchMode,
+) -> Option<&'static str> {
+    if config.search.default_provider != EmbeddingProvider::OpenAi {
+        return None;
+    }
+    if !matches!(mode, SearchMode::Semantic | SearchMode::Hybrid) {
+        return None;
+    }
+    #[cfg(feature = "openai")]
+    {
+        let key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+        if key.trim().is_empty() {
+            return Some("set OPENAI_API_KEY in the environment to enable OpenAI embeddings");
+        }
+        if !cairn_embeddings_openai::config_ready(config.search.embedding_model, key.trim()) {
+            return Some(
+                "set search.embedding_model to an OpenAI text-embedding-3 model \
+                 (e.g. `openai-text-embedding-3-small`) in .cairn/config.yaml",
+            );
+        }
+        None
+    }
+    #[cfg(not(feature = "openai"))]
+    {
+        Some("rebuild with `cargo build --features openai` to enable the OpenAI embedding provider")
     }
 }
 
@@ -929,5 +963,29 @@ mod tests {
         assert_eq!(finite_option(Some(0.5)), Some(0.5));
         assert_eq!(finite_option(Some(f64::NAN)), Some(0.0));
         assert_eq!(finite_option(Some(f64::INFINITY)), Some(0.0));
+    }
+
+    #[test]
+    fn outcome_envelope_maps_semantic_degraded_true() {
+        use cairn_core::generated::envelope::ResponseData;
+
+        let outcome = cairn_core::verbs::search::SearchOutcome {
+            candidates: Vec::new(),
+            explain: None,
+            policy_trace: Vec::new(),
+            excluded: None,
+            degraded_legs: Vec::new(),
+            semantic_degraded: true,
+        };
+
+        let response = outcome_envelope(&outcome, SearchMode::Hybrid);
+        let Some(ResponseData::Search(data)) = response.data else {
+            panic!("search outcome must map to search response data");
+        };
+        assert_eq!(
+            data.semantic_degraded,
+            Some(true),
+            "semantic_degraded=true must be preserved in the search envelope"
+        );
     }
 }

--- a/crates/cairn-cli/tests/envelope_tests.rs
+++ b/crates/cairn-cli/tests/envelope_tests.rs
@@ -1638,6 +1638,7 @@ fn search_default_response_omits_excluded_field() {
         next_cursor: None,
         score_explain: None,
         degraded_legs: None,
+        semantic_degraded: None,
     };
     let json = serde_json::to_string(&data).expect("serializable");
     assert!(
@@ -1664,6 +1665,7 @@ fn search_with_excluded_emits_field() {
         next_cursor: None,
         score_explain: None,
         degraded_legs: None,
+        semantic_degraded: None,
     };
     let json = serde_json::to_string(&data).expect("serializable");
     assert!(
@@ -1685,11 +1687,50 @@ fn search_without_degraded_legs_omits_field() {
         next_cursor: None,
         score_explain: None,
         degraded_legs: None,
+        semantic_degraded: None,
     };
     let json = serde_json::to_string(&data).expect("serializable");
     assert!(
         !json.contains("\"degraded_legs\""),
         "healthy SearchData must not emit degraded_legs; got {json}"
+    );
+}
+
+#[test]
+fn search_without_semantic_degraded_omits_field() {
+    use cairn_core::generated::verbs::search::SearchData;
+
+    let data = SearchData {
+        excluded: None,
+        hits: Vec::new(),
+        next_cursor: None,
+        score_explain: None,
+        degraded_legs: None,
+        semantic_degraded: None,
+    };
+    let json = serde_json::to_string(&data).expect("serializable");
+    assert!(
+        !json.contains("\"semantic_degraded\""),
+        "healthy SearchData must not emit semantic_degraded; got {json}"
+    );
+}
+
+#[test]
+fn search_with_semantic_degraded_emits_true() {
+    use cairn_core::generated::verbs::search::SearchData;
+
+    let data = SearchData {
+        excluded: None,
+        hits: Vec::new(),
+        next_cursor: None,
+        score_explain: None,
+        degraded_legs: None,
+        semantic_degraded: Some(true),
+    };
+    let json = serde_json::to_string(&data).expect("serializable");
+    assert!(
+        json.contains("\"semantic_degraded\":true"),
+        "degraded SearchData must emit semantic_degraded=true; got {json}"
     );
 }
 
@@ -1720,6 +1761,7 @@ fn search_with_degraded_legs_emits_full_entry() {
                 source: Some(DegradedLegEntrySource::AuthSemanticSeed),
             },
         ]),
+        semantic_degraded: None,
     };
     let json = serde_json::to_string(&data).expect("serializable");
     let v: serde_json::Value = serde_json::from_str(&json).expect("roundtrip");

--- a/crates/cairn-cli/tests/search_semantic_degraded_cli.rs
+++ b/crates/cairn-cli/tests/search_semantic_degraded_cli.rs
@@ -1,0 +1,62 @@
+//! End-to-end CLI regression for hybrid search semantic-provider degradation.
+//!
+//! The test drives the real `cairn` binary against a fixture vault. The vault
+//! is indexed with the normal mock embedder, then the CLI subprocess is run
+//! with a failing mock query embedder so hybrid must fall back to the keyword
+//! leg and surface the wire-level `semantic_degraded=true` flag.
+
+#![allow(missing_docs)]
+
+use assert_cmd::Command;
+use cairn_test_fixtures::{RecordSpec, build_hybrid_test_vault};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn hybrid_search_surfaces_semantic_degraded_on_provider_outage() {
+    let vault = build_hybrid_test_vault(&[
+        RecordSpec::from_body("issue106 degraded alpha keyword survivor"),
+        RecordSpec::from_body("issue106 degraded beta keyword survivor"),
+    ])
+    .await;
+
+    let root = vault.root.clone();
+    let dir = vault.dir;
+    drop(vault.store);
+    drop(vault.embedder);
+
+    let output = Command::cargo_bin("cairn")
+        .expect("locate cairn binary")
+        .env("CAIRN_VAULT", &root)
+        .env("CAIRN_MOCK_EMBEDDER", "1")
+        .env("CAIRN_MOCK_EMBEDDER_FAIL", "network")
+        .args(["search", "issue106", "--mode", "hybrid", "--json"])
+        .output()
+        .expect("run cli");
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "hybrid search must commit keyword fallback results. stderr: {stderr}\nstdout: {stdout}"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid json: {e}\nstdout: {stdout}"));
+    assert_eq!(parsed["status"], "committed");
+    assert_eq!(parsed["data"]["semantic_degraded"], true, "{parsed}");
+    let hits = parsed["data"]["hits"].as_array().expect("hits array");
+    assert!(
+        !hits.is_empty(),
+        "keyword fallback must return hits: {parsed}"
+    );
+
+    let degraded_legs = parsed["data"]["degraded_legs"]
+        .as_array()
+        .expect("degraded_legs array");
+    assert!(
+        degraded_legs
+            .iter()
+            .any(|leg| leg["leg"] == "semantic" && leg["reason"] == "timeout"),
+        "transient semantic outage must surface as semantic timeout leg: {parsed}"
+    );
+
+    drop(dir);
+}

--- a/crates/cairn-core/src/generated/schemas/verbs/search.json
+++ b/crates/cairn-core/src/generated/schemas/verbs/search.json
@@ -97,6 +97,10 @@
             "$ref": "#/$defs/ScoreExplain"
           },
           "type": "array"
+        },
+        "semantic_degraded": {
+          "description": "True when the response succeeded after a transient semantic embedding-provider outage. Absent for healthy responses and for fail-closed capability errors.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/crates/cairn-core/src/generated/verbs/search.rs
+++ b/crates/cairn-core/src/generated/verbs/search.rs
@@ -364,6 +364,9 @@ pub struct SearchData {
     /// Optional per-candidate score-component explanations. Present only when args.explain is true (which itself requires the cairn.mcp.v1.policy_trace capability).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub score_explain: Option<Vec<ScoreExplain>>,
+    /// True when the response succeeded after a transient semantic embedding-provider outage. Absent for healthy responses and for fail-closed capability errors.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub semantic_degraded: Option<bool>,
 }
 
 pub const ARGS_SCHEMA: &[u8] = include_bytes!("../schemas/verbs/search.json");

--- a/crates/cairn-core/src/search/degraded.rs
+++ b/crates/cairn-core/src/search/degraded.rs
@@ -11,6 +11,8 @@
 pub enum DegradationReason {
     /// Store does not advertise the capability needed by this leg.
     CapabilityUnavailable,
+    /// External semantic embedding provider had a transient outage.
+    TransientProviderOutage,
     /// Per-leg deadline elapsed before results landed.
     DeadlineExceeded,
     /// `SQLite` returned an error.

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -84,6 +84,10 @@ pub struct SearchOutcome {
     /// surfaces it here so partial-result signaling is not silently
     /// dropped between the store and the wire surface. Issue #191.
     pub degraded_legs: Vec<crate::search::DegradedLeg>,
+    /// True when the response succeeded after a transient semantic
+    /// embedding-provider outage. This is derived from `degraded_legs` and is
+    /// never set for fail-closed capability errors.
+    pub semantic_degraded: bool,
 }
 
 fn candidate_has_reasoning(candidate: &SearchCandidate) -> bool {
@@ -330,12 +334,26 @@ pub async fn run(
         config.search.max_snippet_chars_per_page,
     );
 
+    let semantic_degraded = semantic_degraded(&degraded_legs);
+
     Ok(SearchOutcome {
         candidates,
         explain,
         policy_trace,
         excluded,
         degraded_legs,
+        semantic_degraded,
+    })
+}
+
+fn semantic_degraded(degraded_legs: &[crate::search::DegradedLeg]) -> bool {
+    degraded_legs.iter().any(|leg| {
+        matches!(
+            leg,
+            crate::search::DegradedLeg::Semantic {
+                reason: crate::search::DegradationReason::TransientProviderOutage
+            }
+        )
     })
 }
 
@@ -920,10 +938,15 @@ mod tests {
                 Ok(HybridSearchPage {
                     candidates: vec![],
                     explain: None,
-                    degraded_legs: vec![DegradedLeg::Graph {
-                        reason: DegradationReason::CapabilityUnavailable,
-                        source: GraphSource::All,
-                    }],
+                    degraded_legs: vec![
+                        DegradedLeg::Semantic {
+                            reason: DegradationReason::TransientProviderOutage,
+                        },
+                        DegradedLeg::Graph {
+                            reason: DegradationReason::CapabilityUnavailable,
+                            source: GraphSource::All,
+                        },
+                    ],
                 })
             }
         }
@@ -939,8 +962,12 @@ mod tests {
         .expect("hybrid run");
         assert_eq!(
             outcome.degraded_legs.len(),
-            1,
+            2,
             "hybrid must propagate store's degraded_legs through SearchOutcome"
+        );
+        assert!(
+            outcome.semantic_degraded,
+            "transient semantic provider outage must set semantic_degraded"
         );
     }
 

--- a/crates/cairn-core/src/verbs/search.rs
+++ b/crates/cairn-core/src/verbs/search.rs
@@ -254,18 +254,7 @@ pub async fn run(
             reason: e.to_string(),
         })?;
 
-    let visibility = if request.visibility_allowlist.is_empty() {
-        vec![
-            MemoryVisibility::Private,
-            MemoryVisibility::Session,
-            MemoryVisibility::Project,
-            MemoryVisibility::Team,
-            MemoryVisibility::Org,
-            MemoryVisibility::Public,
-        ]
-    } else {
-        request.visibility_allowlist.clone()
-    };
+    let visibility = visibility_allowlist(&request);
 
     let (candidates, explain, read_filter_exclusions, degraded_legs) = match request.mode {
         SearchMode::Keyword => {
@@ -355,6 +344,21 @@ fn semantic_degraded(degraded_legs: &[crate::search::DegradedLeg]) -> bool {
             }
         )
     })
+}
+
+fn visibility_allowlist(request: &SearchRequest) -> Vec<MemoryVisibility> {
+    if !request.visibility_allowlist.is_empty() {
+        return request.visibility_allowlist.clone();
+    }
+
+    vec![
+        MemoryVisibility::Private,
+        MemoryVisibility::Session,
+        MemoryVisibility::Project,
+        MemoryVisibility::Team,
+        MemoryVisibility::Org,
+        MemoryVisibility::Public,
+    ]
 }
 
 fn search_policy_trace(

--- a/crates/cairn-idl/schema/verbs/search.json
+++ b/crates/cairn-idl/schema/verbs/search.json
@@ -155,6 +155,10 @@
           "description": "Optional per-candidate score-component explanations. Present only when args.explain is true (which itself requires the cairn.mcp.v1.policy_trace capability).",
           "items": { "$ref": "#/$defs/ScoreExplain" }
         },
+        "semantic_degraded": {
+          "type": "boolean",
+          "description": "True when the response succeeded after a transient semantic embedding-provider outage. Absent for healthy responses and for fail-closed capability errors."
+        },
         "degraded_legs": {
           "type": "array",
           "description": "Per-leg degradation entries when one or more search legs (semantic, graph, or graph seed sources) failed or were unavailable. Empty/absent when every requested leg contributed. Lets callers distinguish a low-recall result from a partial-failure result without inspecting server logs.",

--- a/crates/cairn-idl/tests/snapshots/wire_compat_v1__file__verbs_search_json.snap
+++ b/crates/cairn-idl/tests/snapshots/wire_compat_v1__file__verbs_search_json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cairn-idl/tests/wire_compat_v1.rs
+assertion_line: 95
 expression: body
 ---
 {
@@ -158,6 +159,10 @@ expression: body
           "type": "array",
           "description": "Optional per-candidate score-component explanations. Present only when args.explain is true (which itself requires the cairn.mcp.v1.policy_trace capability).",
           "items": { "$ref": "#/$defs/ScoreExplain" }
+        },
+        "semantic_degraded": {
+          "type": "boolean",
+          "description": "True when the response succeeded after a transient semantic embedding-provider outage. Absent for healthy responses and for fail-closed capability errors."
         },
         "degraded_legs": {
           "type": "array",

--- a/crates/cairn-idl/tests/snapshots/wire_compat_v1__manifest_fingerprint.snap
+++ b/crates/cairn-idl/tests/snapshots/wire_compat_v1__manifest_fingerprint.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cairn-idl/tests/wire_compat_v1.rs
+assertion_line: 84
 expression: digest
 ---
-e5c6ad17c663c74aac20fc1a5cf12f7b55cd2d70768d56699bfac77bc551e0ea
+abb0b02e20b59c080154225162e1beb2078a52018ec5d23fc8886736a9922b33

--- a/crates/cairn-mcp/src/generated/schemas/verbs/search.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/search.input.json
@@ -97,6 +97,10 @@
             "$ref": "#/$defs/ScoreExplain"
           },
           "type": "array"
+        },
+        "semantic_degraded": {
+          "description": "True when the response succeeded after a transient semantic embedding-provider outage. Absent for healthy responses and for fail-closed capability errors.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/crates/cairn-mcp/src/generated/schemas/verbs/search.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/search.json
@@ -97,6 +97,10 @@
             "$ref": "#/$defs/ScoreExplain"
           },
           "type": "array"
+        },
+        "semantic_degraded": {
+          "description": "True when the response succeeded after a transient semantic embedding-provider outage. Absent for healthy responses and for fail-closed capability errors.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -1424,6 +1424,7 @@ fn search_outcome_to_result(
         excluded: outcome.excluded.map(|items| to_wire_exclusions(&items)),
         score_explain,
         degraded_legs,
+        semantic_degraded: outcome.semantic_degraded.then_some(true),
     };
 
     let response = crate::verb_envelope::committed(
@@ -1518,6 +1519,7 @@ fn degraded_leg_to_idl(
 
     let reason_to_idl = |r: DegradationReason| match r {
         DegradationReason::CapabilityUnavailable => DegradedLegEntryReason::CapabilityUnavailable,
+        DegradationReason::TransientProviderOutage => DegradedLegEntryReason::Timeout,
         DegradationReason::DeadlineExceeded => DegradedLegEntryReason::Timeout,
         _ => DegradedLegEntryReason::SqlError,
     };

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -1519,8 +1519,9 @@ fn degraded_leg_to_idl(
 
     let reason_to_idl = |r: DegradationReason| match r {
         DegradationReason::CapabilityUnavailable => DegradedLegEntryReason::CapabilityUnavailable,
-        DegradationReason::TransientProviderOutage => DegradedLegEntryReason::Timeout,
-        DegradationReason::DeadlineExceeded => DegradedLegEntryReason::Timeout,
+        DegradationReason::TransientProviderOutage | DegradationReason::DeadlineExceeded => {
+            DegradedLegEntryReason::Timeout
+        }
         _ => DegradedLegEntryReason::SqlError,
     };
     let source_to_idl = |s: GraphSource| match s {

--- a/crates/cairn-mcp/src/verb_envelope.rs
+++ b/crates/cairn-mcp/src/verb_envelope.rs
@@ -402,6 +402,7 @@ mod tests {
             hits: Vec::new(),
             next_cursor: None,
             score_explain: None,
+            semantic_degraded: None,
         })
     }
 

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -644,8 +644,9 @@ fn degraded_leg_to_idl(
 
     let reason_to_idl = |r: DegradationReason| match r {
         DegradationReason::CapabilityUnavailable => DegradedLegEntryReason::CapabilityUnavailable,
-        DegradationReason::TransientProviderOutage => DegradedLegEntryReason::Timeout,
-        DegradationReason::DeadlineExceeded => DegradedLegEntryReason::Timeout,
+        DegradationReason::TransientProviderOutage | DegradationReason::DeadlineExceeded => {
+            DegradedLegEntryReason::Timeout
+        }
         // SqlError + WorkerPanic + future variants (DegradationReason
         // is #[non_exhaustive]) all surface as SqlError on the wire.
         _ => DegradedLegEntryReason::SqlError,

--- a/crates/cairn-sdk/src/transport.rs
+++ b/crates/cairn-sdk/src/transport.rs
@@ -644,6 +644,7 @@ fn degraded_leg_to_idl(
 
     let reason_to_idl = |r: DegradationReason| match r {
         DegradationReason::CapabilityUnavailable => DegradedLegEntryReason::CapabilityUnavailable,
+        DegradationReason::TransientProviderOutage => DegradedLegEntryReason::Timeout,
         DegradationReason::DeadlineExceeded => DegradedLegEntryReason::Timeout,
         // SqlError + WorkerPanic + future variants (DegradationReason
         // is #[non_exhaustive]) all surface as SqlError on the wire.
@@ -736,6 +737,7 @@ fn envelope_from_outcome(
         excluded: outcome.excluded.map(|items| to_wire_exclusions(&items)),
         score_explain,
         degraded_legs,
+        semantic_degraded: outcome.semantic_degraded.then_some(true),
     };
 
     VerbResponse {

--- a/crates/cairn-store-sqlite/src/error.rs
+++ b/crates/cairn-store-sqlite/src/error.rs
@@ -143,6 +143,10 @@ pub enum StoreError {
         message: String,
     },
 
+    /// Embedding provider/runtime failed while serving a query.
+    #[error("embedding error: {0}")]
+    Embedding(#[from] cairn_embeddings_local::EmbeddingError),
+
     /// Background `tokio_rusqlite` worker error (channel closed, panic
     /// in the worker thread, etc.).
     #[error("tokio_rusqlite worker error")]

--- a/crates/cairn-store-sqlite/src/store/hybrid.rs
+++ b/crates/cairn-store-sqlite/src/store/hybrid.rs
@@ -123,9 +123,7 @@ impl SqliteMemoryStore {
             Ok(page) => page,
             Err(e) => {
                 tracing::warn!(error = %e, "semantic leg failed; degrading hybrid response");
-                leg_degradations.push(DegradedLeg::Semantic {
-                    reason: DegradationReason::SqlError,
-                });
+                push_semantic_degradation(&mut leg_degradations, semantic_degradation_reason(&e));
                 cairn_core::contract::memory_store::SemanticSearchPage {
                     candidates: Vec::new(),
                     explain: None,
@@ -158,7 +156,21 @@ impl SqliteMemoryStore {
         // embedded once internally; the v0.1 hybrid path accepts the second
         // embed for simplicity. Future optimization: thread the precomputed
         // vector through a `do_search_semantic_with_vector` shortcut.
-        let query_vector = embed_query_blocking(&embedder, args.query.clone()).await?;
+        let (query_vector, force_skip_rerank) =
+            match embed_query_blocking(&embedder, args.query.clone()).await {
+                Ok(v) => (v, false),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "hybrid rerank query embedding failed; skipping cosine rerank"
+                    );
+                    push_semantic_degradation(
+                        &mut leg_degradations,
+                        semantic_degradation_reason(&e),
+                    );
+                    (Vec::new(), true)
+                }
+            };
 
         // Build the dedup'd candidate id list bounded by `rerank_topk` —
         // RRF only re-ranks its own top-K, so fetching more vectors is waste.
@@ -169,22 +181,18 @@ impl SqliteMemoryStore {
         // skip re-rank and surface a `DegradedLeg::Semantic` entry —
         // unless one is already present from `do_search_semantic` itself
         // (don't double-report a single failure mode).
-        let (doc_vectors, skip_rerank) =
+        let (doc_vectors, skip_rerank) = if force_skip_rerank {
+            (HashMap::new(), true)
+        } else {
             match fetch_doc_vectors(conn, combined_ids, args.model_label.clone()).await {
                 Ok(v) => (v, false),
                 Err(e) => {
                     tracing::warn!(error = %e, "fetch_doc_vectors failed; skipping cosine rerank");
-                    if !leg_degradations
-                        .iter()
-                        .any(|d| matches!(d, DegradedLeg::Semantic { .. }))
-                    {
-                        leg_degradations.push(DegradedLeg::Semantic {
-                            reason: DegradationReason::SqlError,
-                        });
-                    }
+                    push_semantic_degradation(&mut leg_degradations, DegradationReason::SqlError);
                     (HashMap::new(), true)
                 }
-            };
+            }
+        };
         let degraded_legs = leg_degradations;
 
         // Run the pure-function orchestration.
@@ -491,6 +499,53 @@ fn scored_from_semantic(candidates: &[SearchCandidate]) -> Vec<ScoredCandidate> 
         .collect()
 }
 
+fn semantic_degradation_reason(error: &StoreError) -> DegradationReason {
+    match error {
+        StoreError::Embedding(cairn_embeddings_local::EmbeddingError::Network(msg)) => {
+            if is_transient_embedding_network_error(msg) {
+                DegradationReason::TransientProviderOutage
+            } else {
+                DegradationReason::SqlError
+            }
+        }
+        _ => DegradationReason::SqlError,
+    }
+}
+
+fn is_transient_embedding_network_error(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("authentication failed")
+        || lower.contains("http 401")
+        || lower.contains("http 403")
+        || lower.contains("cannot serve")
+        || lower.contains("response parse error")
+        || lower.contains("wrong number of vectors")
+    {
+        return false;
+    }
+    lower.contains("network")
+        || lower.contains("connection")
+        || lower.contains("timeout")
+        || lower.contains("outage")
+        || lower.contains("rate limited")
+        || lower.contains("http 429")
+        || lower.contains("server error")
+        || lower.contains("http 5")
+}
+
+fn push_semantic_degradation(degraded: &mut Vec<DegradedLeg>, reason: DegradationReason) {
+    if let Some(DegradedLeg::Semantic { reason: existing }) = degraded
+        .iter_mut()
+        .find(|leg| matches!(leg, DegradedLeg::Semantic { .. }))
+    {
+        if reason == DegradationReason::TransientProviderOutage {
+            *existing = reason;
+        }
+        return;
+    }
+    degraded.push(DegradedLeg::Semantic { reason });
+}
+
 /// Embed `query` on the blocking pool. Hybrid path embeds once for the
 /// cosine re-rank, distinct from the embed `do_search_semantic` already
 /// performed for the ANN leg — see the docstring on `do_search_hybrid`.
@@ -504,9 +559,7 @@ async fn embed_query_blocking(
         .map_err(|e| StoreError::Invariant {
             what: format!("hybrid embedding task panicked: {e}"),
         })?
-        .map_err(|e| StoreError::Invariant {
-            what: format!("hybrid embed_query failed: {e}"),
-        })
+        .map_err(StoreError::Embedding)
 }
 
 /// Build the union of candidate ids across both legs, deduplicated while
@@ -808,6 +861,25 @@ mod tests {
         blob.extend_from_slice(&[0xAB, 0xCD, 0xEF]); // 3 trailing bytes
         let back = blob_to_f32_vec(&blob);
         assert_eq!(back, v);
+    }
+
+    #[test]
+    fn semantic_degradation_reason_only_marks_transient_provider_failures() {
+        let transient = StoreError::Embedding(cairn_embeddings_local::EmbeddingError::Network(
+            "network error: connection reset".to_owned(),
+        ));
+        assert_eq!(
+            semantic_degradation_reason(&transient),
+            DegradationReason::TransientProviderOutage
+        );
+
+        let auth = StoreError::Embedding(cairn_embeddings_local::EmbeddingError::Network(
+            "authentication failed (HTTP 401)".to_owned(),
+        ));
+        assert_eq!(
+            semantic_degradation_reason(&auth),
+            DegradationReason::SqlError
+        );
     }
 
     #[test]

--- a/crates/cairn-store-sqlite/src/store/search.rs
+++ b/crates/cairn-store-sqlite/src/store/search.rs
@@ -629,9 +629,7 @@ impl SqliteMemoryStore {
                 .map_err(|e| StoreError::Invariant {
                     what: format!("embedding task panicked: {e}"),
                 })?
-                .map_err(|e| StoreError::Invariant {
-                    what: format!("embed_query failed: {e}"),
-                })?;
+                .map_err(StoreError::Embedding)?;
 
         let query_bytes: Vec<u8> = query_vec.iter().flat_map(|&f| f.to_le_bytes()).collect();
         let limit = args.limit.clamp(1, SEARCH_LIMIT_MAX);

--- a/crates/cairn-test-fixtures/src/replay.rs
+++ b/crates/cairn-test-fixtures/src/replay.rs
@@ -953,6 +953,7 @@ mod tests {
                 reason: cairn_core::search::DegradationReason::CapabilityUnavailable,
                 source: cairn_core::search::GraphSource::All,
             }],
+            semantic_degraded: false,
         });
 
         assert_eq!(

--- a/docs/superpowers/plans/2026-05-19-issue-106-openai-semantic-degraded.md
+++ b/docs/superpowers/plans/2026-05-19-issue-106-openai-semantic-degraded.md
@@ -1,0 +1,205 @@
+# Issue 106 OpenAI Semantic Degradation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the explicit `semantic_degraded` search response flag required by issue #106 while preserving existing `degraded_legs` diagnostics.
+
+**Architecture:** Extend the search IDL response data with an optional boolean, regenerate the SDK/MCP schemas, derive the flag in `cairn-core::verbs::search` from semantic degraded-leg reasons, and have the CLI envelope mapper serialize the field. The OpenAI adapter remains opt-in and unchanged.
+
+**Tech Stack:** Rust 2024, `cairn-idl` codegen, `cairn-core`, `cairn-cli`, `serde_json`, generated IDL types.
+
+---
+
+### Task 1: IDL Wire Field
+
+**Files:**
+- Modify: `crates/cairn-idl/schema/verbs/search.json`
+- Regenerate: `crates/cairn-core/src/generated/verbs/search.rs`
+- Regenerate: `crates/cairn-core/src/generated/schemas/verbs/search.json`
+- Regenerate: `crates/cairn-mcp/src/generated/schemas/verbs/search.json`
+- Test: `crates/cairn-cli/tests/envelope_tests.rs`
+
+- [ ] **Step 1: Write failing serialization tests**
+
+Add two tests near the existing `SearchData` degraded-leg tests:
+
+```rust
+#[test]
+fn search_without_semantic_degraded_omits_field() {
+    use cairn_core::generated::verbs::search::SearchData;
+
+    let data = SearchData {
+        excluded: None,
+        hits: Vec::new(),
+        next_cursor: None,
+        score_explain: None,
+        degraded_legs: None,
+        semantic_degraded: None,
+    };
+    let json = serde_json::to_string(&data).expect("serializable");
+    assert!(
+        !json.contains("\"semantic_degraded\""),
+        "healthy SearchData must not emit semantic_degraded; got {json}"
+    );
+}
+
+#[test]
+fn search_with_semantic_degraded_emits_true() {
+    use cairn_core::generated::verbs::search::SearchData;
+
+    let data = SearchData {
+        excluded: None,
+        hits: Vec::new(),
+        next_cursor: None,
+        score_explain: None,
+        degraded_legs: None,
+        semantic_degraded: Some(true),
+    };
+    let json = serde_json::to_string(&data).expect("serializable");
+    assert!(
+        json.contains("\"semantic_degraded\":true"),
+        "degraded SearchData must emit semantic_degraded=true; got {json}"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p cairn-cli --test envelope_tests search_without_semantic_degraded_omits_field --features openai`
+
+Expected: FAIL because `SearchData` has no `semantic_degraded` field.
+
+- [ ] **Step 3: Add the IDL field and regenerate**
+
+Add this property under `Data.properties` in `crates/cairn-idl/schema/verbs/search.json`:
+
+```json
+"semantic_degraded": {
+  "type": "boolean",
+  "description": "True when the response succeeded after a transient semantic embedding-provider outage. Absent for healthy responses and for fail-closed capability errors."
+}
+```
+
+Run: `cargo run -p cairn-idl --bin cairn-codegen --locked`
+
+Expected: generated `SearchData` includes `pub semantic_degraded: Option<bool>` with `skip_serializing_if = "Option::is_none"`.
+
+- [ ] **Step 4: Run serialization tests**
+
+Run: `cargo test -p cairn-cli --test envelope_tests semantic_degraded --features openai`
+
+Expected: PASS.
+
+### Task 2: Core Degradation Semantics
+
+**Files:**
+- Modify: `crates/cairn-core/src/search/degraded.rs`
+- Modify: `crates/cairn-core/src/verbs/search.rs`
+
+- [ ] **Step 1: Write failing core test**
+
+Extend the existing degraded hybrid store test so the store returns:
+
+```rust
+degraded_legs: vec![DegradedLeg::Semantic {
+    reason: DegradationReason::TransientProviderOutage,
+}],
+```
+
+Then assert:
+
+```rust
+assert!(
+    outcome.semantic_degraded,
+    "transient semantic provider outage must set semantic_degraded"
+);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p cairn-core verbs::search::tests::hybrid_propagates_degraded_legs_through_search_outcome`
+
+Expected: FAIL because `TransientProviderOutage` and `SearchOutcome.semantic_degraded` do not exist.
+
+- [ ] **Step 3: Implement minimal core support**
+
+Add `TransientProviderOutage` to `DegradationReason`, add `semantic_degraded: bool` to `SearchOutcome`, and set it in `run` with:
+
+```rust
+let semantic_degraded = degraded_legs.iter().any(|leg| {
+    matches!(
+        leg,
+        crate::search::DegradedLeg::Semantic {
+            reason: crate::search::DegradationReason::TransientProviderOutage
+        }
+    )
+});
+```
+
+Keyword and non-transient semantic degradation must leave the flag false.
+
+- [ ] **Step 4: Run core tests**
+
+Run: `cargo test -p cairn-core verbs::search::tests::hybrid_propagates_degraded_legs_through_search_outcome`
+
+Expected: PASS.
+
+### Task 3: CLI Envelope Mapping
+
+**Files:**
+- Modify: `crates/cairn-cli/src/verbs/search.rs`
+- Modify: `crates/cairn-cli/tests/envelope_tests.rs`
+
+- [ ] **Step 1: Write failing CLI mapping test**
+
+Add or extend an envelope test to build a `SearchOutcome` with `semantic_degraded: true`, call `outcome_envelope`, and assert the serialized search data contains `"semantic_degraded": true`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p cairn-cli --test envelope_tests semantic_degraded --features openai`
+
+Expected: FAIL because `outcome_envelope` does not populate the field.
+
+- [ ] **Step 3: Map the field**
+
+In `outcome_envelope`, set:
+
+```rust
+semantic_degraded: outcome.semantic_degraded.then_some(true),
+```
+
+- [ ] **Step 4: Run CLI tests**
+
+Run: `cargo test -p cairn-cli --test envelope_tests semantic_degraded --features openai`
+
+Expected: PASS.
+
+### Task 4: Verification
+
+**Files:**
+- All changed files
+
+- [ ] **Step 1: Run codegen drift check**
+
+Run: `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
+
+Expected: clean.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p cairn-core verbs::search::tests::hybrid_propagates_degraded_legs_through_search_outcome
+cargo test -p cairn-cli --test envelope_tests semantic_degraded --features openai
+cargo test -p cairn-cli --test openai_provider_status --features openai
+cargo test -p cairn-embeddings-openai --features openai
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Run build check**
+
+Run: `cargo build -p cairn-cli --features openai`
+
+Expected: PASS.

--- a/docs/superpowers/specs/2026-05-19-issue-106-openai-semantic-degraded-design.md
+++ b/docs/superpowers/specs/2026-05-19-issue-106-openai-semantic-degraded-design.md
@@ -1,0 +1,87 @@
+# Issue 106 OpenAI Semantic Degradation Design
+
+## Context
+
+Issue #106 implements the P1 provider-selection slice from design brief
+§19 v0.2 backend options and §5.1 read path. The current `origin/main` already
+contains an opt-in `cairn-embeddings-openai` crate, `cairn-cli` `openai`
+feature gating, provider readiness checks, OpenAI-native embedding model kinds,
+mock wire-format tests, status/search capability tests, and credential redaction
+coverage.
+
+The remaining gap is contract wording: issue #106 and design brief §3.0 / §19
+name `semantic_degraded=true` for transient external-provider outage, while the
+current search response exposes richer `degraded_legs` entries. This design keeps
+the richer diagnostics and adds the explicit compatibility flag.
+
+## Recommendation
+
+Add an optional `semantic_degraded` boolean to the `search` response data.
+Surface it as `true` when a search result was served despite a transient
+semantic-provider outage. Leave it absent for healthy results and for
+fail-closed capability errors.
+
+This preserves the current search API contract and satisfies the literal issue
+acceptance criterion without replacing `degraded_legs`.
+
+## Architecture
+
+The implementation should stay behind existing boundaries:
+
+- `cairn-idl/schema/verbs/search.json` defines the new optional response field.
+- Generated search types carry `semantic_degraded: Option<bool>`.
+- `cairn-core::verbs::search::SearchOutcome` carries a boolean derived from
+  existing internal search degradation information.
+- `cairn-cli` maps `SearchOutcome.semantic_degraded` into the generated response
+  data.
+
+No new provider registry or parallel status mechanism is needed. The OpenAI
+adapter remains opt-in through `cairn-cli --features openai`, and local candle
+embeddings remain the default.
+
+## Semantics
+
+`semantic_degraded` means:
+
+- `true`: the requested search returned results using a fallback or surviving
+  leg after a transient semantic provider outage.
+- absent: no semantic provider outage affected this response.
+
+The field should not be used for:
+
+- compile-time feature absence
+- missing credentials
+- unsupported provider/model configuration
+- local candle model missing
+- an unadvertised semantic or hybrid capability
+
+Those cases must continue to fail closed with `CapabilityUnavailable` and no
+successful search response.
+
+For the first implementation, the flag can be derived from the existing
+degradation model when a `DegradedLeg::Semantic` entry carries a transient
+provider-outage reason. If the current internal enum lacks that reason, add the
+narrowest reason needed rather than broadening all semantic degradation into
+`semantic_degraded=true`.
+
+## Testing
+
+Use TDD for each behavior:
+
+- A generated-envelope or CLI serialization test proves healthy search output
+  omits `semantic_degraded`.
+- A core search test proves a transient semantic-provider outage sets
+  `SearchOutcome.semantic_degraded=true` while preserving `degraded_legs`.
+- A JSON output test proves `semantic_degraded: true` appears in the wire data
+  for the degraded success path.
+- Existing OpenAI readiness tests continue to prove feature-off, missing-key,
+  whitespace-key, and unsupported-model cases fail closed.
+- Existing credential-redaction tests continue to prove API keys are not written
+  into output or debug text.
+
+## Non-Goals
+
+- Do not add Cohere, Voyage, Ollama, or LiteLLM routing in this slice.
+- Do not change v0.1 local search defaults.
+- Do not replace `degraded_legs`.
+- Do not persist provider credentials in the vault.


### PR DESCRIPTION
## Summary
- Adds optional `semantic_degraded` to the search response schema while preserving `degraded_legs` diagnostics.
- Derives the flag from transient semantic-provider degraded legs and threads it through core, CLI, SDK, and MCP envelopes.
- Preserves embedding runtime errors as typed store errors so hybrid search can degrade to keyword results when a semantic provider outage happens.
- Adds a real `cairn search --mode hybrid --json` CLI e2e regression that verifies committed fallback hits, `semantic_degraded=true`, and the semantic timeout degraded leg.
- Keeps OpenAI-specific remediation hints available at the pre-dispatch capability gate.

## Why
Issue #106 calls out a wire-level `semantic_degraded=true` signal for transient semantic provider outages. This completes that acceptance criterion without replacing the richer degraded-leg diagnostics already present upstream.

Closes #106

## Validation
- `cargo test -p cairn-cli --features openai`
- `cargo test -p cairn-cli --test search_semantic_degraded_cli --features openai`
- `cargo test -p cairn-store-sqlite store::hybrid::tests::semantic_degradation_reason_only_marks_transient_provider_failures`
- `cargo test -p cairn-store-sqlite --test hybrid_partial_degradation`
- `cargo test -p cairn-core verbs::search::tests::hybrid_propagates_degraded_legs_through_search_outcome`
- `cargo test -p cairn-mcp --test search_tool`
- `cargo test -p cairn-sdk --test search_dispatch`
- `cargo test -p cairn-idl --test wire_compat_v1 -- --nocapture`
- `cargo test -p cairn-embeddings-openai`
- `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
- `cargo build -p cairn-cli --features openai`
- `scripts/check-core-boundary.sh`
- `git diff --check`
