### PR TITLE
[codex] Add Rowboat memory bridge

### DIFF
--- a/crates/cairn-cli/src/import.rs
+++ b/crates/cairn-cli/src/import.rs
@@ -19,6 +19,8 @@ use walkdir::WalkDir;
 
 const KOI_IMPORT_AUTHOR: &str = "hmn:koi-import:v1";
 const KOI_IMPORT_SENSOR: &str = "snr:koi-v1:import:local:v1";
+const ROWBOAT_IMPORT_AUTHOR: &str = "hmn:rowboat-import:v1";
+const ROWBOAT_IMPORT_SENSOR: &str = "snr:rowboat:import:local:v1";
 const SOURCE_HASH_PREFIX: &str = "sha256:";
 
 /// Build the `cairn import` CLI subcommand.
@@ -31,7 +33,7 @@ pub fn command() -> clap::Command {
                 .long("from")
                 .required(true)
                 .value_name("SYSTEM")
-                .value_parser(["koi-v1"])
+                .value_parser(["koi-v1", "rowboat"])
                 .help("Legacy memory system to import"),
         )
         .arg(
@@ -64,9 +66,6 @@ pub fn run(sub: &clap::ArgMatches, vault_root: &Path) -> std::process::ExitCode 
     let Some(system) = sub.get_one::<String>("from") else {
         return usage_error(json, "from", "--from is required");
     };
-    if system != "koi-v1" {
-        return usage_error(json, "from", "only --from koi-v1 is supported");
-    }
     let Some(archive) = sub.get_one::<PathBuf>("archive") else {
         return usage_error(json, "archive", "archive path is required");
     };
@@ -76,12 +75,20 @@ pub fn run(sub: &clap::ArgMatches, vault_root: &Path) -> std::process::ExitCode 
         .unwrap_or(64)
         .try_into()
         .unwrap_or(64_usize);
-    match map_koi_v1_archive(&KoiImportOptions {
-        source: archive.clone(),
-        batch_size,
-        mode: FlushMode::HumanReview,
-    })
-    .and_then(|report| {
+    let report = match system.as_str() {
+        "koi-v1" => map_koi_v1_archive(&KoiImportOptions {
+            source: archive.clone(),
+            batch_size,
+            mode: FlushMode::HumanReview,
+        }),
+        "rowboat" => map_rowboat_archive(&RowboatImportOptions {
+            source: archive.clone(),
+            batch_size,
+            mode: FlushMode::HumanReview,
+        }),
+        _ => return usage_error(json, "from", "unsupported import system"),
+    };
+    match report.and_then(|report| {
         let migration_report = MigrationReportSummary::from_report(&report);
         write_review_plans(vault_root, &report).map(|paths| ImportCliSummary {
             system: system.clone(),
@@ -211,6 +218,17 @@ pub struct KoiImportOptions {
     pub mode: FlushMode,
 }
 
+/// Options for mapping a Rowboat workspace into Cairn review plans.
+#[derive(Debug, Clone)]
+pub struct RowboatImportOptions {
+    /// Path to the Rowboat work directory.
+    pub source: PathBuf,
+    /// Maximum records per generated review plan.
+    pub batch_size: usize,
+    /// Plan dispatch mode. Issue #155 uses [`FlushMode::HumanReview`].
+    pub mode: FlushMode,
+}
+
 /// One ambiguous legacy field that fell back to a conservative Cairn value.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct ImportAmbiguity {
@@ -323,16 +341,16 @@ pub struct KoiImportReport {
 #[derive(Debug, Error)]
 pub enum ImportError {
     /// Source archive could not be read.
-    #[error("koi import source `{}` is not a directory", .archive.display())]
+    #[error("import source `{}` is not a directory", .archive.display())]
     SourceNotDirectory {
         /// Requested archive root.
         archive: PathBuf,
     },
     /// Batch size must be nonzero.
-    #[error("koi import batch size must be greater than zero")]
+    #[error("import batch size must be greater than zero")]
     InvalidBatchSize,
     /// File I/O failed.
-    #[error("koi import I/O for `{path}`: {source}")]
+    #[error("import I/O for `{path}`: {source}")]
     Io {
         /// File path being read or written.
         path: PathBuf,
@@ -341,7 +359,7 @@ pub enum ImportError {
         source: std::io::Error,
     },
     /// A JSON source file was malformed.
-    #[error("koi import JSON parse for `{path}`: {source}")]
+    #[error("import JSON parse for `{path}`: {source}")]
     Json {
         /// Source file being parsed.
         path: PathBuf,
@@ -351,7 +369,7 @@ pub enum ImportError {
     },
     /// Existing source artifact bytes do not match the imported record.
     #[error(
-        "koi import source artifact conflict for `{}`: existing hash `{existing}` does not match expected `{expected}`",
+        "import source artifact conflict for `{}`: existing hash `{existing}` does not match expected `{expected}`",
         .path.display()
     )]
     SourceArtifactConflict {
@@ -363,7 +381,7 @@ pub enum ImportError {
         existing: String,
     },
     /// A mapped record failed domain validation.
-    #[error("koi import record build for `{path}`: {source}")]
+    #[error("import record build for `{path}`: {source}")]
     Domain {
         /// Source path being mapped.
         path: PathBuf,
@@ -372,7 +390,7 @@ pub enum ImportError {
         source: cairn_core::domain::DomainError,
     },
     /// A review plan could not be serialized.
-    #[error("koi import plan serialize for `{path}`: {source}")]
+    #[error("import plan serialize for `{path}`: {source}")]
     Serialize {
         /// Plan path being written.
         path: PathBuf,
@@ -421,7 +439,14 @@ pub fn map_koi_v1_archive(opts: &KoiImportOptions) -> Result<KoiImportReport, Im
         records.push(mapped.record);
     }
 
-    let plans = plan_records(&opts.source, &records, opts.batch_size, opts.mode)?;
+    let plans = plan_records(
+        "koi-v1",
+        KOI_IMPORT_AUTHOR,
+        &opts.source,
+        &records,
+        opts.batch_size,
+        opts.mode,
+    )?;
     let unsupported_fields = findings
         .iter()
         .filter(|finding| finding.kind == ExternalImportFindingKind::Unsupported)
@@ -435,6 +460,104 @@ pub fn map_koi_v1_archive(opts: &KoiImportOptions) -> Result<KoiImportReport, Im
     Ok(KoiImportReport {
         manifest: ExternalImportManifest {
             system: "koi-v1".to_owned(),
+            items,
+            unsupported_fields,
+            privacy_sensitive_fields,
+        },
+        records,
+        ambiguities,
+        findings,
+        plans,
+    })
+}
+
+/// Map a Rowboat work directory into valid Cairn records and pending review plans.
+///
+/// This bridge imports knowledge markdown notes only. Rowboat sync state is
+/// preserved as manifest context and migration-report findings for review.
+pub fn map_rowboat_archive(opts: &RowboatImportOptions) -> Result<KoiImportReport, ImportError> {
+    if opts.batch_size == 0 {
+        return Err(ImportError::InvalidBatchSize);
+    }
+    if !opts.source.is_dir() {
+        return Err(ImportError::SourceNotDirectory {
+            archive: opts.source.clone(),
+        });
+    }
+
+    let state = read_rowboat_state(&opts.source)?;
+    let mut records = Vec::new();
+    let mut ambiguities = Vec::new();
+    let mut findings = Vec::new();
+    let mut items = Vec::new();
+    let knowledge_root = opts.source.join("knowledge");
+    if knowledge_root.is_dir() {
+        for entry in WalkDir::new(&knowledge_root)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+        {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+                continue;
+            }
+            let raw = fs::read_to_string(path).map_err(|source| ImportError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+            let mapped = map_rowboat_note(path, &opts.source, &raw, &state.workflow_ids)?;
+            ambiguities.extend(mapped.ambiguities);
+            findings.extend(mapped.findings);
+            items.extend(mapped.items);
+            records.push(mapped.record);
+        }
+    }
+    findings.extend(state.findings);
+    items.extend(state.workflow_ids.into_iter().map(|workflow_id| {
+        let provenance = records.first().map_or_else(
+            || ExternalImportProvenance {
+                source_sensor: ROWBOAT_IMPORT_SENSOR.to_owned(),
+                source_hash: format!("{SOURCE_HASH_PREFIX}{:x}", Sha256::digest([])),
+                source_refs: Vec::new(),
+            },
+            |record| ExternalImportProvenance {
+                source_sensor: ROWBOAT_IMPORT_SENSOR.to_owned(),
+                source_hash: record.provenance.source_hash.clone(),
+                source_refs: record.provenance.source_refs.clone(),
+            },
+        );
+        ExternalImportItem {
+            kind: ExternalImportItemKind::Skill,
+            source_path: PathBuf::from("agent_notes_state.json"),
+            legacy_id: Some(workflow_id.clone()),
+            session_ids: Vec::new(),
+            skill_ids: vec![workflow_id],
+            provenance,
+        }
+    }));
+
+    let plans = plan_records(
+        "rowboat",
+        ROWBOAT_IMPORT_AUTHOR,
+        &opts.source,
+        &records,
+        opts.batch_size,
+        opts.mode,
+    )?;
+    let unsupported_fields = findings
+        .iter()
+        .filter(|finding| finding.kind == ExternalImportFindingKind::Unsupported)
+        .cloned()
+        .collect();
+    let privacy_sensitive_fields = findings
+        .iter()
+        .filter(|finding| finding.kind == ExternalImportFindingKind::PrivacySensitive)
+        .cloned()
+        .collect();
+    Ok(KoiImportReport {
+        manifest: ExternalImportManifest {
+            system: "rowboat".to_owned(),
             items,
             unsupported_fields,
             privacy_sensitive_fields,
@@ -494,11 +617,414 @@ pub fn write_review_plans(
     Ok(vec![pending])
 }
 
+struct RowboatState {
+    workflow_ids: Vec<String>,
+    findings: Vec<ExternalImportFinding>,
+}
+
 struct MappedFile {
     record: MemoryRecord,
     ambiguities: Vec<ImportAmbiguity>,
     findings: Vec<ExternalImportFinding>,
     items: Vec<ExternalImportItem>,
+}
+
+fn read_rowboat_state(root: &Path) -> Result<RowboatState, ImportError> {
+    let path = root.join("agent_notes_state.json");
+    if !path.exists() {
+        return Ok(RowboatState {
+            workflow_ids: Vec::new(),
+            findings: Vec::new(),
+        });
+    }
+    let raw = fs::read_to_string(&path).map_err(|source| ImportError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let json = serde_json::from_str::<Value>(&raw).map_err(|source| ImportError::Json {
+        path: PathBuf::from("agent_notes_state.json"),
+        source,
+    })?;
+    let workflow_ids = json
+        .get("workflows")
+        .map(id_values)
+        .unwrap_or_default()
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let findings = findings_from_rowboat_json_object(
+        json.as_object(),
+        Path::new("agent_notes_state.json"),
+        &["last_sync_at", "workflows"],
+    );
+    Ok(RowboatState {
+        workflow_ids,
+        findings,
+    })
+}
+
+fn map_rowboat_note(
+    path: &Path,
+    root: &Path,
+    raw: &str,
+    workflow_ids: &[String],
+) -> Result<MappedFile, ImportError> {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    let (frontmatter, body) = split_markdown_frontmatter(raw);
+    let note_type = frontmatter
+        .get("type")
+        .or_else(|| frontmatter.get("note_type"))
+        .map(String::as_str);
+    let kind = rowboat_kind(note_type);
+    let class = class_for_kind(kind);
+    let issued_at = Rfc3339Timestamp::parse(
+        frontmatter
+            .get("created_at")
+            .or_else(|| frontmatter.get("updated_at"))
+            .cloned()
+            .unwrap_or_else(|| "2026-01-01T00:00:00Z".to_owned()),
+    )
+    .map_err(|source| ImportError::Domain {
+        path: relative.to_path_buf(),
+        source,
+    })?;
+    let author = Identity::parse(ROWBOAT_IMPORT_AUTHOR).map_err(|source| ImportError::Domain {
+        path: relative.to_path_buf(),
+        source,
+    })?;
+    let body = body.trim().to_owned();
+    let body_hash = format!("{:x}", Sha256::digest(body.as_bytes()));
+    let extra_frontmatter = rowboat_extra_frontmatter(
+        relative,
+        &frontmatter,
+        note_type,
+        &body,
+        &body_hash,
+        workflow_ids,
+    );
+    let tags = note_type
+        .into_iter()
+        .map(|value| format!("rowboat:{value}"))
+        .chain(std::iter::once("rowboat".to_owned()))
+        .collect::<Vec<_>>();
+    let identity_seed = format!("{}:{body_hash}", slash_normalized_path(relative));
+    let record = build_rowboat_record(RowboatRecordBuild {
+        relative,
+        identity_seed: &identity_seed,
+        kind,
+        class,
+        body,
+        source_hash: format!("{SOURCE_HASH_PREFIX}{body_hash}"),
+        issued_at,
+        author,
+        tags,
+        extra_frontmatter,
+    })?;
+    record.validate().map_err(|source| ImportError::Domain {
+        path: relative.to_path_buf(),
+        source,
+    })?;
+    let item = ExternalImportItem {
+        kind: ExternalImportItemKind::Record,
+        source_path: relative.to_path_buf(),
+        legacy_id: rowboat_legacy_id(&frontmatter),
+        session_ids: Vec::new(),
+        skill_ids: workflow_ids.to_vec(),
+        provenance: ExternalImportProvenance {
+            source_sensor: ROWBOAT_IMPORT_SENSOR.to_owned(),
+            source_hash: record.provenance.source_hash.clone(),
+            source_refs: record.provenance.source_refs.clone(),
+        },
+    };
+    let findings = findings_from_rowboat_object(
+        Some(&frontmatter),
+        relative,
+        &[
+            "type",
+            "note_type",
+            "source",
+            "rowboat_id",
+            "id",
+            "created_at",
+            "updated_at",
+        ],
+    );
+    Ok(MappedFile {
+        record,
+        ambiguities: Vec::new(),
+        findings,
+        items: vec![item],
+    })
+}
+
+struct RowboatRecordBuild<'a> {
+    relative: &'a Path,
+    identity_seed: &'a str,
+    kind: MemoryKind,
+    class: MemoryClass,
+    body: String,
+    source_hash: String,
+    issued_at: Rfc3339Timestamp,
+    author: Identity,
+    tags: Vec<String>,
+    extra_frontmatter: BTreeMap<String, Value>,
+}
+
+fn rowboat_extra_frontmatter(
+    relative: &Path,
+    frontmatter: &BTreeMap<String, String>,
+    note_type: Option<&str>,
+    body: &str,
+    body_hash: &str,
+    workflow_ids: &[String],
+) -> BTreeMap<String, Value> {
+    let mut extra = BTreeMap::from([
+        (
+            "rowboat_source_path".to_owned(),
+            Value::String(slash_normalized_path(relative)),
+        ),
+        (
+            "rowboat_body_hash".to_owned(),
+            Value::String(body_hash.to_owned()),
+        ),
+    ]);
+    if let Some(note_type) = note_type {
+        extra.insert(
+            "rowboat_note_type".to_owned(),
+            Value::String(note_type.to_owned()),
+        );
+    }
+    if let Some(source) = frontmatter.get("source") {
+        extra.insert("rowboat_source".to_owned(), Value::String(source.clone()));
+    }
+    if let Some(rowboat_id) = rowboat_legacy_id(frontmatter) {
+        extra.insert("rowboat_id".to_owned(), Value::String(rowboat_id));
+    }
+    let wikilinks = rowboat_wikilinks(body);
+    if !wikilinks.is_empty() {
+        extra.insert("rowboat_wikilinks".to_owned(), serde_json::json!(wikilinks));
+    }
+    if !workflow_ids.is_empty() {
+        extra.insert(
+            "rowboat_workflow_ids".to_owned(),
+            serde_json::json!(workflow_ids),
+        );
+    }
+    extra
+}
+
+fn build_rowboat_record(args: RowboatRecordBuild<'_>) -> Result<MemoryRecord, ImportError> {
+    let source_id =
+        SourceId::parse(deterministic_ulid(args.identity_seed, "source").0).map_err(|source| {
+            ImportError::Domain {
+                path: args.relative.to_path_buf(),
+                source,
+            }
+        })?;
+    let source_ref_id = source_id.as_str().to_owned();
+    let source_hash = args.source_hash.clone();
+    let provenance = rowboat_provenance(source_id.clone(), source_ref_id, source_hash, &args)?;
+    Ok(MemoryRecord {
+        id: RecordId::parse(deterministic_ulid(args.identity_seed, "record").0).map_err(
+            |source| ImportError::Domain {
+                path: args.relative.to_path_buf(),
+                source,
+            },
+        )?,
+        target_id: TargetId::parse(deterministic_ulid(args.identity_seed, "target").0).map_err(
+            |source| ImportError::Domain {
+                path: args.relative.to_path_buf(),
+                source,
+            },
+        )?,
+        kind: args.kind,
+        class: args.class,
+        visibility: MemoryVisibility::Private,
+        scope: rowboat_scope(),
+        body: args.body,
+        source_ids: vec![source_id.clone()],
+        provenance,
+        updated_at: args.issued_at.clone(),
+        evidence: EvidenceVector::default(),
+        salience: 0.5,
+        confidence: 0.7,
+        actor_chain: vec![ActorChainEntry {
+            role: ChainRole::Author,
+            identity: args.author,
+            at: args.issued_at,
+        }],
+        signature: placeholder_import_signature(args.relative)?,
+        tags: args.tags,
+        extra_frontmatter: args.extra_frontmatter,
+        consent_model: None,
+    })
+}
+
+fn rowboat_scope() -> ScopeTuple {
+    ScopeTuple {
+        tenant: Some("default".to_owned()),
+        workspace: Some("my-vault".to_owned()),
+        entity: Some("ingest".to_owned()),
+        user: ROWBOAT_IMPORT_AUTHOR.to_owned().into(),
+        ..ScopeTuple::default()
+    }
+}
+
+fn rowboat_provenance(
+    source_id: SourceId,
+    source_ref_id: String,
+    source_hash: String,
+    args: &RowboatRecordBuild<'_>,
+) -> Result<Provenance, ImportError> {
+    Ok(Provenance {
+        source_sensor: Identity::parse(ROWBOAT_IMPORT_SENSOR).map_err(|source| {
+            ImportError::Domain {
+                path: args.relative.to_path_buf(),
+                source,
+            }
+        })?,
+        created_at: args.issued_at.clone(),
+        originating_agent_id: args.author.clone(),
+        source_ids: vec![source_id],
+        source_hash: source_hash.clone(),
+        consent_ref: "consent:rowboat-import".to_owned(),
+        llm_id_if_any: None,
+        source_refs: vec![SourceRef {
+            id: source_ref_id,
+            hash: source_hash,
+        }],
+    })
+}
+
+fn placeholder_import_signature(
+    relative: &Path,
+) -> Result<cairn_core::domain::record::Ed25519Signature, ImportError> {
+    cairn_core::domain::record::Ed25519Signature::parse(format!("ed25519:{}", "b".repeat(128)))
+        .map_err(|source| ImportError::Domain {
+            path: relative.to_path_buf(),
+            source,
+        })
+}
+
+fn rowboat_legacy_id(frontmatter: &BTreeMap<String, String>) -> Option<String> {
+    frontmatter
+        .get("rowboat_id")
+        .or_else(|| frontmatter.get("id"))
+        .cloned()
+}
+
+fn split_markdown_frontmatter(raw: &str) -> (BTreeMap<String, String>, &str) {
+    let Some(rest) = raw.strip_prefix("---\n") else {
+        return (BTreeMap::new(), raw);
+    };
+    let Some(end) = rest.find("\n---\n") else {
+        return (BTreeMap::new(), raw);
+    };
+    let frontmatter_raw = &rest[..end];
+    let body = &rest[end + "\n---\n".len()..];
+    let mut frontmatter = BTreeMap::new();
+    for line in frontmatter_raw.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim().trim_matches('"');
+        if !key.is_empty() && !value.is_empty() {
+            frontmatter.insert(key.to_owned(), value.to_owned());
+        }
+    }
+    (frontmatter, body)
+}
+
+fn rowboat_kind(note_type: Option<&str>) -> MemoryKind {
+    match note_type {
+        Some("People" | "Organizations" | "Projects") => MemoryKind::Entity,
+        _ => MemoryKind::Reference,
+    }
+}
+
+fn rowboat_wikilinks(body: &str) -> Vec<String> {
+    let mut links = BTreeSet::new();
+    let mut rest = body;
+    while let Some(start) = rest.find("[[") {
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find("]]") else {
+            break;
+        };
+        let link = after_start[..end].trim();
+        if !link.is_empty() {
+            links.insert(link.to_owned());
+        }
+        rest = &after_start[end + 2..];
+    }
+    links.into_iter().collect()
+}
+
+fn findings_from_rowboat_object(
+    map: Option<&BTreeMap<String, String>>,
+    relative: &Path,
+    supported: &[&str],
+) -> Vec<ExternalImportFinding> {
+    let Some(map) = map else {
+        return Vec::new();
+    };
+    map.keys()
+        .filter(|key| !supported.contains(&key.as_str()))
+        .map(|key| {
+            let (kind, reason) = if is_privacy_sensitive_field(key) {
+                (
+                    ExternalImportFindingKind::PrivacySensitive,
+                    "legacy field name looks privacy-sensitive and requires review".to_owned(),
+                )
+            } else {
+                (
+                    ExternalImportFindingKind::Unsupported,
+                    "Rowboat field has no neutral Cairn import-manifest target".to_owned(),
+                )
+            };
+            ExternalImportFinding {
+                path: relative.to_path_buf(),
+                kind,
+                field: key.clone(),
+                fallback: None,
+                reason,
+            }
+        })
+        .collect()
+}
+
+fn findings_from_rowboat_json_object(
+    map: Option<&serde_json::Map<String, Value>>,
+    relative: &Path,
+    supported: &[&str],
+) -> Vec<ExternalImportFinding> {
+    let Some(map) = map else {
+        return Vec::new();
+    };
+    map.keys()
+        .filter(|key| !supported.contains(&key.as_str()))
+        .map(|key| {
+            let (kind, reason) = if is_privacy_sensitive_field(key) {
+                (
+                    ExternalImportFindingKind::PrivacySensitive,
+                    "legacy field name looks privacy-sensitive and requires review".to_owned(),
+                )
+            } else {
+                (
+                    ExternalImportFindingKind::Unsupported,
+                    "Rowboat state field has no neutral Cairn import-manifest target".to_owned(),
+                )
+            };
+            ExternalImportFinding {
+                path: relative.to_path_buf(),
+                kind,
+                field: key.clone(),
+                fallback: None,
+                reason,
+            }
+        })
+        .collect()
 }
 
 fn is_importable(path: &Path) -> bool {
@@ -912,13 +1438,15 @@ const fn class_for_kind(kind: MemoryKind) -> MemoryClass {
 }
 
 fn plan_records(
+    system: &str,
+    author_identity: &str,
     source_root: &Path,
     records: &[MemoryRecord],
     batch_size: usize,
     mode: FlushMode,
 ) -> Result<Vec<FlushPlan>, ImportError> {
     let mut plans = Vec::new();
-    let author = Identity::parse(KOI_IMPORT_AUTHOR).map_err(|source| ImportError::Domain {
+    let author = Identity::parse(author_identity).map_err(|source| ImportError::Domain {
         path: source_root.to_path_buf(),
         source,
     })?;
@@ -927,7 +1455,7 @@ fn plan_records(
         let expires_at = (chrono::Utc::now() + chrono::Duration::minutes(5))
             .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
         plans.push(FlushPlan {
-            operation_id: deterministic_operation_id(source_root, idx, chunk),
+            operation_id: deterministic_operation_id(system, source_root, idx, chunk),
             issued_at,
             issuer: author.clone(),
             principal: None,
@@ -953,13 +1481,16 @@ fn plan_records(
 }
 
 fn deterministic_operation_id(
+    system: &str,
     source_root: &Path,
     batch_index: usize,
     records: &[MemoryRecord],
 ) -> Ulid {
     let mut hasher = Sha256::new();
     hasher.update(slash_normalized_path(source_root).as_bytes());
-    hasher.update(b":koi-v1:");
+    hasher.update(b":");
+    hasher.update(system.as_bytes());
+    hasher.update(b":");
     hasher.update(batch_index.to_be_bytes());
     for record in records {
         hasher.update(b":");

--- a/crates/cairn-cli/tests/rowboat_import.rs
+++ b/crates/cairn-cli/tests/rowboat_import.rs
@@ -1,0 +1,250 @@
+//! Consumer acceptance coverage for the Rowboat migration bridge.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use cairn_core::domain::flush_plan::{PersistedPlan, PlannedMutation};
+
+fn cli() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cairn"));
+    cmd.env_remove("CAIRN_VAULT");
+    cmd.env_remove("CAIRN_REGISTRY");
+    cmd
+}
+
+fn bootstrap_vault(vault: &Path) {
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: vault.to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+}
+
+fn run_in_vault(vault: &Path, args: &[&str]) -> Output {
+    cli()
+        .current_dir(vault)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run cairn {args:?}: {e}"))
+}
+
+fn run_json_ok(vault: &Path, args: &[&str]) -> serde_json::Value {
+    let out = run_in_vault(vault, args);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "cairn {args:?} failed\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("cairn {args:?} emitted invalid JSON: {e}"))
+}
+
+fn json_output(out: &Output, args: &[&str]) -> serde_json::Value {
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("cairn {args:?} emitted invalid JSON: {e}"))
+}
+
+fn single_pending_plan(vault: &Path) -> (String, PersistedPlan) {
+    let pending_dir = vault.join(".cairn/flush/pending");
+    let entries: Vec<_> = std::fs::read_dir(&pending_dir)
+        .unwrap_or_else(|e| panic!("read pending dir {}: {e}", pending_dir.display()))
+        .map(|entry| entry.expect("pending dir entry").path())
+        .filter(|path| {
+            path.file_name()
+                .is_some_and(|name| name.to_string_lossy().ends_with(".plan.json"))
+        })
+        .collect();
+    assert_eq!(entries.len(), 1, "expected one pending plan: {entries:?}");
+    let path = &entries[0];
+    let file_name = path.file_name().expect("file name").to_string_lossy();
+    let operation_id = file_name
+        .strip_suffix(".plan.json")
+        .expect("plan suffix")
+        .to_owned();
+    let plan: PersistedPlan =
+        serde_json::from_slice(&std::fs::read(path).expect("read pending plan"))
+            .expect("pending plan json");
+    (operation_id, plan)
+}
+
+fn upsert_record_id(plan: &PersistedPlan) -> String {
+    let Some(PlannedMutation::Upsert { record, .. }) = plan.plan.mutations.first() else {
+        panic!(
+            "expected first mutation to be an upsert: {:?}",
+            plan.plan.mutations
+        );
+    };
+    record.id.as_str().to_owned()
+}
+
+fn hit_record_ids(vault: &Path, query: &str) -> Vec<String> {
+    let search = run_json_ok(vault, &["search", "--mode", "keyword", query, "--json"]);
+    search["data"]["hits"]
+        .as_array()
+        .unwrap_or_else(|| panic!("search hits must be an array: {search}"))
+        .iter()
+        .map(|hit| hit["record_id"].as_str().expect("hit record_id").to_owned())
+        .collect()
+}
+
+fn write_rowboat_fixture(root: &Path, body: &str) {
+    let knowledge = root.join("knowledge");
+    std::fs::create_dir_all(knowledge.join("People")).expect("people dir");
+    std::fs::write(
+        knowledge.join("People").join("Ada Lovelace.md"),
+        format!(
+            r"---
+type: People
+source: Gmail
+rowboat_id: person-ada
+unmapped_field: should-be-reviewed
+---
+# Ada Lovelace
+
+{body}
+
+Works with [[Analytical Engine]] on agent memory planning.
+"
+        ),
+    )
+    .expect("write rowboat note");
+    std::fs::write(
+        root.join("agent_notes_state.json"),
+        r#"{
+          "last_sync_at": "2026-03-04T05:06:07Z",
+          "workflows": [{"id": "wf-gmail", "name": "Gmail Sync"}],
+          "oauth_token": "redacted-before-review"
+        }"#,
+    )
+    .expect("write rowboat state");
+}
+
+#[test]
+fn rowboat_import_plan_applies_to_search_retrieve_lint_and_forget() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    run_json_ok(vault.path(), &["identity", "init-defaults", "--json"]);
+    run_json_ok(
+        vault.path(),
+        &["identity", "provision", "human", "rowboat-import", "--json"],
+    );
+    run_json_ok(
+        vault.path(),
+        &[
+            "identity",
+            "provision",
+            "agent",
+            "cairn-cli:default:writer",
+            "--json",
+        ],
+    );
+    let archive = tempfile::tempdir().expect("rowboat archive");
+    let body = "rowboat bridge remembers lapis relationship marker";
+    write_rowboat_fixture(archive.path(), body);
+
+    let import = run_json_ok(
+        vault.path(),
+        &[
+            "import",
+            "--from",
+            "rowboat",
+            archive.path().to_str().expect("utf-8 archive path"),
+            "--batch-size",
+            "1",
+            "--json",
+        ],
+    );
+    assert_eq!(import["records"], 1, "import summary: {import}");
+    assert_eq!(import["plans"], 1, "import summary: {import}");
+
+    let (operation_id, pending) = single_pending_plan(vault.path());
+    let record_id = upsert_record_id(&pending);
+
+    run_json_ok(vault.path(), &["flush", "apply", &operation_id, "--json"]);
+
+    let hits = hit_record_ids(vault.path(), "lapis");
+    assert_eq!(hits, vec![record_id.clone()], "search should find import");
+
+    let retrieve = run_json_ok(vault.path(), &["retrieve", &record_id, "--json"]);
+    assert!(
+        retrieve["data"]["body"]
+            .as_str()
+            .expect("retrieve body")
+            .contains(body),
+        "retrieve should expose imported body: {retrieve}"
+    );
+
+    let lint_out = run_in_vault(vault.path(), &["lint", "--json"]);
+    let lint = json_output(&lint_out, &["lint", "--json"]);
+    assert_eq!(lint["status"], "committed", "lint should complete: {lint}");
+    assert_eq!(
+        lint["data"]["summary"]["by_severity"]["error"], 0,
+        "imported record should not produce lint errors: {lint}"
+    );
+
+    run_json_ok(vault.path(), &["forget", "--record", &record_id, "--json"]);
+    assert!(
+        hit_record_ids(vault.path(), "lapis").is_empty(),
+        "forgotten import should leave keyword search"
+    );
+}
+
+#[test]
+fn rowboat_import_json_emits_manifest_and_migration_report() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let archive = tempfile::tempdir().expect("rowboat archive");
+    write_rowboat_fixture(archive.path(), "rowboat migration report fixture");
+
+    let import = run_json_ok(
+        vault.path(),
+        &[
+            "import",
+            "--from",
+            "rowboat",
+            archive.path().to_str().expect("utf-8 archive path"),
+            "--batch-size",
+            "1",
+            "--json",
+        ],
+    );
+
+    assert_eq!(import["records"], 1, "import summary: {import}");
+    assert_eq!(
+        import["manifest"]["system"], "rowboat",
+        "manifest: {import}"
+    );
+    assert_eq!(
+        import["manifest"]["items"].as_array().expect("items").len(),
+        2,
+        "record and workflow manifest items should be emitted: {import}"
+    );
+    assert!(
+        import["manifest"]["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .any(|item| item["kind"] == "skill" && item["legacy_id"] == "wf-gmail"),
+        "workflow context should be preserved as a skill-like item: {import}"
+    );
+    assert_eq!(
+        import["migration_report"]["unsupported_fields"], 1,
+        "unsupported note frontmatter should be counted: {import}"
+    );
+    assert_eq!(
+        import["migration_report"]["privacy_sensitive_fields"], 1,
+        "privacy-sensitive state fields should be counted: {import}"
+    );
+    assert!(
+        import["migration_report"]["findings"]
+            .as_array()
+            .expect("findings")
+            .iter()
+            .any(|finding| {
+                finding["field"] == "oauth_token" && finding["kind"] == "privacy_sensitive"
+            }),
+        "privacy-sensitive finding should be emitted: {import}"
+    );
+}

--- a/docs/site/src/reference/generated/commands/import.md
+++ b/docs/site/src/reference/generated/commands/import.md
@@ -15,7 +15,7 @@ Arguments:
   <PATH>  Legacy archive root to scan
 
 Options:
-      --from <SYSTEM>         Legacy memory system to import [possible values: koi-v1]
+      --from <SYSTEM>         Legacy memory system to import [possible values: koi-v1, rowboat]
       --vault <NAME_OR_PATH>  Active vault: name from registry or filesystem path (overrides
                               CAIRN_VAULT)
       --batch-size <U32>      Maximum records per pending review plan [default: 64]


### PR DESCRIPTION
## Summary

- Adds `cairn import --from rowboat` for Rowboat work directories, mapping knowledge markdown notes into reviewable Cairn import records.
- Preserves Rowboat note metadata, wikilinks, workflow context from `agent_notes_state.json`, and migration findings for unsupported or privacy-sensitive fields.
- Adds Rowboat fixture coverage for manifest/report output and apply/search/retrieve/lint/forget behavior while keeping Koi import regression coverage green.

## Issue Coverage

Closes #155.

This PR covers the issue acceptance criteria:

- Rowboat imports are emitted as human-review flush plans.
- Imported records validate against Cairn schema and provenance rules.
- Source workflow context is preserved in the import manifest.
- Unsupported and privacy-sensitive Rowboat fields are reported for review.
- Imported fixtures work through search, retrieve, lint, and forget flows.

## Test Plan

- `cargo test -p cairn-cli --test rowboat_import --locked`
- `cargo test -p cairn-cli --test koi_import --locked`
- `cargo test -p cairn-cli import::tests --locked`
- `cargo clippy -p cairn-cli --all-targets --locked -- -D warnings`
- `cargo fmt --check --all`
- `cargo run -p cairn-cli --bin cairn-docgen --locked -- --check`
- `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
- Manual e2e Rowboat CLI sweep with temporary vaults covering nested notes, batching/apply/search, state-only archives, malformed state, invalid timestamps, non-directory sources, zero batch size, idempotent re-import, tampered source artifact rejection, duplicate bodies, and no-frontmatter markdown with wikilinks.
