### PR TITLE
[codex] Add OpenCode memory import bridge

### DIFF
--- a/crates/cairn-cli/src/import.rs
+++ b/crates/cairn-cli/src/import.rs
@@ -21,6 +21,8 @@ const KOI_IMPORT_AUTHOR: &str = "hmn:koi-import:v1";
 const KOI_IMPORT_SENSOR: &str = "snr:koi-v1:import:local:v1";
 const ROWBOAT_IMPORT_AUTHOR: &str = "hmn:rowboat-import:v1";
 const ROWBOAT_IMPORT_SENSOR: &str = "snr:rowboat:import:local:v1";
+const OPENCODE_IMPORT_AUTHOR: &str = "hmn:opencode-import:v1";
+const OPENCODE_IMPORT_SENSOR: &str = "snr:opencode:import:local:v1";
 const SOURCE_HASH_PREFIX: &str = "sha256:";
 
 /// Build the `cairn import` CLI subcommand.
@@ -33,7 +35,7 @@ pub fn command() -> clap::Command {
                 .long("from")
                 .required(true)
                 .value_name("SYSTEM")
-                .value_parser(["koi-v1", "rowboat"])
+                .value_parser(["koi-v1", "rowboat", "opencode"])
                 .help("Legacy memory system to import"),
         )
         .arg(
@@ -86,7 +88,12 @@ pub fn run(sub: &clap::ArgMatches, vault_root: &Path) -> std::process::ExitCode 
             batch_size,
             mode: FlushMode::HumanReview,
         }),
-        _ => return usage_error(json, "from", "unsupported import system"),
+        "opencode" => map_opencode_archive(&OpenCodeImportOptions {
+            source: archive.clone(),
+            batch_size,
+            mode: FlushMode::HumanReview,
+        }),
+        _ => return usage_error(json, "from", "unsupported import source"),
     };
     match report.and_then(|report| {
         let migration_report = MigrationReportSummary::from_report(&report);
@@ -226,6 +233,17 @@ pub struct RowboatImportOptions {
     /// Maximum records per generated review plan.
     pub batch_size: usize,
     /// Plan dispatch mode. Issue #155 uses [`FlushMode::HumanReview`].
+    pub mode: FlushMode,
+}
+
+/// Options for mapping an OpenCode archive into Cairn review plans.
+#[derive(Debug, Clone)]
+pub struct OpenCodeImportOptions {
+    /// Path to an OpenCode project/session archive root.
+    pub source: PathBuf,
+    /// Maximum records per generated review plan.
+    pub batch_size: usize,
+    /// Plan dispatch mode. Issue #156 uses [`FlushMode::HumanReview`].
     pub mode: FlushMode,
 }
 
@@ -558,6 +576,109 @@ pub fn map_rowboat_archive(opts: &RowboatImportOptions) -> Result<KoiImportRepor
     Ok(KoiImportReport {
         manifest: ExternalImportManifest {
             system: "rowboat".to_owned(),
+            items,
+            unsupported_fields,
+            privacy_sensitive_fields,
+        },
+        records,
+        ambiguities,
+        findings,
+        plans,
+    })
+}
+
+/// Map OpenCode project instructions, session parts, and compaction summaries
+/// into valid Cairn records and pending review plans.
+///
+/// This bridge performs no database writes. The resulting plans can be reviewed
+/// and later applied through the ordinary flush path.
+pub fn map_opencode_archive(opts: &OpenCodeImportOptions) -> Result<KoiImportReport, ImportError> {
+    if opts.batch_size == 0 {
+        return Err(ImportError::InvalidBatchSize);
+    }
+    if !opts.source.is_dir() {
+        return Err(ImportError::SourceNotDirectory {
+            archive: opts.source.clone(),
+        });
+    }
+
+    let mut records = Vec::new();
+    let mut ambiguities = Vec::new();
+    let mut findings = Vec::new();
+    let mut items = Vec::new();
+    for entry in WalkDir::new(&opts.source)
+        .sort_by_file_name()
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_file())
+    {
+        let path = entry.path();
+        let relative = path.strip_prefix(&opts.source).unwrap_or(path);
+        let raw = fs::read_to_string(path).map_err(|source| ImportError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let mapped = if is_opencode_instruction_file(path) {
+            let kind = match path.file_name().and_then(|name| name.to_str()) {
+                Some("AGENTS.md") => MemoryKind::Project,
+                Some("CLAUDE.md" | "CONTEXT.md") => MemoryKind::Rule,
+                _ => MemoryKind::Reference,
+            };
+            vec![map_opencode_record(
+                relative,
+                "instruction",
+                raw.trim().to_owned(),
+                kind,
+                None,
+                None,
+                Vec::new(),
+                Vec::new(),
+                BTreeMap::new(),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )?]
+        } else if path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext == "json")
+        {
+            map_opencode_json(path, relative, &raw)?
+        } else {
+            continue;
+        };
+
+        for mapped_file in mapped {
+            ambiguities.extend(mapped_file.ambiguities);
+            findings.extend(mapped_file.findings);
+            items.extend(mapped_file.items);
+            records.push(mapped_file.record);
+        }
+    }
+
+    let plans = plan_records_for_system(
+        &opts.source,
+        &records,
+        opts.batch_size,
+        opts.mode,
+        OPENCODE_IMPORT_AUTHOR,
+        "opencode",
+    )?;
+    let unsupported_fields = findings
+        .iter()
+        .filter(|finding| finding.kind == ExternalImportFindingKind::Unsupported)
+        .cloned()
+        .collect();
+    let privacy_sensitive_fields = findings
+        .iter()
+        .filter(|finding| finding.kind == ExternalImportFindingKind::PrivacySensitive)
+        .cloned()
+        .collect();
+    Ok(KoiImportReport {
+        manifest: ExternalImportManifest {
+            system: "opencode".to_owned(),
             items,
             unsupported_fields,
             privacy_sensitive_fields,
@@ -1034,6 +1155,411 @@ fn is_importable(path: &Path) -> bool {
     )
 }
 
+fn is_opencode_instruction_file(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some("AGENTS.md" | "CLAUDE.md" | "CONTEXT.md")
+    )
+}
+
+fn map_opencode_json(
+    _path: &Path,
+    relative: &Path,
+    raw: &str,
+) -> Result<Vec<MappedFile>, ImportError> {
+    let json = serde_json::from_str::<Value>(raw).map_err(|source| ImportError::Json {
+        path: relative.to_path_buf(),
+        source,
+    })?;
+    let session_id = session_ids_from_json(Some(&json)).into_iter().next();
+    let scope_tenant = scope_string(json.get("scope"), "tenant");
+    let scope_workspace = scope_string(json.get("scope"), "workspace");
+    let scope_entity = scope_string(json.get("scope"), "entity");
+    let scope_user = scope_string(json.get("scope"), "user");
+    let scope_agent = scope_string(json.get("scope"), "agent");
+    let created_at = json
+        .get("created_at")
+        .or_else(|| json.get("updated_at"))
+        .and_then(Value::as_str);
+    let mut mapped = Vec::new();
+    if let Some(summary) = json
+        .get("summary")
+        .or_else(|| json.get("compaction_summary"))
+    {
+        mapped.extend(map_opencode_summary(
+            relative,
+            summary,
+            session_id.as_deref(),
+            created_at,
+            scope_tenant.as_deref(),
+            scope_workspace.as_deref(),
+            scope_entity.as_deref(),
+            scope_user.as_deref(),
+            scope_agent.as_deref(),
+        )?);
+    }
+    if let Some(parts) = json.get("parts").and_then(Value::as_array) {
+        for (idx, part) in parts.iter().enumerate() {
+            let body = part_text(part)
+                .or_else(|| serde_json::to_string(part).ok())
+                .unwrap_or_default();
+            if body.trim().is_empty() {
+                continue;
+            }
+            let mut extra = BTreeMap::new();
+            extra.insert(
+                "opencode_part_order".to_owned(),
+                serde_json::json!(idx as u64),
+            );
+            if let Some(part_type) = part
+                .get("type")
+                .or_else(|| part.get("role"))
+                .and_then(Value::as_str)
+            {
+                extra.insert(
+                    "opencode_part_type".to_owned(),
+                    Value::String(part_type.to_owned()),
+                );
+            }
+            if let Some(tool) = part.get("tool").and_then(Value::as_str) {
+                extra.insert("opencode_tool".to_owned(), Value::String(tool.to_owned()));
+            }
+            mapped.push(map_opencode_record(
+                relative,
+                &format!("part-{idx}"),
+                body.trim().to_owned(),
+                MemoryKind::Trace,
+                created_at,
+                session_id.as_deref(),
+                Vec::new(),
+                opencode_skill_ids(part),
+                extra,
+                scope_tenant.as_deref(),
+                scope_workspace.as_deref(),
+                scope_entity.as_deref(),
+                scope_user.as_deref(),
+                scope_agent.as_deref(),
+            )?);
+        }
+    }
+    if mapped.is_empty() {
+        mapped.push(map_opencode_record(
+            relative,
+            "json",
+            extract_body(&json).unwrap_or_else(|| raw.trim().to_owned()),
+            MemoryKind::Reference,
+            created_at,
+            session_id.as_deref(),
+            Vec::new(),
+            Vec::new(),
+            BTreeMap::new(),
+            scope_tenant.as_deref(),
+            scope_workspace.as_deref(),
+            scope_entity.as_deref(),
+            scope_user.as_deref(),
+            scope_agent.as_deref(),
+        )?);
+    }
+    let file_findings = findings_from_file(Some(&json), relative, &[]);
+    for mapped_file in &mut mapped {
+        mapped_file.findings.extend(file_findings.clone());
+    }
+    Ok(mapped)
+}
+
+fn map_opencode_summary(
+    relative: &Path,
+    summary: &Value,
+    session_id: Option<&str>,
+    created_at: Option<&str>,
+    scope_tenant: Option<&str>,
+    scope_workspace: Option<&str>,
+    scope_entity: Option<&str>,
+    scope_user: Option<&str>,
+    scope_agent: Option<&str>,
+) -> Result<Vec<MappedFile>, ImportError> {
+    let Some(map) = summary.as_object() else {
+        return Ok(Vec::new());
+    };
+    let fields = [
+        ("Goal", MemoryKind::User, "summary-goal"),
+        ("goal", MemoryKind::User, "summary-goal"),
+        ("Constraints", MemoryKind::Rule, "summary-constraints"),
+        ("constraints", MemoryKind::Rule, "summary-constraints"),
+        ("Progress", MemoryKind::StrategySuccess, "summary-progress"),
+        ("progress", MemoryKind::StrategySuccess, "summary-progress"),
+        (
+            "Decisions",
+            MemoryKind::StrategySuccess,
+            "summary-decisions",
+        ),
+        (
+            "decisions",
+            MemoryKind::StrategySuccess,
+            "summary-decisions",
+        ),
+    ];
+    let mut seen = BTreeSet::new();
+    let mut records = Vec::new();
+    for (field, kind, role) in fields {
+        if seen.contains(role) {
+            continue;
+        }
+        let Some(value) = map.get(field) else {
+            continue;
+        };
+        let Some(body) = summary_field_text(value) else {
+            continue;
+        };
+        seen.insert(role);
+        let mut extra = BTreeMap::new();
+        extra.insert(
+            "opencode_summary_field".to_owned(),
+            Value::String(field.to_owned()),
+        );
+        records.push(map_opencode_record(
+            relative,
+            role,
+            body,
+            kind,
+            created_at,
+            session_id,
+            Vec::new(),
+            Vec::new(),
+            extra,
+            scope_tenant,
+            scope_workspace,
+            scope_entity,
+            scope_user,
+            scope_agent,
+        )?);
+    }
+    Ok(records)
+}
+
+fn part_text(part: &Value) -> Option<String> {
+    ["text", "content", "body", "message"]
+        .iter()
+        .find_map(|key| part.get(*key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|body| !body.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn summary_field_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => {
+            let text = text.trim();
+            (!text.is_empty()).then(|| text.to_owned())
+        }
+        Value::Array(items) => {
+            let lines = items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(|line| format!("- {line}"))
+                .collect::<Vec<_>>();
+            (!lines.is_empty()).then(|| lines.join("\n"))
+        }
+        _ => None,
+    }
+}
+
+fn opencode_skill_ids(part: &Value) -> Vec<String> {
+    let mut ids = BTreeSet::new();
+    if part
+        .get("tool")
+        .and_then(Value::as_str)
+        .is_some_and(|tool| tool == "skill")
+    {
+        ids.insert("skill".to_owned());
+    }
+    if let Some(skills) = part.get("skills") {
+        ids.extend(id_values(skills));
+    }
+    ids.into_iter().collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn map_opencode_record(
+    relative: &Path,
+    role: &str,
+    body: String,
+    kind: MemoryKind,
+    created_at: Option<&str>,
+    session_id: Option<&str>,
+    tags: Vec<String>,
+    skill_ids: Vec<String>,
+    mut extra_frontmatter: BTreeMap<String, Value>,
+    scope_tenant: Option<&str>,
+    scope_workspace: Option<&str>,
+    scope_entity: Option<&str>,
+    scope_user: Option<&str>,
+    scope_agent: Option<&str>,
+) -> Result<MappedFile, ImportError> {
+    let body_hash = format!("{:x}", Sha256::digest(body.as_bytes()));
+    extra_frontmatter.insert(
+        "opencode_source_path".to_owned(),
+        Value::String(slash_normalized_path(relative)),
+    );
+    extra_frontmatter.insert(
+        "opencode_body_hash".to_owned(),
+        Value::String(body_hash.clone()),
+    );
+    extra_frontmatter.insert(
+        "opencode_record_role".to_owned(),
+        Value::String(role.to_owned()),
+    );
+    if let Some(session_id) = session_id {
+        extra_frontmatter.insert(
+            "opencode_session_id".to_owned(),
+            Value::String(session_id.to_owned()),
+        );
+    }
+    let issued_at = Rfc3339Timestamp::parse(
+        created_at
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("2026-01-01T00:00:00Z")
+            .to_owned(),
+    )
+    .map_err(|source| ImportError::Domain {
+        path: relative.to_path_buf(),
+        source,
+    })?;
+    let author = Identity::parse(OPENCODE_IMPORT_AUTHOR).map_err(|source| ImportError::Domain {
+        path: relative.to_path_buf(),
+        source,
+    })?;
+    let identity_seed = format!(
+        "opencode:{}:{role}:{body_hash}",
+        slash_normalized_path(relative)
+    );
+    let source_id =
+        SourceId::parse(deterministic_ulid(&identity_seed, "source").0).map_err(|source| {
+            ImportError::Domain {
+                path: relative.to_path_buf(),
+                source,
+            }
+        })?;
+    let source_ref_id = source_id.as_str().to_owned();
+    let source_hash = format!("{SOURCE_HASH_PREFIX}{body_hash}");
+    let record = MemoryRecord {
+        id: RecordId::parse(deterministic_ulid(&identity_seed, "record").0).map_err(|source| {
+            ImportError::Domain {
+                path: relative.to_path_buf(),
+                source,
+            }
+        })?,
+        target_id: TargetId::parse(deterministic_ulid(&identity_seed, "target").0).map_err(
+            |source| ImportError::Domain {
+                path: relative.to_path_buf(),
+                source,
+            },
+        )?,
+        kind,
+        class: class_for_kind(kind),
+        visibility: MemoryVisibility::Private,
+        scope: ScopeTuple {
+            tenant: scope_tenant.map(ToOwned::to_owned),
+            workspace: scope_workspace.map(ToOwned::to_owned),
+            entity: scope_entity.map(ToOwned::to_owned),
+            session_id: session_id.map(ToOwned::to_owned),
+            user: scope_user
+                .filter(|user| user.starts_with("hmn:"))
+                .map(ToOwned::to_owned)
+                .or_else(|| Some(OPENCODE_IMPORT_AUTHOR.to_owned())),
+            agent: scope_agent
+                .filter(|agent| agent.starts_with("agt:"))
+                .map(ToOwned::to_owned),
+            ..ScopeTuple::default()
+        },
+        body,
+        source_ids: vec![source_id.clone()],
+        provenance: Provenance {
+            source_sensor: Identity::parse(OPENCODE_IMPORT_SENSOR).map_err(|source| {
+                ImportError::Domain {
+                    path: relative.to_path_buf(),
+                    source,
+                }
+            })?,
+            created_at: issued_at.clone(),
+            originating_agent_id: author.clone(),
+            source_ids: vec![source_id],
+            source_hash: source_hash.clone(),
+            consent_ref: "consent:opencode-import".to_owned(),
+            llm_id_if_any: None,
+            source_refs: vec![SourceRef {
+                id: source_ref_id,
+                hash: source_hash,
+            }],
+        },
+        updated_at: issued_at.clone(),
+        evidence: EvidenceVector::default(),
+        salience: 0.5,
+        confidence: 0.7,
+        actor_chain: vec![ActorChainEntry {
+            role: ChainRole::Author,
+            identity: author,
+            at: issued_at,
+        }],
+        signature: cairn_core::domain::record::Ed25519Signature::parse(format!(
+            "ed25519:{}",
+            "c".repeat(128)
+        ))
+        .map_err(|source| ImportError::Domain {
+            path: relative.to_path_buf(),
+            source,
+        })?,
+        tags,
+        extra_frontmatter,
+        consent_model: None,
+    };
+    record.validate().map_err(|source| ImportError::Domain {
+        path: relative.to_path_buf(),
+        source,
+    })?;
+    let item = ExternalImportItem {
+        kind: ExternalImportItemKind::Record,
+        source_path: relative.to_path_buf(),
+        legacy_id: Some(format!("opencode:{role}")),
+        session_ids: session_id.into_iter().map(ToOwned::to_owned).collect(),
+        skill_ids,
+        provenance: ExternalImportProvenance {
+            source_sensor: OPENCODE_IMPORT_SENSOR.to_owned(),
+            source_hash: record.provenance.source_hash.clone(),
+            source_refs: record.provenance.source_refs.clone(),
+        },
+    };
+    let mut items = vec![item.clone()];
+    items.extend(
+        item.session_ids
+            .iter()
+            .map(|session_id| ExternalImportItem {
+                kind: ExternalImportItemKind::Session,
+                source_path: item.source_path.clone(),
+                legacy_id: Some(session_id.clone()),
+                session_ids: vec![session_id.clone()],
+                skill_ids: Vec::new(),
+                provenance: item.provenance.clone(),
+            }),
+    );
+    items.extend(item.skill_ids.iter().map(|skill_id| ExternalImportItem {
+        kind: ExternalImportItemKind::Skill,
+        source_path: item.source_path.clone(),
+        legacy_id: Some(skill_id.clone()),
+        session_ids: Vec::new(),
+        skill_ids: vec![skill_id.clone()],
+        provenance: item.provenance.clone(),
+    }));
+    Ok(MappedFile {
+        record,
+        ambiguities: Vec::new(),
+        findings: Vec::new(),
+        items,
+    })
+}
+
 #[allow(clippy::too_many_lines)]
 fn map_file(path: &Path, root: &Path, raw: &str) -> Result<MappedFile, ImportError> {
     let relative = path.strip_prefix(root).unwrap_or(path);
@@ -1445,8 +1971,26 @@ fn plan_records(
     batch_size: usize,
     mode: FlushMode,
 ) -> Result<Vec<FlushPlan>, ImportError> {
+    plan_records_for_system(
+        source_root,
+        records,
+        batch_size,
+        mode,
+        author_identity,
+        system,
+    )
+}
+
+fn plan_records_for_system(
+    source_root: &Path,
+    records: &[MemoryRecord],
+    batch_size: usize,
+    mode: FlushMode,
+    author_id: &str,
+    system: &str,
+) -> Result<Vec<FlushPlan>, ImportError> {
     let mut plans = Vec::new();
-    let author = Identity::parse(author_identity).map_err(|source| ImportError::Domain {
+    let author = Identity::parse(author_id).map_err(|source| ImportError::Domain {
         path: source_root.to_path_buf(),
         source,
     })?;
@@ -1455,7 +1999,7 @@ fn plan_records(
         let expires_at = (chrono::Utc::now() + chrono::Duration::minutes(5))
             .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
         plans.push(FlushPlan {
-            operation_id: deterministic_operation_id(system, source_root, idx, chunk),
+            operation_id: deterministic_operation_id(source_root, system, idx, chunk),
             issued_at,
             issuer: author.clone(),
             principal: None,
@@ -1481,8 +2025,8 @@ fn plan_records(
 }
 
 fn deterministic_operation_id(
-    system: &str,
     source_root: &Path,
+    system: &str,
     batch_index: usize,
     records: &[MemoryRecord],
 ) -> Ulid {
@@ -1839,5 +2383,150 @@ mod tests {
             report.records[0].provenance.source_hash,
             report.records[1].provenance.source_hash
         );
+    }
+
+    #[test]
+    fn opencode_import_maps_instructions_summaries_and_session_parts() {
+        let archive = tempfile::tempdir().expect("archive");
+        fs::write(
+            archive.path().join("AGENTS.md"),
+            "# Project Memory\n\nUse deterministic import review plans.",
+        )
+        .expect("write agents");
+        fs::write(
+            archive.path().join("CLAUDE.md"),
+            "# Rules\n\nNever write directly to the memory store during migration.",
+        )
+        .expect("write claude");
+        fs::create_dir_all(archive.path().join("sessions")).expect("sessions dir");
+        fs::write(
+            archive.path().join("sessions").join("session.json"),
+            r#"{
+              "id": "ses_01",
+              "session_id": "ses_01",
+              "created_at": "2026-04-01T10:00:00Z",
+              "summary": {
+                "Goal": "Build an OpenCode bridge.",
+                "Constraints": ["Preserve ordering.", "No direct DB writes."],
+                "Progress": "Mapped session parts into trace records.",
+                "Decisions": ["Use reviewable FlushPlans."]
+              },
+              "parts": [
+                {"id": "p1", "type": "user", "text": "Please import OpenCode memory."},
+                {"id": "p2", "type": "tool", "tool": "skill", "text": "Loaded migration skill."},
+                {"id": "p3", "type": "assistant", "text": "Drafted an import plan."}
+              ],
+              "unsupported_private_state": true,
+              "api_token": "redacted-before-review"
+            }"#,
+        )
+        .expect("write session");
+
+        let report = super::map_opencode_archive(&super::OpenCodeImportOptions {
+            source: archive.path().to_path_buf(),
+            batch_size: 64,
+            mode: FlushMode::HumanReview,
+        })
+        .expect("map opencode archive");
+
+        assert_eq!(report.manifest.system, "opencode");
+        assert_eq!(report.records.len(), 9);
+        assert!(
+            report
+                .records
+                .iter()
+                .all(|record| record.validate().is_ok())
+        );
+        assert!(report.records.iter().any(|record| {
+            record.kind == MemoryKind::Project && record.body.contains("Project Memory")
+        }));
+        assert!(report.records.iter().any(|record| {
+            record.kind == MemoryKind::Rule && record.body.contains("Never write directly")
+        }));
+        assert!(report.records.iter().any(|record| {
+            record.kind == MemoryKind::User && record.body.contains("Build an OpenCode bridge")
+        }));
+        assert!(report.records.iter().any(|record| {
+            record.kind == MemoryKind::StrategySuccess
+                && record.body.contains("Use reviewable FlushPlans")
+        }));
+        let trace_orders = report
+            .records
+            .iter()
+            .filter(|record| record.kind == MemoryKind::Trace)
+            .map(|record| {
+                record.extra_frontmatter["opencode_part_order"]
+                    .as_u64()
+                    .expect("part order")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(trace_orders, vec![0, 1, 2]);
+        assert!(report.manifest.items.iter().any(|item| {
+            item.kind == ExternalImportItemKind::Session
+                && item.legacy_id.as_deref() == Some("ses_01")
+        }));
+        assert!(report.manifest.items.iter().any(|item| {
+            item.kind == ExternalImportItemKind::Skill && item.legacy_id.as_deref() == Some("skill")
+        }));
+        assert!(
+            report.findings.iter().any(|finding| {
+                finding.kind == ExternalImportFindingKind::Unsupported
+                    && finding.field == "unsupported_private_state"
+            }),
+            "unsupported OpenCode fields should be review findings: {:?}",
+            report.findings
+        );
+        assert!(
+            report.findings.iter().any(|finding| {
+                finding.kind == ExternalImportFindingKind::PrivacySensitive
+                    && finding.field == "api_token"
+            }),
+            "privacy fields should be review findings: {:?}",
+            report.findings
+        );
+        assert!(
+            report
+                .plans
+                .iter()
+                .all(|plan| plan.mode == FlushMode::HumanReview)
+        );
+    }
+
+    #[test]
+    fn opencode_cli_writes_pending_review_plans_and_source_artifacts() {
+        let archive = tempfile::tempdir().expect("archive");
+        fs::write(
+            archive.path().join("AGENTS.md"),
+            "Project purpose from OpenCode.",
+        )
+        .expect("write agents");
+        let vault = tempfile::tempdir().expect("vault");
+
+        let report = super::map_opencode_archive(&super::OpenCodeImportOptions {
+            source: archive.path().to_path_buf(),
+            batch_size: 1,
+            mode: FlushMode::HumanReview,
+        })
+        .expect("map opencode archive");
+        let written = write_review_plans(vault.path(), &report).expect("write plans");
+
+        assert_eq!(written.len(), 1);
+        let source_id = report.records[0].provenance.source_ids[0].as_str();
+        assert_eq!(
+            fs::read_to_string(vault.path().join(source_id)).expect("source artifact"),
+            report.records[0].body
+        );
+        let plan_path = written[0].join(format!("{}.plan.json", report.plans[0].operation_id.0));
+        let raw = fs::read_to_string(plan_path).expect("plan json");
+        let persisted: cairn_core::domain::flush_plan::PersistedPlan =
+            serde_json::from_str(&raw).expect("persisted plan");
+        assert!(matches!(
+            persisted.status,
+            cairn_core::domain::flush_plan::PlanStatus::Pending
+        ));
+        assert!(matches!(
+            persisted.plan.mutations.first(),
+            Some(PlannedMutation::Upsert { .. })
+        ));
     }
 }

--- a/crates/cairn-cli/src/import.rs
+++ b/crates/cairn-cli/src/import.rs
@@ -614,11 +614,19 @@ pub fn map_opencode_archive(opts: &OpenCodeImportOptions) -> Result<KoiImportRep
     {
         let path = entry.path();
         let relative = path.strip_prefix(&opts.source).unwrap_or(path);
+        let is_instruction = is_opencode_instruction_file(path);
+        let is_json = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext == "json");
+        if !is_instruction && !is_json {
+            continue;
+        }
         let raw = fs::read_to_string(path).map_err(|source| ImportError::Io {
             path: path.to_path_buf(),
             source,
         })?;
-        let mapped = if is_opencode_instruction_file(path) {
+        let mapped = if is_instruction {
             let kind = match path.file_name().and_then(|name| name.to_str()) {
                 Some("AGENTS.md") => MemoryKind::Project,
                 Some("CLAUDE.md" | "CONTEXT.md") => MemoryKind::Rule,
@@ -640,14 +648,8 @@ pub fn map_opencode_archive(opts: &OpenCodeImportOptions) -> Result<KoiImportRep
                 None,
                 None,
             )?]
-        } else if path
-            .extension()
-            .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| ext == "json")
-        {
-            map_opencode_json(path, relative, &raw)?
         } else {
-            continue;
+            map_opencode_json(path, relative, &raw)?
         };
 
         for mapped_file in mapped {
@@ -1261,8 +1263,8 @@ fn map_opencode_json(
         )?);
     }
     let file_findings = findings_from_file(Some(&json), relative, &[]);
-    for mapped_file in &mut mapped {
-        mapped_file.findings.extend(file_findings.clone());
+    if let Some(first_mapped_file) = mapped.first_mut() {
+        first_mapped_file.findings.extend(file_findings);
     }
     Ok(mapped)
 }
@@ -1898,7 +1900,11 @@ fn is_supported_manifest_field(field: &str) -> bool {
             | "kind"
             | "tags"
             | "scope"
+            | "summary"
+            | "compaction_summary"
+            | "parts"
             | "created_at"
+            | "updated_at"
             | "session"
             | "session_id"
             | "skill"
@@ -2410,6 +2416,8 @@ mod tests {
             "# Rules\n\nNever write directly to the memory store during migration.",
         )
         .expect("write claude");
+        fs::write(archive.path().join("screenshot.bin"), [0, 159, 146, 150])
+            .expect("write ignored binary");
         fs::create_dir_all(archive.path().join("sessions")).expect("sessions dir");
         fs::write(
             archive.path().join("sessions").join("session.json"),
@@ -2494,6 +2502,23 @@ mod tests {
                     && finding.field == "api_token"
             }),
             "privacy fields should be review findings: {:?}",
+            report.findings
+        );
+        assert_eq!(
+            report
+                .findings
+                .iter()
+                .filter(|finding| finding.field == "api_token")
+                .count(),
+            1,
+            "file-level findings should not be duplicated for every mapped session record"
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .all(|finding| finding.field != "summary" && finding.field != "parts"),
+            "OpenCode summary and parts are handled fields, not unsupported findings: {:?}",
             report.findings
         );
         assert!(

--- a/crates/cairn-cli/src/import.rs
+++ b/crates/cairn-cli/src/import.rs
@@ -236,10 +236,10 @@ pub struct RowboatImportOptions {
     pub mode: FlushMode,
 }
 
-/// Options for mapping an OpenCode archive into Cairn review plans.
+/// Options for mapping an `OpenCode` archive into Cairn review plans.
 #[derive(Debug, Clone)]
 pub struct OpenCodeImportOptions {
-    /// Path to an OpenCode project/session archive root.
+    /// Path to an `OpenCode` project/session archive root.
     pub source: PathBuf,
     /// Maximum records per generated review plan.
     pub batch_size: usize,
@@ -587,7 +587,7 @@ pub fn map_rowboat_archive(opts: &RowboatImportOptions) -> Result<KoiImportRepor
     })
 }
 
-/// Map OpenCode project instructions, session parts, and compaction summaries
+/// Map `OpenCode` project instructions, session parts, and compaction summaries
 /// into valid Cairn records and pending review plans.
 ///
 /// This bridge performs no database writes. The resulting plans can be reviewed
@@ -1267,6 +1267,10 @@ fn map_opencode_json(
     Ok(mapped)
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "OpenCode scope fields map one-for-one"
+)]
 fn map_opencode_summary(
     relative: &Path,
     summary: &Value,
@@ -1381,7 +1385,11 @@ fn opencode_skill_ids(part: &Value) -> Vec<String> {
     ids.into_iter().collect()
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    reason = "OpenCode record mapping keeps provenance, scope, and metadata together"
+)]
 fn map_opencode_record(
     relative: &Path,
     role: &str,
@@ -2386,6 +2394,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "fixture covers the importer mapping matrix"
+    )]
     fn opencode_import_maps_instructions_summaries_and_session_parts() {
         let archive = tempfile::tempdir().expect("archive");
         fs::write(

--- a/crates/cairn-cli/src/import.rs
+++ b/crates/cairn-cli/src/import.rs
@@ -647,6 +647,7 @@ pub fn map_opencode_archive(opts: &OpenCodeImportOptions) -> Result<KoiImportRep
                 None,
                 None,
                 None,
+                None,
             )?]
         } else {
             map_opencode_json(path, relative, &raw)?
@@ -1164,6 +1165,10 @@ fn is_opencode_instruction_file(path: &Path) -> bool {
     )
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "OpenCode JSON mapping keeps summary, parts, fallback records, and findings together"
+)]
 fn map_opencode_json(
     _path: &Path,
     relative: &Path,
@@ -1241,25 +1246,32 @@ fn map_opencode_json(
                 scope_entity.as_deref(),
                 scope_user.as_deref(),
                 scope_agent.as_deref(),
+                None,
             )?);
         }
     }
     if mapped.is_empty() {
+        let kind = json
+            .get("kind")
+            .and_then(Value::as_str)
+            .and_then(|kind| MemoryKind::parse(kind).ok())
+            .unwrap_or(MemoryKind::Reference);
         mapped.push(map_opencode_record(
             relative,
             "json",
             extract_body(&json).unwrap_or_else(|| raw.trim().to_owned()),
-            MemoryKind::Reference,
+            kind,
             created_at,
             session_id.as_deref(),
-            Vec::new(),
-            Vec::new(),
+            tags_from_json(Some(&json)),
+            skill_ids_from_json(Some(&json)),
             BTreeMap::new(),
             scope_tenant.as_deref(),
             scope_workspace.as_deref(),
             scope_entity.as_deref(),
             scope_user.as_deref(),
             scope_agent.as_deref(),
+            legacy_id(Some(&json)),
         )?);
     }
     let file_findings = findings_from_file(Some(&json), relative, &[]);
@@ -1338,6 +1350,7 @@ fn map_opencode_summary(
             scope_entity,
             scope_user,
             scope_agent,
+            None,
         )?);
     }
     Ok(records)
@@ -1407,6 +1420,7 @@ fn map_opencode_record(
     scope_entity: Option<&str>,
     scope_user: Option<&str>,
     scope_agent: Option<&str>,
+    legacy_id: Option<String>,
 ) -> Result<MappedFile, ImportError> {
     let body_hash = format!("{:x}", Sha256::digest(body.as_bytes()));
     extra_frontmatter.insert(
@@ -1532,7 +1546,7 @@ fn map_opencode_record(
     let item = ExternalImportItem {
         kind: ExternalImportItemKind::Record,
         source_path: relative.to_path_buf(),
-        legacy_id: Some(format!("opencode:{role}")),
+        legacy_id: legacy_id.or_else(|| Some(format!("opencode:{role}"))),
         session_ids: session_id.into_iter().map(ToOwned::to_owned).collect(),
         skill_ids,
         provenance: ExternalImportProvenance {
@@ -1795,6 +1809,19 @@ fn legacy_id(json: Option<&Value>) -> Option<String> {
         .map(str::trim)
         .filter(|id| !id.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn tags_from_json(json: Option<&Value>) -> Vec<String> {
+    json.and_then(|json| json.get("tags").and_then(Value::as_array))
+        .map(|tags| {
+            tags.iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|tag| !tag.is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
 }
 
 fn session_ids_from_json(json: Option<&Value>) -> Vec<String> {
@@ -2418,6 +2445,23 @@ mod tests {
         .expect("write claude");
         fs::write(archive.path().join("screenshot.bin"), [0, 159, 146, 150])
             .expect("write ignored binary");
+        fs::write(
+            archive.path().join("memory.json"),
+            r#"{
+              "id": "json-memory-01",
+              "kind": "rule",
+              "text": "OpenCode fallback JSON preserves typed metadata.",
+              "tags": ["opencode", "fallback"],
+              "skills": [{"id": "json-skill"}],
+              "scope": {
+                "tenant": "default",
+                "workspace": "metadata",
+                "entity": "import",
+                "user": "hmn:tafeng"
+              }
+            }"#,
+        )
+        .expect("write fallback json");
         fs::create_dir_all(archive.path().join("sessions")).expect("sessions dir");
         fs::write(
             archive.path().join("sessions").join("session.json"),
@@ -2450,7 +2494,7 @@ mod tests {
         .expect("map opencode archive");
 
         assert_eq!(report.manifest.system, "opencode");
-        assert_eq!(report.records.len(), 9);
+        assert_eq!(report.records.len(), 10);
         assert!(
             report
                 .records
@@ -2463,6 +2507,14 @@ mod tests {
         assert!(report.records.iter().any(|record| {
             record.kind == MemoryKind::Rule && record.body.contains("Never write directly")
         }));
+        let json_record = report
+            .records
+            .iter()
+            .find(|record| record.body.contains("fallback JSON preserves"))
+            .expect("fallback JSON record");
+        assert_eq!(json_record.kind, MemoryKind::Rule);
+        assert_eq!(json_record.scope.user.as_deref(), Some("hmn:tafeng"));
+        assert!(json_record.tags.iter().any(|tag| tag == "fallback"));
         assert!(report.records.iter().any(|record| {
             record.kind == MemoryKind::User && record.body.contains("Build an OpenCode bridge")
         }));
@@ -2487,6 +2539,15 @@ mod tests {
         }));
         assert!(report.manifest.items.iter().any(|item| {
             item.kind == ExternalImportItemKind::Skill && item.legacy_id.as_deref() == Some("skill")
+        }));
+        assert!(report.manifest.items.iter().any(|item| {
+            item.kind == ExternalImportItemKind::Record
+                && item.legacy_id.as_deref() == Some("json-memory-01")
+                && item.skill_ids == vec!["json-skill"]
+        }));
+        assert!(report.manifest.items.iter().any(|item| {
+            item.kind == ExternalImportItemKind::Skill
+                && item.legacy_id.as_deref() == Some("json-skill")
         }));
         assert!(
             report.findings.iter().any(|finding| {

--- a/crates/cairn-cli/tests/koi_import.rs
+++ b/crates/cairn-cli/tests/koi_import.rs
@@ -1,4 +1,4 @@
-//! Consumer acceptance coverage for the Koi v1 migration bridge.
+//! Consumer acceptance coverage for external memory migration bridges.
 
 use std::path::Path;
 use std::process::{Command, Output};
@@ -30,6 +30,24 @@ fn run_in_vault(vault: &Path, args: &[&str]) -> Output {
 
 fn run_json_ok(vault: &Path, args: &[&str]) -> serde_json::Value {
     let out = run_in_vault(vault, args);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "cairn {args:?} failed\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("cairn {args:?} emitted invalid JSON: {e}"))
+}
+
+fn run_json_ok_with_issuer(vault: &Path, args: &[&str], issuer: &str) -> serde_json::Value {
+    let out = cli()
+        .current_dir(vault)
+        .env("CAIRN_ISSUER", issuer)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run cairn {args:?}: {e}"));
     assert_eq!(
         out.status.code(),
         Some(0),
@@ -77,6 +95,52 @@ fn upsert_record_id(plan: &PersistedPlan) -> String {
         );
     };
     record.id.as_str().to_owned()
+}
+
+fn upsert_record_id_containing(plan: &PersistedPlan, needle: &str) -> String {
+    plan.plan
+        .mutations
+        .iter()
+        .find_map(|mutation| {
+            let PlannedMutation::Upsert { record, .. } = mutation else {
+                return None;
+            };
+            record
+                .body
+                .contains(needle)
+                .then(|| record.id.as_str().to_owned())
+        })
+        .unwrap_or_else(|| panic!("expected an upsert containing {needle:?}: {plan:?}"))
+}
+
+fn upsert_record_scope_containing(
+    plan: &PersistedPlan,
+    needle: &str,
+) -> (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+) {
+    plan.plan
+        .mutations
+        .iter()
+        .find_map(|mutation| {
+            let PlannedMutation::Upsert { record, .. } = mutation else {
+                return None;
+            };
+            record.body.contains(needle).then(|| {
+                (
+                    record.scope.tenant.clone(),
+                    record.scope.workspace.clone(),
+                    record.scope.entity.clone(),
+                    record.scope.user.clone(),
+                    record.scope.agent.clone(),
+                )
+            })
+        })
+        .unwrap_or_else(|| panic!("expected an upsert containing {needle:?}: {plan:?}"))
 }
 
 fn hit_record_ids(vault: &Path, query: &str) -> Vec<String> {
@@ -169,6 +233,166 @@ fn koi_v1_import_plan_applies_to_search_retrieve_lint_and_forget() {
     assert!(
         hit_record_ids(vault.path(), "calico").is_empty(),
         "forgotten import should leave keyword search"
+    );
+}
+
+#[test]
+fn opencode_import_plan_applies_to_search_retrieve_lint_and_forget() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    run_json_ok(vault.path(), &["identity", "init-defaults", "--json"]);
+    run_json_ok(
+        vault.path(),
+        &[
+            "identity",
+            "provision",
+            "human",
+            "opencode-import",
+            "--json",
+        ],
+    );
+    run_json_ok(
+        vault.path(),
+        &["identity", "provision", "human", "tafeng", "--json"],
+    );
+    run_json_ok(
+        vault.path(),
+        &[
+            "identity",
+            "provision",
+            "agent",
+            "opencode:default:import",
+            "--json",
+        ],
+    );
+    run_json_ok(
+        vault.path(),
+        &[
+            "identity",
+            "provision",
+            "sensor",
+            "opencode:import:local",
+            "--json",
+        ],
+    );
+    let archive = tempfile::tempdir().expect("opencode archive");
+    std::fs::write(
+        archive.path().join("AGENTS.md"),
+        "# OpenCode Instructions\n\nProject purpose includes migration persistence.",
+    )
+    .expect("write opencode instructions");
+    std::fs::create_dir_all(archive.path().join("sessions")).expect("sessions dir");
+    std::fs::write(
+        archive.path().join("memory.json"),
+        serde_json::json!({
+            "id": "opencode-memory-001",
+            "kind": "reference",
+            "text": "OpenCode retrieve acceptance stores opencoderetrieve marker.",
+            "scope": {
+                "tenant": "default",
+                "workspace": "my-vault",
+                "entity": "ingest",
+                "user": "hmn:tafeng"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write opencode memory");
+    std::fs::write(
+        archive.path().join("sessions").join("session.json"),
+        serde_json::json!({
+            "id": "ses_issue_156",
+            "session_id": "ses_issue_156",
+            "created_at": "2026-04-01T10:00:00Z",
+            "scope": {
+                "tenant": "default",
+                "workspace": "my-vault",
+                "entity": "ingest",
+                "user": "hmn:tafeng"
+            },
+            "summary": {
+                "Goal": "Migrate OpenCode memory through reviewable plans.",
+                "Constraints": ["Preserve typed part ordering."],
+                "Progress": "Imported zephyrcheckpoint session part.",
+                "Decisions": ["Use Cairn FlushPlans."]
+            },
+            "parts": [
+                {"id": "p1", "type": "user", "text": "Please preserve zephyrcheckpoint in imported traces."},
+                {"id": "p2", "type": "tool", "tool": "skill", "text": "Loaded migration skill."}
+            ]
+        })
+        .to_string(),
+    )
+    .expect("write opencode session");
+
+    let import = run_json_ok(
+        vault.path(),
+        &[
+            "import",
+            "--from",
+            "opencode",
+            archive.path().to_str().expect("utf-8 archive path"),
+            "--batch-size",
+            "64",
+            "--json",
+        ],
+    );
+    assert_eq!(import["manifest"]["system"], "opencode", "import: {import}");
+    assert_eq!(import["records"], 8, "import summary: {import}");
+    assert_eq!(import["plans"], 1, "import summary: {import}");
+    assert!(
+        import["manifest"]["items"]
+            .as_array()
+            .expect("manifest items")
+            .iter()
+            .any(|item| item["kind"] == "skill" && item["legacy_id"] == "skill"),
+        "OpenCode skill tool part should emit a skill manifest item: {import}"
+    );
+
+    let (operation_id, pending) = single_pending_plan(vault.path());
+    let record_id = upsert_record_id_containing(&pending, "Please preserve zephyrcheckpoint");
+    let retrieve_record_id = upsert_record_id_containing(&pending, "opencoderetrieve");
+    assert_eq!(
+        upsert_record_scope_containing(&pending, "Please preserve zephyrcheckpoint"),
+        (
+            Some("default".to_owned()),
+            Some("my-vault".to_owned()),
+            Some("ingest".to_owned()),
+            Some("hmn:tafeng".to_owned()),
+            None
+        )
+    );
+
+    run_json_ok(vault.path(), &["flush", "apply", &operation_id, "--json"]);
+
+    let hits = hit_record_ids(vault.path(), "zephyrcheckpoint");
+    assert!(
+        hits.contains(&record_id),
+        "search should find imported OpenCode trace {record_id}; hits: {hits:?}"
+    );
+
+    let retrieve = run_json_ok_with_issuer(
+        vault.path(),
+        &["retrieve", &retrieve_record_id, "--json"],
+        "hmn:tafeng:v1",
+    );
+    assert_eq!(
+        retrieve["data"]["body"], "OpenCode retrieve acceptance stores opencoderetrieve marker.",
+        "retrieve should expose imported OpenCode record body: {retrieve}"
+    );
+
+    let lint_out = run_in_vault(vault.path(), &["lint", "--json"]);
+    let lint = json_output(&lint_out, &["lint", "--json"]);
+    assert_eq!(lint["status"], "committed", "lint should complete: {lint}");
+    assert_eq!(
+        lint["data"]["summary"]["by_severity"]["error"], 0,
+        "OpenCode imported records should not produce lint errors: {lint}"
+    );
+
+    run_json_ok(vault.path(), &["forget", "--record", &record_id, "--json"]);
+    assert!(
+        !hit_record_ids(vault.path(), "zephyrcheckpoint").contains(&record_id),
+        "forgotten OpenCode trace should leave keyword search"
     );
 }
 

--- a/crates/cairn-cli/tests/koi_import.rs
+++ b/crates/cairn-cli/tests/koi_import.rs
@@ -113,6 +113,10 @@ fn upsert_record_id_containing(plan: &PersistedPlan, needle: &str) -> String {
         .unwrap_or_else(|| panic!("expected an upsert containing {needle:?}: {plan:?}"))
 }
 
+#[allow(
+    clippy::type_complexity,
+    reason = "scope tuple mirrors the persisted record fields asserted by the fixture"
+)]
 fn upsert_record_scope_containing(
     plan: &PersistedPlan,
     needle: &str,
@@ -237,6 +241,10 @@ fn koi_v1_import_plan_applies_to_search_retrieve_lint_and_forget() {
 }
 
 #[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "end-to-end import fixture keeps workflow steps together"
+)]
 fn opencode_import_plan_applies_to_search_retrieve_lint_and_forget() {
     let vault = tempfile::tempdir().expect("temp vault");
     bootstrap_vault(vault.path());

--- a/docs/site/src/reference/generated/commands/import.md
+++ b/docs/site/src/reference/generated/commands/import.md
@@ -15,7 +15,8 @@ Arguments:
   <PATH>  Legacy archive root to scan
 
 Options:
-      --from <SYSTEM>         Legacy memory system to import [possible values: koi-v1, rowboat]
+      --from <SYSTEM>         Legacy memory system to import [possible values: koi-v1, rowboat,
+                              opencode]
       --vault <NAME_OR_PATH>  Active vault: name from registry or filesystem path (overrides
                               CAIRN_VAULT)
       --batch-size <U32>      Maximum records per pending review plan [default: 64]


### PR DESCRIPTION
## Summary

- Add `cairn import --from opencode` support for OpenCode instruction files, summary sections, session parts, and fallback JSON records.
- Preserve source artifacts, OpenCode metadata, fallback JSON kind/tags/skills/legacy IDs, findings, and scoped record ownership in pending review plans.
- Cover the bridge with unit tests, consumer acceptance tests, and manual e2e/corner-case import flows through apply, search, retrieve, lint, and forget.

Fixes #156. This PR will close issue #156 when merged.

## Validation

- `cargo build -p cairn-cli --bin cairn`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo run -p cairn-cli --bin cairn-docgen --locked -- --check`
- `cargo test -p cairn-cli import::tests`
- `cargo test -p cairn-cli --test koi_import`
- Manual e2e: rich OpenCode archive (`AGENTS.md`, `CLAUDE.md`, fallback JSON, summaries, typed parts, ignored binary) through import, pending plan apply, search, retrieve, lint, and forget.
- Manual corners: empty archive, ignored binary-only archive, malformed JSON, `--batch-size 0`, unsupported `--from`, invalid `created_at`.
