### PR TITLE
[codex] Add Hermes Agent import bridge

### DIFF
--- a/crates/cairn-cli/src/import.rs
+++ b/crates/cairn-cli/src/import.rs
@@ -23,6 +23,8 @@ const ROWBOAT_IMPORT_AUTHOR: &str = "hmn:rowboat-import:v1";
 const ROWBOAT_IMPORT_SENSOR: &str = "snr:rowboat:import:local:v1";
 const OPENCODE_IMPORT_AUTHOR: &str = "hmn:opencode-import:v1";
 const OPENCODE_IMPORT_SENSOR: &str = "snr:opencode:import:local:v1";
+const HERMES_IMPORT_AUTHOR: &str = "hmn:hermes-import:v1";
+const HERMES_IMPORT_SENSOR: &str = "snr:hermes-agent:import:local:v1";
 const SOURCE_HASH_PREFIX: &str = "sha256:";
 
 /// Build the `cairn import` CLI subcommand.
@@ -35,7 +37,7 @@ pub fn command() -> clap::Command {
                 .long("from")
                 .required(true)
                 .value_name("SYSTEM")
-                .value_parser(["koi-v1", "rowboat", "opencode"])
+                .value_parser(["koi-v1", "rowboat", "opencode", "hermes-agent"])
                 .help("Legacy memory system to import"),
         )
         .arg(
@@ -89,6 +91,11 @@ pub fn run(sub: &clap::ArgMatches, vault_root: &Path) -> std::process::ExitCode 
             mode: FlushMode::HumanReview,
         }),
         "opencode" => map_opencode_archive(&OpenCodeImportOptions {
+            source: archive.clone(),
+            batch_size,
+            mode: FlushMode::HumanReview,
+        }),
+        "hermes-agent" => map_hermes_agent_archive(&KoiImportOptions {
             source: archive.clone(),
             batch_size,
             mode: FlushMode::HumanReview,
@@ -1792,6 +1799,322 @@ fn map_file(path: &Path, root: &Path, raw: &str) -> Result<MappedFile, ImportErr
         findings,
         items,
     })
+}
+
+/// Map a Hermes Agent archive into valid Cairn records and pending review plans.
+///
+/// Hermes stores builtin memory as markdown files with `§` entry delimiters.
+/// This bridge treats each entry as one reviewable Cairn record and preserves
+/// skills as playbook candidates.
+pub fn map_hermes_agent_archive(opts: &KoiImportOptions) -> Result<KoiImportReport, ImportError> {
+    if opts.batch_size == 0 {
+        return Err(ImportError::InvalidBatchSize);
+    }
+    let source = hermes_archive_root(&opts.source);
+    if !source.is_dir() {
+        return Err(ImportError::SourceNotDirectory {
+            archive: opts.source.clone(),
+        });
+    }
+
+    let mut records = Vec::new();
+    let mut items = Vec::new();
+    for spec in hermes_builtin_specs(&source) {
+        if !spec.path.is_file() {
+            continue;
+        }
+        let raw = fs::read_to_string(&spec.path).map_err(|source| ImportError::Io {
+            path: spec.path.clone(),
+            source,
+        })?;
+        let mapped = map_hermes_sections(&source, &spec.path, &raw, spec.kind, None)?;
+        items.extend(mapped.items);
+        records.extend(mapped.records);
+    }
+
+    let skills = source.join("skills");
+    if skills.is_dir() {
+        for entry in WalkDir::new(&skills)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+        {
+            let path = entry.path();
+            if !is_importable(path) {
+                continue;
+            }
+            let raw = fs::read_to_string(path).map_err(|source| ImportError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            let skill_id = hermes_skill_id(&skills, path);
+            let mapped =
+                map_hermes_sections(&source, path, &raw, MemoryKind::Playbook, Some(&skill_id))?;
+            items.extend(mapped.items);
+            records.extend(mapped.records);
+        }
+    }
+
+    let plans = plan_records(
+        "hermes-agent",
+        HERMES_IMPORT_AUTHOR,
+        &source,
+        &records,
+        opts.batch_size,
+        opts.mode,
+    )?;
+    Ok(KoiImportReport {
+        manifest: ExternalImportManifest {
+            system: "hermes-agent".to_owned(),
+            items,
+            unsupported_fields: Vec::new(),
+            privacy_sensitive_fields: Vec::new(),
+        },
+        records,
+        ambiguities: Vec::new(),
+        findings: Vec::new(),
+        plans,
+    })
+}
+
+struct HermesBuiltinSpec {
+    path: PathBuf,
+    kind: MemoryKind,
+}
+
+struct MappedHermesFile {
+    records: Vec<MemoryRecord>,
+    items: Vec<ExternalImportItem>,
+}
+
+fn hermes_archive_root(source: &Path) -> PathBuf {
+    let nested = source.join(".hermes");
+    if nested.is_dir() {
+        nested
+    } else {
+        source.to_path_buf()
+    }
+}
+
+fn hermes_builtin_specs(source: &Path) -> Vec<HermesBuiltinSpec> {
+    vec![
+        HermesBuiltinSpec {
+            path: source.join("memories/MEMORY.md"),
+            kind: MemoryKind::Reference,
+        },
+        HermesBuiltinSpec {
+            path: source.join("memories/USER.md"),
+            kind: MemoryKind::User,
+        },
+        HermesBuiltinSpec {
+            path: source.join("SOUL.md"),
+            kind: MemoryKind::Rule,
+        },
+    ]
+}
+
+fn map_hermes_sections(
+    root: &Path,
+    path: &Path,
+    raw: &str,
+    default_kind: MemoryKind,
+    skill_id: Option<&str>,
+) -> Result<MappedHermesFile, ImportError> {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    let sections = hermes_sections(raw);
+    let mut records = Vec::new();
+    let mut items = Vec::new();
+    for (idx, body) in sections.into_iter().enumerate() {
+        let kind = hermes_kind(default_kind, &body);
+        let record = hermes_record(relative, idx, &body, kind, skill_id)?;
+        let item = ExternalImportItem {
+            kind: ExternalImportItemKind::Record,
+            source_path: relative.to_path_buf(),
+            legacy_id: Some(hermes_legacy_id(relative, idx)),
+            session_ids: Vec::new(),
+            skill_ids: skill_id.into_iter().map(ToOwned::to_owned).collect(),
+            provenance: ExternalImportProvenance {
+                source_sensor: HERMES_IMPORT_SENSOR.to_owned(),
+                source_hash: record.provenance.source_hash.clone(),
+                source_refs: record.provenance.source_refs.clone(),
+            },
+        };
+        if let Some(skill_id) = skill_id {
+            items.push(ExternalImportItem {
+                kind: ExternalImportItemKind::Skill,
+                source_path: relative.to_path_buf(),
+                legacy_id: Some(skill_id.to_owned()),
+                session_ids: Vec::new(),
+                skill_ids: vec![skill_id.to_owned()],
+                provenance: item.provenance.clone(),
+            });
+        }
+        items.push(item);
+        records.push(record);
+    }
+    Ok(MappedHermesFile { records, items })
+}
+
+fn hermes_sections(raw: &str) -> Vec<String> {
+    raw.split('§')
+        .map(str::trim)
+        .filter(|section| !section.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn hermes_kind(default_kind: MemoryKind, body: &str) -> MemoryKind {
+    if default_kind == MemoryKind::Reference && body.to_ascii_lowercase().contains("trajectory") {
+        MemoryKind::Trace
+    } else {
+        default_kind
+    }
+}
+
+fn hermes_record(
+    relative: &Path,
+    section_index: usize,
+    body: &str,
+    kind: MemoryKind,
+    skill_id: Option<&str>,
+) -> Result<MemoryRecord, ImportError> {
+    let body_hash = format!("{:x}", Sha256::digest(body.as_bytes()));
+    let identity_seed = format!(
+        "hermes-agent:{}:{section_index}:{body_hash}",
+        slash_normalized_path(relative)
+    );
+    let source_id =
+        SourceId::parse(deterministic_ulid(&identity_seed, "source").0).map_err(|source| {
+            ImportError::Domain {
+                path: relative.to_path_buf(),
+                source,
+            }
+        })?;
+    let source_ref_id = source_id.as_str().to_owned();
+    let source_hash = format!("{SOURCE_HASH_PREFIX}{body_hash}");
+    let issued_at =
+        Rfc3339Timestamp::parse("2026-01-01T00:00:00Z".to_owned()).map_err(|source| {
+            ImportError::Domain {
+                path: relative.to_path_buf(),
+                source,
+            }
+        })?;
+    let author = Identity::parse(HERMES_IMPORT_AUTHOR).map_err(|source| ImportError::Domain {
+        path: relative.to_path_buf(),
+        source,
+    })?;
+    let mut extra_frontmatter = BTreeMap::new();
+    extra_frontmatter.insert(
+        "hermes_agent_source_path".to_owned(),
+        Value::String(slash_normalized_path(relative)),
+    );
+    extra_frontmatter.insert(
+        "hermes_agent_section_index".to_owned(),
+        Value::Number(section_index.into()),
+    );
+    extra_frontmatter.insert(
+        "hermes_agent_body_hash".to_owned(),
+        Value::String(body_hash),
+    );
+    if let Some(skill_id) = skill_id {
+        extra_frontmatter.insert(
+            "hermes_agent_skill_id".to_owned(),
+            Value::String(skill_id.to_owned()),
+        );
+    }
+    let tags = skill_id
+        .map(|skill_id| vec!["hermes-agent".to_owned(), format!("skill:{skill_id}")])
+        .unwrap_or_else(|| vec!["hermes-agent".to_owned()]);
+    let record = MemoryRecord {
+        id: RecordId::parse(deterministic_ulid(&identity_seed, "record").0).map_err(|source| {
+            ImportError::Domain {
+                path: relative.to_path_buf(),
+                source,
+            }
+        })?,
+        target_id: TargetId::parse(deterministic_ulid(&identity_seed, "target").0).map_err(
+            |source| ImportError::Domain {
+                path: relative.to_path_buf(),
+                source,
+            },
+        )?,
+        kind,
+        class: class_for_kind(kind),
+        visibility: MemoryVisibility::Private,
+        scope: ScopeTuple {
+            tenant: Some("default".to_owned()),
+            workspace: Some("my-vault".to_owned()),
+            entity: Some("ingest".to_owned()),
+            user: Some(HERMES_IMPORT_AUTHOR.to_owned()),
+            ..ScopeTuple::default()
+        },
+        body: body.to_owned(),
+        source_ids: vec![source_id.clone()],
+        provenance: Provenance {
+            source_sensor: Identity::parse(HERMES_IMPORT_SENSOR).map_err(|source| {
+                ImportError::Domain {
+                    path: relative.to_path_buf(),
+                    source,
+                }
+            })?,
+            created_at: issued_at.clone(),
+            originating_agent_id: author.clone(),
+            source_ids: vec![source_id],
+            source_hash: source_hash.clone(),
+            consent_ref: "consent:hermes-agent-import".to_owned(),
+            llm_id_if_any: None,
+            source_refs: vec![SourceRef {
+                id: source_ref_id,
+                hash: source_hash,
+            }],
+        },
+        updated_at: issued_at.clone(),
+        evidence: EvidenceVector::default(),
+        salience: if kind == MemoryKind::Playbook {
+            0.7
+        } else {
+            0.5
+        },
+        confidence: 0.7,
+        actor_chain: vec![ActorChainEntry {
+            role: ChainRole::Author,
+            identity: author,
+            at: issued_at,
+        }],
+        signature: cairn_core::domain::record::Ed25519Signature::parse(format!(
+            "ed25519:{}",
+            "b".repeat(128)
+        ))
+        .map_err(|source| ImportError::Domain {
+            path: relative.to_path_buf(),
+            source,
+        })?,
+        tags,
+        extra_frontmatter,
+        consent_model: None,
+    };
+    record.validate().map_err(|source| ImportError::Domain {
+        path: relative.to_path_buf(),
+        source,
+    })?;
+    Ok(record)
+}
+
+fn hermes_legacy_id(relative: &Path, section_index: usize) -> String {
+    format!("{}#{section_index}", slash_normalized_path(relative))
+}
+
+fn hermes_skill_id(skills_root: &Path, path: &Path) -> String {
+    let relative = path.strip_prefix(skills_root).unwrap_or(path);
+    let without_extension = relative.with_extension("");
+    let skill_id = slash_normalized_path(&without_extension);
+    let skill_id = skill_id.trim_matches('/').trim();
+    if skill_id.is_empty() {
+        "skill".to_owned()
+    } else {
+        skill_id.to_owned()
+    }
 }
 
 fn extract_body(json: &Value) -> Option<String> {

--- a/crates/cairn-cli/src/import.rs
+++ b/crates/cairn-cli/src/import.rs
@@ -1925,6 +1925,7 @@ fn map_hermes_sections(
     let sections = hermes_sections(raw);
     let mut records = Vec::new();
     let mut items = Vec::new();
+    let mut skill_item = None;
     for (idx, body) in sections.into_iter().enumerate() {
         let kind = hermes_kind(default_kind, &body);
         let record = hermes_record(relative, idx, &body, kind, skill_id)?;
@@ -1941,7 +1942,7 @@ fn map_hermes_sections(
             },
         };
         if let Some(skill_id) = skill_id {
-            items.push(ExternalImportItem {
+            skill_item.get_or_insert_with(|| ExternalImportItem {
                 kind: ExternalImportItemKind::Skill,
                 source_path: relative.to_path_buf(),
                 legacy_id: Some(skill_id.to_owned()),
@@ -1952,6 +1953,9 @@ fn map_hermes_sections(
         }
         items.push(item);
         records.push(record);
+    }
+    if let Some(skill_item) = skill_item {
+        items.push(skill_item);
     }
     Ok(MappedHermesFile { records, items })
 }
@@ -2004,28 +2008,6 @@ fn hermes_record(
         path: relative.to_path_buf(),
         source,
     })?;
-    let mut extra_frontmatter = BTreeMap::new();
-    extra_frontmatter.insert(
-        "hermes_agent_source_path".to_owned(),
-        Value::String(slash_normalized_path(relative)),
-    );
-    extra_frontmatter.insert(
-        "hermes_agent_section_index".to_owned(),
-        Value::Number(section_index.into()),
-    );
-    extra_frontmatter.insert(
-        "hermes_agent_body_hash".to_owned(),
-        Value::String(body_hash),
-    );
-    if let Some(skill_id) = skill_id {
-        extra_frontmatter.insert(
-            "hermes_agent_skill_id".to_owned(),
-            Value::String(skill_id.to_owned()),
-        );
-    }
-    let tags = skill_id
-        .map(|skill_id| vec!["hermes-agent".to_owned(), format!("skill:{skill_id}")])
-        .unwrap_or_else(|| vec!["hermes-agent".to_owned()]);
     let record = MemoryRecord {
         id: RecordId::parse(deterministic_ulid(&identity_seed, "record").0).map_err(|source| {
             ImportError::Domain {
@@ -2042,33 +2024,17 @@ fn hermes_record(
         kind,
         class: class_for_kind(kind),
         visibility: MemoryVisibility::Private,
-        scope: ScopeTuple {
-            tenant: Some("default".to_owned()),
-            workspace: Some("my-vault".to_owned()),
-            entity: Some("ingest".to_owned()),
-            user: Some(HERMES_IMPORT_AUTHOR.to_owned()),
-            ..ScopeTuple::default()
-        },
+        scope: hermes_scope(),
         body: body.to_owned(),
         source_ids: vec![source_id.clone()],
-        provenance: Provenance {
-            source_sensor: Identity::parse(HERMES_IMPORT_SENSOR).map_err(|source| {
-                ImportError::Domain {
-                    path: relative.to_path_buf(),
-                    source,
-                }
-            })?,
-            created_at: issued_at.clone(),
-            originating_agent_id: author.clone(),
-            source_ids: vec![source_id],
-            source_hash: source_hash.clone(),
-            consent_ref: "consent:hermes-agent-import".to_owned(),
-            llm_id_if_any: None,
-            source_refs: vec![SourceRef {
-                id: source_ref_id,
-                hash: source_hash,
-            }],
-        },
+        provenance: hermes_provenance(
+            relative,
+            &issued_at,
+            author.clone(),
+            source_id,
+            source_ref_id,
+            source_hash,
+        )?,
         updated_at: issued_at.clone(),
         evidence: EvidenceVector::default(),
         salience: if kind == MemoryKind::Playbook {
@@ -2090,8 +2056,8 @@ fn hermes_record(
             path: relative.to_path_buf(),
             source,
         })?,
-        tags,
-        extra_frontmatter,
+        tags: hermes_tags(skill_id),
+        extra_frontmatter: hermes_extra_frontmatter(relative, section_index, body_hash, skill_id),
         consent_model: None,
     };
     record.validate().map_err(|source| ImportError::Domain {
@@ -2099,6 +2065,79 @@ fn hermes_record(
         source,
     })?;
     Ok(record)
+}
+
+fn hermes_scope() -> ScopeTuple {
+    ScopeTuple {
+        tenant: Some("default".to_owned()),
+        workspace: Some("my-vault".to_owned()),
+        entity: Some("ingest".to_owned()),
+        user: Some(HERMES_IMPORT_AUTHOR.to_owned()),
+        ..ScopeTuple::default()
+    }
+}
+
+fn hermes_provenance(
+    relative: &Path,
+    issued_at: &Rfc3339Timestamp,
+    author: Identity,
+    source_id: SourceId,
+    source_ref_id: String,
+    source_hash: String,
+) -> Result<Provenance, ImportError> {
+    Ok(Provenance {
+        source_sensor: Identity::parse(HERMES_IMPORT_SENSOR).map_err(|source| {
+            ImportError::Domain {
+                path: relative.to_path_buf(),
+                source,
+            }
+        })?,
+        created_at: issued_at.clone(),
+        originating_agent_id: author,
+        source_ids: vec![source_id],
+        source_hash: source_hash.clone(),
+        consent_ref: "consent:hermes-agent-import".to_owned(),
+        llm_id_if_any: None,
+        source_refs: vec![SourceRef {
+            id: source_ref_id,
+            hash: source_hash,
+        }],
+    })
+}
+
+fn hermes_extra_frontmatter(
+    relative: &Path,
+    section_index: usize,
+    body_hash: String,
+    skill_id: Option<&str>,
+) -> BTreeMap<String, Value> {
+    let mut extra_frontmatter = BTreeMap::new();
+    extra_frontmatter.insert(
+        "hermes_agent_source_path".to_owned(),
+        Value::String(slash_normalized_path(relative)),
+    );
+    extra_frontmatter.insert(
+        "hermes_agent_section_index".to_owned(),
+        Value::Number(section_index.into()),
+    );
+    extra_frontmatter.insert(
+        "hermes_agent_body_hash".to_owned(),
+        Value::String(body_hash),
+    );
+    if let Some(skill_id) = skill_id {
+        extra_frontmatter.insert(
+            "hermes_agent_skill_id".to_owned(),
+            Value::String(skill_id.to_owned()),
+        );
+    }
+    extra_frontmatter
+}
+
+fn hermes_tags(skill_id: Option<&str>) -> Vec<String> {
+    skill_id.map_or_else(
+        || vec!["hermes-agent".to_owned()],
+        |skill_id| vec!["hermes-agent".to_owned(), format!("skill:{skill_id}")],
+    )
 }
 
 fn hermes_legacy_id(relative: &Path, section_index: usize) -> String {

--- a/crates/cairn-cli/tests/hermes_import.rs
+++ b/crates/cairn-cli/tests/hermes_import.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 use std::process::{Command, Output};
 
+use cairn_core::domain::MemoryKind;
 use cairn_core::domain::flush_plan::{PersistedPlan, PlannedMutation};
 
 fn cli() -> Command {
@@ -82,6 +83,19 @@ fn record_id_containing(plan: &PersistedPlan, needle: &str) -> String {
         .unwrap_or_else(|| panic!("expected imported record containing `{needle}`: {plan:?}"))
 }
 
+fn record_kind_containing(plan: &PersistedPlan, needle: &str) -> MemoryKind {
+    plan.plan
+        .mutations
+        .iter()
+        .find_map(|mutation| match mutation {
+            PlannedMutation::Upsert { record, .. } if record.body.contains(needle) => {
+                Some(record.kind)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("expected imported record containing `{needle}`: {plan:?}"))
+}
+
 fn hit_record_ids(vault: &Path, query: &str) -> Vec<String> {
     let search = run_json_ok(vault, &["search", "--mode", "keyword", query, "--json"]);
     search["data"]["hits"]
@@ -113,7 +127,8 @@ fn write_hermes_fixture(archive: &Path) {
     .expect("write SOUL.md");
     std::fs::write(
         archive.join("skills/review-plan.md"),
-        "§ Playbook: review imported Hermes records before applying them.",
+        "§ Playbook: review imported Hermes records before applying them.\n\
+         § Playbook: validate imported Hermes records after applying them.",
     )
     .expect("write skill");
 }
@@ -152,11 +167,15 @@ fn hermes_agent_import_plan_applies_to_search_retrieve_lint_and_forget() {
             "--json",
         ],
     );
-    assert_eq!(import["records"], 5, "import summary: {import}");
+    assert_eq!(import["records"], 6, "import summary: {import}");
     assert_eq!(import["plans"], 1, "import summary: {import}");
 
     let (operation_id, pending) = single_pending_plan(vault.path());
     let record_id = record_id_containing(&pending, "heliotrope");
+    assert_eq!(
+        record_kind_containing(&pending, "trajectory candidate"),
+        MemoryKind::Trace
+    );
 
     run_json_ok(vault.path(), &["flush", "apply", &operation_id, "--json"]);
 
@@ -204,7 +223,7 @@ fn hermes_agent_import_json_emits_manifest_sections_and_skill_items() {
         ],
     );
 
-    assert_eq!(import["records"], 5, "import summary: {import}");
+    assert_eq!(import["records"], 6, "import summary: {import}");
     assert_eq!(
         import["manifest"]["system"], "hermes-agent",
         "manifest: {import}"
@@ -218,6 +237,16 @@ fn hermes_agent_import_json_emits_manifest_sections_and_skill_items() {
                 && item["legacy_id"] == "review-plan"
                 && item["skill_ids"] == serde_json::json!(["review-plan"])),
         "skill manifest item should be emitted: {import}"
+    );
+    assert_eq!(
+        import["manifest"]["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .filter(|item| item["kind"] == "skill" && item["legacy_id"] == "review-plan")
+            .count(),
+        1,
+        "skill manifest item should be emitted once per skill file: {import}"
     );
     assert!(
         import["migration_report"]["findings"]

--- a/crates/cairn-cli/tests/hermes_import.rs
+++ b/crates/cairn-cli/tests/hermes_import.rs
@@ -1,0 +1,229 @@
+//! Consumer acceptance coverage for the Hermes Agent migration bridge.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use cairn_core::domain::flush_plan::{PersistedPlan, PlannedMutation};
+
+fn cli() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cairn"));
+    cmd.env_remove("CAIRN_VAULT");
+    cmd.env_remove("CAIRN_REGISTRY");
+    cmd
+}
+
+fn bootstrap_vault(vault: &Path) {
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: vault.to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+}
+
+fn run_in_vault(vault: &Path, args: &[&str]) -> Output {
+    cli()
+        .current_dir(vault)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run cairn {args:?}: {e}"))
+}
+
+fn run_json_ok(vault: &Path, args: &[&str]) -> serde_json::Value {
+    let out = run_in_vault(vault, args);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "cairn {args:?} failed\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("cairn {args:?} emitted invalid JSON: {e}"))
+}
+
+fn json_output(out: &Output, args: &[&str]) -> serde_json::Value {
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("cairn {args:?} emitted invalid JSON: {e}"))
+}
+
+fn single_pending_plan(vault: &Path) -> (String, PersistedPlan) {
+    let pending_dir = vault.join(".cairn/flush/pending");
+    let entries: Vec<_> = std::fs::read_dir(&pending_dir)
+        .unwrap_or_else(|e| panic!("read pending dir {}: {e}", pending_dir.display()))
+        .map(|entry| entry.expect("pending dir entry").path())
+        .filter(|path| {
+            path.file_name()
+                .is_some_and(|name| name.to_string_lossy().ends_with(".plan.json"))
+        })
+        .collect();
+    assert_eq!(entries.len(), 1, "expected one pending plan: {entries:?}");
+    let path = &entries[0];
+    let file_name = path.file_name().expect("file name").to_string_lossy();
+    let operation_id = file_name
+        .strip_suffix(".plan.json")
+        .expect("plan suffix")
+        .to_owned();
+    let plan: PersistedPlan =
+        serde_json::from_slice(&std::fs::read(path).expect("read pending plan"))
+            .expect("pending plan json");
+    (operation_id, plan)
+}
+
+fn record_id_containing(plan: &PersistedPlan, needle: &str) -> String {
+    plan.plan
+        .mutations
+        .iter()
+        .find_map(|mutation| match mutation {
+            PlannedMutation::Upsert { record, .. } if record.body.contains(needle) => {
+                Some(record.id.as_str().to_owned())
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("expected imported record containing `{needle}`: {plan:?}"))
+}
+
+fn hit_record_ids(vault: &Path, query: &str) -> Vec<String> {
+    let search = run_json_ok(vault, &["search", "--mode", "keyword", query, "--json"]);
+    search["data"]["hits"]
+        .as_array()
+        .unwrap_or_else(|| panic!("search hits must be an array: {search}"))
+        .iter()
+        .map(|hit| hit["record_id"].as_str().expect("hit record_id").to_owned())
+        .collect()
+}
+
+fn write_hermes_fixture(archive: &Path) {
+    std::fs::create_dir_all(archive.join("memories")).expect("memories dir");
+    std::fs::create_dir_all(archive.join("skills")).expect("skills dir");
+    std::fs::write(
+        archive.join("memories/MEMORY.md"),
+        "§ hermes acceptance bridge remembers heliotrope telemetry marker\n\
+         § hermes trajectory candidate: when imports are reviewed, search after apply",
+    )
+    .expect("write MEMORY.md");
+    std::fs::write(
+        archive.join("memories/USER.md"),
+        "§ User prefers compact Hermes migration reports.",
+    )
+    .expect("write USER.md");
+    std::fs::write(
+        archive.join("SOUL.md"),
+        "§ Always route imported memory through reviewable plans.",
+    )
+    .expect("write SOUL.md");
+    std::fs::write(
+        archive.join("skills/review-plan.md"),
+        "§ Playbook: review imported Hermes records before applying them.",
+    )
+    .expect("write skill");
+}
+
+#[test]
+fn hermes_agent_import_plan_applies_to_search_retrieve_lint_and_forget() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    run_json_ok(vault.path(), &["identity", "init-defaults", "--json"]);
+    run_json_ok(
+        vault.path(),
+        &["identity", "provision", "human", "hermes-import", "--json"],
+    );
+    run_json_ok(
+        vault.path(),
+        &[
+            "identity",
+            "provision",
+            "agent",
+            "cairn-cli:default:writer",
+            "--json",
+        ],
+    );
+    let archive = tempfile::tempdir().expect("hermes archive");
+    write_hermes_fixture(archive.path());
+
+    let import = run_json_ok(
+        vault.path(),
+        &[
+            "import",
+            "--from",
+            "hermes-agent",
+            archive.path().to_str().expect("utf-8 archive path"),
+            "--batch-size",
+            "16",
+            "--json",
+        ],
+    );
+    assert_eq!(import["records"], 5, "import summary: {import}");
+    assert_eq!(import["plans"], 1, "import summary: {import}");
+
+    let (operation_id, pending) = single_pending_plan(vault.path());
+    let record_id = record_id_containing(&pending, "heliotrope");
+
+    run_json_ok(vault.path(), &["flush", "apply", &operation_id, "--json"]);
+
+    let hits = hit_record_ids(vault.path(), "heliotrope");
+    assert_eq!(hits, vec![record_id.clone()], "search should find import");
+
+    let retrieve = run_json_ok(vault.path(), &["retrieve", &record_id, "--json"]);
+    assert_eq!(
+        retrieve["data"]["body"], "hermes acceptance bridge remembers heliotrope telemetry marker",
+        "retrieve should expose imported Hermes body: {retrieve}"
+    );
+
+    let lint_out = run_in_vault(vault.path(), &["lint", "--json"]);
+    let lint = json_output(&lint_out, &["lint", "--json"]);
+    assert_eq!(lint["status"], "committed", "lint should complete: {lint}");
+    assert_eq!(
+        lint["data"]["summary"]["by_severity"]["error"], 0,
+        "imported record should not produce lint errors: {lint}"
+    );
+
+    run_json_ok(vault.path(), &["forget", "--record", &record_id, "--json"]);
+    assert!(
+        hit_record_ids(vault.path(), "heliotrope").is_empty(),
+        "forgotten Hermes import should leave keyword search"
+    );
+}
+
+#[test]
+fn hermes_agent_import_json_emits_manifest_sections_and_skill_items() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let archive = tempfile::tempdir().expect("hermes archive");
+    write_hermes_fixture(archive.path());
+
+    let import = run_json_ok(
+        vault.path(),
+        &[
+            "import",
+            "--from",
+            "hermes-agent",
+            archive.path().to_str().expect("utf-8 archive path"),
+            "--batch-size",
+            "16",
+            "--json",
+        ],
+    );
+
+    assert_eq!(import["records"], 5, "import summary: {import}");
+    assert_eq!(
+        import["manifest"]["system"], "hermes-agent",
+        "manifest: {import}"
+    );
+    assert!(
+        import["manifest"]["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .any(|item| item["kind"] == "skill"
+                && item["legacy_id"] == "review-plan"
+                && item["skill_ids"] == serde_json::json!(["review-plan"])),
+        "skill manifest item should be emitted: {import}"
+    );
+    assert!(
+        import["migration_report"]["findings"]
+            .as_array()
+            .expect("findings")
+            .is_empty(),
+        "plain Hermes markdown fixture should not require field review: {import}"
+    );
+}

--- a/crates/cairn-cli/tests/hermes_import.rs
+++ b/crates/cairn-cli/tests/hermes_import.rs
@@ -256,3 +256,48 @@ fn hermes_agent_import_json_emits_manifest_sections_and_skill_items() {
         "plain Hermes markdown fixture should not require field review: {import}"
     );
 }
+
+#[test]
+fn hermes_agent_import_preserves_nested_skill_identity() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let archive = tempfile::tempdir().expect("hermes archive");
+    std::fs::create_dir_all(archive.path().join("skills/frontend")).expect("frontend skills dir");
+    std::fs::create_dir_all(archive.path().join("skills/backend")).expect("backend skills dir");
+    std::fs::write(
+        archive.path().join("skills/frontend/review.md"),
+        "§ Frontend review playbook",
+    )
+    .expect("write frontend skill");
+    std::fs::write(
+        archive.path().join("skills/backend/review.md"),
+        "§ Backend review playbook",
+    )
+    .expect("write backend skill");
+
+    let import = run_json_ok(
+        vault.path(),
+        &[
+            "import",
+            "--from",
+            "hermes-agent",
+            archive.path().to_str().expect("utf-8 archive path"),
+            "--batch-size",
+            "16",
+            "--json",
+        ],
+    );
+
+    let skill_ids: std::collections::BTreeSet<_> = import["manifest"]["items"]
+        .as_array()
+        .expect("items")
+        .iter()
+        .filter(|item| item["kind"] == "skill")
+        .map(|item| item["legacy_id"].as_str().expect("legacy_id"))
+        .collect();
+    assert_eq!(
+        skill_ids,
+        std::collections::BTreeSet::from(["backend/review", "frontend/review"]),
+        "nested skill paths should remain distinct: {import}"
+    );
+}

--- a/docs/site/src/reference/generated/commands/import.md
+++ b/docs/site/src/reference/generated/commands/import.md
@@ -16,7 +16,7 @@ Arguments:
 
 Options:
       --from <SYSTEM>         Legacy memory system to import [possible values: koi-v1, rowboat,
-                              opencode]
+                              opencode, hermes-agent]
       --vault <NAME_OR_PATH>  Active vault: name from registry or filesystem path (overrides
                               CAIRN_VAULT)
       --batch-size <U32>      Maximum records per pending review plan [default: 64]


### PR DESCRIPTION
## Summary

- Add `cairn import --from hermes-agent` support for Hermes markdown memory archives.
- Map `memories/MEMORY.md`, `memories/USER.md`, `SOUL.md`, and `skills/*` entries into reviewable Cairn records split on `§` delimiters.
- Preserve Hermes skills as playbook candidates, including nested skill identities, and emit neutral manifest metadata through pending human-review FlushPlans.

## Issue Closure

This PR is intended to close issue #154 after merge. The implemented bridge covers the Hermes Agent migration shape documented in the design brief: `MEMORY.md`, `USER.md`, `SOUL.md`, and `skills/*`.

Closes #154.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p cairn-cli --test hermes_import`
- `cargo test -p cairn-cli --test koi_import`
- `cargo test -p cairn-cli import`
- `cargo run -p cairn-cli --bin cairn-docgen --locked -- --check`
- Manual E2E: parent `.hermes`, direct `.hermes`, nested skills, multi-section files, empty sections, no-delimiter markdown, ignored extensions, batch splitting, repeat import, apply/search/retrieve/lint/forget, empty/missing archive errors, `--batch-size 0`, and source artifact conflict.
