### PR TITLE
[codex] Add OpenClaw import bridge

### DIFF
--- a/crates/cairn-cli/src/import.rs
+++ b/crates/cairn-cli/src/import.rs
@@ -19,6 +19,8 @@ use walkdir::WalkDir;
 
 const KOI_IMPORT_AUTHOR: &str = "hmn:koi-import:v1";
 const KOI_IMPORT_SENSOR: &str = "snr:koi-v1:import:local:v1";
+const OPENCLAW_IMPORT_AUTHOR: &str = "hmn:openclaw-import:v1";
+const OPENCLAW_IMPORT_SENSOR: &str = "snr:openclaw:import:local:v1";
 const ROWBOAT_IMPORT_AUTHOR: &str = "hmn:rowboat-import:v1";
 const ROWBOAT_IMPORT_SENSOR: &str = "snr:rowboat:import:local:v1";
 const OPENCODE_IMPORT_AUTHOR: &str = "hmn:opencode-import:v1";
@@ -26,6 +28,42 @@ const OPENCODE_IMPORT_SENSOR: &str = "snr:opencode:import:local:v1";
 const HERMES_IMPORT_AUTHOR: &str = "hmn:hermes-import:v1";
 const HERMES_IMPORT_SENSOR: &str = "snr:hermes-agent:import:local:v1";
 const SOURCE_HASH_PREFIX: &str = "sha256:";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImportSystem {
+    KoiV1,
+    OpenClaw,
+}
+
+impl ImportSystem {
+    const fn spec(self) -> ImportSpec {
+        match self {
+            Self::KoiV1 => ImportSpec {
+                system: "koi-v1",
+                author: KOI_IMPORT_AUTHOR,
+                sensor: KOI_IMPORT_SENSOR,
+                consent_ref: "consent:koi-v1-import",
+                frontmatter_prefix: "koi_v1",
+            },
+            Self::OpenClaw => ImportSpec {
+                system: "openclaw",
+                author: OPENCLAW_IMPORT_AUTHOR,
+                sensor: OPENCLAW_IMPORT_SENSOR,
+                consent_ref: "consent:openclaw-import",
+                frontmatter_prefix: "openclaw",
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ImportSpec {
+    system: &'static str,
+    author: &'static str,
+    sensor: &'static str,
+    consent_ref: &'static str,
+    frontmatter_prefix: &'static str,
+}
 
 /// Build the `cairn import` CLI subcommand.
 #[must_use]
@@ -37,7 +75,7 @@ pub fn command() -> clap::Command {
                 .long("from")
                 .required(true)
                 .value_name("SYSTEM")
-                .value_parser(["koi-v1", "rowboat", "opencode", "hermes-agent"])
+                .value_parser(["koi-v1", "openclaw", "rowboat", "opencode", "hermes-agent"])
                 .help("Legacy memory system to import"),
         )
         .arg(
@@ -79,12 +117,29 @@ pub fn run(sub: &clap::ArgMatches, vault_root: &Path) -> std::process::ExitCode 
         .unwrap_or(64)
         .try_into()
         .unwrap_or(64_usize);
+    let default_workspace = match configured_default_workspace(vault_root, json) {
+        Ok(default_workspace) => default_workspace,
+        Err(code) => return code,
+    };
     let report = match system.as_str() {
-        "koi-v1" => map_koi_v1_archive(&KoiImportOptions {
-            source: archive.clone(),
-            batch_size,
-            mode: FlushMode::HumanReview,
-        }),
+        "koi-v1" => map_archive(
+            ImportSystem::KoiV1,
+            &KoiImportOptions {
+                source: archive.clone(),
+                batch_size,
+                mode: FlushMode::HumanReview,
+            },
+            &default_workspace,
+        ),
+        "openclaw" => map_archive(
+            ImportSystem::OpenClaw,
+            &KoiImportOptions {
+                source: archive.clone(),
+                batch_size,
+                mode: FlushMode::HumanReview,
+            },
+            &default_workspace,
+        ),
         "rowboat" => map_rowboat_archive(&RowboatImportOptions {
             source: archive.clone(),
             batch_size,
@@ -199,6 +254,32 @@ impl MigrationReportSummary {
             findings: report.findings.clone(),
         }
     }
+}
+
+fn configured_default_workspace(
+    vault_root: &Path,
+    json: bool,
+) -> Result<String, std::process::ExitCode> {
+    crate::config::load(vault_root, &crate::config::CliOverrides::default())
+        .map(|config| config.vault.name)
+        .map_err(|err| {
+            if json {
+                let response = serde_json::json!({
+                    "status": "error",
+                    "error": {
+                        "code": "ConfigError",
+                        "message": err.to_string(),
+                    }
+                });
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&response).unwrap_or_else(|_| "{}".to_owned())
+                );
+            } else {
+                eprintln!("cairn import: config error — {err:#}");
+            }
+            std::process::ExitCode::from(78)
+        })
 }
 
 fn usage_error(json: bool, field: &str, message: &str) -> std::process::ExitCode {
@@ -430,6 +511,14 @@ pub enum ImportError {
 /// This bridge performs no database writes. The resulting plans can be reviewed
 /// and later applied through the ordinary flush path.
 pub fn map_koi_v1_archive(opts: &KoiImportOptions) -> Result<KoiImportReport, ImportError> {
+    map_archive(ImportSystem::KoiV1, opts, "my-vault")
+}
+
+fn map_archive(
+    system: ImportSystem,
+    opts: &KoiImportOptions,
+    default_workspace: &str,
+) -> Result<KoiImportReport, ImportError> {
     if opts.batch_size == 0 {
         return Err(ImportError::InvalidBatchSize);
     }
@@ -443,6 +532,7 @@ pub fn map_koi_v1_archive(opts: &KoiImportOptions) -> Result<KoiImportReport, Im
     let mut ambiguities = Vec::new();
     let mut findings = Vec::new();
     let mut items = Vec::new();
+    let spec = system.spec();
     for entry in WalkDir::new(&opts.source)
         .sort_by_file_name()
         .into_iter()
@@ -450,14 +540,14 @@ pub fn map_koi_v1_archive(opts: &KoiImportOptions) -> Result<KoiImportReport, Im
         .filter(|entry| entry.file_type().is_file())
     {
         let path = entry.path();
-        if !is_importable(path) {
+        if !is_importable(system, path, &opts.source) {
             continue;
         }
         let raw = fs::read_to_string(path).map_err(|source| ImportError::Io {
             path: path.to_path_buf(),
             source,
         })?;
-        let mapped = map_file(path, &opts.source, &raw)?;
+        let mapped = map_file(path, &opts.source, &raw, spec, default_workspace)?;
         ambiguities.extend(mapped.ambiguities);
         findings.extend(mapped.findings);
         items.extend(mapped.items);
@@ -465,8 +555,8 @@ pub fn map_koi_v1_archive(opts: &KoiImportOptions) -> Result<KoiImportReport, Im
     }
 
     let plans = plan_records(
-        "koi-v1",
-        KOI_IMPORT_AUTHOR,
+        spec.system,
+        spec.author,
         &opts.source,
         &records,
         opts.batch_size,
@@ -484,7 +574,7 @@ pub fn map_koi_v1_archive(opts: &KoiImportOptions) -> Result<KoiImportReport, Im
         .collect();
     Ok(KoiImportReport {
         manifest: ExternalImportManifest {
-            system: "koi-v1".to_owned(),
+            system: spec.system.to_owned(),
             items,
             unsupported_fields,
             privacy_sensitive_fields,
@@ -1158,10 +1248,26 @@ fn findings_from_rowboat_json_object(
         .collect()
 }
 
-fn is_importable(path: &Path) -> bool {
-    matches!(
+fn is_importable(system: ImportSystem, path: &Path, root: &Path) -> bool {
+    let importable_extension = matches!(
         path.extension().and_then(|ext| ext.to_str()),
         Some("json" | "md" | "txt")
+    );
+    if !importable_extension {
+        return false;
+    }
+    if system == ImportSystem::KoiV1 {
+        return true;
+    }
+
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    let mut components = relative
+        .components()
+        .filter_map(|component| component.as_os_str().to_str());
+    matches!(
+        (components.next(), components.next()),
+        (Some("MEMORY.md" | "SOUL.md"), None)
+            | (Some("memory" | "sessions" | "transcripts"), Some(_))
     )
 }
 
@@ -1592,7 +1698,13 @@ fn map_opencode_record(
 }
 
 #[allow(clippy::too_many_lines)]
-fn map_file(path: &Path, root: &Path, raw: &str) -> Result<MappedFile, ImportError> {
+fn map_file(
+    path: &Path,
+    root: &Path,
+    raw: &str,
+    spec: ImportSpec,
+    default_workspace: &str,
+) -> Result<MappedFile, ImportError> {
     let relative = path.strip_prefix(root).unwrap_or(path);
     let parsed_json = if path
         .extension()
@@ -1618,12 +1730,16 @@ fn map_file(path: &Path, root: &Path, raw: &str) -> Result<MappedFile, ImportErr
         .as_ref()
         .and_then(|json| json.get("kind").and_then(Value::as_str))
         .and_then(|kind| MemoryKind::parse(kind).ok())
+        .or_else(|| kind_hint_for_path(spec, relative))
         .unwrap_or_else(|| {
             ambiguities.push(ImportAmbiguity {
                 path: relative.to_path_buf(),
                 field: "kind",
                 fallback: MemoryKind::Reference.as_str().to_owned(),
-                reason: "legacy Koi item did not declare a Cairn memory kind".to_owned(),
+                reason: format!(
+                    "legacy {} item did not declare a Cairn memory kind",
+                    spec.system
+                ),
             });
             MemoryKind::Reference
         });
@@ -1639,25 +1755,28 @@ fn map_file(path: &Path, root: &Path, raw: &str) -> Result<MappedFile, ImportErr
         path: relative.to_path_buf(),
         source,
     })?;
-    let author = Identity::parse(KOI_IMPORT_AUTHOR).map_err(|source| ImportError::Domain {
+    let author = Identity::parse(spec.author).map_err(|source| ImportError::Domain {
         path: relative.to_path_buf(),
         source,
     })?;
-    let scope = scope_from_json(parsed_json.as_ref());
+    let scope = scope_from_json(parsed_json.as_ref(), spec, default_workspace);
     let mut extra_frontmatter = BTreeMap::new();
     extra_frontmatter.insert(
-        "koi_v1_source_path".to_owned(),
+        format!("{}_source_path", spec.frontmatter_prefix),
         Value::String(slash_normalized_path(relative)),
     );
     extra_frontmatter.insert(
-        "koi_v1_body_hash".to_owned(),
+        format!("{}_body_hash", spec.frontmatter_prefix),
         Value::String(body_hash.clone()),
     );
     if let Some(id) = parsed_json
         .as_ref()
         .and_then(|json| json.get("id").and_then(Value::as_str))
     {
-        extra_frontmatter.insert("koi_v1_id".to_owned(), Value::String(id.to_owned()));
+        extra_frontmatter.insert(
+            format!("{}_id", spec.frontmatter_prefix),
+            Value::String(id.to_owned()),
+        );
     }
     if let Some(project) = parsed_json
         .as_ref()
@@ -1665,13 +1784,16 @@ fn map_file(path: &Path, root: &Path, raw: &str) -> Result<MappedFile, ImportErr
         .and_then(|scope| scope_string(Some(scope), "project"))
     {
         extra_frontmatter.insert(
-            "koi_v1_scope_project".to_owned(),
+            format!("{}_scope_project", spec.frontmatter_prefix),
             Value::String(project.clone()),
         );
         ambiguities.push(ImportAmbiguity {
             path: relative.to_path_buf(),
             field: "scope.project",
-            fallback: "extra_frontmatter.koi_v1_scope_project".to_owned(),
+            fallback: format!(
+                "extra_frontmatter.{}_scope_project",
+                spec.frontmatter_prefix
+            ),
             reason: "Cairn records cannot yet use project as an addressable scope dimension"
                 .to_owned(),
         });
@@ -1717,17 +1839,15 @@ fn map_file(path: &Path, root: &Path, raw: &str) -> Result<MappedFile, ImportErr
         body,
         source_ids: vec![source_id.clone()],
         provenance: Provenance {
-            source_sensor: Identity::parse(KOI_IMPORT_SENSOR).map_err(|source| {
-                ImportError::Domain {
-                    path: relative.to_path_buf(),
-                    source,
-                }
+            source_sensor: Identity::parse(spec.sensor).map_err(|source| ImportError::Domain {
+                path: relative.to_path_buf(),
+                source,
             })?,
             created_at: issued_at.clone(),
             originating_agent_id: author.clone(),
             source_ids: vec![source_id],
             source_hash: source_hash.clone(),
-            consent_ref: "consent:koi-v1-import".to_owned(),
+            consent_ref: spec.consent_ref.to_owned(),
             llm_id_if_any: None,
             source_refs: vec![SourceRef {
                 id: source_ref_id,
@@ -1766,7 +1886,7 @@ fn map_file(path: &Path, root: &Path, raw: &str) -> Result<MappedFile, ImportErr
         session_ids: session_ids_from_json(parsed_json.as_ref()),
         skill_ids: skill_ids_from_json(parsed_json.as_ref()),
         provenance: ExternalImportProvenance {
-            source_sensor: KOI_IMPORT_SENSOR.to_owned(),
+            source_sensor: spec.sensor.to_owned(),
             source_hash: record.provenance.source_hash.clone(),
             source_refs: record.provenance.source_refs.clone(),
         },
@@ -2317,21 +2437,36 @@ fn is_privacy_sensitive_field(field: &str) -> bool {
     .any(|marker| field.contains(marker))
 }
 
-fn scope_from_json(json: Option<&Value>) -> ScopeTuple {
+fn kind_hint_for_path(spec: ImportSpec, relative: &Path) -> Option<MemoryKind> {
+    if spec.system != "openclaw" {
+        return None;
+    }
+    let relative = slash_normalized_path(relative);
+    match relative.as_str() {
+        "MEMORY.md" => Some(MemoryKind::User),
+        "SOUL.md" => Some(MemoryKind::Rule),
+        _ => relative
+            .strip_prefix("memory/")
+            .and_then(|path| path.rsplit('/').next())
+            .and_then(|file_name| file_name.rsplit_once('.').map(|(stem, _)| stem))
+            .and_then(|stem| MemoryKind::parse(stem).ok()),
+    }
+}
+
+fn scope_from_json(json: Option<&Value>, spec: ImportSpec, default_workspace: &str) -> ScopeTuple {
     let scope = json.and_then(|json| json.get("scope"));
     ScopeTuple {
-        tenant: scope_string(scope, "tenant"),
-        workspace: scope_string(scope, "workspace"),
+        tenant: scope_string(scope, "tenant").or_else(|| Some("default".to_owned())),
+        workspace: scope_string(scope, "workspace").or_else(|| Some(default_workspace.to_owned())),
         project: None,
         session_id: scope_string(scope, "session_id"),
-        entity: scope_string(scope, "entity"),
+        entity: scope_string(scope, "entity").or_else(|| Some("ingest".to_owned())),
         user: scope
             .and_then(|scope| scope.get("user"))
             .and_then(Value::as_str)
             .filter(|value| value.starts_with("hmn:"))
-            .unwrap_or(KOI_IMPORT_AUTHOR)
-            .to_owned()
-            .into(),
+            .map(ToOwned::to_owned)
+            .or_else(|| (spec.system == "koi-v1").then(|| KOI_IMPORT_AUTHOR.to_owned())),
         agent: scope
             .and_then(|scope| scope.get("agent"))
             .and_then(Value::as_str)

--- a/crates/cairn-cli/src/import.rs
+++ b/crates/cairn-cli/src/import.rs
@@ -121,41 +121,8 @@ pub fn run(sub: &clap::ArgMatches, vault_root: &Path) -> std::process::ExitCode 
         Ok(default_workspace) => default_workspace,
         Err(code) => return code,
     };
-    let report = match system.as_str() {
-        "koi-v1" => map_archive(
-            ImportSystem::KoiV1,
-            &KoiImportOptions {
-                source: archive.clone(),
-                batch_size,
-                mode: FlushMode::HumanReview,
-            },
-            &default_workspace,
-        ),
-        "openclaw" => map_archive(
-            ImportSystem::OpenClaw,
-            &KoiImportOptions {
-                source: archive.clone(),
-                batch_size,
-                mode: FlushMode::HumanReview,
-            },
-            &default_workspace,
-        ),
-        "rowboat" => map_rowboat_archive(&RowboatImportOptions {
-            source: archive.clone(),
-            batch_size,
-            mode: FlushMode::HumanReview,
-        }),
-        "opencode" => map_opencode_archive(&OpenCodeImportOptions {
-            source: archive.clone(),
-            batch_size,
-            mode: FlushMode::HumanReview,
-        }),
-        "hermes-agent" => map_hermes_agent_archive(&KoiImportOptions {
-            source: archive.clone(),
-            batch_size,
-            mode: FlushMode::HumanReview,
-        }),
-        _ => return usage_error(json, "from", "unsupported import source"),
+    let Some(report) = create_import_report(system, archive, batch_size, &default_workspace) else {
+        return usage_error(json, "from", "unsupported import system");
     };
     match report.and_then(|report| {
         let migration_report = MigrationReportSummary::from_report(&report);
@@ -220,6 +187,51 @@ pub fn run(sub: &clap::ArgMatches, vault_root: &Path) -> std::process::ExitCode 
             std::process::ExitCode::from(1)
         }
     }
+}
+
+fn create_import_report(
+    system: &str,
+    archive: &Path,
+    batch_size: usize,
+    default_workspace: &str,
+) -> Option<Result<KoiImportReport, ImportError>> {
+    let source = archive.to_path_buf();
+    Some(match system {
+        "koi-v1" => map_archive(
+            ImportSystem::KoiV1,
+            &KoiImportOptions {
+                source,
+                batch_size,
+                mode: FlushMode::HumanReview,
+            },
+            default_workspace,
+        ),
+        "openclaw" => map_archive(
+            ImportSystem::OpenClaw,
+            &KoiImportOptions {
+                source,
+                batch_size,
+                mode: FlushMode::HumanReview,
+            },
+            default_workspace,
+        ),
+        "rowboat" => map_rowboat_archive(&RowboatImportOptions {
+            source,
+            batch_size,
+            mode: FlushMode::HumanReview,
+        }),
+        "opencode" => map_opencode_archive(&OpenCodeImportOptions {
+            source,
+            batch_size,
+            mode: FlushMode::HumanReview,
+        }),
+        "hermes-agent" => map_hermes_agent_archive(&KoiImportOptions {
+            source,
+            batch_size,
+            mode: FlushMode::HumanReview,
+        }),
+        _ => return None,
+    })
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -1249,11 +1261,7 @@ fn findings_from_rowboat_json_object(
 }
 
 fn is_importable(system: ImportSystem, path: &Path, root: &Path) -> bool {
-    let importable_extension = matches!(
-        path.extension().and_then(|ext| ext.to_str()),
-        Some("json" | "md" | "txt")
-    );
-    if !importable_extension {
+    if !has_importable_extension(path) {
         return false;
     }
     if system == ImportSystem::KoiV1 {
@@ -1268,6 +1276,13 @@ fn is_importable(system: ImportSystem, path: &Path, root: &Path) -> bool {
         (components.next(), components.next()),
         (Some("MEMORY.md" | "SOUL.md"), None)
             | (Some("memory" | "sessions" | "transcripts"), Some(_))
+    )
+}
+
+fn has_importable_extension(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("json" | "md" | "txt")
     )
 }
 
@@ -1961,7 +1976,7 @@ pub fn map_hermes_agent_archive(opts: &KoiImportOptions) -> Result<KoiImportRepo
             .filter(|entry| entry.file_type().is_file())
         {
             let path = entry.path();
-            if !is_importable(path) {
+            if !has_importable_extension(path) {
                 continue;
             }
             let raw = fs::read_to_string(path).map_err(|source| ImportError::Io {
@@ -2610,8 +2625,8 @@ mod tests {
     use cairn_core::domain::{FlushMode, MemoryClass, MemoryKind, PlannedMutation};
 
     use super::{
-        ExternalImportFindingKind, ExternalImportItemKind, KoiImportOptions, map_koi_v1_archive,
-        write_review_plans,
+        ExternalImportFindingKind, ExternalImportItemKind, ImportSystem, KoiImportOptions,
+        map_archive, map_koi_v1_archive, write_review_plans,
     };
 
     #[test]
@@ -2693,6 +2708,33 @@ mod tests {
                     && ambiguity.fallback == "extra_frontmatter.koi_v1_scope_project"),
             "project scope fallback should be reported for review: {:?}",
             report.ambiguities
+        );
+    }
+
+    #[test]
+    fn koi_v1_import_uses_configured_default_workspace_when_scope_omits_it() {
+        let archive = tempfile::tempdir().expect("archive");
+        fs::write(
+            archive.path().join("memory.json"),
+            r#"{"text":"Scoped by vault config.","kind":"reference"}"#,
+        )
+        .expect("write fixture");
+
+        let report = map_archive(
+            ImportSystem::KoiV1,
+            &KoiImportOptions {
+                source: archive.path().to_path_buf(),
+                batch_size: 64,
+                mode: FlushMode::HumanReview,
+            },
+            "research-vault",
+        )
+        .expect("map archive");
+
+        assert_eq!(report.records.len(), 1);
+        assert_eq!(
+            report.records[0].scope.workspace.as_deref(),
+            Some("research-vault")
         );
     }
 

--- a/crates/cairn-cli/tests/openclaw_import.rs
+++ b/crates/cairn-cli/tests/openclaw_import.rs
@@ -1,4 +1,4 @@
-//! Consumer acceptance coverage for the OpenClaw migration bridge.
+//! Consumer acceptance coverage for the `OpenClaw` migration bridge.
 
 use std::path::Path;
 use std::process::{Command, Output};
@@ -18,6 +18,16 @@ fn bootstrap_vault(vault: &Path) {
         force: false,
     })
     .expect("bootstrap vault");
+}
+
+fn set_vault_name(vault: &Path, name: &str) {
+    let config_path = vault.join(".cairn/config.yaml");
+    let config = std::fs::read_to_string(&config_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", config_path.display()));
+    let updated = config.replacen("name: my-vault", &format!("name: {name}"), 1);
+    assert_ne!(updated, config, "default vault name should be present");
+    std::fs::write(&config_path, updated)
+        .unwrap_or_else(|e| panic!("write {}: {e}", config_path.display()));
 }
 
 fn run_in_vault(vault: &Path, args: &[&str]) -> Output {
@@ -169,6 +179,7 @@ fn openclaw_import_plan_applies_to_search_retrieve_lint_and_forget() {
 fn openclaw_import_json_emits_manifest_and_kind_hints() {
     let vault = tempfile::tempdir().expect("temp vault");
     bootstrap_vault(vault.path());
+    set_vault_name(vault.path(), "openclaw-vault");
     let archive = tempfile::tempdir().expect("openclaw archive");
     let memory_dir = archive.path().join("memory");
     std::fs::create_dir_all(&memory_dir).expect("memory dir");
@@ -226,5 +237,15 @@ fn openclaw_import_json_emits_manifest_and_kind_hints() {
     assert_eq!(
         import["migration_report"]["unsupported_fields"], 0,
         "markdown-only OpenClaw fixtures should not report unsupported fields: {import}"
+    );
+
+    let (_operation_id, pending) = single_pending_plan(vault.path());
+    assert!(
+        pending.plan.mutations.iter().all(|mutation| matches!(
+            mutation,
+            PlannedMutation::Upsert { record, .. }
+                if record.scope.workspace.as_deref() == Some("openclaw-vault")
+        )),
+        "OpenClaw imports without explicit scope should use the configured vault workspace: {pending:?}"
     );
 }

--- a/crates/cairn-cli/tests/openclaw_import.rs
+++ b/crates/cairn-cli/tests/openclaw_import.rs
@@ -1,0 +1,230 @@
+//! Consumer acceptance coverage for the OpenClaw migration bridge.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use cairn_core::domain::flush_plan::{PersistedPlan, PlannedMutation};
+
+fn cli() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cairn"));
+    cmd.env_remove("CAIRN_VAULT");
+    cmd.env_remove("CAIRN_REGISTRY");
+    cmd
+}
+
+fn bootstrap_vault(vault: &Path) {
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: vault.to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+}
+
+fn run_in_vault(vault: &Path, args: &[&str]) -> Output {
+    cli()
+        .current_dir(vault)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run cairn {args:?}: {e}"))
+}
+
+fn run_json_ok(vault: &Path, args: &[&str]) -> serde_json::Value {
+    let out = run_in_vault(vault, args);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "cairn {args:?} failed\nstderr: {}\nstdout: {}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("cairn {args:?} emitted invalid JSON: {e}"))
+}
+
+fn json_output(out: &Output, args: &[&str]) -> serde_json::Value {
+    serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("cairn {args:?} emitted invalid JSON: {e}"))
+}
+
+fn single_pending_plan(vault: &Path) -> (String, PersistedPlan) {
+    let pending_dir = vault.join(".cairn/flush/pending");
+    let entries: Vec<_> = std::fs::read_dir(&pending_dir)
+        .unwrap_or_else(|e| panic!("read pending dir {}: {e}", pending_dir.display()))
+        .map(|entry| entry.expect("pending dir entry").path())
+        .filter(|path| {
+            path.file_name()
+                .is_some_and(|name| name.to_string_lossy().ends_with(".plan.json"))
+        })
+        .collect();
+    assert_eq!(entries.len(), 1, "expected one pending plan: {entries:?}");
+    let path = &entries[0];
+    let file_name = path.file_name().expect("file name").to_string_lossy();
+    let operation_id = file_name
+        .strip_suffix(".plan.json")
+        .expect("plan suffix")
+        .to_owned();
+    let plan: PersistedPlan =
+        serde_json::from_slice(&std::fs::read(path).expect("read pending plan"))
+            .expect("pending plan json");
+    (operation_id, plan)
+}
+
+fn upsert_record_id(plan: &PersistedPlan) -> String {
+    let Some(PlannedMutation::Upsert { record, .. }) = plan.plan.mutations.first() else {
+        panic!(
+            "expected first mutation to be an upsert: {:?}",
+            plan.plan.mutations
+        );
+    };
+    record.id.as_str().to_owned()
+}
+
+fn hit_record_ids(vault: &Path, query: &str) -> Vec<String> {
+    let search = run_json_ok(vault, &["search", "--mode", "keyword", query, "--json"]);
+    search["data"]["hits"]
+        .as_array()
+        .unwrap_or_else(|| panic!("search hits must be an array: {search}"))
+        .iter()
+        .map(|hit| hit["record_id"].as_str().expect("hit record_id").to_owned())
+        .collect()
+}
+
+#[test]
+fn openclaw_import_plan_applies_to_search_retrieve_lint_and_forget() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    run_json_ok(vault.path(), &["identity", "init-defaults", "--json"]);
+    run_json_ok(
+        vault.path(),
+        &[
+            "identity",
+            "provision",
+            "human",
+            "openclaw-import",
+            "--json",
+        ],
+    );
+    run_json_ok(
+        vault.path(),
+        &[
+            "identity",
+            "provision",
+            "agent",
+            "cairn-cli:default:writer",
+            "--json",
+        ],
+    );
+
+    let archive = tempfile::tempdir().expect("openclaw archive");
+    let memory_dir = archive.path().join("memory");
+    std::fs::create_dir_all(&memory_dir).expect("memory dir");
+    let openclaw_body = "openclaw acceptance bridge remembers quartz telemetry marker";
+    std::fs::write(memory_dir.join("reference.md"), openclaw_body).expect("write memory");
+
+    let import = run_json_ok(
+        vault.path(),
+        &[
+            "import",
+            "--from",
+            "openclaw",
+            archive.path().to_str().expect("utf-8 archive path"),
+            "--batch-size",
+            "1",
+            "--json",
+        ],
+    );
+    assert_eq!(import["records"], 1, "import summary: {import}");
+    assert_eq!(import["plans"], 1, "import summary: {import}");
+
+    let (operation_id, pending) = single_pending_plan(vault.path());
+    let record_id = upsert_record_id(&pending);
+
+    run_json_ok(vault.path(), &["flush", "apply", &operation_id, "--json"]);
+
+    let hits = hit_record_ids(vault.path(), "quartz");
+    assert_eq!(hits, vec![record_id.clone()], "search should find import");
+
+    let retrieve = run_json_ok(vault.path(), &["retrieve", &record_id, "--json"]);
+    assert_eq!(
+        retrieve["data"]["body"], openclaw_body,
+        "retrieve should expose imported body: {retrieve}"
+    );
+
+    let lint_out = run_in_vault(vault.path(), &["lint", "--json"]);
+    let lint = json_output(&lint_out, &["lint", "--json"]);
+    assert_eq!(lint["status"], "committed", "lint should complete: {lint}");
+    assert_eq!(
+        lint["data"]["summary"]["by_severity"]["error"], 0,
+        "imported record should not produce lint errors: {lint}"
+    );
+
+    run_json_ok(vault.path(), &["forget", "--record", &record_id, "--json"]);
+    assert!(
+        hit_record_ids(vault.path(), "quartz").is_empty(),
+        "forgotten import should leave keyword search"
+    );
+}
+
+#[test]
+fn openclaw_import_json_emits_manifest_and_kind_hints() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let archive = tempfile::tempdir().expect("openclaw archive");
+    let memory_dir = archive.path().join("memory");
+    std::fs::create_dir_all(&memory_dir).expect("memory dir");
+    std::fs::write(
+        archive.path().join("MEMORY.md"),
+        "# User Preferences\n\nOpenClaw user prefers terse status updates.",
+    )
+    .expect("write MEMORY");
+    std::fs::write(
+        archive.path().join("SOUL.md"),
+        "# Core Rules\n\nNever publish private source references.",
+    )
+    .expect("write SOUL");
+    std::fs::write(
+        memory_dir.join("workflow.md"),
+        "# Deployment Workflow\n\nRun fixture import checks before release.",
+    )
+    .expect("write memory item");
+
+    let import = run_json_ok(
+        vault.path(),
+        &[
+            "import",
+            "--from",
+            "openclaw",
+            archive.path().to_str().expect("utf-8 archive path"),
+            "--batch-size",
+            "64",
+            "--json",
+        ],
+    );
+
+    assert_eq!(import["records"], 3, "import summary: {import}");
+    assert_eq!(
+        import["manifest"]["system"], "openclaw",
+        "manifest: {import}"
+    );
+    assert_eq!(
+        import["manifest"]["items"].as_array().expect("items").len(),
+        3,
+        "OpenClaw markdown artifacts should become record manifest items: {import}"
+    );
+    assert!(
+        import["manifest"]["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .all(|item| item["provenance"]["source_sensor"] == "snr:openclaw:import:local:v1"),
+        "all items should preserve OpenClaw provenance: {import}"
+    );
+    assert_eq!(
+        import["migration_report"]["ambiguous_fields"], 0,
+        "known OpenClaw artifact names should supply kind hints: {import}"
+    );
+    assert_eq!(
+        import["migration_report"]["unsupported_fields"], 0,
+        "markdown-only OpenClaw fixtures should not report unsupported fields: {import}"
+    );
+}

--- a/docs/site/src/reference/generated/commands/import.md
+++ b/docs/site/src/reference/generated/commands/import.md
@@ -15,8 +15,8 @@ Arguments:
   <PATH>  Legacy archive root to scan
 
 Options:
-      --from <SYSTEM>         Legacy memory system to import [possible values: koi-v1, rowboat,
-                              opencode, hermes-agent]
+      --from <SYSTEM>         Legacy memory system to import [possible values: koi-v1, openclaw,
+                              rowboat, opencode, hermes-agent]
       --vault <NAME_OR_PATH>  Active vault: name from registry or filesystem path (overrides
                               CAIRN_VAULT)
       --batch-size <U32>      Maximum records per pending review plan [default: 64]


### PR DESCRIPTION
## Summary

- Add `cairn import --from openclaw` using the neutral external-memory import manifest and review-plan flow.
- Preserve OpenClaw-specific provenance, source hashes, consent references, and source metadata for imported artifacts.
- Cover OpenClaw fixture imports across manifest output, pending review plans, search, retrieve, lint, and forget while keeping Koi, Rowboat, OpenCode, and Hermes import regression coverage green.

## Issue

Closes #153.

## Test Plan

- `cargo run -p cairn-cli --bin cairn-docgen --locked -- --write`
- `cargo fmt --check`
- `cargo test -p cairn-cli --test openclaw_import --test koi_import --test rowboat_import --test hermes_import -- --nocapture`
- `cargo test -p cairn-cli import::tests -- --nocapture`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `git diff --check`
- Local `git merge-tree` against latest `origin/main` reports no textual conflicts.
- Manual E2E OpenClaw matrix covering allowlisted paths, ignored paths, batch splitting, apply/search/retrieve/lint, explicit JSON scope override, malformed JSON, unsupported system, and zero batch size.
