### PR TITLE
[codex] Add signed share links and promotion consent gates

### DIFF
--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -96,9 +96,10 @@ pub use session_tree::{
     SessionTreeNode,
 };
 pub use sharing::{
-    PromotionConsentPayload, PromotionConsentReceipt, PromotionGateInput, ShareLinkPayload,
-    SharingDecisionKind, SharingGateRejection, SharingPolicyAction, SharingPolicySubject,
-    SharingRevocationState, SignedShareLink, verify_promotion_gate,
+    PromotionConsentPayload, PromotionConsentReceipt, PromotionGateInput, ShareLinkGateInput,
+    ShareLinkPayload, SharingDecisionKind, SharingGateRejection, SharingPolicyAction,
+    SharingPolicySubject, SharingRevocationState, SignedShareLink, verify_promotion_gate,
+    verify_share_link_grant,
 };
 pub use source_id::SourceId;
 pub use source_ref::{SourceRef, validate_source_refs};

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -96,8 +96,9 @@ pub use session_tree::{
     SessionTreeNode,
 };
 pub use sharing::{
-    PromotionConsentPayload, PromotionConsentReceipt, ShareLinkPayload, SharingDecisionKind,
-    SharingPolicyAction, SharingPolicySubject, SharingRevocationState, SignedShareLink,
+    PromotionConsentPayload, PromotionConsentReceipt, PromotionGateInput, ShareLinkPayload,
+    SharingDecisionKind, SharingGateRejection, SharingPolicyAction, SharingPolicySubject,
+    SharingRevocationState, SignedShareLink, verify_promotion_gate,
 };
 pub use source_id::SourceId;
 pub use source_ref::{SourceRef, validate_source_refs};

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -97,9 +97,9 @@ pub use session_tree::{
 };
 pub use sharing::{
     PromotionConsentPayload, PromotionConsentReceipt, PromotionGateInput, ShareLinkGateInput,
-    ShareLinkPayload, SharingDecisionKind, SharingGateRejection, SharingPolicyAction,
-    SharingPolicySubject, SharingRevocationState, SignedShareLink, verify_promotion_gate,
-    verify_share_link_grant,
+    ShareLinkJournalDecision, ShareLinkPayload, SharingDecisionKind, SharingGateRejection,
+    SharingPolicyAction, SharingPolicySubject, SharingRevocationState, SignedShareLink,
+    verify_promotion_gate, verify_share_link_grant,
 };
 pub use source_id::SourceId;
 pub use source_ref::{SourceRef, validate_source_refs};

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -44,6 +44,7 @@ pub mod scope;
 pub mod sensor_policy;
 pub mod session;
 pub mod session_tree;
+pub mod sharing;
 pub mod source_id;
 pub mod source_ref;
 pub mod target_id;
@@ -94,6 +95,7 @@ pub use session_tree::{
     BranchKind, MergeStrategy, SessionMerge, SessionParent, SessionTree, SessionTreeError,
     SessionTreeNode,
 };
+pub use sharing::{SharingDecisionKind, SharingPolicyAction, SharingPolicySubject};
 pub use source_id::SourceId;
 pub use source_ref::{SourceRef, validate_source_refs};
 pub use target_id::TargetId;

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -95,7 +95,10 @@ pub use session_tree::{
     BranchKind, MergeStrategy, SessionMerge, SessionParent, SessionTree, SessionTreeError,
     SessionTreeNode,
 };
-pub use sharing::{SharingDecisionKind, SharingPolicyAction, SharingPolicySubject};
+pub use sharing::{
+    PromotionConsentPayload, PromotionConsentReceipt, ShareLinkPayload, SharingDecisionKind,
+    SharingPolicyAction, SharingPolicySubject, SharingRevocationState, SignedShareLink,
+};
 pub use source_id::SourceId;
 pub use source_ref::{SourceRef, validate_source_refs};
 pub use target_id::TargetId;

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -227,6 +227,12 @@ pub struct ShareLinkGateInput<'a> {
     pub now: &'a Rfc3339Timestamp,
     /// Expected record-set or grant-manifest hash.
     pub expected_target_hash: &'a str,
+    /// Principal attempting to redeem the link. `None` is allowed only for bearer links.
+    pub requesting_principal: Option<&'a Identity>,
+    /// Issuer identity used to resolve `signer_key`.
+    pub issuer: &'a Identity,
+    /// Issuer key version used to resolve `signer_key`.
+    pub issuer_key_version: u32,
     /// Verifying key for `link.payload.issuer`.
     pub signer_key: &'a VerifyingKey,
     /// Revocation state supplied by store/identity layer.
@@ -519,6 +525,15 @@ pub fn verify_share_link_grant(
         return Err(reject_share_link(SharingDecisionKind::InvalidShape, error));
     }
 
+    if input.issuer != &input.link.payload.issuer
+        || input.issuer_key_version != input.link.payload.key_version
+    {
+        return Err(reject_share_link(
+            SharingDecisionKind::BadSignature,
+            DomainError::InvalidSignature,
+        ));
+    }
+
     let signature_result = (|| {
         let bytes = crate::domain::canonical::canonical_bytes(&input.link.payload)
             .map_err(|_| DomainError::InvalidSignature)?;
@@ -533,6 +548,17 @@ pub fn verify_share_link_grant(
             SharingDecisionKind::BadSignature,
             DomainError::InvalidSignature,
         ));
+    }
+
+    if let Some(expected_grantee) = &input.link.payload.grantee {
+        if input.requesting_principal != Some(expected_grantee) {
+            return Err(reject_share_link(
+                SharingDecisionKind::ScopeMismatch,
+                DomainError::ScopeDenied {
+                    message: "share link grantee does not match requesting principal".to_owned(),
+                },
+            ));
+        }
     }
 
     if input.link.payload.target_hash != input.expected_target_hash {

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -8,8 +8,8 @@ use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 use crate::domain::{
-    CanonicalRecordHash, DomainError, Ed25519Signature, Identity, MemoryRecord, MemoryVisibility,
-    Rfc3339Timestamp, ScopeTuple,
+    CanonicalRecordHash, ConsentPayload, DomainError, Ed25519Signature, Identity, MemoryRecord,
+    MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
 };
 use crate::policy_trace::{PolicyDetail, PolicyGate, PolicyOutcome, PolicyTraceEntry};
 use crate::rebac::{RebacAction, RebacContext};
@@ -99,6 +99,27 @@ impl SharingDecisionKind {
             Self::NotHuman => "not_human",
             Self::NoRebacRelation => "no_rebac_relation",
             Self::InvalidShape => "invalid_shape",
+        }
+    }
+}
+
+/// Consent journal decision for a share link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShareLinkJournalDecision {
+    /// Link grant.
+    Grant,
+    /// Link revoke.
+    Revoke,
+}
+
+impl ShareLinkJournalDecision {
+    /// Body-free policy code.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Grant => "grant",
+            Self::Revoke => "revoke",
         }
     }
 }
@@ -251,6 +272,17 @@ pub struct SharingGateRejection {
 }
 
 impl PromotionConsentReceipt {
+    /// Build the body-free `ConsentPayload` for a promotion journal row.
+    #[must_use]
+    pub fn promote_consent_payload(&self) -> ConsentPayload {
+        ConsentPayload::PromoteReceipt {
+            target_id_hash: self.payload.target_id_hash.clone(),
+            from_tier: self.payload.from_tier,
+            to_tier: self.payload.to_tier,
+            receipt_id: self.receipt_id.clone(),
+        }
+    }
+
     /// Validate body-free shape before or after signature verification.
     pub fn validate_shape(&self) -> Result<(), DomainError> {
         validate_id("receipt_id", &self.receipt_id)?;
@@ -303,6 +335,19 @@ impl PromotionConsentReceipt {
 }
 
 impl SignedShareLink {
+    /// Build the body-free subject and `ConsentPayload` for a share-link journal row.
+    #[must_use]
+    pub fn decision_payload(&self, decision: ShareLinkJournalDecision) -> (String, ConsentPayload) {
+        let subject_code = format!("share_link:{}", self.link_id.to_ascii_lowercase());
+        (
+            subject_code.clone(),
+            ConsentPayload::Decision {
+                subject_code,
+                policy_code: Some(decision.as_str().to_owned()),
+            },
+        )
+    }
+
     /// Validate body-free shape before or after signature verification.
     pub fn validate_shape(&self) -> Result<(), DomainError> {
         validate_id("link_id", &self.link_id)?;

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -219,6 +219,22 @@ pub struct PromotionGateInput<'a> {
     pub rebac: &'a RebacContext,
 }
 
+/// Inputs for signed share-link grant evaluation.
+pub struct ShareLinkGateInput<'a> {
+    /// Signed link being evaluated.
+    pub link: &'a SignedShareLink,
+    /// Evaluation timestamp.
+    pub now: &'a Rfc3339Timestamp,
+    /// Expected record-set or grant-manifest hash.
+    pub expected_target_hash: &'a str,
+    /// Verifying key for `link.payload.issuer`.
+    pub signer_key: &'a VerifyingKey,
+    /// Revocation state supplied by store/identity layer.
+    pub revocation: &'a SharingRevocationState,
+    /// Maximum tier the issuer may grant.
+    pub max_tier: MemoryVisibility,
+}
+
 /// Denial with both typed error and body-free trace.
 #[derive(Debug)]
 pub struct SharingGateRejection {
@@ -486,6 +502,95 @@ pub fn verify_promotion_gate(
     ))
 }
 
+/// Verify a signed share link before honoring the grant.
+pub fn verify_share_link_grant(
+    input: ShareLinkGateInput<'_>,
+) -> Result<PolicyTraceEntry, SharingGateRejection> {
+    if input.link.payload.issuer.kind() != crate::domain::IdentityKind::Human {
+        return Err(reject_share_link(
+            SharingDecisionKind::NotHuman,
+            DomainError::Unauthorized {
+                message: "share link issuer must be a human identity".to_owned(),
+            },
+        ));
+    }
+
+    if let Err(error) = input.link.validate_shape() {
+        return Err(reject_share_link(SharingDecisionKind::InvalidShape, error));
+    }
+
+    let signature_result = (|| {
+        let bytes = crate::domain::canonical::canonical_bytes(&input.link.payload)
+            .map_err(|_| DomainError::InvalidSignature)?;
+        let signature = decode_signature(&input.link.signature)?;
+        input
+            .signer_key
+            .verify(&bytes, &signature)
+            .map_err(|_| DomainError::InvalidSignature)
+    })();
+    if signature_result.is_err() {
+        return Err(reject_share_link(
+            SharingDecisionKind::BadSignature,
+            DomainError::InvalidSignature,
+        ));
+    }
+
+    if input.link.payload.target_hash != input.expected_target_hash {
+        return Err(reject_share_link(
+            SharingDecisionKind::TargetMismatch,
+            DomainError::InvalidPayloadHash {
+                message: "share link target_hash does not match expected target".to_owned(),
+            },
+        ));
+    }
+
+    if input.link.payload.grant_tier > input.max_tier {
+        return Err(reject_share_link(
+            SharingDecisionKind::TierMismatch,
+            DomainError::UnsupportedVisibility {
+                value: format!(
+                    "share link grant_tier `{}` exceeds authorized max `{}`",
+                    input.link.payload.grant_tier.as_str(),
+                    input.max_tier.as_str()
+                ),
+            },
+        ));
+    }
+
+    if input.now.cmp_chronological(&input.link.payload.expires_at) != std::cmp::Ordering::Less {
+        return Err(reject_share_link(
+            SharingDecisionKind::Expired,
+            DomainError::ExpiredIntent {
+                issued_at: input.link.payload.issued_at.as_str().to_owned(),
+                expires_at: input.link.payload.expires_at.as_str().to_owned(),
+                now: input.now.as_str().to_owned(),
+            },
+        ));
+    }
+
+    if input.revocation.signer_key_revoked
+        || input
+            .revocation
+            .revoked_share_link_ids
+            .contains(&input.link.link_id)
+    {
+        return Err(reject_share_link(
+            SharingDecisionKind::Revoked,
+            DomainError::Unauthorized {
+                message: "share link or signer key was revoked".to_owned(),
+            },
+        ));
+    }
+
+    Ok(sharing_trace(
+        PolicyGate::ShareLink,
+        PolicyOutcome::Pass,
+        SharingPolicySubject::ShareLink,
+        SharingPolicyAction::Grant,
+        SharingDecisionKind::Allowed,
+    ))
+}
+
 fn reject_promotion(reason: SharingDecisionKind, error: DomainError) -> SharingGateRejection {
     SharingGateRejection {
         error,
@@ -494,6 +599,19 @@ fn reject_promotion(reason: SharingDecisionKind, error: DomainError) -> SharingG
             PolicyOutcome::Deny,
             SharingPolicySubject::ConsentReceipt,
             SharingPolicyAction::Promote,
+            reason,
+        ),
+    }
+}
+
+fn reject_share_link(reason: SharingDecisionKind, error: DomainError) -> SharingGateRejection {
+    SharingGateRejection {
+        error,
+        trace: sharing_trace(
+            PolicyGate::ShareLink,
+            PolicyOutcome::Deny,
+            SharingPolicySubject::ShareLink,
+            SharingPolicyAction::Grant,
             reason,
         ),
     }

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -232,6 +232,10 @@ pub struct PromotionGateInput<'a> {
     pub now: &'a Rfc3339Timestamp,
     /// WAL operation id being applied.
     pub operation_id: &'a str,
+    /// Human signer identity used to resolve `signer_key`.
+    pub signer_identity: &'a Identity,
+    /// Human signer key version used to resolve `signer_key`.
+    pub signer_key_version: u32,
     /// Human signer verifying key.
     pub signer_key: &'a VerifyingKey,
     /// Apply-time revocation state.
@@ -414,6 +418,15 @@ pub fn verify_promotion_gate(
 
     if let Err(error) = input.receipt.validate_shape() {
         return Err(reject_promotion(SharingDecisionKind::InvalidShape, error));
+    }
+
+    if input.signer_identity != &input.receipt.payload.human_identity
+        || input.signer_key_version != input.receipt.payload.key_version
+    {
+        return Err(reject_promotion(
+            SharingDecisionKind::BadSignature,
+            DomainError::InvalidSignature,
+        ));
     }
 
     let signature_result = (|| {
@@ -722,10 +735,30 @@ fn validate_id(field: &'static str, value: &str) -> Result<(), DomainError> {
 }
 
 fn validate_ulid(field: &'static str, value: &str) -> Result<(), DomainError> {
-    ulid::Ulid::from_string(value).map_err(|_| DomainError::MalformedScope {
-        message: format!("{field} must be a ULID"),
-    })?;
+    if value.len() != 26 {
+        return Err(DomainError::MalformedScope {
+            message: format!("{field} must be a 26-char ULID"),
+        });
+    }
+    let bytes = value.as_bytes();
+    if !matches!(bytes[0], b'0'..=b'7') {
+        return Err(DomainError::MalformedScope {
+            message: format!("{field} first char must be 0..=7"),
+        });
+    }
+    if !bytes[1..].iter().copied().all(is_crockford_base32) {
+        return Err(DomainError::MalformedScope {
+            message: format!("{field} must be uppercase Crockford base32"),
+        });
+    }
     Ok(())
+}
+
+fn is_crockford_base32(b: u8) -> bool {
+    matches!(
+        b,
+        b'0'..=b'9' | b'A'..=b'H' | b'J' | b'K' | b'M' | b'N' | b'P'..=b'T' | b'V'..=b'Z'
+    )
 }
 
 fn validate_bound_id(

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -8,8 +8,11 @@ use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 use crate::domain::{
-    DomainError, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+    CanonicalRecordHash, DomainError, Ed25519Signature, Identity, MemoryRecord, MemoryVisibility,
+    Rfc3339Timestamp, ScopeTuple,
 };
+use crate::policy_trace::{PolicyDetail, PolicyGate, PolicyOutcome, PolicyTraceEntry};
+use crate::rebac::{RebacAction, RebacContext};
 
 const MAX_TARGET_ID_HASHES: usize = 64;
 
@@ -194,6 +197,37 @@ pub struct SharingRevocationState {
     pub signer_key_revoked: bool,
 }
 
+/// Inputs for the shared-tier promotion gate.
+pub struct PromotionGateInput<'a> {
+    /// Record being promoted.
+    pub record: &'a MemoryRecord,
+    /// Current visibility tier requested by the apply operation.
+    pub from_tier: MemoryVisibility,
+    /// Target visibility tier requested by the apply operation.
+    pub to_tier: MemoryVisibility,
+    /// Signed consent receipt authorizing the promotion.
+    pub receipt: &'a PromotionConsentReceipt,
+    /// Apply-time wall clock.
+    pub now: &'a Rfc3339Timestamp,
+    /// WAL operation id being applied.
+    pub operation_id: &'a str,
+    /// Human signer verifying key.
+    pub signer_key: &'a VerifyingKey,
+    /// Apply-time revocation state.
+    pub revocation: &'a SharingRevocationState,
+    /// Apply-time `ReBAC` relation context.
+    pub rebac: &'a RebacContext,
+}
+
+/// Denial with both typed error and body-free trace.
+#[derive(Debug)]
+pub struct SharingGateRejection {
+    /// Typed domain error for the caller.
+    pub error: DomainError,
+    /// Body-free policy trace for audit and response surfaces.
+    pub trace: PolicyTraceEntry,
+}
+
 impl PromotionConsentReceipt {
     /// Validate body-free shape before or after signature verification.
     pub fn validate_shape(&self) -> Result<(), DomainError> {
@@ -295,6 +329,170 @@ impl SignedShareLink {
         key.verify(&bytes, &signature)
             .map_err(|_| DomainError::InvalidSignature)
     }
+}
+
+/// Verify that a signed consent receipt authorizes a shared-tier promotion at
+/// apply time.
+pub fn verify_promotion_gate(
+    input: PromotionGateInput<'_>,
+) -> Result<PolicyTraceEntry, SharingGateRejection> {
+    if let Err(error) = input.receipt.validate_shape() {
+        return Err(reject_promotion(SharingDecisionKind::InvalidShape, error));
+    }
+
+    let signature_result = (|| {
+        let bytes = crate::domain::canonical::canonical_bytes(&input.receipt.payload)
+            .map_err(|_| DomainError::InvalidSignature)?;
+        let signature = decode_signature(&input.receipt.signature)?;
+        input
+            .signer_key
+            .verify(&bytes, &signature)
+            .map_err(|_| DomainError::InvalidSignature)
+    })();
+    if signature_result.is_err() {
+        return Err(reject_promotion(
+            SharingDecisionKind::BadSignature,
+            DomainError::InvalidSignature,
+        ));
+    }
+
+    if input.receipt.payload.human_identity.kind() != crate::domain::IdentityKind::Human {
+        return Err(reject_promotion(
+            SharingDecisionKind::NotHuman,
+            DomainError::Unauthorized {
+                message: "promotion receipt signer must be a human identity".to_owned(),
+            },
+        ));
+    }
+
+    let target_hash_matches = CanonicalRecordHash::compute(input.record)
+        .map(|hash| hash.as_str() == input.receipt.payload.target_hash)
+        .unwrap_or(false);
+    if !target_hash_matches {
+        return Err(reject_promotion(
+            SharingDecisionKind::TargetMismatch,
+            DomainError::InvalidPayloadHash {
+                message: "promotion receipt target_hash does not match record".to_owned(),
+            },
+        ));
+    }
+
+    if input.receipt.payload.scope != input.record.scope {
+        return Err(reject_promotion(
+            SharingDecisionKind::ScopeMismatch,
+            DomainError::ScopeDenied {
+                message: "promotion receipt scope does not match record scope".to_owned(),
+            },
+        ));
+    }
+
+    if input.receipt.payload.operation_id != input.operation_id {
+        return Err(reject_promotion(
+            SharingDecisionKind::ScopeMismatch,
+            DomainError::ScopeDenied {
+                message: "promotion receipt operation_id does not match apply operation".to_owned(),
+            },
+        ));
+    }
+
+    if input.receipt.payload.from_tier != input.from_tier
+        || input.receipt.payload.to_tier != input.to_tier
+    {
+        return Err(reject_promotion(
+            SharingDecisionKind::TierMismatch,
+            DomainError::UnsupportedVisibility {
+                value: format!(
+                    "receipt tiers {}->{} do not match requested {}->{}",
+                    input.receipt.payload.from_tier.as_str(),
+                    input.receipt.payload.to_tier.as_str(),
+                    input.from_tier.as_str(),
+                    input.to_tier.as_str()
+                ),
+            },
+        ));
+    }
+
+    if input
+        .now
+        .cmp_chronological(&input.receipt.payload.expires_at)
+        != std::cmp::Ordering::Less
+    {
+        return Err(reject_promotion(
+            SharingDecisionKind::Expired,
+            DomainError::ExpiredIntent {
+                issued_at: input.receipt.payload.issued_at.as_str().to_owned(),
+                expires_at: input.receipt.payload.expires_at.as_str().to_owned(),
+                now: input.now.as_str().to_owned(),
+            },
+        ));
+    }
+
+    if input.revocation.signer_key_revoked
+        || input
+            .revocation
+            .revoked_receipt_ids
+            .contains(&input.receipt.receipt_id)
+    {
+        return Err(reject_promotion(
+            SharingDecisionKind::Revoked,
+            DomainError::Unauthorized {
+                message: "promotion receipt or signer key was revoked".to_owned(),
+            },
+        ));
+    }
+
+    let rebac_decision = input.rebac.evaluate(
+        RebacAction::Write,
+        &input.receipt.payload.scope,
+        input.to_tier,
+    );
+    if !rebac_decision.allowed() {
+        return Err(reject_promotion(
+            SharingDecisionKind::NoRebacRelation,
+            DomainError::ScopeDenied {
+                message: "missing ReBAC write relation for promotion".to_owned(),
+            },
+        ));
+    }
+
+    Ok(sharing_trace(
+        PolicyGate::ConsentReceipt,
+        PolicyOutcome::Pass,
+        SharingPolicySubject::ConsentReceipt,
+        SharingPolicyAction::Promote,
+        SharingDecisionKind::Allowed,
+    ))
+}
+
+fn reject_promotion(reason: SharingDecisionKind, error: DomainError) -> SharingGateRejection {
+    SharingGateRejection {
+        error,
+        trace: sharing_trace(
+            PolicyGate::ConsentReceipt,
+            PolicyOutcome::Deny,
+            SharingPolicySubject::ConsentReceipt,
+            SharingPolicyAction::Promote,
+            reason,
+        ),
+    }
+}
+
+fn sharing_trace(
+    gate: PolicyGate,
+    outcome: PolicyOutcome,
+    subject: SharingPolicySubject,
+    action: SharingPolicyAction,
+    reason: SharingDecisionKind,
+) -> PolicyTraceEntry {
+    PolicyTraceEntry::new(
+        gate,
+        outcome,
+        PolicyDetail::Sharing {
+            subject,
+            action,
+            reason,
+        },
+    )
 }
 
 fn validate_id(field: &'static str, value: &str) -> Result<(), DomainError> {

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -336,6 +336,15 @@ impl SignedShareLink {
 pub fn verify_promotion_gate(
     input: PromotionGateInput<'_>,
 ) -> Result<PolicyTraceEntry, SharingGateRejection> {
+    if input.receipt.payload.human_identity.kind() != crate::domain::IdentityKind::Human {
+        return Err(reject_promotion(
+            SharingDecisionKind::NotHuman,
+            DomainError::Unauthorized {
+                message: "promotion receipt signer must be a human identity".to_owned(),
+            },
+        ));
+    }
+
     if let Err(error) = input.receipt.validate_shape() {
         return Err(reject_promotion(SharingDecisionKind::InvalidShape, error));
     }
@@ -353,15 +362,6 @@ pub fn verify_promotion_gate(
         return Err(reject_promotion(
             SharingDecisionKind::BadSignature,
             DomainError::InvalidSignature,
-        ));
-    }
-
-    if input.receipt.payload.human_identity.kind() != crate::domain::IdentityKind::Human {
-        return Err(reject_promotion(
-            SharingDecisionKind::NotHuman,
-            DomainError::Unauthorized {
-                message: "promotion receipt signer must be a human identity".to_owned(),
-            },
         ));
     }
 

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -78,7 +78,7 @@ pub enum SharingDecisionKind {
     Revoked,
     /// Issuer or signer was not a human identity.
     NotHuman,
-    /// ReBAC denied the shared-tier write.
+    /// `ReBAC` denied the shared-tier write.
     NoRebacRelation,
     /// Shape validation failed before signature verification.
     InvalidShape,
@@ -219,6 +219,7 @@ pub struct SharingRevocationState {
 }
 
 /// Inputs for the shared-tier promotion gate.
+#[derive(Clone, Copy)]
 pub struct PromotionGateInput<'a> {
     /// Record being promoted.
     pub record: &'a MemoryRecord,
@@ -245,6 +246,7 @@ pub struct PromotionGateInput<'a> {
 }
 
 /// Inputs for signed share-link grant evaluation.
+#[derive(Clone, Copy)]
 pub struct ShareLinkGateInput<'a> {
     /// Signed link being evaluated.
     pub link: &'a SignedShareLink,
@@ -407,6 +409,21 @@ impl SignedShareLink {
 pub fn verify_promotion_gate(
     input: PromotionGateInput<'_>,
 ) -> Result<PolicyTraceEntry, SharingGateRejection> {
+    verify_promotion_receipt(input)?;
+    verify_promotion_target(input)?;
+    verify_promotion_freshness(input)?;
+    verify_promotion_rebac(input)?;
+
+    Ok(sharing_trace(
+        PolicyGate::ConsentReceipt,
+        PolicyOutcome::Pass,
+        SharingPolicySubject::ConsentReceipt,
+        SharingPolicyAction::Promote,
+        SharingDecisionKind::Allowed,
+    ))
+}
+
+fn verify_promotion_receipt(input: PromotionGateInput<'_>) -> Result<(), SharingGateRejection> {
     if input.receipt.payload.human_identity.kind() != crate::domain::IdentityKind::Human {
         return Err(reject_promotion(
             SharingDecisionKind::NotHuman,
@@ -444,7 +461,10 @@ pub fn verify_promotion_gate(
             DomainError::InvalidSignature,
         ));
     }
+    Ok(())
+}
 
+fn verify_promotion_target(input: PromotionGateInput<'_>) -> Result<(), SharingGateRejection> {
     if input.record.visibility != input.from_tier {
         return Err(reject_promotion(
             SharingDecisionKind::TierMismatch,
@@ -459,8 +479,7 @@ pub fn verify_promotion_gate(
     }
 
     let target_hash_matches = CanonicalRecordHash::compute(input.record)
-        .map(|hash| hash.as_str() == input.receipt.payload.target_hash)
-        .unwrap_or(false);
+        .is_ok_and(|hash| hash.as_str() == input.receipt.payload.target_hash);
     if !target_hash_matches {
         return Err(reject_promotion(
             SharingDecisionKind::TargetMismatch,
@@ -504,7 +523,10 @@ pub fn verify_promotion_gate(
             },
         ));
     }
+    Ok(())
+}
 
+fn verify_promotion_freshness(input: PromotionGateInput<'_>) -> Result<(), SharingGateRejection> {
     if input
         .now
         .cmp_chronological(&input.receipt.payload.expires_at)
@@ -533,7 +555,10 @@ pub fn verify_promotion_gate(
             },
         ));
     }
+    Ok(())
+}
 
+fn verify_promotion_rebac(input: PromotionGateInput<'_>) -> Result<(), SharingGateRejection> {
     if input.rebac.principal() != Some(&input.receipt.payload.human_identity) {
         return Err(reject_promotion(
             SharingDecisionKind::NoRebacRelation,
@@ -556,14 +581,7 @@ pub fn verify_promotion_gate(
             },
         ));
     }
-
-    Ok(sharing_trace(
-        PolicyGate::ConsentReceipt,
-        PolicyOutcome::Pass,
-        SharingPolicySubject::ConsentReceipt,
-        SharingPolicyAction::Promote,
-        SharingDecisionKind::Allowed,
-    ))
+    Ok(())
 }
 
 /// Verify a signed share link before honoring the grant.
@@ -608,15 +626,15 @@ pub fn verify_share_link_grant(
         ));
     }
 
-    if let Some(expected_grantee) = &input.link.payload.grantee {
-        if input.requesting_principal != Some(expected_grantee) {
-            return Err(reject_share_link(
-                SharingDecisionKind::ScopeMismatch,
-                DomainError::ScopeDenied {
-                    message: "share link grantee does not match requesting principal".to_owned(),
-                },
-            ));
-        }
+    if let Some(expected_grantee) = &input.link.payload.grantee
+        && input.requesting_principal != Some(expected_grantee)
+    {
+        return Err(reject_share_link(
+            SharingDecisionKind::ScopeMismatch,
+            DomainError::ScopeDenied {
+                message: "share link grantee does not match requesting principal".to_owned(),
+            },
+        ));
     }
 
     if input.link.payload.target_hash != input.expected_target_hash {
@@ -827,15 +845,17 @@ fn validate_target_hash(value: &str) -> Result<(), DomainError> {
 }
 
 fn validate_hash(field: &'static str, value: &str) -> Result<(), DomainError> {
-    if let Some(hex) = value.strip_prefix("sha256:") {
-        if hex.len() == 64 && is_lowercase_hex(hex) {
-            return Ok(());
-        }
+    if let Some(hex) = value.strip_prefix("sha256:")
+        && hex.len() == 64
+        && is_lowercase_hex(hex)
+    {
+        return Ok(());
     }
-    if let Some(hex) = value.strip_prefix("hash:") {
-        if (32..=128).contains(&hex.len()) && is_lowercase_hex(hex) {
-            return Ok(());
-        }
+    if let Some(hex) = value.strip_prefix("hash:")
+        && (32..=128).contains(&hex.len())
+        && is_lowercase_hex(hex)
+    {
+        return Ok(());
     }
     Err(DomainError::InvalidPayloadHash {
         message: format!(

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -181,7 +181,8 @@ pub struct ShareLinkPayload {
 }
 
 /// Revocation state supplied by the store or identity layer at evaluation time.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SharingRevocationState {
     /// Receipt ids that can no longer authorize promotion.
     pub revoked_receipt_ids: BTreeSet<String>,

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -1,0 +1,92 @@
+//! Signed share links and promotion consent receipts (brief §4.2, §5.6, §12.a, §14).
+//!
+//! This module is pure domain logic: no I/O, no keychain lookup, no DB writes.
+
+use serde::{Deserialize, Serialize};
+
+/// Policy-trace subject for sharing gates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SharingPolicySubject {
+    /// Promotion consent receipt gate.
+    ConsentReceipt,
+    /// Signed share-link grant gate.
+    ShareLink,
+}
+
+impl SharingPolicySubject {
+    /// Body-free detail token.
+    #[must_use]
+    pub const fn as_detail_str(self) -> &'static str {
+        match self {
+            Self::ConsentReceipt => "consent",
+            Self::ShareLink => "share_link",
+        }
+    }
+}
+
+/// Sharing action captured in policy trace detail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SharingPolicyAction {
+    /// Promotion across visibility tiers.
+    Promote,
+    /// Share-link grant evaluation.
+    Grant,
+}
+
+impl SharingPolicyAction {
+    /// Body-free detail token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Promote => "promote",
+            Self::Grant => "grant",
+        }
+    }
+}
+
+/// Body-free decision reason for signed sharing gates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SharingDecisionKind {
+    /// Gate allowed the operation.
+    Allowed,
+    /// Receipt or link expired before apply/evaluation.
+    Expired,
+    /// Target hash or target-id hash set did not match.
+    TargetMismatch,
+    /// Scope did not match the requested operation.
+    ScopeMismatch,
+    /// Tier did not match or exceeded the grant.
+    TierMismatch,
+    /// Signature verification failed.
+    BadSignature,
+    /// Receipt, link, or signer key was revoked.
+    Revoked,
+    /// Issuer or signer was not a human identity.
+    NotHuman,
+    /// ReBAC denied the shared-tier write.
+    NoRebacRelation,
+    /// Shape validation failed before signature verification.
+    InvalidShape,
+}
+
+impl SharingDecisionKind {
+    /// Body-free detail token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Allowed => "allowed",
+            Self::Expired => "expired",
+            Self::TargetMismatch => "target_mismatch",
+            Self::ScopeMismatch => "scope_mismatch",
+            Self::TierMismatch => "tier_mismatch",
+            Self::BadSignature => "bad_signature",
+            Self::Revoked => "revoked",
+            Self::NotHuman => "not_human",
+            Self::NoRebacRelation => "no_rebac_relation",
+            Self::InvalidShape => "invalid_shape",
+        }
+    }
+}

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -11,6 +11,8 @@ use crate::domain::{
     DomainError, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
 };
 
+const MAX_TARGET_ID_HASHES: usize = 64;
+
 /// Policy-trace subject for sharing gates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -197,6 +199,12 @@ impl PromotionConsentReceipt {
     pub fn validate_shape(&self) -> Result<(), DomainError> {
         validate_id("receipt_id", &self.receipt_id)?;
         validate_ulid("operation_id", &self.payload.operation_id)?;
+        validate_bound_id(
+            "receipt_id",
+            &self.receipt_id,
+            "rcpt-",
+            &self.payload.operation_id,
+        )?;
         validate_nonce(&self.payload.nonce)?;
         validate_chain_parents(&self.payload.chain_parents)?;
         validate_target_hash(&self.payload.target_hash)?;
@@ -243,16 +251,15 @@ impl SignedShareLink {
     pub fn validate_shape(&self) -> Result<(), DomainError> {
         validate_id("link_id", &self.link_id)?;
         validate_ulid("operation_id", &self.payload.operation_id)?;
+        validate_bound_id(
+            "link_id",
+            &self.link_id,
+            "share-",
+            &self.payload.operation_id,
+        )?;
         validate_nonce(&self.payload.nonce)?;
         validate_target_hash(&self.payload.target_hash)?;
-        if self.payload.target_id_hashes.is_empty() {
-            return Err(DomainError::InvalidPayloadHash {
-                message: "target_id_hashes must not be empty".to_owned(),
-            });
-        }
-        for h in &self.payload.target_id_hashes {
-            validate_hash("target_id_hashes", h)?;
-        }
+        validate_target_id_hashes(&self.payload.target_id_hashes)?;
         validate_shared_tier("grant_tier", self.payload.grant_tier)?;
         self.payload.scope.validate()?;
         if self.payload.issuer.kind() != crate::domain::IdentityKind::Human {
@@ -309,6 +316,21 @@ fn validate_ulid(field: &'static str, value: &str) -> Result<(), DomainError> {
     ulid::Ulid::from_string(value).map_err(|_| DomainError::MalformedScope {
         message: format!("{field} must be a ULID"),
     })?;
+    Ok(())
+}
+
+fn validate_bound_id(
+    field: &'static str,
+    value: &str,
+    prefix: &str,
+    operation_id: &str,
+) -> Result<(), DomainError> {
+    let expected = format!("{prefix}{operation_id}");
+    if value != expected {
+        return Err(DomainError::MalformedScope {
+            message: format!("{field} must equal `{expected}`"),
+        });
+    }
     Ok(())
 }
 
@@ -378,6 +400,30 @@ fn validate_hash(field: &'static str, value: &str) -> Result<(), DomainError> {
             "{field} must be sha256:<64 lowercase hex> or hash:<32..=128 lowercase hex>"
         ),
     })
+}
+
+fn validate_target_id_hashes(values: &[String]) -> Result<(), DomainError> {
+    if values.is_empty() {
+        return Err(DomainError::InvalidPayloadHash {
+            message: "target_id_hashes must not be empty".to_owned(),
+        });
+    }
+    if values.len() > MAX_TARGET_ID_HASHES {
+        return Err(DomainError::InvalidPayloadHash {
+            message: format!("target_id_hashes exceeds {MAX_TARGET_ID_HASHES} items"),
+        });
+    }
+
+    let mut seen = BTreeSet::new();
+    for value in values {
+        validate_hash("target_id_hashes", value)?;
+        if !seen.insert(value) {
+            return Err(DomainError::InvalidPayloadHash {
+                message: "target_id_hashes must be unique".to_owned(),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn validate_shared_promotion_tiers(

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -2,7 +2,14 @@
 //!
 //! This module is pure domain logic: no I/O, no keychain lookup, no DB writes.
 
+use std::collections::BTreeSet;
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde::{Deserialize, Serialize};
+
+use crate::domain::{
+    DomainError, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+};
 
 /// Policy-trace subject for sharing gates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -88,5 +95,339 @@ impl SharingDecisionKind {
             Self::NoRebacRelation => "no_rebac_relation",
             Self::InvalidShape => "invalid_shape",
         }
+    }
+}
+
+/// Signed consent receipt authorizing one visibility promotion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionConsentReceipt {
+    /// Stable receipt identifier used for revocation and journal references.
+    pub receipt_id: String,
+    /// Signed body-free receipt payload.
+    pub payload: PromotionConsentPayload,
+    /// Ed25519 signature over canonical JSON of `payload`.
+    pub signature: Ed25519Signature,
+}
+
+/// Body-free payload signed by a human for shared-tier promotion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionConsentPayload {
+    /// WAL operation id this receipt authorizes.
+    pub operation_id: String,
+    /// Fresh 16-byte base64 nonce.
+    pub nonce: String,
+    /// Parent operation ids this promotion depends on.
+    pub chain_parents: Vec<String>,
+    /// Canonical hash of the record being promoted.
+    pub target_hash: String,
+    /// Salted or canonical hash of the target id.
+    pub target_id_hash: String,
+    /// Current record visibility tier.
+    pub from_tier: MemoryVisibility,
+    /// Requested promoted visibility tier.
+    pub to_tier: MemoryVisibility,
+    /// Scope the receipt authorizes.
+    pub scope: ScopeTuple,
+    /// Human principal that signed the receipt.
+    pub human_identity: Identity,
+    /// Receipt issue time.
+    pub issued_at: Rfc3339Timestamp,
+    /// Receipt expiry time.
+    pub expires_at: Rfc3339Timestamp,
+    /// Signer's key version.
+    pub key_version: u32,
+}
+
+/// Signed share link authorizing a bounded grant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SignedShareLink {
+    /// Stable link id used for revocation and consent journal subject codes.
+    pub link_id: String,
+    /// Signed body-free link payload.
+    pub payload: ShareLinkPayload,
+    /// Ed25519 signature over canonical JSON of `payload`.
+    pub signature: Ed25519Signature,
+}
+
+/// Body-free payload for a signed share-link grant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ShareLinkPayload {
+    /// Operation id that minted the link.
+    pub operation_id: String,
+    /// Fresh 16-byte base64 nonce.
+    pub nonce: String,
+    /// Hash of the record-set manifest or target grant payload.
+    pub target_hash: String,
+    /// Salted or canonical target-id hashes included in the grant.
+    pub target_id_hashes: Vec<String>,
+    /// Scope the link may expose.
+    pub scope: ScopeTuple,
+    /// Shared tier granted by the link.
+    pub grant_tier: MemoryVisibility,
+    /// Optional grantee. `None` means bearer-style access.
+    pub grantee: Option<Identity>,
+    /// Human issuer that granted the share link.
+    pub issuer: Identity,
+    /// Link issue time.
+    pub issued_at: Rfc3339Timestamp,
+    /// Link expiry time.
+    pub expires_at: Rfc3339Timestamp,
+    /// Issuer key version.
+    pub key_version: u32,
+}
+
+/// Revocation state supplied by the store or identity layer at evaluation time.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SharingRevocationState {
+    /// Receipt ids that can no longer authorize promotion.
+    pub revoked_receipt_ids: BTreeSet<String>,
+    /// Share link ids that can no longer authorize grants.
+    pub revoked_share_link_ids: BTreeSet<String>,
+    /// Whether the current signer key is revoked.
+    pub signer_key_revoked: bool,
+}
+
+impl PromotionConsentReceipt {
+    /// Validate body-free shape before or after signature verification.
+    pub fn validate_shape(&self) -> Result<(), DomainError> {
+        validate_id("receipt_id", &self.receipt_id)?;
+        validate_ulid("operation_id", &self.payload.operation_id)?;
+        validate_nonce(&self.payload.nonce)?;
+        validate_chain_parents(&self.payload.chain_parents)?;
+        validate_target_hash(&self.payload.target_hash)?;
+        validate_hash("target_id_hash", &self.payload.target_id_hash)?;
+        validate_shared_promotion_tiers(self.payload.from_tier, self.payload.to_tier)?;
+        self.payload.scope.validate()?;
+        if self.payload.human_identity.kind() != crate::domain::IdentityKind::Human {
+            return Err(DomainError::Unauthorized {
+                message: "promotion receipt signer must be a human identity".to_owned(),
+            });
+        }
+        if self.payload.key_version == 0 {
+            return Err(DomainError::Unauthorized {
+                message: "promotion receipt key_version must be >= 1".to_owned(),
+            });
+        }
+        if self
+            .payload
+            .expires_at
+            .cmp_chronological(&self.payload.issued_at)
+            != std::cmp::Ordering::Greater
+        {
+            return Err(DomainError::ExpiredIntent {
+                issued_at: self.payload.issued_at.as_str().to_owned(),
+                expires_at: self.payload.expires_at.as_str().to_owned(),
+                now: self.payload.expires_at.as_str().to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Verify the Ed25519 signature over canonical payload bytes.
+    pub fn verify_signature(&self, key: &VerifyingKey) -> Result<(), DomainError> {
+        self.validate_shape()?;
+        let bytes = crate::domain::canonical::canonical_bytes(&self.payload)?;
+        let signature = decode_signature(&self.signature)?;
+        key.verify(&bytes, &signature)
+            .map_err(|_| DomainError::InvalidSignature)
+    }
+}
+
+impl SignedShareLink {
+    /// Validate body-free shape before or after signature verification.
+    pub fn validate_shape(&self) -> Result<(), DomainError> {
+        validate_id("link_id", &self.link_id)?;
+        validate_ulid("operation_id", &self.payload.operation_id)?;
+        validate_nonce(&self.payload.nonce)?;
+        validate_target_hash(&self.payload.target_hash)?;
+        if self.payload.target_id_hashes.is_empty() {
+            return Err(DomainError::InvalidPayloadHash {
+                message: "target_id_hashes must not be empty".to_owned(),
+            });
+        }
+        for h in &self.payload.target_id_hashes {
+            validate_hash("target_id_hashes", h)?;
+        }
+        validate_shared_tier("grant_tier", self.payload.grant_tier)?;
+        self.payload.scope.validate()?;
+        if self.payload.issuer.kind() != crate::domain::IdentityKind::Human {
+            return Err(DomainError::Unauthorized {
+                message: "share link issuer must be a human identity".to_owned(),
+            });
+        }
+        if self.payload.key_version == 0 {
+            return Err(DomainError::Unauthorized {
+                message: "share link key_version must be >= 1".to_owned(),
+            });
+        }
+        if self
+            .payload
+            .expires_at
+            .cmp_chronological(&self.payload.issued_at)
+            != std::cmp::Ordering::Greater
+        {
+            return Err(DomainError::ExpiredIntent {
+                issued_at: self.payload.issued_at.as_str().to_owned(),
+                expires_at: self.payload.expires_at.as_str().to_owned(),
+                now: self.payload.expires_at.as_str().to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Verify the Ed25519 signature over canonical payload bytes.
+    pub fn verify_signature(&self, key: &VerifyingKey) -> Result<(), DomainError> {
+        self.validate_shape()?;
+        let bytes = crate::domain::canonical::canonical_bytes(&self.payload)?;
+        let signature = decode_signature(&self.signature)?;
+        key.verify(&bytes, &signature)
+            .map_err(|_| DomainError::InvalidSignature)
+    }
+}
+
+fn validate_id(field: &'static str, value: &str) -> Result<(), DomainError> {
+    if value.is_empty() || value.len() > 128 {
+        return Err(DomainError::EmptyField { field });
+    }
+    if !value
+        .bytes()
+        .all(|b| matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b':' | b'-'))
+    {
+        return Err(DomainError::MalformedScope {
+            message: format!("{field} chars must be in [A-Za-z0-9._:-]"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_ulid(field: &'static str, value: &str) -> Result<(), DomainError> {
+    ulid::Ulid::from_string(value).map_err(|_| DomainError::MalformedScope {
+        message: format!("{field} must be a ULID"),
+    })?;
+    Ok(())
+}
+
+fn validate_chain_parents(values: &[String]) -> Result<(), DomainError> {
+    if values.len() > 64 {
+        return Err(DomainError::MalformedScope {
+            message: "chain_parents exceeds 64 items".to_owned(),
+        });
+    }
+    let mut seen = BTreeSet::new();
+    for value in values {
+        validate_ulid("chain_parents", value)?;
+        if !seen.insert(value) {
+            return Err(DomainError::MalformedScope {
+                message: "chain_parents must be unique".to_owned(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_nonce(value: &str) -> Result<(), DomainError> {
+    let bytes = value.as_bytes();
+    let (head, tail) = match bytes.len() {
+        22 => (&bytes[..21], bytes[21]),
+        24 if bytes[22] == b'=' && bytes[23] == b'=' => (&bytes[..21], bytes[21]),
+        _ => {
+            return Err(DomainError::MissingSignature {
+                message: "nonce must encode 16 base64 bytes".to_owned(),
+            });
+        }
+    };
+    let base64 = |b: &u8| matches!(*b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/');
+    if !head.iter().all(base64) || !matches!(tail, b'A' | b'Q' | b'g' | b'w') {
+        return Err(DomainError::MissingSignature {
+            message: "nonce must be canonical 16-byte base64".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_target_hash(value: &str) -> Result<(), DomainError> {
+    if let Some(hex) = value.strip_prefix("sha256:")
+        && hex.len() == 64
+        && is_lowercase_hex(hex)
+    {
+        return Ok(());
+    }
+    Err(DomainError::InvalidPayloadHash {
+        message: "target_hash must be sha256:<64 lowercase hex>".to_owned(),
+    })
+}
+
+fn validate_hash(field: &'static str, value: &str) -> Result<(), DomainError> {
+    if let Some(hex) = value.strip_prefix("sha256:") {
+        if hex.len() == 64 && is_lowercase_hex(hex) {
+            return Ok(());
+        }
+    }
+    if let Some(hex) = value.strip_prefix("hash:") {
+        if (32..=128).contains(&hex.len()) && is_lowercase_hex(hex) {
+            return Ok(());
+        }
+    }
+    Err(DomainError::InvalidPayloadHash {
+        message: format!(
+            "{field} must be sha256:<64 lowercase hex> or hash:<32..=128 lowercase hex>"
+        ),
+    })
+}
+
+fn validate_shared_promotion_tiers(
+    from_tier: MemoryVisibility,
+    to_tier: MemoryVisibility,
+) -> Result<(), DomainError> {
+    validate_shared_tier("to_tier", to_tier)?;
+    if to_tier <= from_tier {
+        return Err(DomainError::UnsupportedVisibility {
+            value: format!(
+                "to_tier `{}` must be broader than from_tier `{}`",
+                to_tier.as_str(),
+                from_tier.as_str()
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn validate_shared_tier(field: &'static str, tier: MemoryVisibility) -> Result<(), DomainError> {
+    if crate::rebac::is_shared_tier(tier) {
+        return Ok(());
+    }
+    Err(DomainError::UnsupportedVisibility {
+        value: format!("{field} `{}` is not a shared tier", tier.as_str()),
+    })
+}
+
+fn is_lowercase_hex(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+fn decode_signature(signature: &Ed25519Signature) -> Result<Signature, DomainError> {
+    let Some(hex) = signature.as_str().strip_prefix("ed25519:") else {
+        return Err(DomainError::InvalidSignature);
+    };
+    let mut bytes = [0_u8; 64];
+    for (idx, pair) in hex.as_bytes().chunks_exact(2).enumerate() {
+        let hi = hex_nibble(pair[0]).ok_or(DomainError::InvalidSignature)?;
+        let lo = hex_nibble(pair[1]).ok_or(DomainError::InvalidSignature)?;
+        bytes[idx] = (hi << 4) | lo;
+    }
+    Ok(Signature::from_bytes(&bytes))
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        _ => None,
     }
 }

--- a/crates/cairn-core/src/domain/sharing.rs
+++ b/crates/cairn-core/src/domain/sharing.rs
@@ -365,6 +365,19 @@ pub fn verify_promotion_gate(
         ));
     }
 
+    if input.record.visibility != input.from_tier {
+        return Err(reject_promotion(
+            SharingDecisionKind::TierMismatch,
+            DomainError::UnsupportedVisibility {
+                value: format!(
+                    "record visibility `{}` does not match requested from_tier `{}`",
+                    input.record.visibility.as_str(),
+                    input.from_tier.as_str()
+                ),
+            },
+        ));
+    }
+
     let target_hash_matches = CanonicalRecordHash::compute(input.record)
         .map(|hash| hash.as_str() == input.receipt.payload.target_hash)
         .unwrap_or(false);
@@ -437,6 +450,15 @@ pub fn verify_promotion_gate(
             SharingDecisionKind::Revoked,
             DomainError::Unauthorized {
                 message: "promotion receipt or signer key was revoked".to_owned(),
+            },
+        ));
+    }
+
+    if input.rebac.principal() != Some(&input.receipt.payload.human_identity) {
+        return Err(reject_promotion(
+            SharingDecisionKind::NoRebacRelation,
+            DomainError::ScopeDenied {
+                message: "ReBAC principal does not match promotion receipt signer".to_owned(),
             },
         ));
     }

--- a/crates/cairn-core/src/policy_trace/detail.rs
+++ b/crates/cairn-core/src/policy_trace/detail.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 use crate::domain::MemoryVisibility;
+use crate::domain::sharing::{SharingDecisionKind, SharingPolicyAction, SharingPolicySubject};
 use crate::pipeline::filter::{DiscardReason, RedactionTag};
 use crate::rebac::{RebacAction, RebacDecisionKind};
 
@@ -40,6 +41,15 @@ pub enum PolicyDetail {
         tier: MemoryVisibility,
         /// Body-free allow/deny reason.
         reason: RebacDecisionKind,
+    },
+    /// Signed sharing gate decision metadata.
+    Sharing {
+        /// Consent receipt or share link.
+        subject: SharingPolicySubject,
+        /// Promote or grant.
+        action: SharingPolicyAction,
+        /// Body-free allow/deny reason.
+        reason: SharingDecisionKind,
     },
     /// Stable error code. Construction is validated; a free-text
     /// message cannot be slipped in via `&'static str`.
@@ -139,6 +149,16 @@ impl PolicyDetail {
                 "rebac:{}:{}:{}",
                 action.as_str(),
                 tier.as_str(),
+                reason.as_str()
+            ),
+            Self::Sharing {
+                subject,
+                action,
+                reason,
+            } => format!(
+                "{}:{}:{}",
+                subject.as_detail_str(),
+                action.as_str(),
                 reason.as_str()
             ),
             Self::ErrorCode(c) => format!("error:{}", c.as_str()),

--- a/crates/cairn-core/src/policy_trace/gate.rs
+++ b/crates/cairn-core/src/policy_trace/gate.rs
@@ -39,6 +39,10 @@ pub enum PolicyGate {
     SearchReadFilter,
     /// `ReBAC` relation gate for shared-tier reads and writes.
     Rebac,
+    /// Consent receipt gate for shared-tier promotion.
+    ConsentReceipt,
+    /// Signed share-link grant gate.
+    ShareLink,
     /// Local sensor consent gate.
     SensorConsent,
 }
@@ -62,6 +66,8 @@ impl PolicyGate {
             Self::SearchCapability => "search.capability",
             Self::SearchReadFilter => "search.read_filter",
             Self::Rebac => "rebac",
+            Self::ConsentReceipt => "consent_receipt",
+            Self::ShareLink => "share_link",
             Self::SensorConsent => "sensor_consent",
         }
     }

--- a/crates/cairn-core/tests/policy_trace_detail.rs
+++ b/crates/cairn-core/tests/policy_trace_detail.rs
@@ -5,6 +5,7 @@
 use std::collections::BTreeMap;
 
 use cairn_core::domain::MemoryVisibility;
+use cairn_core::domain::sharing::{SharingDecisionKind, SharingPolicyAction, SharingPolicySubject};
 use cairn_core::pipeline::filter::{DiscardReason, RedactionTag};
 use cairn_core::policy_trace::{PolicyDetail, PolicyErrorCode};
 use cairn_core::rebac::{RebacAction, RebacDecisionKind};
@@ -52,6 +53,26 @@ fn rebac_detail_serializes_action_tier_and_reason() {
         reason: RebacDecisionKind::DeniedNoRelation,
     };
     assert_eq!(d.to_wire_string(), "rebac:read:project:no_relation");
+}
+
+#[test]
+fn consent_receipt_detail_serializes_action_and_reason() {
+    let d = PolicyDetail::Sharing {
+        subject: SharingPolicySubject::ConsentReceipt,
+        action: SharingPolicyAction::Promote,
+        reason: SharingDecisionKind::TargetMismatch,
+    };
+    assert_eq!(d.to_wire_string(), "consent:promote:target_mismatch");
+}
+
+#[test]
+fn share_link_detail_serializes_action_and_reason() {
+    let d = PolicyDetail::Sharing {
+        subject: SharingPolicySubject::ShareLink,
+        action: SharingPolicyAction::Grant,
+        reason: SharingDecisionKind::Revoked,
+    };
+    assert_eq!(d.to_wire_string(), "share_link:grant:revoked");
 }
 
 #[test]

--- a/crates/cairn-core/tests/policy_trace_gate.rs
+++ b/crates/cairn-core/tests/policy_trace_gate.rs
@@ -14,6 +14,8 @@ fn display_matches_wire_vocabulary() {
         (PolicyGate::ScopeCheck, "scope_check"),
         (PolicyGate::ForgetCapability, "forget_capability"),
         (PolicyGate::Rebac, "rebac"),
+        (PolicyGate::ConsentReceipt, "consent_receipt"),
+        (PolicyGate::ShareLink, "share_link"),
         (PolicyGate::ConsentJournalAppend, "consent_journal_append"),
         (PolicyGate::ReadFilterRelevance, "read_filter_relevance"),
         (PolicyGate::ReadFilterStaleness, "read_filter_staleness"),

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -2,11 +2,12 @@
 
 use cairn_core::domain::identity::keys::SigningKey;
 use cairn_core::domain::sharing::{
-    ShareLinkGateInput, ShareLinkPayload, SharingDecisionKind, SharingRevocationState,
-    SignedShareLink, verify_share_link_grant,
+    ShareLinkGateInput, ShareLinkJournalDecision, ShareLinkPayload, SharingDecisionKind,
+    SharingRevocationState, SignedShareLink, verify_share_link_grant,
 };
 use cairn_core::domain::{
-    self, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+    self, ConsentEvent, ConsentKind, Ed25519Signature, Identity, MemoryVisibility,
+    Rfc3339Timestamp, ScopeTuple,
 };
 use cairn_core::policy_trace::{PolicyGate, PolicyOutcome};
 
@@ -540,4 +541,40 @@ fn share_link_gate_rejects_issuer_key_version_context_mismatch() {
         SharingDecisionKind::BadSignature,
         |err| matches!(err, domain::DomainError::InvalidSignature),
     );
+}
+
+#[test]
+fn share_link_grant_consent_event_is_body_free_and_valid() {
+    let link = signed_link();
+    let (subject, payload) = link.decision_payload(ShareLinkJournalDecision::Grant);
+    let event = ConsentEvent {
+        consent_id: "01HQZX9F5N0000000000000006".to_owned(),
+        kind: ConsentKind::Grant,
+        actor: Identity::parse("hmn:tafeng").expect("human"),
+        subject,
+        scope: "tenant=default,workspace=vault-a,entity=session".to_owned(),
+        op_id: Some(link.payload.operation_id.clone()),
+        sensor_id: None,
+        payload,
+        decided_at: Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("decided"),
+        expires_at: Some(link.payload.expires_at.clone()),
+    };
+
+    event.validate().expect("journal event valid");
+    let serialized = serde_json::to_value(&event).expect("json").to_string();
+    for banned in [
+        "\"body\"",
+        "\"text\"",
+        "\"content\"",
+        "\"raw\"",
+        "\"snippet\"",
+        "\"command\"",
+        "\"url\"",
+        "\"title\"",
+        "\"file_path\"",
+        "\"input\"",
+        "\"message\"",
+    ] {
+        assert!(!serialized.contains(banned), "banned field {banned}");
+    }
 }

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -6,7 +6,7 @@ use cairn_core::domain::sharing::{
     SharingRevocationState, SignedShareLink, verify_share_link_grant,
 };
 use cairn_core::domain::{
-    self, ConsentEvent, ConsentKind, Ed25519Signature, Identity, MemoryVisibility,
+    self, ConsentEvent, ConsentKind, ConsentPayload, Ed25519Signature, Identity, MemoryVisibility,
     Rfc3339Timestamp, ScopeTuple,
 };
 use cairn_core::policy_trace::{PolicyGate, PolicyOutcome};
@@ -114,6 +114,25 @@ fn assert_link_shape_err(
         .validate_shape()
         .expect_err(&format!("{name} should fail shape validation"));
     assert!(expected(err), "{name} returned unexpected error");
+}
+
+fn assert_body_free_event(event: &ConsentEvent) {
+    let serialized = serde_json::to_value(event).expect("json").to_string();
+    for banned in [
+        "\"body\"",
+        "\"text\"",
+        "\"content\"",
+        "\"raw\"",
+        "\"snippet\"",
+        "\"command\"",
+        "\"url\"",
+        "\"title\"",
+        "\"file_path\"",
+        "\"input\"",
+        "\"message\"",
+    ] {
+        assert!(!serialized.contains(banned), "banned field {banned}");
+    }
 }
 
 #[test]
@@ -561,20 +580,50 @@ fn share_link_grant_consent_event_is_body_free_and_valid() {
     };
 
     event.validate().expect("journal event valid");
-    let serialized = serde_json::to_value(&event).expect("json").to_string();
-    for banned in [
-        "\"body\"",
-        "\"text\"",
-        "\"content\"",
-        "\"raw\"",
-        "\"snippet\"",
-        "\"command\"",
-        "\"url\"",
-        "\"title\"",
-        "\"file_path\"",
-        "\"input\"",
-        "\"message\"",
-    ] {
-        assert!(!serialized.contains(banned), "banned field {banned}");
+    assert_body_free_event(&event);
+    assert_eq!(
+        event.subject,
+        format!("share_link:{}", link.link_id.to_ascii_lowercase())
+    );
+    match &event.payload {
+        ConsentPayload::Decision {
+            subject_code,
+            policy_code,
+        } => {
+            assert_eq!(subject_code, &event.subject);
+            assert_eq!(policy_code, &Some("grant".to_owned()));
+        }
+        payload => panic!("unexpected payload: {payload:?}"),
+    }
+}
+
+#[test]
+fn share_link_revoke_consent_event_is_body_free_and_valid() {
+    let link = signed_link();
+    let (subject, payload) = link.decision_payload(ShareLinkJournalDecision::Revoke);
+    let event = ConsentEvent {
+        consent_id: "01HQZX9F5N0000000000000007".to_owned(),
+        kind: ConsentKind::Revoke,
+        actor: Identity::parse("hmn:tafeng").expect("human"),
+        subject,
+        scope: "tenant=default,workspace=vault-a,entity=session".to_owned(),
+        op_id: Some(link.payload.operation_id.clone()),
+        sensor_id: None,
+        payload,
+        decided_at: Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("decided"),
+        expires_at: Some(link.payload.expires_at.clone()),
+    };
+
+    event.validate().expect("journal event valid");
+    assert_body_free_event(&event);
+    match &event.payload {
+        ConsentPayload::Decision {
+            subject_code,
+            policy_code,
+        } => {
+            assert_eq!(subject_code, &event.subject);
+            assert_eq!(policy_code, &Some("revoke".to_owned()));
+        }
+        payload => panic!("unexpected payload: {payload:?}"),
     }
 }

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -1,0 +1,94 @@
+//! Signed share-link shape and signature tests.
+
+use cairn_core::domain::identity::keys::SigningKey;
+use cairn_core::domain::sharing::{ShareLinkPayload, SignedShareLink};
+use cairn_core::domain::{
+    Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+};
+
+fn signer() -> SigningKey {
+    SigningKey::from_bytes(&[9_u8; 32])
+}
+
+fn signature_for<T: serde::Serialize>(payload: &T) -> Ed25519Signature {
+    let bytes = cairn_core::domain::canonical::canonical_bytes(payload).expect("canonical bytes");
+    let sig = signer().sign(&bytes);
+    Ed25519Signature::parse(format!("ed25519:{}", hex(&sig.to_bytes()))).expect("signature")
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn scope() -> ScopeTuple {
+    ScopeTuple {
+        tenant: Some("default".to_owned()),
+        workspace: Some("vault-a".to_owned()),
+        entity: Some("session".to_owned()),
+        ..ScopeTuple::default()
+    }
+}
+
+fn link_payload() -> ShareLinkPayload {
+    ShareLinkPayload {
+        operation_id: "01HQZX9F5N0000000000000004".to_owned(),
+        nonce: "AAAAAAAAAAAAAAAAAAAAAA==".to_owned(),
+        target_hash: format!("sha256:{}", "c".repeat(64)),
+        target_id_hashes: vec![format!("hash:{}", "d".repeat(32))],
+        scope: scope(),
+        grant_tier: MemoryVisibility::Team,
+        grantee: Some(Identity::parse("agt:cairn-cli:default:reader:v1").expect("agent")),
+        issuer: Identity::parse("hmn:tafeng").expect("human"),
+        issued_at: Rfc3339Timestamp::parse("2026-05-21T12:00:00Z").expect("issued"),
+        expires_at: Rfc3339Timestamp::parse("2026-05-22T12:00:00Z").expect("expires"),
+        key_version: 1,
+    }
+}
+
+fn signed_link() -> SignedShareLink {
+    let payload = link_payload();
+    let signature = signature_for(&payload);
+    SignedShareLink {
+        link_id: "share-01HQZX9F5N0000000000000004".to_owned(),
+        payload,
+        signature,
+    }
+}
+
+#[test]
+fn share_link_signature_verifies() {
+    let link = signed_link();
+    link.verify_signature(&signer().verifying_key())
+        .expect("signature verifies");
+}
+
+#[test]
+fn share_link_rejects_tampered_scope() {
+    let mut link = signed_link();
+    link.payload.scope.entity = Some("other".to_owned());
+    let err = link
+        .verify_signature(&signer().verifying_key())
+        .expect_err("tampering breaks signature");
+    assert!(matches!(
+        err,
+        cairn_core::domain::DomainError::InvalidSignature
+    ));
+}
+
+#[test]
+fn share_link_shape_rejects_empty_target_id_hashes() {
+    let mut link = signed_link();
+    link.payload.target_id_hashes.clear();
+    let err = link
+        .validate_shape()
+        .expect_err("empty target set rejected");
+    assert!(matches!(
+        err,
+        cairn_core::domain::DomainError::InvalidPayloadHash { .. }
+    ));
+}

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -74,6 +74,9 @@ fn share_link_input<'a>(
         link,
         now,
         expected_target_hash: &link.payload.target_hash,
+        requesting_principal: link.payload.grantee.as_ref(),
+        issuer: &link.payload.issuer,
+        issuer_key_version: link.payload.key_version,
         signer_key,
         revocation,
         max_tier: MemoryVisibility::Team,
@@ -84,12 +87,25 @@ fn assert_share_link_rejection_detail(
     input: ShareLinkGateInput<'_>,
     expected: SharingDecisionKind,
 ) {
+    assert_share_link_rejection(input, expected, |_| true);
+}
+
+fn assert_share_link_rejection(
+    input: ShareLinkGateInput<'_>,
+    expected: SharingDecisionKind,
+    expected_error: impl FnOnce(&domain::DomainError) -> bool,
+) {
     let rejection = verify_share_link_grant(input).expect_err("share-link gate should reject");
     assert_eq!(rejection.trace.gate, PolicyGate::ShareLink);
     assert_eq!(rejection.trace.outcome, PolicyOutcome::Deny);
     assert_eq!(
         rejection.trace.detail.to_wire_string(),
         format!("share_link:grant:{}", expected.as_str())
+    );
+    assert!(
+        expected_error(&rejection.error),
+        "unexpected share-link rejection error: {:?}",
+        rejection.error
     );
 }
 
@@ -301,6 +317,60 @@ fn share_link_gate_allows_valid_link() {
 }
 
 #[test]
+fn share_link_gate_allows_recipient_bound_link_for_matching_principal() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+    let grantee = link.payload.grantee.as_ref().expect("grantee");
+
+    let trace = verify_share_link_grant(ShareLinkGateInput {
+        requesting_principal: Some(grantee),
+        ..share_link_input(&link, &now, &revocation, &signer_key)
+    })
+    .expect("share-link gate allows matching grantee");
+
+    assert_eq!(trace.gate, PolicyGate::ShareLink);
+    assert_eq!(trace.outcome, PolicyOutcome::Pass);
+    assert_eq!(trace.detail.to_wire_string(), "share_link:grant:allowed");
+}
+
+#[test]
+fn share_link_gate_rejects_recipient_bound_link_without_principal() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+
+    assert_share_link_rejection(
+        ShareLinkGateInput {
+            requesting_principal: None,
+            ..share_link_input(&link, &now, &revocation, &signer_key)
+        },
+        SharingDecisionKind::ScopeMismatch,
+        |err| matches!(err, domain::DomainError::ScopeDenied { .. }),
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_recipient_bound_link_for_different_principal() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+    let other_principal = Identity::parse("agt:cairn-cli:default:other:v1").expect("agent");
+
+    assert_share_link_rejection(
+        ShareLinkGateInput {
+            requesting_principal: Some(&other_principal),
+            ..share_link_input(&link, &now, &revocation, &signer_key)
+        },
+        SharingDecisionKind::ScopeMismatch,
+        |err| matches!(err, domain::DomainError::ScopeDenied { .. }),
+    );
+}
+
+#[test]
 fn share_link_gate_allows_bearer_link_with_expiry_and_revocation_checks() {
     let mut link = signed_link();
     link.payload.grantee = None;
@@ -324,9 +394,10 @@ fn share_link_gate_rejects_expired_link() {
     let revocation = SharingRevocationState::default();
     let signer_key = signer().verifying_key();
 
-    assert_share_link_rejection_detail(
+    assert_share_link_rejection(
         share_link_input(&link, &now, &revocation, &signer_key),
         SharingDecisionKind::Expired,
+        |err| matches!(err, domain::DomainError::ExpiredIntent { .. }),
     );
 }
 
@@ -340,9 +411,27 @@ fn share_link_gate_rejects_revoked_link() {
         .insert("share-01HQZX9F5N0000000000000004".to_owned());
     let signer_key = signer().verifying_key();
 
-    assert_share_link_rejection_detail(
+    assert_share_link_rejection(
         share_link_input(&link, &now, &revocation, &signer_key),
         SharingDecisionKind::Revoked,
+        |err| matches!(err, domain::DomainError::Unauthorized { .. }),
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_revoked_signer_key() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState {
+        signer_key_revoked: true,
+        ..SharingRevocationState::default()
+    };
+    let signer_key = signer().verifying_key();
+
+    assert_share_link_rejection(
+        share_link_input(&link, &now, &revocation, &signer_key),
+        SharingDecisionKind::Revoked,
+        |err| matches!(err, domain::DomainError::Unauthorized { .. }),
     );
 }
 
@@ -373,5 +462,85 @@ fn share_link_gate_rejects_tier_above_authorized_max() {
     assert_share_link_rejection_detail(
         share_link_input(&link, &now, &revocation, &signer_key),
         SharingDecisionKind::TierMismatch,
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_invalid_shape() {
+    let mut link = signed_link();
+    link.payload.nonce = "not-base64".to_owned();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+
+    assert_share_link_rejection_detail(
+        share_link_input(&link, &now, &revocation, &signer_key),
+        SharingDecisionKind::InvalidShape,
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_non_human_issuer_with_specific_reason() {
+    let mut link = signed_link();
+    link.payload.issuer = Identity::parse("agt:cairn-cli:default:issuer:v1").expect("agent");
+    link.signature = signature_for(&link.payload);
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+
+    assert_share_link_rejection(
+        share_link_input(&link, &now, &revocation, &signer_key),
+        SharingDecisionKind::NotHuman,
+        |err| matches!(err, domain::DomainError::Unauthorized { .. }),
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_bad_signature() {
+    let mut link = signed_link();
+    link.payload.target_id_hashes = vec![format!("hash:{}", "e".repeat(32))];
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+
+    assert_share_link_rejection(
+        share_link_input(&link, &now, &revocation, &signer_key),
+        SharingDecisionKind::BadSignature,
+        |err| matches!(err, domain::DomainError::InvalidSignature),
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_issuer_identity_context_mismatch() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+    let issuer = Identity::parse("hmn:other").expect("human");
+
+    assert_share_link_rejection(
+        ShareLinkGateInput {
+            issuer: &issuer,
+            ..share_link_input(&link, &now, &revocation, &signer_key)
+        },
+        SharingDecisionKind::BadSignature,
+        |err| matches!(err, domain::DomainError::InvalidSignature),
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_issuer_key_version_context_mismatch() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+
+    assert_share_link_rejection(
+        ShareLinkGateInput {
+            issuer_key_version: link.payload.key_version + 1,
+            ..share_link_input(&link, &now, &revocation, &signer_key)
+        },
+        SharingDecisionKind::BadSignature,
+        |err| matches!(err, domain::DomainError::InvalidSignature),
     );
 }

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -1,7 +1,7 @@
 //! Signed share-link shape and signature tests.
 
 use cairn_core::domain::identity::keys::SigningKey;
-use cairn_core::domain::sharing::{ShareLinkPayload, SignedShareLink};
+use cairn_core::domain::sharing::{ShareLinkPayload, SharingRevocationState, SignedShareLink};
 use cairn_core::domain::{
     Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
 };
@@ -91,4 +91,28 @@ fn share_link_shape_rejects_empty_target_id_hashes() {
         err,
         cairn_core::domain::DomainError::InvalidPayloadHash { .. }
     ));
+}
+
+#[test]
+fn sharing_revocation_state_serializes_and_denies_unknown_fields() {
+    let mut state = SharingRevocationState::default();
+    state
+        .revoked_receipt_ids
+        .insert("rcpt-01HQZX9F5N0000000000000002".to_owned());
+    state
+        .revoked_share_link_ids
+        .insert("share-01HQZX9F5N0000000000000004".to_owned());
+    state.signer_key_revoked = true;
+
+    let json = serde_json::to_value(&state).expect("serialize revocation state");
+    assert_eq!(json["signer_key_revoked"], true);
+
+    let err = serde_json::from_value::<SharingRevocationState>(serde_json::json!({
+        "revoked_receipt_ids": [],
+        "revoked_share_link_ids": [],
+        "signer_key_revoked": false,
+        "unexpected": true
+    }))
+    .expect_err("unknown field rejected");
+    assert!(err.to_string().contains("unknown field"));
 }

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -1,10 +1,14 @@
 //! Signed share-link shape and signature tests.
 
 use cairn_core::domain::identity::keys::SigningKey;
-use cairn_core::domain::sharing::{ShareLinkPayload, SharingRevocationState, SignedShareLink};
+use cairn_core::domain::sharing::{
+    ShareLinkGateInput, ShareLinkPayload, SharingDecisionKind, SharingRevocationState,
+    SignedShareLink, verify_share_link_grant,
+};
 use cairn_core::domain::{
     self, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
 };
+use cairn_core::policy_trace::{PolicyGate, PolicyOutcome};
 
 fn signer() -> SigningKey {
     SigningKey::from_bytes(&[9_u8; 32])
@@ -58,6 +62,35 @@ fn signed_link() -> SignedShareLink {
         payload,
         signature,
     }
+}
+
+fn share_link_input<'a>(
+    link: &'a SignedShareLink,
+    now: &'a Rfc3339Timestamp,
+    revocation: &'a SharingRevocationState,
+    signer_key: &'a ed25519_dalek::VerifyingKey,
+) -> ShareLinkGateInput<'a> {
+    ShareLinkGateInput {
+        link,
+        now,
+        expected_target_hash: &link.payload.target_hash,
+        signer_key,
+        revocation,
+        max_tier: MemoryVisibility::Team,
+    }
+}
+
+fn assert_share_link_rejection_detail(
+    input: ShareLinkGateInput<'_>,
+    expected: SharingDecisionKind,
+) {
+    let rejection = verify_share_link_grant(input).expect_err("share-link gate should reject");
+    assert_eq!(rejection.trace.gate, PolicyGate::ShareLink);
+    assert_eq!(rejection.trace.outcome, PolicyOutcome::Deny);
+    assert_eq!(
+        rejection.trace.detail.to_wire_string(),
+        format!("share_link:grant:{}", expected.as_str())
+    );
 }
 
 fn assert_link_shape_err(
@@ -250,4 +283,95 @@ fn sharing_revocation_state_serializes_and_denies_unknown_fields() {
     }))
     .expect_err("unknown field rejected");
     assert!(err.to_string().contains("unknown field"));
+}
+
+#[test]
+fn share_link_gate_allows_valid_link() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+
+    let trace = verify_share_link_grant(share_link_input(&link, &now, &revocation, &signer_key))
+        .expect("share-link gate allows valid link");
+
+    assert_eq!(trace.gate, PolicyGate::ShareLink);
+    assert_eq!(trace.outcome, PolicyOutcome::Pass);
+    assert_eq!(trace.detail.to_wire_string(), "share_link:grant:allowed");
+}
+
+#[test]
+fn share_link_gate_allows_bearer_link_with_expiry_and_revocation_checks() {
+    let mut link = signed_link();
+    link.payload.grantee = None;
+    link.signature = signature_for(&link.payload);
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+
+    let trace = verify_share_link_grant(share_link_input(&link, &now, &revocation, &signer_key))
+        .expect("share-link gate allows bearer link");
+
+    assert_eq!(trace.gate, PolicyGate::ShareLink);
+    assert_eq!(trace.outcome, PolicyOutcome::Pass);
+    assert_eq!(trace.detail.to_wire_string(), "share_link:grant:allowed");
+}
+
+#[test]
+fn share_link_gate_rejects_expired_link() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-23T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+
+    assert_share_link_rejection_detail(
+        share_link_input(&link, &now, &revocation, &signer_key),
+        SharingDecisionKind::Expired,
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_revoked_link() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let mut revocation = SharingRevocationState::default();
+    revocation
+        .revoked_share_link_ids
+        .insert("share-01HQZX9F5N0000000000000004".to_owned());
+    let signer_key = signer().verifying_key();
+
+    assert_share_link_rejection_detail(
+        share_link_input(&link, &now, &revocation, &signer_key),
+        SharingDecisionKind::Revoked,
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_target_hash_mismatch() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+    let expected_target_hash = format!("sha256:{}", "0".repeat(64));
+    let input = ShareLinkGateInput {
+        expected_target_hash: &expected_target_hash,
+        ..share_link_input(&link, &now, &revocation, &signer_key)
+    };
+
+    assert_share_link_rejection_detail(input, SharingDecisionKind::TargetMismatch);
+}
+
+#[test]
+fn share_link_gate_rejects_tier_above_authorized_max() {
+    let mut link = signed_link();
+    link.payload.grant_tier = MemoryVisibility::Org;
+    link.signature = signature_for(&link.payload);
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let signer_key = signer().verifying_key();
+
+    assert_share_link_rejection_detail(
+        share_link_input(&link, &now, &revocation, &signer_key),
+        SharingDecisionKind::TierMismatch,
+    );
 }

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -220,6 +220,22 @@ fn share_link_shape_rejects_required_bad_fields() {
             |e| matches!(e, domain::DomainError::MalformedScope { .. }),
         ),
         (
+            "lowercase operation_id",
+            |l| {
+                l.payload.operation_id = "01hqzx9f5n0000000000000004".to_owned();
+                l.link_id = "share-01hqzx9f5n0000000000000004".to_owned();
+            },
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
+            "overflow operation_id",
+            |l| {
+                l.payload.operation_id = "81HQZX9F5N0000000000000004".to_owned();
+                l.link_id = "share-81HQZX9F5N0000000000000004".to_owned();
+            },
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
             "malformed nonce",
             |l| l.payload.nonce = "not-base64".to_owned(),
             |e| matches!(e, domain::DomainError::MissingSignature { .. }),

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -3,7 +3,7 @@
 use cairn_core::domain::identity::keys::SigningKey;
 use cairn_core::domain::sharing::{ShareLinkPayload, SharingRevocationState, SignedShareLink};
 use cairn_core::domain::{
-    Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+    self, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
 };
 
 fn signer() -> SigningKey {
@@ -60,6 +60,19 @@ fn signed_link() -> SignedShareLink {
     }
 }
 
+fn assert_link_shape_err(
+    name: &str,
+    mutate: impl FnOnce(&mut SignedShareLink),
+    expected: fn(domain::DomainError) -> bool,
+) {
+    let mut link = signed_link();
+    mutate(&mut link);
+    let err = link
+        .validate_shape()
+        .expect_err(&format!("{name} should fail shape validation"));
+    assert!(expected(err), "{name} returned unexpected error");
+}
+
 #[test]
 fn share_link_signature_verifies() {
     let link = signed_link();
@@ -91,6 +104,128 @@ fn share_link_shape_rejects_empty_target_id_hashes() {
         err,
         cairn_core::domain::DomainError::InvalidPayloadHash { .. }
     ));
+}
+
+#[test]
+fn share_link_rejects_rewrapped_link_id() {
+    assert_link_shape_err(
+        "rewrapped link_id",
+        |link| link.link_id = "share-01HQZX9F5N0000000000000009".to_owned(),
+        |err| matches!(err, domain::DomainError::MalformedScope { .. }),
+    );
+}
+
+#[test]
+fn share_link_shape_rejects_too_many_and_duplicate_target_id_hashes() {
+    assert_link_shape_err(
+        "too many target_id_hashes",
+        |link| {
+            link.payload.target_id_hashes = (0..65).map(|idx| format!("hash:{idx:032x}")).collect();
+        },
+        |err| matches!(err, domain::DomainError::InvalidPayloadHash { .. }),
+    );
+
+    assert_link_shape_err(
+        "duplicate target_id_hashes",
+        |link| {
+            link.payload.target_id_hashes = vec![
+                format!("hash:{}", "d".repeat(32)),
+                format!("hash:{}", "d".repeat(32)),
+            ];
+        },
+        |err| matches!(err, domain::DomainError::InvalidPayloadHash { .. }),
+    );
+}
+
+#[test]
+fn share_link_shape_rejects_required_bad_fields() {
+    let cases: &[(
+        &str,
+        fn(&mut SignedShareLink),
+        fn(domain::DomainError) -> bool,
+    )] = &[
+        (
+            "malformed link_id",
+            |l| l.link_id = "bad id".to_owned(),
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
+            "malformed operation_id",
+            |l| {
+                l.payload.operation_id = "not-a-ulid".to_owned();
+                l.link_id = "share-not-a-ulid".to_owned();
+            },
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
+            "malformed nonce",
+            |l| l.payload.nonce = "not-base64".to_owned(),
+            |e| matches!(e, domain::DomainError::MissingSignature { .. }),
+        ),
+        (
+            "bad target_hash",
+            |l| {
+                l.payload.target_hash = format!("sha256:{}", "C".repeat(64));
+            },
+            |e| matches!(e, domain::DomainError::InvalidPayloadHash { .. }),
+        ),
+        (
+            "invalid tier",
+            |l| l.payload.grant_tier = MemoryVisibility::Private,
+            |e| matches!(e, domain::DomainError::UnsupportedVisibility { .. }),
+        ),
+        (
+            "non-human issuer",
+            |l| {
+                l.payload.issuer =
+                    Identity::parse("agt:cairn-cli:default:reader:v1").expect("agent");
+            },
+            |e| matches!(e, domain::DomainError::Unauthorized { .. }),
+        ),
+        (
+            "zero key_version",
+            |l| l.payload.key_version = 0,
+            |e| matches!(e, domain::DomainError::Unauthorized { .. }),
+        ),
+        (
+            "expires at issued_at",
+            |l| l.payload.expires_at = l.payload.issued_at.clone(),
+            |e| matches!(e, domain::DomainError::ExpiredIntent { .. }),
+        ),
+    ];
+
+    for (name, mutate, expected) in cases {
+        assert_link_shape_err(name, *mutate, *expected);
+    }
+}
+
+#[test]
+fn share_link_denies_unknown_wrapper_and_payload_fields() {
+    let wrapper_err = serde_json::from_value::<SignedShareLink>(serde_json::json!({
+        "link_id": "share-01HQZX9F5N0000000000000004",
+        "payload": link_payload(),
+        "signature": signature_for(&link_payload()),
+        "unexpected": true
+    }))
+    .expect_err("wrapper unknown field rejected");
+    assert!(wrapper_err.to_string().contains("unknown field"));
+
+    let payload_err = serde_json::from_value::<ShareLinkPayload>(serde_json::json!({
+        "operation_id": "01HQZX9F5N0000000000000004",
+        "nonce": "AAAAAAAAAAAAAAAAAAAAAA==",
+        "target_hash": format!("sha256:{}", "c".repeat(64)),
+        "target_id_hashes": [format!("hash:{}", "d".repeat(32))],
+        "scope": scope(),
+        "grant_tier": "team",
+        "grantee": "agt:cairn-cli:default:reader:v1",
+        "issuer": "hmn:tafeng",
+        "issued_at": "2026-05-21T12:00:00Z",
+        "expires_at": "2026-05-22T12:00:00Z",
+        "key_version": 1,
+        "unexpected": true
+    }))
+    .expect_err("payload unknown field rejected");
+    assert!(payload_err.to_string().contains("unknown field"));
 }
 
 #[test]

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -11,6 +11,15 @@ use cairn_core::domain::{
 };
 use cairn_core::policy_trace::{PolicyGate, PolicyOutcome};
 
+type ShareLinkMutator = fn(&mut SignedShareLink);
+type ShareLinkErrorPredicate = fn(domain::DomainError) -> bool;
+
+struct ShareLinkShapeCase {
+    name: &'static str,
+    mutate: ShareLinkMutator,
+    expected: ShareLinkErrorPredicate,
+}
+
 fn signer() -> SigningKey {
     SigningKey::from_bytes(&[9_u8; 32])
 }
@@ -201,79 +210,75 @@ fn share_link_shape_rejects_too_many_and_duplicate_target_id_hashes() {
 
 #[test]
 fn share_link_shape_rejects_required_bad_fields() {
-    let cases: &[(
-        &str,
-        fn(&mut SignedShareLink),
-        fn(domain::DomainError) -> bool,
-    )] = &[
-        (
-            "malformed link_id",
-            |l| l.link_id = "bad id".to_owned(),
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "malformed operation_id",
-            |l| {
+    let cases: &[ShareLinkShapeCase] = &[
+        ShareLinkShapeCase {
+            name: "malformed link_id",
+            mutate: |l| l.link_id = "bad id".to_owned(),
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ShareLinkShapeCase {
+            name: "malformed operation_id",
+            mutate: |l| {
                 l.payload.operation_id = "not-a-ulid".to_owned();
                 l.link_id = "share-not-a-ulid".to_owned();
             },
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "lowercase operation_id",
-            |l| {
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ShareLinkShapeCase {
+            name: "lowercase operation_id",
+            mutate: |l| {
                 l.payload.operation_id = "01hqzx9f5n0000000000000004".to_owned();
                 l.link_id = "share-01hqzx9f5n0000000000000004".to_owned();
             },
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "overflow operation_id",
-            |l| {
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ShareLinkShapeCase {
+            name: "overflow operation_id",
+            mutate: |l| {
                 l.payload.operation_id = "81HQZX9F5N0000000000000004".to_owned();
                 l.link_id = "share-81HQZX9F5N0000000000000004".to_owned();
             },
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "malformed nonce",
-            |l| l.payload.nonce = "not-base64".to_owned(),
-            |e| matches!(e, domain::DomainError::MissingSignature { .. }),
-        ),
-        (
-            "bad target_hash",
-            |l| {
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ShareLinkShapeCase {
+            name: "malformed nonce",
+            mutate: |l| l.payload.nonce = "not-base64".to_owned(),
+            expected: |e| matches!(e, domain::DomainError::MissingSignature { .. }),
+        },
+        ShareLinkShapeCase {
+            name: "bad target_hash",
+            mutate: |l| {
                 l.payload.target_hash = format!("sha256:{}", "C".repeat(64));
             },
-            |e| matches!(e, domain::DomainError::InvalidPayloadHash { .. }),
-        ),
-        (
-            "invalid tier",
-            |l| l.payload.grant_tier = MemoryVisibility::Private,
-            |e| matches!(e, domain::DomainError::UnsupportedVisibility { .. }),
-        ),
-        (
-            "non-human issuer",
-            |l| {
+            expected: |e| matches!(e, domain::DomainError::InvalidPayloadHash { .. }),
+        },
+        ShareLinkShapeCase {
+            name: "invalid tier",
+            mutate: |l| l.payload.grant_tier = MemoryVisibility::Private,
+            expected: |e| matches!(e, domain::DomainError::UnsupportedVisibility { .. }),
+        },
+        ShareLinkShapeCase {
+            name: "non-human issuer",
+            mutate: |l| {
                 l.payload.issuer =
                     Identity::parse("agt:cairn-cli:default:reader:v1").expect("agent");
             },
-            |e| matches!(e, domain::DomainError::Unauthorized { .. }),
-        ),
-        (
-            "zero key_version",
-            |l| l.payload.key_version = 0,
-            |e| matches!(e, domain::DomainError::Unauthorized { .. }),
-        ),
-        (
-            "expires at issued_at",
-            |l| l.payload.expires_at = l.payload.issued_at.clone(),
-            |e| matches!(e, domain::DomainError::ExpiredIntent { .. }),
-        ),
+            expected: |e| matches!(e, domain::DomainError::Unauthorized { .. }),
+        },
+        ShareLinkShapeCase {
+            name: "zero key_version",
+            mutate: |l| l.payload.key_version = 0,
+            expected: |e| matches!(e, domain::DomainError::Unauthorized { .. }),
+        },
+        ShareLinkShapeCase {
+            name: "expires at issued_at",
+            mutate: |l| l.payload.expires_at = l.payload.issued_at.clone(),
+            expected: |e| matches!(e, domain::DomainError::ExpiredIntent { .. }),
+        },
     ];
 
-    for (name, mutate, expected) in cases {
-        assert_link_shape_err(name, *mutate, *expected);
+    for case in cases {
+        assert_link_shape_err(case.name, case.mutate, case.expected);
     }
 }
 

--- a/crates/cairn-core/tests/share_link.rs
+++ b/crates/cairn-core/tests/share_link.rs
@@ -83,13 +83,6 @@ fn share_link_input<'a>(
     }
 }
 
-fn assert_share_link_rejection_detail(
-    input: ShareLinkGateInput<'_>,
-    expected: SharingDecisionKind,
-) {
-    assert_share_link_rejection(input, expected, |_| true);
-}
-
 fn assert_share_link_rejection(
     input: ShareLinkGateInput<'_>,
     expected: SharingDecisionKind,
@@ -447,7 +440,9 @@ fn share_link_gate_rejects_target_hash_mismatch() {
         ..share_link_input(&link, &now, &revocation, &signer_key)
     };
 
-    assert_share_link_rejection_detail(input, SharingDecisionKind::TargetMismatch);
+    assert_share_link_rejection(input, SharingDecisionKind::TargetMismatch, |err| {
+        matches!(err, domain::DomainError::InvalidPayloadHash { .. })
+    });
 }
 
 #[test]
@@ -459,9 +454,10 @@ fn share_link_gate_rejects_tier_above_authorized_max() {
     let revocation = SharingRevocationState::default();
     let signer_key = signer().verifying_key();
 
-    assert_share_link_rejection_detail(
+    assert_share_link_rejection(
         share_link_input(&link, &now, &revocation, &signer_key),
         SharingDecisionKind::TierMismatch,
+        |err| matches!(err, domain::DomainError::UnsupportedVisibility { .. }),
     );
 }
 
@@ -473,9 +469,10 @@ fn share_link_gate_rejects_invalid_shape() {
     let revocation = SharingRevocationState::default();
     let signer_key = signer().verifying_key();
 
-    assert_share_link_rejection_detail(
+    assert_share_link_rejection(
         share_link_input(&link, &now, &revocation, &signer_key),
         SharingDecisionKind::InvalidShape,
+        |err| matches!(err, domain::DomainError::MissingSignature { .. }),
     );
 }
 

--- a/crates/cairn-core/tests/sharing_receipt.rs
+++ b/crates/cairn-core/tests/sharing_receipt.rs
@@ -4,7 +4,8 @@ use cairn_core::domain::identity::keys::SigningKey;
 use cairn_core::domain::record::tests_export::sample_record;
 use cairn_core::domain::sharing::{PromotionConsentPayload, PromotionConsentReceipt};
 use cairn_core::domain::{
-    CanonicalRecordHash, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+    self, CanonicalRecordHash, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp,
+    ScopeTuple,
 };
 
 fn signer() -> SigningKey {
@@ -74,6 +75,19 @@ fn signed_receipt() -> PromotionConsentReceipt {
     }
 }
 
+fn assert_receipt_shape_err(
+    name: &str,
+    mutate: impl FnOnce(&mut PromotionConsentReceipt),
+    expected: fn(domain::DomainError) -> bool,
+) {
+    let mut receipt = signed_receipt();
+    mutate(&mut receipt);
+    let err = receipt
+        .validate_shape()
+        .expect_err(&format!("{name} should fail shape validation"));
+    assert!(expected(err), "{name} returned unexpected error");
+}
+
 #[test]
 fn promotion_receipt_signature_verifies() {
     let receipt = signed_receipt();
@@ -103,6 +117,106 @@ fn promotion_receipt_shape_rejects_raw_target_id_hash() {
     assert!(matches!(
         err,
         cairn_core::domain::DomainError::InvalidPayloadHash { .. }
-            | cairn_core::domain::DomainError::ScopeDenied { .. }
     ));
+}
+
+#[test]
+fn promotion_receipt_rejects_rewrapped_receipt_id() {
+    assert_receipt_shape_err(
+        "rewrapped receipt_id",
+        |receipt| receipt.receipt_id = "rcpt-01HQZX9F5N0000000000000009".to_owned(),
+        |err| matches!(err, domain::DomainError::MalformedScope { .. }),
+    );
+}
+
+#[test]
+fn promotion_receipt_shape_rejects_required_bad_fields() {
+    let cases: &[(
+        &str,
+        fn(&mut PromotionConsentReceipt),
+        fn(domain::DomainError) -> bool,
+    )] = &[
+        (
+            "malformed receipt_id",
+            |r| r.receipt_id = "bad id".to_owned(),
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
+            "malformed operation_id",
+            |r| {
+                r.payload.operation_id = "not-a-ulid".to_owned();
+                r.receipt_id = "rcpt-not-a-ulid".to_owned();
+            },
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
+            "malformed nonce",
+            |r| r.payload.nonce = "not-base64".to_owned(),
+            |e| matches!(e, domain::DomainError::MissingSignature { .. }),
+        ),
+        (
+            "bad target_hash",
+            |r| {
+                r.payload.target_hash = format!("sha256:{}", "A".repeat(64));
+            },
+            |e| matches!(e, domain::DomainError::InvalidPayloadHash { .. }),
+        ),
+        (
+            "invalid tier",
+            |r| r.payload.to_tier = MemoryVisibility::Private,
+            |e| matches!(e, domain::DomainError::UnsupportedVisibility { .. }),
+        ),
+        (
+            "non-human signer",
+            |r| {
+                r.payload.human_identity =
+                    Identity::parse("agt:cairn-cli:default:reader:v1").expect("agent");
+            },
+            |e| matches!(e, domain::DomainError::Unauthorized { .. }),
+        ),
+        (
+            "zero key_version",
+            |r| r.payload.key_version = 0,
+            |e| matches!(e, domain::DomainError::Unauthorized { .. }),
+        ),
+        (
+            "expires at issued_at",
+            |r| r.payload.expires_at = r.payload.issued_at.clone(),
+            |e| matches!(e, domain::DomainError::ExpiredIntent { .. }),
+        ),
+    ];
+
+    for (name, mutate, expected) in cases {
+        assert_receipt_shape_err(name, *mutate, *expected);
+    }
+}
+
+#[test]
+fn promotion_receipt_denies_unknown_wrapper_and_payload_fields() {
+    let wrapper_err = serde_json::from_value::<PromotionConsentReceipt>(serde_json::json!({
+        "receipt_id": "rcpt-01HQZX9F5N0000000000000002",
+        "payload": receipt_payload(),
+        "signature": signature_for(&receipt_payload()),
+        "unexpected": true
+    }))
+    .expect_err("wrapper unknown field rejected");
+    assert!(wrapper_err.to_string().contains("unknown field"));
+
+    let payload_err = serde_json::from_value::<PromotionConsentPayload>(serde_json::json!({
+        "operation_id": "01HQZX9F5N0000000000000002",
+        "nonce": "AAAAAAAAAAAAAAAAAAAAAA==",
+        "chain_parents": ["01HQZX9F5N0000000000000003"],
+        "target_hash": receipt_payload().target_hash,
+        "target_id_hash": format!("hash:{}", "b".repeat(32)),
+        "from_tier": "private",
+        "to_tier": "team",
+        "scope": receipt_scope(),
+        "human_identity": "hmn:tafeng",
+        "issued_at": "2026-05-21T12:00:00Z",
+        "expires_at": "2026-05-22T12:00:00Z",
+        "key_version": 1,
+        "unexpected": true
+    }))
+    .expect_err("payload unknown field rejected");
+    assert!(payload_err.to_string().contains("unknown field"));
 }

--- a/crates/cairn-core/tests/sharing_receipt.rs
+++ b/crates/cairn-core/tests/sharing_receipt.rs
@@ -15,6 +15,15 @@ use cairn_core::domain::{
 use cairn_core::policy_trace::{PolicyGate, PolicyOutcome};
 use cairn_core::rebac::{RebacAction, RebacContext, RebacRelation};
 
+type ReceiptMutator = fn(&mut PromotionConsentReceipt);
+type ReceiptErrorPredicate = fn(domain::DomainError) -> bool;
+
+struct ReceiptShapeCase {
+    name: &'static str,
+    mutate: ReceiptMutator,
+    expected: ReceiptErrorPredicate,
+}
+
 fn signer() -> SigningKey {
     SigningKey::from_bytes(&[7_u8; 32])
 }
@@ -143,93 +152,89 @@ fn promotion_receipt_rejects_rewrapped_receipt_id() {
 
 #[test]
 fn promotion_receipt_shape_rejects_required_bad_fields() {
-    let cases: &[(
-        &str,
-        fn(&mut PromotionConsentReceipt),
-        fn(domain::DomainError) -> bool,
-    )] = &[
-        (
-            "malformed receipt_id",
-            |r| r.receipt_id = "bad id".to_owned(),
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "malformed operation_id",
-            |r| {
+    let cases: &[ReceiptShapeCase] = &[
+        ReceiptShapeCase {
+            name: "malformed receipt_id",
+            mutate: |r| r.receipt_id = "bad id".to_owned(),
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ReceiptShapeCase {
+            name: "malformed operation_id",
+            mutate: |r| {
                 r.payload.operation_id = "not-a-ulid".to_owned();
                 r.receipt_id = "rcpt-not-a-ulid".to_owned();
             },
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "lowercase operation_id",
-            |r| {
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ReceiptShapeCase {
+            name: "lowercase operation_id",
+            mutate: |r| {
                 r.payload.operation_id = "01hqzx9f5n0000000000000002".to_owned();
                 r.receipt_id = "rcpt-01hqzx9f5n0000000000000002".to_owned();
             },
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "overflow operation_id",
-            |r| {
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ReceiptShapeCase {
+            name: "overflow operation_id",
+            mutate: |r| {
                 r.payload.operation_id = "81HQZX9F5N0000000000000002".to_owned();
                 r.receipt_id = "rcpt-81HQZX9F5N0000000000000002".to_owned();
             },
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "lowercase chain_parent",
-            |r| {
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ReceiptShapeCase {
+            name: "lowercase chain_parent",
+            mutate: |r| {
                 r.payload.chain_parents = vec!["01hqzx9f5n0000000000000003".to_owned()];
             },
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "overflow chain_parent",
-            |r| {
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ReceiptShapeCase {
+            name: "overflow chain_parent",
+            mutate: |r| {
                 r.payload.chain_parents = vec!["81HQZX9F5N0000000000000003".to_owned()];
             },
-            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
-        ),
-        (
-            "malformed nonce",
-            |r| r.payload.nonce = "not-base64".to_owned(),
-            |e| matches!(e, domain::DomainError::MissingSignature { .. }),
-        ),
-        (
-            "bad target_hash",
-            |r| {
+            expected: |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        },
+        ReceiptShapeCase {
+            name: "malformed nonce",
+            mutate: |r| r.payload.nonce = "not-base64".to_owned(),
+            expected: |e| matches!(e, domain::DomainError::MissingSignature { .. }),
+        },
+        ReceiptShapeCase {
+            name: "bad target_hash",
+            mutate: |r| {
                 r.payload.target_hash = format!("sha256:{}", "A".repeat(64));
             },
-            |e| matches!(e, domain::DomainError::InvalidPayloadHash { .. }),
-        ),
-        (
-            "invalid tier",
-            |r| r.payload.to_tier = MemoryVisibility::Private,
-            |e| matches!(e, domain::DomainError::UnsupportedVisibility { .. }),
-        ),
-        (
-            "non-human signer",
-            |r| {
+            expected: |e| matches!(e, domain::DomainError::InvalidPayloadHash { .. }),
+        },
+        ReceiptShapeCase {
+            name: "invalid tier",
+            mutate: |r| r.payload.to_tier = MemoryVisibility::Private,
+            expected: |e| matches!(e, domain::DomainError::UnsupportedVisibility { .. }),
+        },
+        ReceiptShapeCase {
+            name: "non-human signer",
+            mutate: |r| {
                 r.payload.human_identity =
                     Identity::parse("agt:cairn-cli:default:reader:v1").expect("agent");
             },
-            |e| matches!(e, domain::DomainError::Unauthorized { .. }),
-        ),
-        (
-            "zero key_version",
-            |r| r.payload.key_version = 0,
-            |e| matches!(e, domain::DomainError::Unauthorized { .. }),
-        ),
-        (
-            "expires at issued_at",
-            |r| r.payload.expires_at = r.payload.issued_at.clone(),
-            |e| matches!(e, domain::DomainError::ExpiredIntent { .. }),
-        ),
+            expected: |e| matches!(e, domain::DomainError::Unauthorized { .. }),
+        },
+        ReceiptShapeCase {
+            name: "zero key_version",
+            mutate: |r| r.payload.key_version = 0,
+            expected: |e| matches!(e, domain::DomainError::Unauthorized { .. }),
+        },
+        ReceiptShapeCase {
+            name: "expires at issued_at",
+            mutate: |r| r.payload.expires_at = r.payload.issued_at.clone(),
+            expected: |e| matches!(e, domain::DomainError::ExpiredIntent { .. }),
+        },
     ];
 
-    for (name, mutate, expected) in cases {
-        assert_receipt_shape_err(name, *mutate, *expected);
+    for case in cases {
+        assert_receipt_shape_err(case.name, case.mutate, case.expected);
     }
 }
 

--- a/crates/cairn-core/tests/sharing_receipt.rs
+++ b/crates/cairn-core/tests/sharing_receipt.rs
@@ -162,6 +162,36 @@ fn promotion_receipt_shape_rejects_required_bad_fields() {
             |e| matches!(e, domain::DomainError::MalformedScope { .. }),
         ),
         (
+            "lowercase operation_id",
+            |r| {
+                r.payload.operation_id = "01hqzx9f5n0000000000000002".to_owned();
+                r.receipt_id = "rcpt-01hqzx9f5n0000000000000002".to_owned();
+            },
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
+            "overflow operation_id",
+            |r| {
+                r.payload.operation_id = "81HQZX9F5N0000000000000002".to_owned();
+                r.receipt_id = "rcpt-81HQZX9F5N0000000000000002".to_owned();
+            },
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
+            "lowercase chain_parent",
+            |r| {
+                r.payload.chain_parents = vec!["01hqzx9f5n0000000000000003".to_owned()];
+            },
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
+            "overflow chain_parent",
+            |r| {
+                r.payload.chain_parents = vec!["81HQZX9F5N0000000000000003".to_owned()];
+            },
+            |e| matches!(e, domain::DomainError::MalformedScope { .. }),
+        ),
+        (
             "malformed nonce",
             |r| r.payload.nonce = "not-base64".to_owned(),
             |e| matches!(e, domain::DomainError::MissingSignature { .. }),
@@ -275,6 +305,8 @@ fn promotion_input<'a>(
         receipt,
         now,
         operation_id: "01HQZX9F5N0000000000000002",
+        signer_identity: &receipt.payload.human_identity,
+        signer_key_version: receipt.payload.key_version,
         signer_key: signer_verifying_key(),
         revocation,
         rebac,
@@ -339,6 +371,41 @@ fn promotion_gate_rejects_bad_signature() {
 
     assert_promotion_rejection_detail(
         promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::BadSignature,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_signer_identity_context_mismatch() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+    let other = Identity::parse("hmn:other").expect("human");
+
+    assert_promotion_rejection_detail(
+        PromotionGateInput {
+            signer_identity: &other,
+            ..promotion_input(&record, &receipt, &now, &revocation, &rebac)
+        },
+        SharingDecisionKind::BadSignature,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_signer_key_version_context_mismatch() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        PromotionGateInput {
+            signer_key_version: receipt.payload.key_version + 1,
+            ..promotion_input(&record, &receipt, &now, &revocation, &rebac)
+        },
         SharingDecisionKind::BadSignature,
     );
 }

--- a/crates/cairn-core/tests/sharing_receipt.rs
+++ b/crates/cairn-core/tests/sharing_receipt.rs
@@ -9,8 +9,8 @@ use cairn_core::domain::sharing::{
     SharingRevocationState, verify_promotion_gate,
 };
 use cairn_core::domain::{
-    self, CanonicalRecordHash, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp,
-    ScopeTuple,
+    self, CanonicalRecordHash, ConsentEvent, ConsentKind, Ed25519Signature, Identity,
+    MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
 };
 use cairn_core::policy_trace::{PolicyGate, PolicyOutcome};
 use cairn_core::rebac::{RebacAction, RebacContext, RebacRelation};
@@ -513,4 +513,41 @@ fn promotion_gate_rejects_missing_rebac_write_relation() {
         promotion_input(&record, &receipt, &now, &revocation, &rebac),
         SharingDecisionKind::NoRebacRelation,
     );
+}
+
+#[test]
+fn promotion_receipt_consent_event_is_body_free_and_valid() {
+    let receipt = signed_receipt();
+    let payload = receipt.promote_consent_payload();
+    let event = ConsentEvent {
+        consent_id: "01HQZX9F5N0000000000000005".to_owned(),
+        kind: ConsentKind::PromoteReceipt,
+        actor: Identity::parse("hmn:tafeng").expect("human"),
+        subject: receipt.payload.target_id_hash.clone(),
+        scope: "tenant=default,workspace=vault-a,entity=ingest,user=hmn:tafeng".to_owned(),
+        op_id: Some(receipt.payload.operation_id.clone()),
+        sensor_id: None,
+        payload,
+        decided_at: Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("decided"),
+        expires_at: Some(receipt.payload.expires_at.clone()),
+    };
+
+    event.validate().expect("journal event valid");
+    let value = serde_json::to_value(&event).expect("json");
+    let serialized = value.to_string();
+    for banned in [
+        "\"body\"",
+        "\"text\"",
+        "\"content\"",
+        "\"raw\"",
+        "\"snippet\"",
+        "\"command\"",
+        "\"url\"",
+        "\"title\"",
+        "\"file_path\"",
+        "\"input\"",
+        "\"message\"",
+    ] {
+        assert!(!serialized.contains(banned), "banned field {banned}");
+    }
 }

--- a/crates/cairn-core/tests/sharing_receipt.rs
+++ b/crates/cairn-core/tests/sharing_receipt.rs
@@ -12,6 +12,7 @@ use cairn_core::domain::{
     self, CanonicalRecordHash, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp,
     ScopeTuple,
 };
+use cairn_core::policy_trace::{PolicyGate, PolicyOutcome};
 use cairn_core::rebac::{RebacAction, RebacContext, RebacRelation};
 
 fn signer() -> SigningKey {
@@ -246,6 +247,20 @@ fn rebac_for_team_write() -> RebacContext {
     )
 }
 
+fn rebac_for_other_team_write() -> RebacContext {
+    let principal = Identity::parse("hmn:other").expect("human");
+    let scope = receipt_scope();
+    RebacContext::new(
+        principal.clone(),
+        vec![RebacRelation::new(
+            principal,
+            RebacAction::Write,
+            scope,
+            MemoryVisibility::Team,
+        )],
+    )
+}
+
 fn promotion_input<'a>(
     record: &'a cairn_core::domain::MemoryRecord,
     receipt: &'a PromotionConsentReceipt,
@@ -268,6 +283,8 @@ fn promotion_input<'a>(
 
 fn assert_promotion_rejection_detail(input: PromotionGateInput<'_>, expected: SharingDecisionKind) {
     let rejection = verify_promotion_gate(input).expect_err("promotion gate should reject");
+    assert_eq!(rejection.trace.gate, PolicyGate::ConsentReceipt);
+    assert_eq!(rejection.trace.outcome, PolicyOutcome::Deny);
     assert_eq!(
         rejection.trace.detail.to_wire_string(),
         format!("consent:promote:{}", expected.as_str())
@@ -291,7 +308,39 @@ fn promotion_gate_allows_valid_receipt_and_rebac_relation() {
     ))
     .expect("promotion gate allows valid receipt");
 
+    assert_eq!(trace.gate, PolicyGate::ConsentReceipt);
+    assert_eq!(trace.outcome, PolicyOutcome::Pass);
     assert_eq!(trace.detail.to_wire_string(), "consent:promote:allowed");
+}
+
+#[test]
+fn promotion_gate_rejects_invalid_shape() {
+    let record = scoped_record();
+    let mut receipt = signed_receipt();
+    receipt.payload.nonce = "not-base64".to_owned();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::InvalidShape,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_bad_signature() {
+    let record = scoped_record();
+    let mut receipt = signed_receipt();
+    receipt.payload.target_id_hash = format!("hash:{}", "c".repeat(32));
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::BadSignature,
+    );
 }
 
 #[test]
@@ -324,6 +373,70 @@ fn promotion_gate_rejects_target_hash_mismatch() {
 }
 
 #[test]
+fn promotion_gate_rejects_scope_mismatch() {
+    let record = scoped_record();
+    let mut receipt = signed_receipt();
+    receipt.payload.scope.workspace = Some("vault-b".to_owned());
+    receipt.signature = signature_for(&receipt.payload);
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::ScopeMismatch,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_operation_id_mismatch() {
+    let record = scoped_record();
+    let mut receipt = signed_receipt();
+    receipt.payload.operation_id = "01HQZX9F5N0000000000000004".to_owned();
+    receipt.receipt_id = "rcpt-01HQZX9F5N0000000000000004".to_owned();
+    receipt.signature = signature_for(&receipt.payload);
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::ScopeMismatch,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_tier_mismatch() {
+    let record = scoped_record();
+    let mut receipt = signed_receipt();
+    receipt.payload.from_tier = MemoryVisibility::Session;
+    receipt.signature = signature_for(&receipt.payload);
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::TierMismatch,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_record_visibility_mismatch() {
+    let mut record = scoped_record();
+    record.visibility = MemoryVisibility::Session;
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::TierMismatch,
+    );
+}
+
+#[test]
 fn promotion_gate_rejects_revoked_receipt() {
     let record = scoped_record();
     let receipt = signed_receipt();
@@ -332,6 +445,23 @@ fn promotion_gate_rejects_revoked_receipt() {
     revocation
         .revoked_receipt_ids
         .insert("rcpt-01HQZX9F5N0000000000000002".to_owned());
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::Revoked,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_revoked_signer_key() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState {
+        signer_key_revoked: true,
+        ..SharingRevocationState::default()
+    };
     let rebac = rebac_for_team_write();
 
     assert_promotion_rejection_detail(
@@ -354,6 +484,20 @@ fn promotion_gate_rejects_non_human_signer() {
     assert_promotion_rejection_detail(
         promotion_input(&record, &receipt, &now, &revocation, &rebac),
         SharingDecisionKind::NotHuman,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_rebac_principal_mismatch() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_other_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::NoRebacRelation,
     );
 }
 

--- a/crates/cairn-core/tests/sharing_receipt.rs
+++ b/crates/cairn-core/tests/sharing_receipt.rs
@@ -1,15 +1,26 @@
 //! Promotion consent receipt shape and signature tests.
 
+use std::sync::OnceLock;
+
 use cairn_core::domain::identity::keys::SigningKey;
 use cairn_core::domain::record::tests_export::sample_record;
-use cairn_core::domain::sharing::{PromotionConsentPayload, PromotionConsentReceipt};
+use cairn_core::domain::sharing::{
+    PromotionConsentPayload, PromotionConsentReceipt, PromotionGateInput, SharingDecisionKind,
+    SharingRevocationState, verify_promotion_gate,
+};
 use cairn_core::domain::{
     self, CanonicalRecordHash, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp,
     ScopeTuple,
 };
+use cairn_core::rebac::{RebacAction, RebacContext, RebacRelation};
 
 fn signer() -> SigningKey {
     SigningKey::from_bytes(&[7_u8; 32])
+}
+
+fn signer_verifying_key() -> &'static ed25519_dalek::VerifyingKey {
+    static KEY: OnceLock<ed25519_dalek::VerifyingKey> = OnceLock::new();
+    KEY.get_or_init(|| signer().verifying_key())
 }
 
 fn signature_for<T: serde::Serialize>(payload: &T) -> Ed25519Signature {
@@ -219,4 +230,126 @@ fn promotion_receipt_denies_unknown_wrapper_and_payload_fields() {
     }))
     .expect_err("payload unknown field rejected");
     assert!(payload_err.to_string().contains("unknown field"));
+}
+
+fn rebac_for_team_write() -> RebacContext {
+    let principal = Identity::parse("hmn:tafeng").expect("human");
+    let scope = receipt_scope();
+    RebacContext::new(
+        principal.clone(),
+        vec![RebacRelation::new(
+            principal,
+            RebacAction::Write,
+            scope,
+            MemoryVisibility::Team,
+        )],
+    )
+}
+
+fn promotion_input<'a>(
+    record: &'a cairn_core::domain::MemoryRecord,
+    receipt: &'a PromotionConsentReceipt,
+    now: &'a Rfc3339Timestamp,
+    revocation: &'a SharingRevocationState,
+    rebac: &'a RebacContext,
+) -> PromotionGateInput<'a> {
+    PromotionGateInput {
+        record,
+        from_tier: MemoryVisibility::Private,
+        to_tier: MemoryVisibility::Team,
+        receipt,
+        now,
+        operation_id: "01HQZX9F5N0000000000000002",
+        signer_key: signer_verifying_key(),
+        revocation,
+        rebac,
+    }
+}
+
+fn assert_promotion_rejection_detail(input: PromotionGateInput<'_>, expected: SharingDecisionKind) {
+    let rejection = verify_promotion_gate(input).expect_err("promotion gate should reject");
+    assert_eq!(
+        rejection.trace.detail.to_wire_string(),
+        format!("consent:promote:{}", expected.as_str())
+    );
+}
+
+#[test]
+fn promotion_gate_allows_valid_receipt_and_rebac_relation() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    let trace = verify_promotion_gate(promotion_input(
+        &record,
+        &receipt,
+        &now,
+        &revocation,
+        &rebac,
+    ))
+    .expect("promotion gate allows valid receipt");
+
+    assert_eq!(trace.detail.to_wire_string(), "consent:promote:allowed");
+}
+
+#[test]
+fn promotion_gate_rejects_expired_receipt_at_apply_time() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-23T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::Expired,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_target_hash_mismatch() {
+    let mut record = scoped_record();
+    let receipt = signed_receipt();
+    record.body.push_str(" changed after signing");
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::TargetMismatch,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_revoked_receipt() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let mut revocation = SharingRevocationState::default();
+    revocation
+        .revoked_receipt_ids
+        .insert("rcpt-01HQZX9F5N0000000000000002".to_owned());
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::Revoked,
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_missing_rebac_write_relation() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = RebacContext::for_principal(Identity::parse("hmn:tafeng").expect("human"));
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::NoRebacRelation,
+    );
 }

--- a/crates/cairn-core/tests/sharing_receipt.rs
+++ b/crates/cairn-core/tests/sharing_receipt.rs
@@ -341,6 +341,23 @@ fn promotion_gate_rejects_revoked_receipt() {
 }
 
 #[test]
+fn promotion_gate_rejects_non_human_signer() {
+    let record = scoped_record();
+    let mut receipt = signed_receipt();
+    receipt.payload.human_identity =
+        Identity::parse("agt:cairn-cli:default:reader:v1").expect("agent");
+    receipt.signature = signature_for(&receipt.payload);
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    assert_promotion_rejection_detail(
+        promotion_input(&record, &receipt, &now, &revocation, &rebac),
+        SharingDecisionKind::NotHuman,
+    );
+}
+
+#[test]
 fn promotion_gate_rejects_missing_rebac_write_relation() {
     let record = scoped_record();
     let receipt = signed_receipt();

--- a/crates/cairn-core/tests/sharing_receipt.rs
+++ b/crates/cairn-core/tests/sharing_receipt.rs
@@ -1,0 +1,108 @@
+//! Promotion consent receipt shape and signature tests.
+
+use cairn_core::domain::identity::keys::SigningKey;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::sharing::{PromotionConsentPayload, PromotionConsentReceipt};
+use cairn_core::domain::{
+    CanonicalRecordHash, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+};
+
+fn signer() -> SigningKey {
+    SigningKey::from_bytes(&[7_u8; 32])
+}
+
+fn signature_for<T: serde::Serialize>(payload: &T) -> Ed25519Signature {
+    let bytes = cairn_core::domain::canonical::canonical_bytes(payload).expect("canonical bytes");
+    let sig = signer().sign(&bytes);
+    Ed25519Signature::parse(format!("ed25519:{}", hex(&sig.to_bytes()))).expect("signature")
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn scoped_record() -> cairn_core::domain::MemoryRecord {
+    let mut record = sample_record();
+    record.scope = receipt_scope();
+    record.visibility = MemoryVisibility::Private;
+    record
+}
+
+fn receipt_scope() -> ScopeTuple {
+    ScopeTuple {
+        tenant: Some("default".to_owned()),
+        workspace: Some("vault-a".to_owned()),
+        entity: Some("ingest".to_owned()),
+        user: Some("hmn:tafeng".to_owned()),
+        ..ScopeTuple::default()
+    }
+}
+
+fn receipt_payload() -> PromotionConsentPayload {
+    let record = scoped_record();
+    PromotionConsentPayload {
+        operation_id: "01HQZX9F5N0000000000000002".to_owned(),
+        nonce: "AAAAAAAAAAAAAAAAAAAAAA==".to_owned(),
+        chain_parents: vec!["01HQZX9F5N0000000000000003".to_owned()],
+        target_hash: CanonicalRecordHash::compute(&record)
+            .expect("record hash")
+            .as_str()
+            .to_owned(),
+        target_id_hash: format!("hash:{}", "b".repeat(32)),
+        from_tier: MemoryVisibility::Private,
+        to_tier: MemoryVisibility::Team,
+        scope: receipt_scope(),
+        human_identity: Identity::parse("hmn:tafeng").expect("human"),
+        issued_at: Rfc3339Timestamp::parse("2026-05-21T12:00:00Z").expect("issued"),
+        expires_at: Rfc3339Timestamp::parse("2026-05-22T12:00:00Z").expect("expires"),
+        key_version: 1,
+    }
+}
+
+fn signed_receipt() -> PromotionConsentReceipt {
+    let payload = receipt_payload();
+    let signature = signature_for(&payload);
+    PromotionConsentReceipt {
+        receipt_id: "rcpt-01HQZX9F5N0000000000000002".to_owned(),
+        payload,
+        signature,
+    }
+}
+
+#[test]
+fn promotion_receipt_signature_verifies() {
+    let receipt = signed_receipt();
+    receipt
+        .verify_signature(&signer().verifying_key())
+        .expect("signature verifies");
+}
+
+#[test]
+fn promotion_receipt_rejects_tampered_target_hash() {
+    let mut receipt = signed_receipt();
+    receipt.payload.target_hash = format!("sha256:{}", "0".repeat(64));
+    let err = receipt
+        .verify_signature(&signer().verifying_key())
+        .expect_err("tampering breaks signature");
+    assert!(matches!(
+        err,
+        cairn_core::domain::DomainError::InvalidSignature
+    ));
+}
+
+#[test]
+fn promotion_receipt_shape_rejects_raw_target_id_hash() {
+    let mut receipt = signed_receipt();
+    receipt.payload.target_id_hash = "01HQZX9F5N0000000000000000".to_owned();
+    let err = receipt.validate_shape().expect_err("raw id rejected");
+    assert!(matches!(
+        err,
+        cairn_core::domain::DomainError::InvalidPayloadHash { .. }
+            | cairn_core::domain::DomainError::ScopeDenied { .. }
+    ));
+}

--- a/docs/superpowers/plans/2026-05-21-issue-122-share-links-consent.md
+++ b/docs/superpowers/plans/2026-05-21-issue-122-share-links-consent.md
@@ -1,0 +1,1833 @@
+# Signed Share Links and Consent-Gated Promotion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the core domain substrate for signed share links and consent-gated promotion receipts from issue #122.
+
+**Architecture:** Add a pure `cairn-core::domain::sharing` module that owns signed receipt/link payloads, canonical payload verification, apply-time promotion/share validation, revocation checks, and body-free consent journal helpers. Reuse existing `CanonicalRecordHash`, `Rfc3339Timestamp`, `Identity`, `RebacContext`, `ConsentPayload`, and `PolicyTraceEntry` types so adapters and WAL/store code can call one shared policy implementation.
+
+**Tech Stack:** Rust 2024, `serde`, existing `ed25519-dalek`, existing `chrono` support on `Rfc3339Timestamp`, existing `ulid`, existing `cairn-core` policy trace and ReBAC modules.
+
+---
+
+## File Structure
+
+- Create `crates/cairn-core/src/domain/sharing.rs`
+  - Owns `PromotionConsentPayload`, `PromotionConsentReceipt`, `SignedShareLink`, `ShareLinkPayload`, `SharingRevocationState`, gate inputs, gate rejection type, sharing policy enums, signature verification, hash/nonce/ULID validation, and consent journal helper functions.
+- Modify `crates/cairn-core/src/domain/mod.rs`
+  - Adds `pub mod sharing;` and re-exports the public sharing types/functions used by tests and future adapters.
+- Modify `crates/cairn-core/src/policy_trace/gate.rs`
+  - Adds `PolicyGate::ConsentReceipt` and `PolicyGate::ShareLink`.
+- Modify `crates/cairn-core/src/policy_trace/detail.rs`
+  - Adds `PolicyDetail::Sharing` and renders `consent:promote:<reason>` / `share_link:grant:<reason>`.
+- Modify `crates/cairn-core/tests/policy_trace_gate.rs`
+  - Pins new gate wire strings.
+- Modify `crates/cairn-core/tests/policy_trace_detail.rs`
+  - Pins new body-free detail wire strings.
+- Create `crates/cairn-core/tests/sharing_receipt.rs`
+  - Covers receipt signature verification, promotion gate allow/deny, ReBAC denial, expiry, revocation, mismatch, and body-free journal helpers.
+- Create `crates/cairn-core/tests/share_link.rs`
+  - Covers signed share-link grant allow/deny, bearer links, expiry, revocation, mismatch, and body-free journal helpers.
+
+---
+
+### Task 1: Policy Trace Vocabulary
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+- Create: `crates/cairn-core/src/domain/sharing.rs`
+- Modify: `crates/cairn-core/src/policy_trace/gate.rs`
+- Modify: `crates/cairn-core/src/policy_trace/detail.rs`
+- Test: `crates/cairn-core/tests/policy_trace_gate.rs`
+- Test: `crates/cairn-core/tests/policy_trace_detail.rs`
+
+- [ ] **Step 1: Write the failing policy trace tests**
+
+Add these imports to `crates/cairn-core/tests/policy_trace_detail.rs`:
+
+```rust
+use cairn_core::domain::sharing::{
+    SharingDecisionKind, SharingPolicyAction, SharingPolicySubject,
+};
+```
+
+Add these tests to `crates/cairn-core/tests/policy_trace_detail.rs`:
+
+```rust
+#[test]
+fn consent_receipt_detail_serializes_action_and_reason() {
+    let d = PolicyDetail::Sharing {
+        subject: SharingPolicySubject::ConsentReceipt,
+        action: SharingPolicyAction::Promote,
+        reason: SharingDecisionKind::TargetMismatch,
+    };
+    assert_eq!(d.to_wire_string(), "consent:promote:target_mismatch");
+}
+
+#[test]
+fn share_link_detail_serializes_action_and_reason() {
+    let d = PolicyDetail::Sharing {
+        subject: SharingPolicySubject::ShareLink,
+        action: SharingPolicyAction::Grant,
+        reason: SharingDecisionKind::Revoked,
+    };
+    assert_eq!(d.to_wire_string(), "share_link:grant:revoked");
+}
+```
+
+Add these cases to the `cases` array in `crates/cairn-core/tests/policy_trace_gate.rs`:
+
+```rust
+(PolicyGate::ConsentReceipt, "consent_receipt"),
+(PolicyGate::ShareLink, "share_link"),
+```
+
+- [ ] **Step 2: Run the policy trace tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test policy_trace_detail --test policy_trace_gate
+```
+
+Expected: FAIL with errors mentioning missing `domain::sharing`, missing `PolicyDetail::Sharing`, or missing `PolicyGate::ConsentReceipt`.
+
+- [ ] **Step 3: Add the minimal sharing enums and policy trace variants**
+
+Create `crates/cairn-core/src/domain/sharing.rs` with this initial content:
+
+```rust
+//! Signed share links and promotion consent receipts (brief §4.2, §5.6, §12.a, §14).
+//!
+//! This module is pure domain logic: no I/O, no keychain lookup, no DB writes.
+
+use serde::{Deserialize, Serialize};
+
+/// Policy-trace subject for sharing gates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SharingPolicySubject {
+    /// Promotion consent receipt gate.
+    ConsentReceipt,
+    /// Signed share-link grant gate.
+    ShareLink,
+}
+
+impl SharingPolicySubject {
+    /// Body-free detail token.
+    #[must_use]
+    pub const fn as_detail_str(self) -> &'static str {
+        match self {
+            Self::ConsentReceipt => "consent",
+            Self::ShareLink => "share_link",
+        }
+    }
+}
+
+/// Sharing action captured in policy trace detail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SharingPolicyAction {
+    /// Promotion across visibility tiers.
+    Promote,
+    /// Share-link grant evaluation.
+    Grant,
+}
+
+impl SharingPolicyAction {
+    /// Body-free detail token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Promote => "promote",
+            Self::Grant => "grant",
+        }
+    }
+}
+
+/// Body-free decision reason for signed sharing gates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SharingDecisionKind {
+    /// Gate allowed the operation.
+    Allowed,
+    /// Receipt or link expired before apply/evaluation.
+    Expired,
+    /// Target hash or target-id hash set did not match.
+    TargetMismatch,
+    /// Scope did not match the requested operation.
+    ScopeMismatch,
+    /// Tier did not match or exceeded the grant.
+    TierMismatch,
+    /// Signature verification failed.
+    BadSignature,
+    /// Receipt, link, or signer key was revoked.
+    Revoked,
+    /// Issuer or signer was not a human identity.
+    NotHuman,
+    /// ReBAC denied the shared-tier write.
+    NoRebacRelation,
+    /// Shape validation failed before signature verification.
+    InvalidShape,
+}
+
+impl SharingDecisionKind {
+    /// Body-free detail token.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Allowed => "allowed",
+            Self::Expired => "expired",
+            Self::TargetMismatch => "target_mismatch",
+            Self::ScopeMismatch => "scope_mismatch",
+            Self::TierMismatch => "tier_mismatch",
+            Self::BadSignature => "bad_signature",
+            Self::Revoked => "revoked",
+            Self::NotHuman => "not_human",
+            Self::NoRebacRelation => "no_rebac_relation",
+            Self::InvalidShape => "invalid_shape",
+        }
+    }
+}
+```
+
+In `crates/cairn-core/src/domain/mod.rs`, add the module and re-exports:
+
+```rust
+pub mod sharing;
+```
+
+```rust
+pub use sharing::{SharingDecisionKind, SharingPolicyAction, SharingPolicySubject};
+```
+
+In `crates/cairn-core/src/policy_trace/gate.rs`, add enum variants:
+
+```rust
+/// Consent receipt gate for shared-tier promotion.
+ConsentReceipt,
+/// Signed share-link grant gate.
+ShareLink,
+```
+
+Add match arms in `PolicyGate::as_str`:
+
+```rust
+Self::ConsentReceipt => "consent_receipt",
+Self::ShareLink => "share_link",
+```
+
+In `crates/cairn-core/src/policy_trace/detail.rs`, add this import:
+
+```rust
+use crate::domain::sharing::{
+    SharingDecisionKind, SharingPolicyAction, SharingPolicySubject,
+};
+```
+
+Add this `PolicyDetail` variant after `Rebac`:
+
+```rust
+/// Signed sharing gate decision metadata.
+Sharing {
+    /// Consent receipt or share link.
+    subject: SharingPolicySubject,
+    /// Promote or grant.
+    action: SharingPolicyAction,
+    /// Body-free allow/deny reason.
+    reason: SharingDecisionKind,
+},
+```
+
+Add this `to_wire_string` match arm:
+
+```rust
+Self::Sharing {
+    subject,
+    action,
+    reason,
+} => format!(
+    "{}:{}:{}",
+    subject.as_detail_str(),
+    action.as_str(),
+    reason.as_str()
+),
+```
+
+- [ ] **Step 4: Run the policy trace tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test policy_trace_detail --test policy_trace_gate
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add crates/cairn-core/src/domain/mod.rs crates/cairn-core/src/domain/sharing.rs crates/cairn-core/src/policy_trace/gate.rs crates/cairn-core/src/policy_trace/detail.rs crates/cairn-core/tests/policy_trace_gate.rs crates/cairn-core/tests/policy_trace_detail.rs
+git commit -m "feat(core): add sharing policy trace vocabulary"
+```
+
+---
+
+### Task 2: Signed Receipt and Share-Link Shapes
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/sharing.rs`
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+- Test: `crates/cairn-core/tests/sharing_receipt.rs`
+- Test: `crates/cairn-core/tests/share_link.rs`
+
+- [ ] **Step 1: Write failing signature and shape tests**
+
+Create `crates/cairn-core/tests/sharing_receipt.rs` with:
+
+```rust
+use cairn_core::domain::identity::keys::SigningKey;
+use cairn_core::domain::record::tests_export::sample_record;
+use cairn_core::domain::sharing::{PromotionConsentPayload, PromotionConsentReceipt};
+use cairn_core::domain::{
+    CanonicalRecordHash, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp,
+    ScopeTuple,
+};
+
+fn signer() -> SigningKey {
+    SigningKey::from_bytes(&[7_u8; 32])
+}
+
+fn signature_for<T: serde::Serialize>(payload: &T) -> Ed25519Signature {
+    let bytes = cairn_core::domain::canonical::canonical_bytes(payload).expect("canonical bytes");
+    let sig = signer().sign(&bytes);
+    Ed25519Signature::parse(format!("ed25519:{}", hex(&sig.to_bytes()))).expect("signature")
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn scoped_record() -> cairn_core::domain::MemoryRecord {
+    let mut record = sample_record();
+    record.scope = receipt_scope();
+    record.visibility = MemoryVisibility::Private;
+    record
+}
+
+fn receipt_scope() -> ScopeTuple {
+    ScopeTuple {
+        tenant: Some("default".to_owned()),
+        workspace: Some("vault-a".to_owned()),
+        entity: Some("ingest".to_owned()),
+        user: Some("hmn:tafeng".to_owned()),
+        ..ScopeTuple::default()
+    }
+}
+
+fn receipt_payload() -> PromotionConsentPayload {
+    let record = scoped_record();
+    PromotionConsentPayload {
+        operation_id: "01HQZX9F5N0000000000000002".to_owned(),
+        nonce: "AAAAAAAAAAAAAAAAAAAAAA==".to_owned(),
+        chain_parents: vec!["01HQZX9F5N0000000000000003".to_owned()],
+        target_hash: CanonicalRecordHash::compute(&record)
+            .expect("record hash")
+            .as_str()
+            .to_owned(),
+        target_id_hash: format!("hash:{}", "b".repeat(32)),
+        from_tier: MemoryVisibility::Private,
+        to_tier: MemoryVisibility::Team,
+        scope: receipt_scope(),
+        human_identity: Identity::parse("hmn:tafeng").expect("human"),
+        issued_at: Rfc3339Timestamp::parse("2026-05-21T12:00:00Z").expect("issued"),
+        expires_at: Rfc3339Timestamp::parse("2026-05-22T12:00:00Z").expect("expires"),
+        key_version: 1,
+    }
+}
+
+fn signed_receipt() -> PromotionConsentReceipt {
+    let payload = receipt_payload();
+    let signature = signature_for(&payload);
+    PromotionConsentReceipt {
+        receipt_id: "rcpt-01HQZX9F5N0000000000000002".to_owned(),
+        payload,
+        signature,
+    }
+}
+
+#[test]
+fn promotion_receipt_signature_verifies() {
+    let receipt = signed_receipt();
+    receipt
+        .verify_signature(&signer().verifying_key())
+        .expect("signature verifies");
+}
+
+#[test]
+fn promotion_receipt_rejects_tampered_target_hash() {
+    let mut receipt = signed_receipt();
+    receipt.payload.target_hash = format!("sha256:{}", "0".repeat(64));
+    let err = receipt
+        .verify_signature(&signer().verifying_key())
+        .expect_err("tampering breaks signature");
+    assert!(matches!(err, cairn_core::domain::DomainError::InvalidSignature));
+}
+
+#[test]
+fn promotion_receipt_shape_rejects_raw_target_id_hash() {
+    let mut receipt = signed_receipt();
+    receipt.payload.target_id_hash = "01HQZX9F5N0000000000000000".to_owned();
+    let err = receipt.validate_shape().expect_err("raw id rejected");
+    assert!(matches!(
+        err,
+        cairn_core::domain::DomainError::InvalidPayloadHash { .. }
+            | cairn_core::domain::DomainError::ScopeDenied { .. }
+    ));
+}
+```
+
+Create `crates/cairn-core/tests/share_link.rs` with:
+
+```rust
+use cairn_core::domain::identity::keys::SigningKey;
+use cairn_core::domain::sharing::{ShareLinkPayload, SignedShareLink};
+use cairn_core::domain::{
+    Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+};
+
+fn signer() -> SigningKey {
+    SigningKey::from_bytes(&[9_u8; 32])
+}
+
+fn signature_for<T: serde::Serialize>(payload: &T) -> Ed25519Signature {
+    let bytes = cairn_core::domain::canonical::canonical_bytes(payload).expect("canonical bytes");
+    let sig = signer().sign(&bytes);
+    Ed25519Signature::parse(format!("ed25519:{}", hex(&sig.to_bytes()))).expect("signature")
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn scope() -> ScopeTuple {
+    ScopeTuple {
+        tenant: Some("default".to_owned()),
+        workspace: Some("vault-a".to_owned()),
+        entity: Some("session".to_owned()),
+        ..ScopeTuple::default()
+    }
+}
+
+fn link_payload() -> ShareLinkPayload {
+    ShareLinkPayload {
+        operation_id: "01HQZX9F5N0000000000000004".to_owned(),
+        nonce: "AAAAAAAAAAAAAAAAAAAAAA==".to_owned(),
+        target_hash: format!("sha256:{}", "c".repeat(64)),
+        target_id_hashes: vec![format!("hash:{}", "d".repeat(32))],
+        scope: scope(),
+        grant_tier: MemoryVisibility::Team,
+        grantee: Some(Identity::parse("agt:cairn-cli:default:reader:v1").expect("agent")),
+        issuer: Identity::parse("hmn:tafeng").expect("human"),
+        issued_at: Rfc3339Timestamp::parse("2026-05-21T12:00:00Z").expect("issued"),
+        expires_at: Rfc3339Timestamp::parse("2026-05-22T12:00:00Z").expect("expires"),
+        key_version: 1,
+    }
+}
+
+fn signed_link() -> SignedShareLink {
+    let payload = link_payload();
+    let signature = signature_for(&payload);
+    SignedShareLink {
+        link_id: "share-01HQZX9F5N0000000000000004".to_owned(),
+        payload,
+        signature,
+    }
+}
+
+#[test]
+fn share_link_signature_verifies() {
+    let link = signed_link();
+    link.verify_signature(&signer().verifying_key())
+        .expect("signature verifies");
+}
+
+#[test]
+fn share_link_rejects_tampered_scope() {
+    let mut link = signed_link();
+    link.payload.scope.entity = Some("other".to_owned());
+    let err = link
+        .verify_signature(&signer().verifying_key())
+        .expect_err("tampering breaks signature");
+    assert!(matches!(err, cairn_core::domain::DomainError::InvalidSignature));
+}
+
+#[test]
+fn share_link_shape_rejects_empty_target_id_hashes() {
+    let mut link = signed_link();
+    link.payload.target_id_hashes.clear();
+    let err = link.validate_shape().expect_err("empty target set rejected");
+    assert!(matches!(err, cairn_core::domain::DomainError::InvalidPayloadHash { .. }));
+}
+```
+
+- [ ] **Step 2: Run sharing shape tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test sharing_receipt --test share_link
+```
+
+Expected: FAIL with unresolved imports for `PromotionConsentPayload`, `PromotionConsentReceipt`, `ShareLinkPayload`, `SignedShareLink`, or missing methods.
+
+- [ ] **Step 3: Implement receipt/link shapes, shape validation, and signature verification**
+
+Replace `crates/cairn-core/src/domain/sharing.rs` with the Task 1 enums plus these imports and types:
+
+```rust
+use std::collections::BTreeSet;
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{
+    DomainError, Ed25519Signature, Identity, MemoryVisibility, Rfc3339Timestamp, ScopeTuple,
+};
+```
+
+Add these structs below the sharing policy enums:
+
+```rust
+/// Signed consent receipt authorizing one visibility promotion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionConsentReceipt {
+    /// Stable receipt identifier used for revocation and journal references.
+    pub receipt_id: String,
+    /// Signed body-free receipt payload.
+    pub payload: PromotionConsentPayload,
+    /// Ed25519 signature over canonical JSON of `payload`.
+    pub signature: Ed25519Signature,
+}
+
+/// Body-free payload signed by a human for shared-tier promotion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromotionConsentPayload {
+    /// WAL operation id this receipt authorizes.
+    pub operation_id: String,
+    /// Fresh 16-byte base64 nonce.
+    pub nonce: String,
+    /// Parent operation ids this promotion depends on.
+    pub chain_parents: Vec<String>,
+    /// Canonical hash of the record being promoted.
+    pub target_hash: String,
+    /// Salted or canonical hash of the target id.
+    pub target_id_hash: String,
+    /// Current record visibility tier.
+    pub from_tier: MemoryVisibility,
+    /// Requested promoted visibility tier.
+    pub to_tier: MemoryVisibility,
+    /// Scope the receipt authorizes.
+    pub scope: ScopeTuple,
+    /// Human principal that signed the receipt.
+    pub human_identity: Identity,
+    /// Receipt issue time.
+    pub issued_at: Rfc3339Timestamp,
+    /// Receipt expiry time.
+    pub expires_at: Rfc3339Timestamp,
+    /// Signer's key version.
+    pub key_version: u32,
+}
+
+/// Signed share link authorizing a bounded grant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SignedShareLink {
+    /// Stable link id used for revocation and consent journal subject codes.
+    pub link_id: String,
+    /// Signed body-free link payload.
+    pub payload: ShareLinkPayload,
+    /// Ed25519 signature over canonical JSON of `payload`.
+    pub signature: Ed25519Signature,
+}
+
+/// Body-free payload for a signed share-link grant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ShareLinkPayload {
+    /// Operation id that minted the link.
+    pub operation_id: String,
+    /// Fresh 16-byte base64 nonce.
+    pub nonce: String,
+    /// Hash of the record-set manifest or target grant payload.
+    pub target_hash: String,
+    /// Salted or canonical target-id hashes included in the grant.
+    pub target_id_hashes: Vec<String>,
+    /// Scope the link may expose.
+    pub scope: ScopeTuple,
+    /// Shared tier granted by the link.
+    pub grant_tier: MemoryVisibility,
+    /// Optional grantee. `None` means bearer-style access.
+    pub grantee: Option<Identity>,
+    /// Human issuer that granted the share link.
+    pub issuer: Identity,
+    /// Link issue time.
+    pub issued_at: Rfc3339Timestamp,
+    /// Link expiry time.
+    pub expires_at: Rfc3339Timestamp,
+    /// Issuer key version.
+    pub key_version: u32,
+}
+
+/// Revocation state supplied by the store or identity layer at evaluation time.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SharingRevocationState {
+    /// Receipt ids that can no longer authorize promotion.
+    pub revoked_receipt_ids: BTreeSet<String>,
+    /// Share link ids that can no longer authorize grants.
+    pub revoked_share_link_ids: BTreeSet<String>,
+    /// Whether the current signer key is revoked.
+    pub signer_key_revoked: bool,
+}
+```
+
+Add these impls and helper functions:
+
+```rust
+impl PromotionConsentReceipt {
+    /// Validate body-free shape before or after signature verification.
+    pub fn validate_shape(&self) -> Result<(), DomainError> {
+        validate_id("receipt_id", &self.receipt_id)?;
+        validate_ulid("operation_id", &self.payload.operation_id)?;
+        validate_nonce(&self.payload.nonce)?;
+        validate_chain_parents(&self.payload.chain_parents)?;
+        validate_target_hash(&self.payload.target_hash)?;
+        validate_hash("target_id_hash", &self.payload.target_id_hash)?;
+        validate_shared_promotion_tiers(self.payload.from_tier, self.payload.to_tier)?;
+        self.payload.scope.validate()?;
+        if self.payload.human_identity.kind() != crate::domain::IdentityKind::Human {
+            return Err(DomainError::Unauthorized {
+                message: "promotion receipt signer must be a human identity".to_owned(),
+            });
+        }
+        if self.payload.key_version == 0 {
+            return Err(DomainError::Unauthorized {
+                message: "promotion receipt key_version must be >= 1".to_owned(),
+            });
+        }
+        if self
+            .payload
+            .expires_at
+            .cmp_chronological(&self.payload.issued_at)
+            != std::cmp::Ordering::Greater
+        {
+            return Err(DomainError::ExpiredIntent {
+                issued_at: self.payload.issued_at.as_str().to_owned(),
+                expires_at: self.payload.expires_at.as_str().to_owned(),
+                now: self.payload.expires_at.as_str().to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Verify the Ed25519 signature over canonical payload bytes.
+    pub fn verify_signature(&self, key: &VerifyingKey) -> Result<(), DomainError> {
+        self.validate_shape()?;
+        let bytes = crate::domain::canonical::canonical_bytes(&self.payload)?;
+        let signature = decode_signature(&self.signature)?;
+        key.verify(&bytes, &signature)
+            .map_err(|_| DomainError::InvalidSignature)
+    }
+}
+
+impl SignedShareLink {
+    /// Validate body-free shape before or after signature verification.
+    pub fn validate_shape(&self) -> Result<(), DomainError> {
+        validate_id("link_id", &self.link_id)?;
+        validate_ulid("operation_id", &self.payload.operation_id)?;
+        validate_nonce(&self.payload.nonce)?;
+        validate_target_hash(&self.payload.target_hash)?;
+        if self.payload.target_id_hashes.is_empty() {
+            return Err(DomainError::InvalidPayloadHash {
+                message: "target_id_hashes must not be empty".to_owned(),
+            });
+        }
+        for h in &self.payload.target_id_hashes {
+            validate_hash("target_id_hashes", h)?;
+        }
+        validate_shared_tier("grant_tier", self.payload.grant_tier)?;
+        self.payload.scope.validate()?;
+        if self.payload.issuer.kind() != crate::domain::IdentityKind::Human {
+            return Err(DomainError::Unauthorized {
+                message: "share link issuer must be a human identity".to_owned(),
+            });
+        }
+        if self.payload.key_version == 0 {
+            return Err(DomainError::Unauthorized {
+                message: "share link key_version must be >= 1".to_owned(),
+            });
+        }
+        if self
+            .payload
+            .expires_at
+            .cmp_chronological(&self.payload.issued_at)
+            != std::cmp::Ordering::Greater
+        {
+            return Err(DomainError::ExpiredIntent {
+                issued_at: self.payload.issued_at.as_str().to_owned(),
+                expires_at: self.payload.expires_at.as_str().to_owned(),
+                now: self.payload.expires_at.as_str().to_owned(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Verify the Ed25519 signature over canonical payload bytes.
+    pub fn verify_signature(&self, key: &VerifyingKey) -> Result<(), DomainError> {
+        self.validate_shape()?;
+        let bytes = crate::domain::canonical::canonical_bytes(&self.payload)?;
+        let signature = decode_signature(&self.signature)?;
+        key.verify(&bytes, &signature)
+            .map_err(|_| DomainError::InvalidSignature)
+    }
+}
+
+fn validate_id(field: &'static str, value: &str) -> Result<(), DomainError> {
+    if value.is_empty() || value.len() > 128 {
+        return Err(DomainError::EmptyField { field });
+    }
+    if !value
+        .bytes()
+        .all(|b| matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b':' | b'-'))
+    {
+        return Err(DomainError::MalformedScope {
+            message: format!("{field} chars must be in [A-Za-z0-9._:-]"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_ulid(field: &'static str, value: &str) -> Result<(), DomainError> {
+    ulid::Ulid::from_string(value).map_err(|_| DomainError::MalformedScope {
+        message: format!("{field} must be a ULID"),
+    })?;
+    Ok(())
+}
+
+fn validate_chain_parents(values: &[String]) -> Result<(), DomainError> {
+    if values.len() > 64 {
+        return Err(DomainError::MalformedScope {
+            message: "chain_parents exceeds 64 items".to_owned(),
+        });
+    }
+    let mut seen = BTreeSet::new();
+    for value in values {
+        validate_ulid("chain_parents", value)?;
+        if !seen.insert(value) {
+            return Err(DomainError::MalformedScope {
+                message: "chain_parents must be unique".to_owned(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_nonce(value: &str) -> Result<(), DomainError> {
+    let bytes = value.as_bytes();
+    let (head, tail) = match bytes.len() {
+        22 => (&bytes[..21], bytes[21]),
+        24 if bytes[22] == b'=' && bytes[23] == b'=' => (&bytes[..21], bytes[21]),
+        _ => {
+            return Err(DomainError::MissingSignature {
+                message: "nonce must encode 16 base64 bytes".to_owned(),
+            });
+        }
+    };
+    let base64 = |b: &u8| matches!(*b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'+' | b'/');
+    if !head.iter().all(base64) || !matches!(tail, b'A' | b'Q' | b'g' | b'w') {
+        return Err(DomainError::MissingSignature {
+            message: "nonce must be canonical 16-byte base64".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_target_hash(value: &str) -> Result<(), DomainError> {
+    if let Some(hex) = value.strip_prefix("sha256:")
+        && hex.len() == 64
+        && is_lowercase_hex(hex)
+    {
+        return Ok(());
+    }
+    Err(DomainError::InvalidPayloadHash {
+        message: "target_hash must be sha256:<64 lowercase hex>".to_owned(),
+    })
+}
+
+fn validate_hash(field: &'static str, value: &str) -> Result<(), DomainError> {
+    if let Some(hex) = value.strip_prefix("sha256:") {
+        if hex.len() == 64 && is_lowercase_hex(hex) {
+            return Ok(());
+        }
+    }
+    if let Some(hex) = value.strip_prefix("hash:") {
+        if (32..=128).contains(&hex.len()) && is_lowercase_hex(hex) {
+            return Ok(());
+        }
+    }
+    Err(DomainError::InvalidPayloadHash {
+        message: format!("{field} must be sha256:<64 lowercase hex> or hash:<32..=128 lowercase hex>"),
+    })
+}
+
+fn validate_shared_promotion_tiers(
+    from_tier: MemoryVisibility,
+    to_tier: MemoryVisibility,
+) -> Result<(), DomainError> {
+    validate_shared_tier("to_tier", to_tier)?;
+    if to_tier <= from_tier {
+        return Err(DomainError::UnsupportedVisibility {
+            value: format!("to_tier `{}` must be broader than from_tier `{}`", to_tier.as_str(), from_tier.as_str()),
+        });
+    }
+    Ok(())
+}
+
+fn validate_shared_tier(field: &'static str, tier: MemoryVisibility) -> Result<(), DomainError> {
+    if crate::rebac::is_shared_tier(tier) {
+        return Ok(());
+    }
+    Err(DomainError::UnsupportedVisibility {
+        value: format!("{field} `{}` is not a shared tier", tier.as_str()),
+    })
+}
+
+fn is_lowercase_hex(value: &str) -> bool {
+    value.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+fn decode_signature(signature: &Ed25519Signature) -> Result<Signature, DomainError> {
+    let Some(hex) = signature.as_str().strip_prefix("ed25519:") else {
+        return Err(DomainError::InvalidSignature);
+    };
+    let mut bytes = [0_u8; 64];
+    for (idx, pair) in hex.as_bytes().chunks_exact(2).enumerate() {
+        let hi = hex_nibble(pair[0]).ok_or(DomainError::InvalidSignature)?;
+        let lo = hex_nibble(pair[1]).ok_or(DomainError::InvalidSignature)?;
+        bytes[idx] = (hi << 4) | lo;
+    }
+    Ok(Signature::from_bytes(&bytes))
+}
+
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        _ => None,
+    }
+}
+```
+
+In `crates/cairn-core/src/domain/mod.rs`, extend the sharing re-export:
+
+```rust
+pub use sharing::{
+    PromotionConsentPayload, PromotionConsentReceipt, ShareLinkPayload, SharingDecisionKind,
+    SharingPolicyAction, SharingPolicySubject, SharingRevocationState, SignedShareLink,
+};
+```
+
+- [ ] **Step 4: Run shape tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test sharing_receipt --test share_link
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add crates/cairn-core/src/domain/sharing.rs crates/cairn-core/src/domain/mod.rs crates/cairn-core/tests/sharing_receipt.rs crates/cairn-core/tests/share_link.rs
+git commit -m "feat(core): add signed sharing payloads"
+```
+
+---
+
+### Task 3: Promotion Apply-Time Gate
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/sharing.rs`
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+- Test: `crates/cairn-core/tests/sharing_receipt.rs`
+
+- [ ] **Step 1: Add failing promotion gate tests**
+
+Append these imports to `crates/cairn-core/tests/sharing_receipt.rs`:
+
+```rust
+use cairn_core::domain::sharing::{
+    PromotionGateInput, SharingDecisionKind, SharingRevocationState, verify_promotion_gate,
+};
+use cairn_core::rebac::{RebacAction, RebacContext, RebacRelation};
+```
+
+Append these helper functions:
+
+```rust
+fn rebac_for_team_write() -> RebacContext {
+    let principal = Identity::parse("hmn:tafeng").expect("human");
+    let scope = receipt_scope();
+    RebacContext::new(
+        principal.clone(),
+        vec![RebacRelation::new(
+            principal,
+            RebacAction::Write,
+            scope,
+            MemoryVisibility::Team,
+        )],
+    )
+}
+
+fn promotion_input<'a>(
+    record: &'a cairn_core::domain::MemoryRecord,
+    receipt: &'a PromotionConsentReceipt,
+    now: &'a Rfc3339Timestamp,
+    revocation: &'a SharingRevocationState,
+    rebac: &'a RebacContext,
+) -> PromotionGateInput<'a> {
+    PromotionGateInput {
+        record,
+        from_tier: MemoryVisibility::Private,
+        to_tier: MemoryVisibility::Team,
+        receipt,
+        now,
+        operation_id: "01HQZX9F5N0000000000000002",
+        signer_key: &signer().verifying_key(),
+        revocation,
+        rebac,
+    }
+}
+```
+
+Append these tests:
+
+```rust
+#[test]
+fn promotion_gate_allows_valid_receipt_and_rebac_relation() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    let trace = verify_promotion_gate(promotion_input(
+        &record,
+        &receipt,
+        &now,
+        &revocation,
+        &rebac,
+    ))
+    .expect("promotion allowed");
+
+    assert_eq!(trace.detail.to_wire_string(), "consent:promote:allowed");
+}
+
+#[test]
+fn promotion_gate_rejects_expired_receipt_at_apply_time() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-23T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    let err = verify_promotion_gate(promotion_input(
+        &record,
+        &receipt,
+        &now,
+        &revocation,
+        &rebac,
+    ))
+    .expect_err("expired receipt denied");
+
+    assert_eq!(err.trace.detail.to_wire_string(), "consent:promote:expired");
+}
+
+#[test]
+fn promotion_gate_rejects_target_hash_mismatch() {
+    let mut record = scoped_record();
+    record.body.push_str(" changed after receipt signing");
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = rebac_for_team_write();
+
+    let err = verify_promotion_gate(promotion_input(
+        &record,
+        &receipt,
+        &now,
+        &revocation,
+        &rebac,
+    ))
+    .expect_err("target mismatch denied");
+
+    assert_eq!(
+        err.trace.detail.to_wire_string(),
+        "consent:promote:target_mismatch"
+    );
+}
+
+#[test]
+fn promotion_gate_rejects_revoked_receipt() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let mut revocation = SharingRevocationState::default();
+    revocation
+        .revoked_receipt_ids
+        .insert("rcpt-01HQZX9F5N0000000000000002".to_owned());
+    let rebac = rebac_for_team_write();
+
+    let err = verify_promotion_gate(promotion_input(
+        &record,
+        &receipt,
+        &now,
+        &revocation,
+        &rebac,
+    ))
+    .expect_err("revoked receipt denied");
+
+    assert_eq!(err.trace.detail.to_wire_string(), "consent:promote:revoked");
+}
+
+#[test]
+fn promotion_gate_rejects_missing_rebac_write_relation() {
+    let record = scoped_record();
+    let receipt = signed_receipt();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let rebac = RebacContext::for_principal(Identity::parse("hmn:tafeng").expect("human"));
+
+    let err = verify_promotion_gate(promotion_input(
+        &record,
+        &receipt,
+        &now,
+        &revocation,
+        &rebac,
+    ))
+    .expect_err("missing ReBAC relation denied");
+
+    assert_eq!(
+        err.trace.detail.to_wire_string(),
+        "consent:promote:no_rebac_relation"
+    );
+}
+```
+
+- [ ] **Step 2: Run promotion gate tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test sharing_receipt
+```
+
+Expected: FAIL with unresolved imports for `PromotionGateInput` and `verify_promotion_gate`.
+
+- [ ] **Step 3: Implement promotion gate**
+
+Add these imports to `crates/cairn-core/src/domain/sharing.rs`:
+
+```rust
+use crate::domain::{CanonicalRecordHash, MemoryRecord};
+use crate::policy_trace::{PolicyDetail, PolicyGate, PolicyOutcome, PolicyTraceEntry};
+use crate::rebac::{RebacAction, RebacContext};
+```
+
+Add these types and functions:
+
+```rust
+/// Inputs for the shared-tier promotion gate.
+pub struct PromotionGateInput<'a> {
+    /// Record being promoted, still at `from_tier`.
+    pub record: &'a MemoryRecord,
+    /// Current tier.
+    pub from_tier: MemoryVisibility,
+    /// Requested shared tier.
+    pub to_tier: MemoryVisibility,
+    /// Signed receipt presented at apply time.
+    pub receipt: &'a PromotionConsentReceipt,
+    /// Apply-time timestamp.
+    pub now: &'a Rfc3339Timestamp,
+    /// WAL operation id being applied.
+    pub operation_id: &'a str,
+    /// Verifying key for `receipt.payload.human_identity`.
+    pub signer_key: &'a VerifyingKey,
+    /// Revocation state supplied by store/identity layer.
+    pub revocation: &'a SharingRevocationState,
+    /// Existing ReBAC context from #121.
+    pub rebac: &'a RebacContext,
+}
+
+/// Denial with both typed error and body-free trace.
+#[derive(Debug)]
+pub struct SharingGateRejection {
+    /// Typed domain error.
+    pub error: DomainError,
+    /// Body-free trace entry explaining the denial.
+    pub trace: PolicyTraceEntry,
+}
+
+/// Verify a promotion consent receipt at WAL apply time.
+pub fn verify_promotion_gate(
+    input: PromotionGateInput<'_>,
+) -> Result<PolicyTraceEntry, SharingGateRejection> {
+    if let Err(error) = input.receipt.validate_shape() {
+        return Err(reject_promotion(SharingDecisionKind::InvalidShape, error));
+    }
+    if input.receipt.verify_signature(input.signer_key).is_err() {
+        return Err(reject_promotion(
+            SharingDecisionKind::BadSignature,
+            DomainError::InvalidSignature,
+        ));
+    }
+    if input.receipt.payload.human_identity.kind() != crate::domain::IdentityKind::Human {
+        return Err(reject_promotion(
+            SharingDecisionKind::NotHuman,
+            DomainError::Unauthorized {
+                message: "promotion receipt signer must be human".to_owned(),
+            },
+        ));
+    }
+    let computed = CanonicalRecordHash::compute(input.record).map_err(|error| {
+        reject_promotion(SharingDecisionKind::TargetMismatch, error)
+    })?;
+    if computed.as_str() != input.receipt.payload.target_hash {
+        return Err(reject_promotion(
+            SharingDecisionKind::TargetMismatch,
+            DomainError::InvalidPayloadHash {
+                message: "promotion receipt target_hash does not match record".to_owned(),
+            },
+        ));
+    }
+    if input.receipt.payload.scope != input.record.scope {
+        return Err(reject_promotion(
+            SharingDecisionKind::ScopeMismatch,
+            DomainError::ScopeDenied {
+                message: "promotion receipt scope does not match record scope".to_owned(),
+            },
+        ));
+    }
+    if input.receipt.payload.operation_id != input.operation_id {
+        return Err(reject_promotion(
+            SharingDecisionKind::ScopeMismatch,
+            DomainError::ScopeDenied {
+                message: "promotion receipt operation_id does not match WAL operation".to_owned(),
+            },
+        ));
+    }
+    if input.receipt.payload.from_tier != input.from_tier
+        || input.receipt.payload.to_tier != input.to_tier
+    {
+        return Err(reject_promotion(
+            SharingDecisionKind::TierMismatch,
+            DomainError::UnsupportedVisibility {
+                value: "promotion receipt tiers do not match requested promotion".to_owned(),
+            },
+        ));
+    }
+    if input.now.cmp_chronological(&input.receipt.payload.expires_at)
+        != std::cmp::Ordering::Less
+    {
+        return Err(reject_promotion(
+            SharingDecisionKind::Expired,
+            DomainError::ExpiredIntent {
+                issued_at: input.receipt.payload.issued_at.as_str().to_owned(),
+                expires_at: input.receipt.payload.expires_at.as_str().to_owned(),
+                now: input.now.as_str().to_owned(),
+            },
+        ));
+    }
+    if input.revocation.signer_key_revoked
+        || input
+            .revocation
+            .revoked_receipt_ids
+            .contains(&input.receipt.receipt_id)
+    {
+        return Err(reject_promotion(
+            SharingDecisionKind::Revoked,
+            DomainError::Unauthorized {
+                message: "promotion receipt or signer key is revoked".to_owned(),
+            },
+        ));
+    }
+    let decision = input
+        .rebac
+        .evaluate(RebacAction::Write, &input.receipt.payload.scope, input.to_tier);
+    if !decision.allowed() {
+        return Err(reject_promotion(
+            SharingDecisionKind::NoRebacRelation,
+            DomainError::ScopeDenied {
+                message: "rebac denied shared-tier promotion write".to_owned(),
+            },
+        ));
+    }
+    Ok(sharing_trace(
+        PolicyGate::ConsentReceipt,
+        PolicyOutcome::Pass,
+        SharingPolicySubject::ConsentReceipt,
+        SharingPolicyAction::Promote,
+        SharingDecisionKind::Allowed,
+    ))
+}
+
+fn reject_promotion(reason: SharingDecisionKind, error: DomainError) -> SharingGateRejection {
+    SharingGateRejection {
+        error,
+        trace: sharing_trace(
+            PolicyGate::ConsentReceipt,
+            PolicyOutcome::Deny,
+            SharingPolicySubject::ConsentReceipt,
+            SharingPolicyAction::Promote,
+            reason,
+        ),
+    }
+}
+
+fn sharing_trace(
+    gate: PolicyGate,
+    outcome: PolicyOutcome,
+    subject: SharingPolicySubject,
+    action: SharingPolicyAction,
+    reason: SharingDecisionKind,
+) -> PolicyTraceEntry {
+    PolicyTraceEntry::new(
+        gate,
+        outcome,
+        PolicyDetail::Sharing {
+            subject,
+            action,
+            reason,
+        },
+    )
+}
+```
+
+In `crates/cairn-core/src/domain/mod.rs`, extend sharing re-exports:
+
+```rust
+pub use sharing::{
+    PromotionConsentPayload, PromotionConsentReceipt, PromotionGateInput, ShareLinkPayload,
+    SharingDecisionKind, SharingGateRejection, SharingPolicyAction, SharingPolicySubject,
+    SharingRevocationState, SignedShareLink, verify_promotion_gate,
+};
+```
+
+- [ ] **Step 4: Run promotion gate tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test sharing_receipt
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```bash
+git add crates/cairn-core/src/domain/sharing.rs crates/cairn-core/src/domain/mod.rs crates/cairn-core/tests/sharing_receipt.rs
+git commit -m "feat(core): validate promotion consent receipts"
+```
+
+---
+
+### Task 4: Share-Link Grant Gate
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/sharing.rs`
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+- Test: `crates/cairn-core/tests/share_link.rs`
+
+- [ ] **Step 1: Add failing share-link gate tests**
+
+Append these imports to `crates/cairn-core/tests/share_link.rs`:
+
+```rust
+use cairn_core::domain::sharing::{
+    ShareLinkGateInput, SharingRevocationState, verify_share_link_grant,
+};
+```
+
+Append this helper:
+
+```rust
+fn share_link_input<'a>(
+    link: &'a SignedShareLink,
+    now: &'a Rfc3339Timestamp,
+    revocation: &'a SharingRevocationState,
+) -> ShareLinkGateInput<'a> {
+    ShareLinkGateInput {
+        link,
+        now,
+        expected_target_hash: &link.payload.target_hash,
+        signer_key: &signer().verifying_key(),
+        revocation,
+        max_tier: MemoryVisibility::Team,
+    }
+}
+```
+
+Append these tests:
+
+```rust
+#[test]
+fn share_link_gate_allows_valid_link() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+
+    let trace = verify_share_link_grant(share_link_input(&link, &now, &revocation))
+        .expect("grant allowed");
+
+    assert_eq!(trace.detail.to_wire_string(), "share_link:grant:allowed");
+}
+
+#[test]
+fn share_link_gate_allows_bearer_link_with_expiry_and_revocation_checks() {
+    let mut link = signed_link();
+    link.payload.grantee = None;
+    link.signature = signature_for(&link.payload);
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+
+    let trace = verify_share_link_grant(share_link_input(&link, &now, &revocation))
+        .expect("bearer grant allowed");
+
+    assert_eq!(trace.detail.to_wire_string(), "share_link:grant:allowed");
+}
+
+#[test]
+fn share_link_gate_rejects_expired_link() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-23T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+
+    let err = verify_share_link_grant(share_link_input(&link, &now, &revocation))
+        .expect_err("expired link denied");
+
+    assert_eq!(err.trace.detail.to_wire_string(), "share_link:grant:expired");
+}
+
+#[test]
+fn share_link_gate_rejects_revoked_link() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let mut revocation = SharingRevocationState::default();
+    revocation
+        .revoked_share_link_ids
+        .insert("share-01HQZX9F5N0000000000000004".to_owned());
+
+    let err = verify_share_link_grant(share_link_input(&link, &now, &revocation))
+        .expect_err("revoked link denied");
+
+    assert_eq!(err.trace.detail.to_wire_string(), "share_link:grant:revoked");
+}
+
+#[test]
+fn share_link_gate_rejects_target_hash_mismatch() {
+    let link = signed_link();
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+    let input = ShareLinkGateInput {
+        expected_target_hash: &format!("sha256:{}", "0".repeat(64)),
+        ..share_link_input(&link, &now, &revocation)
+    };
+
+    let err = verify_share_link_grant(input).expect_err("target mismatch denied");
+
+    assert_eq!(
+        err.trace.detail.to_wire_string(),
+        "share_link:grant:target_mismatch"
+    );
+}
+
+#[test]
+fn share_link_gate_rejects_tier_above_authorized_max() {
+    let mut link = signed_link();
+    link.payload.grant_tier = MemoryVisibility::Org;
+    link.signature = signature_for(&link.payload);
+    let now = Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("now");
+    let revocation = SharingRevocationState::default();
+
+    let err = verify_share_link_grant(share_link_input(&link, &now, &revocation))
+        .expect_err("tier above max denied");
+
+    assert_eq!(
+        err.trace.detail.to_wire_string(),
+        "share_link:grant:tier_mismatch"
+    );
+}
+```
+
+- [ ] **Step 2: Run share-link gate tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test share_link
+```
+
+Expected: FAIL with unresolved imports for `ShareLinkGateInput` and `verify_share_link_grant`.
+
+- [ ] **Step 3: Implement share-link gate**
+
+Add these types and functions to `crates/cairn-core/src/domain/sharing.rs`:
+
+```rust
+/// Inputs for signed share-link grant evaluation.
+pub struct ShareLinkGateInput<'a> {
+    /// Signed link being evaluated.
+    pub link: &'a SignedShareLink,
+    /// Evaluation timestamp.
+    pub now: &'a Rfc3339Timestamp,
+    /// Expected record-set or grant-manifest hash.
+    pub expected_target_hash: &'a str,
+    /// Verifying key for `link.payload.issuer`.
+    pub signer_key: &'a VerifyingKey,
+    /// Revocation state supplied by store/identity layer.
+    pub revocation: &'a SharingRevocationState,
+    /// Maximum tier the issuer may grant.
+    pub max_tier: MemoryVisibility,
+}
+
+/// Verify a signed share link before honoring the grant.
+pub fn verify_share_link_grant(
+    input: ShareLinkGateInput<'_>,
+) -> Result<PolicyTraceEntry, SharingGateRejection> {
+    if let Err(error) = input.link.validate_shape() {
+        return Err(reject_share_link(SharingDecisionKind::InvalidShape, error));
+    }
+    if input.link.verify_signature(input.signer_key).is_err() {
+        return Err(reject_share_link(
+            SharingDecisionKind::BadSignature,
+            DomainError::InvalidSignature,
+        ));
+    }
+    if input.link.payload.issuer.kind() != crate::domain::IdentityKind::Human {
+        return Err(reject_share_link(
+            SharingDecisionKind::NotHuman,
+            DomainError::Unauthorized {
+                message: "share link issuer must be human".to_owned(),
+            },
+        ));
+    }
+    if input.link.payload.target_hash != input.expected_target_hash {
+        return Err(reject_share_link(
+            SharingDecisionKind::TargetMismatch,
+            DomainError::InvalidPayloadHash {
+                message: "share link target_hash does not match expected target".to_owned(),
+            },
+        ));
+    }
+    if input.link.payload.grant_tier > input.max_tier {
+        return Err(reject_share_link(
+            SharingDecisionKind::TierMismatch,
+            DomainError::UnsupportedVisibility {
+                value: "share link grant_tier exceeds issuer authorization".to_owned(),
+            },
+        ));
+    }
+    if input.now.cmp_chronological(&input.link.payload.expires_at)
+        != std::cmp::Ordering::Less
+    {
+        return Err(reject_share_link(
+            SharingDecisionKind::Expired,
+            DomainError::ExpiredIntent {
+                issued_at: input.link.payload.issued_at.as_str().to_owned(),
+                expires_at: input.link.payload.expires_at.as_str().to_owned(),
+                now: input.now.as_str().to_owned(),
+            },
+        ));
+    }
+    if input.revocation.signer_key_revoked
+        || input
+            .revocation
+            .revoked_share_link_ids
+            .contains(&input.link.link_id)
+    {
+        return Err(reject_share_link(
+            SharingDecisionKind::Revoked,
+            DomainError::Unauthorized {
+                message: "share link or signer key is revoked".to_owned(),
+            },
+        ));
+    }
+    Ok(sharing_trace(
+        PolicyGate::ShareLink,
+        PolicyOutcome::Pass,
+        SharingPolicySubject::ShareLink,
+        SharingPolicyAction::Grant,
+        SharingDecisionKind::Allowed,
+    ))
+}
+
+fn reject_share_link(reason: SharingDecisionKind, error: DomainError) -> SharingGateRejection {
+    SharingGateRejection {
+        error,
+        trace: sharing_trace(
+            PolicyGate::ShareLink,
+            PolicyOutcome::Deny,
+            SharingPolicySubject::ShareLink,
+            SharingPolicyAction::Grant,
+            reason,
+        ),
+    }
+}
+```
+
+In `crates/cairn-core/src/domain/mod.rs`, extend sharing re-exports:
+
+```rust
+pub use sharing::{
+    PromotionConsentPayload, PromotionConsentReceipt, PromotionGateInput, ShareLinkGateInput,
+    ShareLinkPayload, SharingDecisionKind, SharingGateRejection, SharingPolicyAction,
+    SharingPolicySubject, SharingRevocationState, SignedShareLink, verify_promotion_gate,
+    verify_share_link_grant,
+};
+```
+
+- [ ] **Step 4: Run share-link tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test share_link
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+Run:
+
+```bash
+git add crates/cairn-core/src/domain/sharing.rs crates/cairn-core/src/domain/mod.rs crates/cairn-core/tests/share_link.rs
+git commit -m "feat(core): validate signed share links"
+```
+
+---
+
+### Task 5: Body-Free Consent Journal Helpers
+
+**Files:**
+- Modify: `crates/cairn-core/src/domain/sharing.rs`
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+- Test: `crates/cairn-core/tests/sharing_receipt.rs`
+- Test: `crates/cairn-core/tests/share_link.rs`
+
+- [ ] **Step 1: Add failing consent journal helper tests**
+
+Append these imports to `crates/cairn-core/tests/sharing_receipt.rs`:
+
+```rust
+use cairn_core::domain::{ConsentEvent, ConsentKind};
+```
+
+Append this test:
+
+```rust
+#[test]
+fn promotion_receipt_consent_event_is_body_free_and_valid() {
+    let receipt = signed_receipt();
+    let payload = receipt.promote_consent_payload();
+    let event = ConsentEvent {
+        consent_id: "01HQZX9F5N0000000000000005".to_owned(),
+        kind: ConsentKind::PromoteReceipt,
+        actor: Identity::parse("hmn:tafeng").expect("human"),
+        subject: receipt.payload.target_id_hash.clone(),
+        scope: "tenant=default,workspace=vault-a,entity=ingest,user=hmn:tafeng".to_owned(),
+        op_id: Some(receipt.payload.operation_id.clone()),
+        sensor_id: None,
+        payload,
+        decided_at: Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("decided"),
+        expires_at: Some(receipt.payload.expires_at.clone()),
+    };
+
+    event.validate().expect("journal event valid");
+    let value = serde_json::to_value(&event).expect("json");
+    let serialized = value.to_string();
+    for banned in [
+        "\"body\"",
+        "\"text\"",
+        "\"content\"",
+        "\"raw\"",
+        "\"snippet\"",
+        "\"command\"",
+        "\"url\"",
+        "\"title\"",
+        "\"file_path\"",
+        "\"input\"",
+        "\"message\"",
+    ] {
+        assert!(!serialized.contains(banned), "banned field {banned}");
+    }
+}
+```
+
+Append these imports to `crates/cairn-core/tests/share_link.rs`:
+
+```rust
+use cairn_core::domain::{ConsentEvent, ConsentKind};
+use cairn_core::domain::sharing::ShareLinkJournalDecision;
+```
+
+Append this test:
+
+```rust
+#[test]
+fn share_link_grant_consent_event_is_body_free_and_valid() {
+    let link = signed_link();
+    let (subject, payload) = link.decision_payload(ShareLinkJournalDecision::Grant);
+    let event = ConsentEvent {
+        consent_id: "01HQZX9F5N0000000000000006".to_owned(),
+        kind: ConsentKind::Grant,
+        actor: Identity::parse("hmn:tafeng").expect("human"),
+        subject,
+        scope: "tenant=default,workspace=vault-a,entity=session".to_owned(),
+        op_id: Some(link.payload.operation_id.clone()),
+        sensor_id: None,
+        payload,
+        decided_at: Rfc3339Timestamp::parse("2026-05-21T12:30:00Z").expect("decided"),
+        expires_at: Some(link.payload.expires_at.clone()),
+    };
+
+    event.validate().expect("journal event valid");
+    let serialized = serde_json::to_value(&event).expect("json").to_string();
+    for banned in [
+        "\"body\"",
+        "\"text\"",
+        "\"content\"",
+        "\"raw\"",
+        "\"snippet\"",
+        "\"command\"",
+        "\"url\"",
+        "\"title\"",
+        "\"file_path\"",
+        "\"input\"",
+        "\"message\"",
+    ] {
+        assert!(!serialized.contains(banned), "banned field {banned}");
+    }
+}
+```
+
+- [ ] **Step 2: Run helper tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test sharing_receipt --test share_link
+```
+
+Expected: FAIL with missing `promote_consent_payload`, `ShareLinkJournalDecision`, or `decision_payload`.
+
+- [ ] **Step 3: Implement body-free helper functions**
+
+Add this import to `crates/cairn-core/src/domain/sharing.rs`:
+
+```rust
+use crate::domain::ConsentPayload;
+```
+
+Add this enum and impl block:
+
+```rust
+/// Consent journal decision for a share link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShareLinkJournalDecision {
+    /// Link grant.
+    Grant,
+    /// Link revoke.
+    Revoke,
+}
+
+impl ShareLinkJournalDecision {
+    /// Body-free policy code.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Grant => "grant",
+            Self::Revoke => "revoke",
+        }
+    }
+}
+```
+
+Add this method to `impl PromotionConsentReceipt`:
+
+```rust
+/// Build the body-free `ConsentPayload` for a promotion journal row.
+#[must_use]
+pub fn promote_consent_payload(&self) -> ConsentPayload {
+    ConsentPayload::PromoteReceipt {
+        target_id_hash: self.payload.target_id_hash.clone(),
+        from_tier: self.payload.from_tier,
+        to_tier: self.payload.to_tier,
+        receipt_id: self.receipt_id.clone(),
+    }
+}
+```
+
+Add this method to `impl SignedShareLink`:
+
+```rust
+/// Build the body-free subject and `ConsentPayload` for a share-link journal row.
+#[must_use]
+pub fn decision_payload(&self, decision: ShareLinkJournalDecision) -> (String, ConsentPayload) {
+    (
+        format!("share_link:{}", self.link_id),
+        ConsentPayload::Decision {
+            subject_code: format!("share_link:{}", self.link_id),
+            policy_code: Some(decision.as_str().to_owned()),
+        },
+    )
+}
+```
+
+In `crates/cairn-core/src/domain/mod.rs`, extend sharing re-exports:
+
+```rust
+pub use sharing::{
+    PromotionConsentPayload, PromotionConsentReceipt, PromotionGateInput, ShareLinkGateInput,
+    ShareLinkJournalDecision, ShareLinkPayload, SharingDecisionKind, SharingGateRejection,
+    SharingPolicyAction, SharingPolicySubject, SharingRevocationState, SignedShareLink,
+    verify_promotion_gate, verify_share_link_grant,
+};
+```
+
+- [ ] **Step 4: Run helper tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test sharing_receipt --test share_link
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 5**
+
+Run:
+
+```bash
+git add crates/cairn-core/src/domain/sharing.rs crates/cairn-core/src/domain/mod.rs crates/cairn-core/tests/sharing_receipt.rs crates/cairn-core/tests/share_link.rs
+git commit -m "feat(core): add body-free sharing journal helpers"
+```
+
+---
+
+### Task 6: Full Verification and Cleanup
+
+**Files:**
+- Modify only files already touched if compiler, clippy, or formatting requires local cleanup.
+
+- [ ] **Step 1: Run focused sharing tests**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test sharing_receipt --test share_link
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run policy trace regression tests**
+
+Run:
+
+```bash
+cargo test -p cairn-core --test policy_trace_detail --test policy_trace_gate --test rebac_policy
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full core tests**
+
+Run:
+
+```bash
+cargo test -p cairn-core
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run workspace formatting and boundary checks**
+
+Run:
+
+```bash
+cargo fmt --check
+scripts/check-core-boundary.sh
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Run workspace tests if local time budget allows**
+
+Run:
+
+```bash
+cargo test --workspace
+```
+
+Expected: PASS. If this is too slow or fails in unrelated crates, capture the failing command output and keep the focused `cairn-core` evidence in the final report.
+
+- [ ] **Step 6: Commit cleanup if there were changes**
+
+Run only if Step 1 through Step 5 produced code changes:
+
+```bash
+git add crates/cairn-core/src/domain/sharing.rs crates/cairn-core/src/domain/mod.rs crates/cairn-core/src/policy_trace/gate.rs crates/cairn-core/src/policy_trace/detail.rs crates/cairn-core/tests/policy_trace_gate.rs crates/cairn-core/tests/policy_trace_detail.rs crates/cairn-core/tests/sharing_receipt.rs crates/cairn-core/tests/share_link.rs
+git commit -m "test(core): verify signed sharing gates"
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Signed promotion receipts: Tasks 2 and 3.
+  - Signed share links: Tasks 2 and 4.
+  - Target hashes, scopes, nonces, expirations, and human identities: Tasks 2 through 4.
+  - Expired and mismatched receipt rejection at apply time: Task 3.
+  - Revocation tests: Tasks 3 and 4.
+  - Body-free consent journal metadata: Task 5.
+  - ReBAC dependency from #121: Task 3.
+- Red-flag scan:
+  - The plan contains no deferred implementation notes and no unspecified validation steps.
+- Type consistency:
+  - `PromotionConsentPayload`, `PromotionConsentReceipt`, `ShareLinkPayload`, `SignedShareLink`, `SharingRevocationState`, `PromotionGateInput`, `ShareLinkGateInput`, and `SharingGateRejection` are introduced before later tasks use them.
+  - `SharingDecisionKind` tokens match the policy trace tests.
+  - `ShareLinkJournalDecision` is introduced in Task 5 before tests use it.

--- a/docs/superpowers/specs/2026-05-21-issue-122-share-links-consent-design.md
+++ b/docs/superpowers/specs/2026-05-21-issue-122-share-links-consent-design.md
@@ -1,0 +1,259 @@
+# Signed Share Links and Consent-Gated Promotion Design - Issue #122
+
+**Date:** 2026-05-21
+**Issue:** [#122 - Implement signed share links and consent-gated promotions](https://github.com/windoliver/cairn/issues/122)
+**Brief sections:** section 4.2 Identity; section 5.6 WAL promote; section 11.3 Constraint gates; section 12.a Distribution Model; section 14 Privacy and Consent
+**Dependency:** #121, merged by PR #397, provides the ReBAC shared-tier decision surface this design builds on.
+**Status:** Design approved; written-spec review pending
+
+---
+
+## 1. Scope
+
+Implement the core validation substrate for signed share links and consent-gated promotion into shared tiers. A record may move from local tiers into `project`, `team`, `org`, or `public` only when the apply-time gate sees a fresh, signed, non-revoked, body-free consent receipt that matches the exact target, scope, tier, operation, nonce, expiry, and human identity.
+
+This PR adds:
+
+- A typed promotion consent receipt model.
+- A typed signed share link model for time-bound grants.
+- Canonical hashing and Ed25519 verification helpers for those payloads.
+- Apply-time validation that rejects expired, mismatched, malformed, non-human, or revoked receipts.
+- Body-free policy trace details for consent and share-link decisions.
+- Tests for valid signatures, tampering, expiry, mismatch, revocation, and body-free persistence.
+
+Out of scope: org-wide propagation policy UI, hub transport, public indexing, and a full `promote` CLI command. This design focuses on the core rules and pure data needed by the WAL/store workflow to safely call `policy.verify_receipt`.
+
+---
+
+## 2. Architecture
+
+The implementation stays inside the existing boundaries.
+
+| Layer | Location | Responsibility |
+|---|---|---|
+| Receipt and link domain types | `cairn-core::domain::sharing` | Pure serde data, canonical payload bytes, validation, no I/O. |
+| Signature verification | `cairn-core::domain::sharing` using existing `ed25519-dalek` dependency | Verify detached Ed25519 signatures over canonical bytes. |
+| Apply-time gate | `cairn-core::domain::sharing::PromotionGate` | Check receipt/link freshness, hash binding, scope binding, human signer, tier, nonce, revocation, and ReBAC relation. |
+| Policy trace vocabulary | `cairn-core::policy_trace` | Body-free gate/detail strings for allow and deny reasons. |
+| Consent journal payload | `cairn-core::domain::consent` | Store only receipt ids, target id hashes, tiers, and symbolic codes. |
+
+`cairn-core` remains pure: no keychain lookup, no wall-clock source, no DB writes. Callers pass the current timestamp, verifying key, revocation state, and existing ReBAC context into the gate. The SQLite/WAL layer remains responsible for atomic `primary.update_tier`, `rebac.add_relation`, and `consent_journal.append(promote)` as described in section 5.6.
+
+---
+
+## 3. Promotion Consent Receipt
+
+The receipt is a detached-signature envelope. Field order is stable and used for canonical JSON. The signature covers every payload field except the signature itself.
+
+```rust
+pub struct PromotionConsentReceipt {
+    pub receipt_id: String,
+    pub payload: PromotionConsentPayload,
+    pub signature: Ed25519Signature,
+}
+
+pub struct PromotionConsentPayload {
+    pub operation_id: String,
+    pub nonce: String,
+    pub chain_parents: Vec<String>,
+    pub target_hash: String,
+    pub target_id_hash: String,
+    pub from_tier: MemoryVisibility,
+    pub to_tier: MemoryVisibility,
+    pub scope: ScopeTuple,
+    pub human_identity: Identity,
+    pub issued_at: Rfc3339Timestamp,
+    pub expires_at: Rfc3339Timestamp,
+    pub key_version: u32,
+}
+```
+
+Validation rules:
+
+- `human_identity` must be a human identity (`hmn:` on `origin/main`).
+- `to_tier` must be broader than `from_tier`.
+- `to_tier` must be one of `project`, `team`, `org`, or `public`.
+- `target_hash` must be `sha256:<64 lowercase hex>` and must match the canonical hash of the record being promoted.
+- `target_id_hash` must match the consent journal hash grammar: either `sha256:<64 lowercase hex>` or `hash:<32..=128 lowercase hex>`. Raw record ids are rejected.
+- `nonce` must be a 16-byte base64 nonce using the same shape as signed intents.
+- `operation_id` must be ULID-shaped and must match the WAL operation being applied.
+- `expires_at` must be after `issued_at`, and the current apply-time instant must be before `expires_at`.
+- `chain_parents` must contain no more than 64 unique ULID-shaped ids.
+- The receipt must not contain body, text, URL, title, command, raw content, or other banned content-bearing fields.
+
+The gate re-checks all rules at apply time. A receipt that was valid when proposed but expired before WAL apply is rejected.
+
+---
+
+## 4. Signed Share Links
+
+A share link is a grant token for read access to a record set, session, or scope. It is tamper-evident and revocable. It does not itself promote the record; it authorizes a bounded share/grant relation that the propagation or retrieve path can evaluate.
+
+```rust
+pub struct SignedShareLink {
+    pub link_id: String,
+    pub payload: ShareLinkPayload,
+    pub signature: Ed25519Signature,
+}
+
+pub struct ShareLinkPayload {
+    pub operation_id: String,
+    pub nonce: String,
+    pub target_hash: String,
+    pub target_id_hashes: Vec<String>,
+    pub scope: ScopeTuple,
+    pub grant_tier: MemoryVisibility,
+    pub grantee: Option<Identity>,
+    pub issuer: Identity,
+    pub issued_at: Rfc3339Timestamp,
+    pub expires_at: Rfc3339Timestamp,
+    pub key_version: u32,
+}
+```
+
+Validation rules:
+
+- `issuer` must be the human who granted sharing.
+- `grant_tier` must be shared (`project`, `team`, `org`, `public`) and must not exceed the issuer's authorized tier.
+- `target_hash` binds the link to the grant payload or record-set manifest, not to display text.
+- `target_id_hashes` must each match `sha256:<64 lowercase hex>` or `hash:<32..=128 lowercase hex>`. The link never stores raw ids or body bytes.
+- `grantee`, when present, must be a parseable human or agent identity. An absent grantee means bearer-style access, still bounded by expiry and revocation.
+- Revocation is checked by `link_id` and by issuer key revocation state before any relation is honored.
+
+Share links write `ConsentKind::Grant` / `ConsentKind::Revoke` journal entries with `subject_code = "share_link:<link_id>"`. The payload remains symbolic and body-free.
+
+---
+
+## 5. Apply-Time Promotion Gate
+
+The promotion gate takes explicit inputs:
+
+```rust
+pub struct PromotionGateInput<'a> {
+    pub record: &'a MemoryRecord,
+    pub from_tier: MemoryVisibility,
+    pub to_tier: MemoryVisibility,
+    pub receipt: &'a PromotionConsentReceipt,
+    pub now: &'a Rfc3339Timestamp,
+    pub operation_id: &'a str,
+    pub signer_key: &'a ed25519_dalek::VerifyingKey,
+    pub revocation: &'a SharingRevocationState,
+    pub rebac: &'a RebacContext,
+}
+
+pub struct SharingRevocationState {
+    pub revoked_receipt_ids: BTreeSet<String>,
+    pub revoked_share_link_ids: BTreeSet<String>,
+    pub signer_key_revoked: bool,
+}
+```
+
+The gate evaluates in this order:
+
+1. Shape validation: receipt id, nonce, operation id, timestamps, tiers, and banned fields.
+2. Signature validation: canonical receipt payload verifies against `signer_key`.
+3. Human binding: receipt signer is the payload's `human_identity`.
+4. Target binding: `receipt.payload.target_hash` equals `CanonicalRecordHash::compute(record)`.
+5. Scope binding: receipt scope equals the record's tenant/workspace/entity and identity scope relevant to the promotion.
+6. Tier binding: receipt `from_tier`/`to_tier` equals the requested promotion.
+7. Freshness: `now < expires_at`.
+8. Revocation: receipt id is absent from `revoked_receipt_ids` and `signer_key_revoked` is false.
+9. ReBAC: existing #121 context allows a write relation for the requested shared tier.
+
+Any denial returns a typed error and a body-free policy trace detail. The gate does not mutate state. The WAL/store layer calls it immediately before the atomic transaction that updates the tier, adds the ReBAC relation, and appends the consent journal row.
+
+---
+
+## 6. Policy Trace and Errors
+
+Add policy trace vocabulary without leaking user content:
+
+- Gate: `consent_receipt`
+- Gate: `share_link`
+- Details:
+  - `consent:promote:allowed`
+  - `consent:promote:expired`
+  - `consent:promote:target_mismatch`
+  - `consent:promote:scope_mismatch`
+  - `consent:promote:tier_mismatch`
+  - `consent:promote:bad_signature`
+  - `consent:promote:revoked`
+  - `consent:promote:not_human`
+  - `share_link:grant:allowed`
+  - `share_link:grant:expired`
+  - `share_link:grant:revoked`
+  - `share_link:grant:target_mismatch`
+
+Errors should use existing `DomainError` variants where they already fit (`InvalidSignature`, `ExpiredIntent`, `ScopeDenied`, `Unauthorized`). If the existing variants produce ambiguous call-site logic, add narrow variants for promotion receipts and share links with symbolic messages only.
+
+---
+
+## 7. Consent Journal Privacy
+
+Promotion consent journal rows use the existing body-free `ConsentKind::PromoteReceipt` payload:
+
+```rust
+ConsentPayload::PromoteReceipt {
+    target_id_hash,
+    from_tier,
+    to_tier,
+    receipt_id,
+}
+```
+
+Share links use the existing `Decision` payload:
+
+```rust
+ConsentPayload::Decision {
+    subject_code: format!("share_link:{link_id}"),
+    policy_code: Some("grant" | "revoke"),
+}
+```
+
+No receipt, share-link, or journal payload may serialize banned field names such as `body`, `text`, `content`, `raw`, `snippet`, `command`, `url`, `title`, `file_path`, `input`, `payload_text`, `user_input`, or `message`.
+
+---
+
+## 8. Testing
+
+Tests are written first.
+
+Core receipt tests:
+
+- A well-formed promotion receipt verifies and authorizes `private -> team`.
+- Tampering with `target_hash`, scope, nonce, operation id, tier, or human identity fails verification or apply-time validation.
+- An expired receipt fails at apply time even if the signature is valid.
+- A revoked receipt id fails closed.
+- A non-human issuer cannot authorize shared-tier promotion.
+- Receipt serialization does not contain banned body-bearing fields.
+
+Share-link tests:
+
+- A well-formed share link verifies and produces an allowed grant decision.
+- Tampering with target hashes, scope, grant tier, expiry, or issuer fails.
+- Revoked link ids fail closed.
+- Bearer-style links still require expiry and revocation checks.
+- Share-link journal events remain body-free.
+
+ReBAC integration tests:
+
+- A valid receipt without a matching ReBAC write relation still denies promotion.
+- A valid receipt plus matching write relation allows promotion.
+- `private` and `session` behavior remain unchanged.
+
+Verification commands:
+
+- `cargo test -p cairn-core sharing`
+- `cargo test -p cairn-core rebac_policy`
+- `cargo test -p cairn-core policy_trace`
+- `cargo test --workspace`
+- `cargo fmt --check`
+- `scripts/check-core-boundary.sh`
+
+---
+
+## 9. Open Constraints
+
+This design assumes the implementation branch is based on `origin/main` at or after merge commit `6206217c`, where #121 introduced `crate::rebac` and body-free ReBAC policy traces. Implementing from the older detached checkout would require redoing that prerequisite work and would create an unnecessary merge conflict.
+
+The exact CLI and MCP shape for user-facing `cairn share` / `cairn promote` is intentionally not specified here. The core model must land first so later surfaces can reuse one policy implementation rather than recreating consent rules in adapters.


### PR DESCRIPTION
## Summary
- Adds body-free sharing policy trace vocabulary for promotion consent receipts and signed share-link grants.
- Adds signed promotion consent receipt and share-link payload validation, issuer/signer context binding, revocation checks, and gate decisions.
- Adds body-free journal helpers plus focused coverage for shape validation, signature/context mismatches, revocation, and policy trace serialization.

Closes #122.

## Verification
- `cargo test -p cairn-core --test sharing_receipt --test share_link`
- `cargo test -p cairn-core --test policy_trace_detail --test policy_trace_gate --test rebac_policy`
- `scripts/check-core-boundary.sh`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p cairn-core`
- `cargo test --workspace`
