### PR TITLE
[codex] Add agent audit and canary controls

### DIFF
--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -3802,6 +3802,56 @@ fn require_existing_vault(json: bool, vault_root: &Path, db_path: &Path) -> Opti
 mod tests {
     use super::*;
 
+    use cairn_core::contract::agent_provider::AgentBudgetConsumed;
+    use cairn_core::domain::{
+        AgentWorkerAuditRecord, AgentWorkerAuditSummary, AgentWorkerFailureMode, AgentWorkerKind,
+        AgentWorkerStatus, ScopeTuple,
+    };
+
+    fn trusted_agent_worker_audit_summary() -> AgentWorkerAuditSummary {
+        AgentWorkerAuditSummary::from_records(&[AgentWorkerAuditRecord {
+            operation_id: "op-trusted".to_owned(),
+            worker_kind: AgentWorkerKind::Dream,
+            worker_name: "agent_dream".to_owned(),
+            agent_identity: "agt:cairn-dream:v1".to_owned(),
+            scope: Some(ScopeTuple {
+                tenant: Some("tenant-a".to_owned()),
+                agent: Some("agt:cairn-dream:v1".to_owned()),
+                ..ScopeTuple::default()
+            }),
+            status: AgentWorkerStatus::Aborted,
+            generated_candidates: 2,
+            accepted_candidates: 1,
+            budget_consumed: AgentBudgetConsumed {
+                turns: 3,
+                tool_calls: 4,
+                cost_units: 99,
+            },
+            failure_mode: Some(AgentWorkerFailureMode::ProviderUnavailable),
+            canary_label: Some("canary-05".to_owned()),
+        }])
+    }
+
+    fn spoofed_agent_worker_audit_summary() -> AgentWorkerAuditSummary {
+        AgentWorkerAuditSummary::from_records(&[AgentWorkerAuditRecord {
+            operation_id: "op-spoofed".to_owned(),
+            worker_kind: AgentWorkerKind::Extractor,
+            worker_name: "spoofed_agent".to_owned(),
+            agent_identity: "agt:spoofed:v1".to_owned(),
+            scope: None,
+            status: AgentWorkerStatus::Completed,
+            generated_candidates: 100,
+            accepted_candidates: 100,
+            budget_consumed: AgentBudgetConsumed {
+                turns: 1,
+                tool_calls: 1,
+                cost_units: 10_000,
+            },
+            failure_mode: None,
+            canary_label: Some("spoofed-canary".to_owned()),
+        }])
+    }
+
     #[test]
     fn fix_markdown_result_counts_written_and_current() {
         // written=2 means 2 files were written/updated
@@ -3922,36 +3972,11 @@ mod tests {
     #[tokio::test]
     async fn lint_handler_projects_persisted_agent_worker_audit() {
         use cairn_core::config::CairnConfig;
-        use cairn_core::contract::agent_provider::AgentBudgetConsumed;
-        use cairn_core::domain::{
-            AgentWorkerAuditRecord, AgentWorkerAuditSummary, AgentWorkerFailureMode,
-            AgentWorkerKind, AgentWorkerStatus, ScopeTuple,
-        };
         use cairn_store_sqlite::SqliteIdentityRegistry;
         use cairn_test_fixtures::store::{FixtureStore, sample_record};
 
         let store = FixtureStore::default();
-        let audit_summary = AgentWorkerAuditSummary::from_records(&[AgentWorkerAuditRecord {
-            operation_id: "op-agent-1".to_owned(),
-            worker_kind: AgentWorkerKind::Dream,
-            worker_name: "agent_dream".to_owned(),
-            agent_identity: "agt:cairn-dream:v1".to_owned(),
-            scope: Some(ScopeTuple {
-                tenant: Some("tenant-a".to_owned()),
-                agent: Some("agt:cairn-dream:v1".to_owned()),
-                ..ScopeTuple::default()
-            }),
-            status: AgentWorkerStatus::Aborted,
-            generated_candidates: 2,
-            accepted_candidates: 1,
-            budget_consumed: AgentBudgetConsumed {
-                turns: 3,
-                tool_calls: 4,
-                cost_units: 99,
-            },
-            failure_mode: Some(AgentWorkerFailureMode::ProviderUnavailable),
-            canary_label: Some("canary-05".to_owned()),
-        }]);
+        let audit_summary = trusted_agent_worker_audit_summary();
         let mut record = sample_record();
         record.extra_frontmatter.insert(
             "evaluation".to_owned(),
@@ -3993,54 +4018,14 @@ mod tests {
     #[tokio::test]
     async fn lint_handler_ignores_untrusted_agent_worker_audit_frontmatter() {
         use cairn_core::config::CairnConfig;
-        use cairn_core::contract::agent_provider::AgentBudgetConsumed;
-        use cairn_core::domain::{
-            AgentWorkerAuditRecord, AgentWorkerAuditSummary, AgentWorkerFailureMode,
-            AgentWorkerKind, AgentWorkerStatus, Rfc3339Timestamp, ScopeTuple,
-        };
+        use cairn_core::domain::Rfc3339Timestamp;
         use cairn_store_sqlite::SqliteIdentityRegistry;
         use cairn_test_fixtures::sample_record as seeded_sample_record;
         use cairn_test_fixtures::store::{FixtureStore, sample_record};
 
         let store = FixtureStore::default();
-        let trusted_summary = AgentWorkerAuditSummary::from_records(&[AgentWorkerAuditRecord {
-            operation_id: "op-trusted".to_owned(),
-            worker_kind: AgentWorkerKind::Dream,
-            worker_name: "agent_dream".to_owned(),
-            agent_identity: "agt:cairn-dream:v1".to_owned(),
-            scope: Some(ScopeTuple {
-                tenant: Some("tenant-a".to_owned()),
-                agent: Some("agt:cairn-dream:v1".to_owned()),
-                ..ScopeTuple::default()
-            }),
-            status: AgentWorkerStatus::Aborted,
-            generated_candidates: 2,
-            accepted_candidates: 1,
-            budget_consumed: AgentBudgetConsumed {
-                turns: 3,
-                tool_calls: 4,
-                cost_units: 99,
-            },
-            failure_mode: Some(AgentWorkerFailureMode::ProviderUnavailable),
-            canary_label: Some("canary-05".to_owned()),
-        }]);
-        let spoofed_summary = AgentWorkerAuditSummary::from_records(&[AgentWorkerAuditRecord {
-            operation_id: "op-spoofed".to_owned(),
-            worker_kind: AgentWorkerKind::Extractor,
-            worker_name: "spoofed_agent".to_owned(),
-            agent_identity: "agt:spoofed:v1".to_owned(),
-            scope: None,
-            status: AgentWorkerStatus::Completed,
-            generated_candidates: 100,
-            accepted_candidates: 100,
-            budget_consumed: AgentBudgetConsumed {
-                turns: 1,
-                tool_calls: 1,
-                cost_units: 10_000,
-            },
-            failure_mode: None,
-            canary_label: Some("spoofed-canary".to_owned()),
-        }]);
+        let trusted_summary = trusted_agent_worker_audit_summary();
+        let spoofed_summary = spoofed_agent_worker_audit_summary();
 
         let mut trusted = sample_record();
         trusted.updated_at = Rfc3339Timestamp::parse("2026-05-23T10:00:00Z").expect("timestamp");

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1387,6 +1387,8 @@ struct PersistedAgentWorkerAudit {
     canary_state: Option<cairn_core::domain::AgentCanaryState>,
 }
 
+const EVALUATION_HANDLER_PRODUCED_BY: &str = "cairn-workflows::EvaluationHandler";
+
 fn latest_agent_worker_audit(
     lint_records: &[cairn_core::verbs::lint::LintRecord],
 ) -> Option<PersistedAgentWorkerAudit> {
@@ -1403,20 +1405,17 @@ fn latest_agent_worker_audit(
 fn persisted_agent_worker_audit(
     record: &cairn_core::domain::record::MemoryRecord,
 ) -> Option<PersistedAgentWorkerAudit> {
-    let evaluation = record.extra_frontmatter.get("evaluation");
-    let summary_value = evaluation
-        .and_then(|value| value.get("agent_worker_audit"))
-        .or_else(|| record.extra_frontmatter.get("agent_worker_audit"))?;
+    let evaluation = record.extra_frontmatter.get("evaluation")?;
+    if evaluation
+        .get("produced_by")
+        .and_then(serde_json::Value::as_str)
+        != Some(EVALUATION_HANDLER_PRODUCED_BY)
+    {
+        return None;
+    }
+    let summary_value = evaluation.get("agent_worker_audit")?;
     let summary = serde_json::from_value(summary_value.clone()).ok()?;
-    let canary_state = evaluation
-        .and_then(agent_canary_state_from_object)
-        .or_else(|| {
-            record
-                .extra_frontmatter
-                .get("agent_canary_state")
-                .or_else(|| record.extra_frontmatter.get("rollout_state"))
-                .and_then(|value| serde_json::from_value(value.clone()).ok())
-        });
+    let canary_state = agent_canary_state_from_object(evaluation);
 
     Some(PersistedAgentWorkerAudit {
         summary,
@@ -3989,6 +3988,121 @@ mod tests {
             report.failure_modes["provider_unavailable"],
             serde_json::json!(1)
         );
+    }
+
+    #[tokio::test]
+    async fn lint_handler_ignores_untrusted_agent_worker_audit_frontmatter() {
+        use cairn_core::config::CairnConfig;
+        use cairn_core::contract::agent_provider::AgentBudgetConsumed;
+        use cairn_core::domain::{
+            AgentWorkerAuditRecord, AgentWorkerAuditSummary, AgentWorkerFailureMode,
+            AgentWorkerKind, AgentWorkerStatus, Rfc3339Timestamp, ScopeTuple,
+        };
+        use cairn_store_sqlite::SqliteIdentityRegistry;
+        use cairn_test_fixtures::sample_record as seeded_sample_record;
+        use cairn_test_fixtures::store::{FixtureStore, sample_record};
+
+        let store = FixtureStore::default();
+        let trusted_summary = AgentWorkerAuditSummary::from_records(&[AgentWorkerAuditRecord {
+            operation_id: "op-trusted".to_owned(),
+            worker_kind: AgentWorkerKind::Dream,
+            worker_name: "agent_dream".to_owned(),
+            agent_identity: "agt:cairn-dream:v1".to_owned(),
+            scope: Some(ScopeTuple {
+                tenant: Some("tenant-a".to_owned()),
+                agent: Some("agt:cairn-dream:v1".to_owned()),
+                ..ScopeTuple::default()
+            }),
+            status: AgentWorkerStatus::Aborted,
+            generated_candidates: 2,
+            accepted_candidates: 1,
+            budget_consumed: AgentBudgetConsumed {
+                turns: 3,
+                tool_calls: 4,
+                cost_units: 99,
+            },
+            failure_mode: Some(AgentWorkerFailureMode::ProviderUnavailable),
+            canary_label: Some("canary-05".to_owned()),
+        }]);
+        let spoofed_summary = AgentWorkerAuditSummary::from_records(&[AgentWorkerAuditRecord {
+            operation_id: "op-spoofed".to_owned(),
+            worker_kind: AgentWorkerKind::Extractor,
+            worker_name: "spoofed_agent".to_owned(),
+            agent_identity: "agt:spoofed:v1".to_owned(),
+            scope: None,
+            status: AgentWorkerStatus::Completed,
+            generated_candidates: 100,
+            accepted_candidates: 100,
+            budget_consumed: AgentBudgetConsumed {
+                turns: 1,
+                tool_calls: 1,
+                cost_units: 10_000,
+            },
+            failure_mode: None,
+            canary_label: Some("spoofed-canary".to_owned()),
+        }]);
+
+        let mut trusted = sample_record();
+        trusted.updated_at = Rfc3339Timestamp::parse("2026-05-23T10:00:00Z").expect("timestamp");
+        trusted.extra_frontmatter.insert(
+            "evaluation".to_owned(),
+            serde_json::json!({
+                "agent_worker_audit": trusted_summary,
+                "agent_canary_state": "canary",
+                "produced_by": "cairn-workflows::EvaluationHandler",
+            }),
+        );
+        store.upsert(&trusted).await.expect("trusted upsert");
+
+        let mut untrusted_evaluation = seeded_sample_record(2);
+        untrusted_evaluation.updated_at =
+            Rfc3339Timestamp::parse("2026-05-23T11:00:00Z").expect("timestamp");
+        untrusted_evaluation.extra_frontmatter.insert(
+            "evaluation".to_owned(),
+            serde_json::json!({
+                "agent_worker_audit": spoofed_summary,
+                "agent_canary_state": "rolled_back",
+                "produced_by": "user-editable-frontmatter",
+            }),
+        );
+        store
+            .upsert(&untrusted_evaluation)
+            .await
+            .expect("untrusted evaluation upsert");
+
+        let mut untrusted_top_level = seeded_sample_record(3);
+        untrusted_top_level.updated_at =
+            Rfc3339Timestamp::parse("2026-05-23T12:00:00Z").expect("timestamp");
+        untrusted_top_level.extra_frontmatter.insert(
+            "agent_worker_audit".to_owned(),
+            serde_json::json!(spoofed_summary),
+        );
+        untrusted_top_level
+            .extra_frontmatter
+            .insert("rollout_state".to_owned(), serde_json::json!("rolled_back"));
+        store
+            .upsert(&untrusted_top_level)
+            .await
+            .expect("untrusted top-level upsert");
+
+        let registry = SqliteIdentityRegistry::open_in_memory().expect("open registry");
+        let cfg = CairnConfig::default();
+        let vault = tempfile::tempdir().expect("tempdir");
+        let result = lint_handler(&store, &registry, None, &cfg, false, vault.path())
+            .await
+            .expect("handler");
+        let report = result
+            .data
+            .agent_worker_audit
+            .expect("lint data includes agent worker audit");
+
+        assert!(report.observed_records);
+        assert_eq!(report.cost_units, 99);
+        assert_eq!(
+            report.rollout_state,
+            Some(cairn_core::generated::verbs::lint::AgentWorkerAuditReportRolloutState::Canary)
+        );
+        assert_eq!(report.workers[0].worker_name, "agent_dream");
     }
 
     #[tokio::test]

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -1292,6 +1292,10 @@ pub async fn lint_handler(
         WorkflowJobsReaderOutcome::Ready(r) => Some(r),
         WorkflowJobsReaderOutcome::Absent | WorkflowJobsReaderOutcome::Unavailable(_) => None,
     };
+    let persisted_agent_worker_audit = latest_agent_worker_audit(&lint_records);
+    let persisted_agent_canary_state = persisted_agent_worker_audit
+        .as_ref()
+        .and_then(|audit| audit.canary_state);
     let now_ms = chrono::Utc::now().timestamp_millis();
     let inputs = LintInputs {
         records: &lint_records,
@@ -1308,6 +1312,10 @@ pub async fn lint_handler(
         consent_journal: &consent_journal,
         workflow_jobs: workflow_jobs_reader
             .map(|r| r as &dyn cairn_core::contract::workflow_jobs::WorkflowJobsReader),
+        agent_worker_audit: persisted_agent_worker_audit
+            .as_ref()
+            .map(|audit| &audit.summary),
+        agent_canary_state: persisted_agent_canary_state,
         now_ms,
     };
     let mut data = run_checks(&inputs).await;
@@ -1372,6 +1380,57 @@ pub async fn lint_handler(
         report_path,
         has_error,
     })
+}
+
+struct PersistedAgentWorkerAudit {
+    summary: cairn_core::domain::AgentWorkerAuditSummary,
+    canary_state: Option<cairn_core::domain::AgentCanaryState>,
+}
+
+fn latest_agent_worker_audit(
+    lint_records: &[cairn_core::verbs::lint::LintRecord],
+) -> Option<PersistedAgentWorkerAudit> {
+    lint_records
+        .iter()
+        .filter_map(|lint_record| {
+            persisted_agent_worker_audit(&lint_record.stored.record)
+                .map(|audit| (&lint_record.stored.record.updated_at, audit))
+        })
+        .max_by(|(left_ts, _), (right_ts, _)| left_ts.cmp_chronological(right_ts))
+        .map(|(_, audit)| audit)
+}
+
+fn persisted_agent_worker_audit(
+    record: &cairn_core::domain::record::MemoryRecord,
+) -> Option<PersistedAgentWorkerAudit> {
+    let evaluation = record.extra_frontmatter.get("evaluation");
+    let summary_value = evaluation
+        .and_then(|value| value.get("agent_worker_audit"))
+        .or_else(|| record.extra_frontmatter.get("agent_worker_audit"))?;
+    let summary = serde_json::from_value(summary_value.clone()).ok()?;
+    let canary_state = evaluation
+        .and_then(agent_canary_state_from_object)
+        .or_else(|| {
+            record
+                .extra_frontmatter
+                .get("agent_canary_state")
+                .or_else(|| record.extra_frontmatter.get("rollout_state"))
+                .and_then(|value| serde_json::from_value(value.clone()).ok())
+        });
+
+    Some(PersistedAgentWorkerAudit {
+        summary,
+        canary_state,
+    })
+}
+
+fn agent_canary_state_from_object(
+    value: &serde_json::Value,
+) -> Option<cairn_core::domain::AgentCanaryState> {
+    value
+        .get("agent_canary_state")
+        .or_else(|| value.get("rollout_state"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
 }
 
 async fn build_source_artifacts(
@@ -3859,6 +3918,77 @@ mod tests {
             .await
             .expect("read lint-report.md");
         assert!(body.contains("# Lint report"));
+    }
+
+    #[tokio::test]
+    async fn lint_handler_projects_persisted_agent_worker_audit() {
+        use cairn_core::config::CairnConfig;
+        use cairn_core::contract::agent_provider::AgentBudgetConsumed;
+        use cairn_core::domain::{
+            AgentWorkerAuditRecord, AgentWorkerAuditSummary, AgentWorkerFailureMode,
+            AgentWorkerKind, AgentWorkerStatus, ScopeTuple,
+        };
+        use cairn_store_sqlite::SqliteIdentityRegistry;
+        use cairn_test_fixtures::store::{FixtureStore, sample_record};
+
+        let store = FixtureStore::default();
+        let audit_summary = AgentWorkerAuditSummary::from_records(&[AgentWorkerAuditRecord {
+            operation_id: "op-agent-1".to_owned(),
+            worker_kind: AgentWorkerKind::Dream,
+            worker_name: "agent_dream".to_owned(),
+            agent_identity: "agt:cairn-dream:v1".to_owned(),
+            scope: Some(ScopeTuple {
+                tenant: Some("tenant-a".to_owned()),
+                agent: Some("agt:cairn-dream:v1".to_owned()),
+                ..ScopeTuple::default()
+            }),
+            status: AgentWorkerStatus::Aborted,
+            generated_candidates: 2,
+            accepted_candidates: 1,
+            budget_consumed: AgentBudgetConsumed {
+                turns: 3,
+                tool_calls: 4,
+                cost_units: 99,
+            },
+            failure_mode: Some(AgentWorkerFailureMode::ProviderUnavailable),
+            canary_label: Some("canary-05".to_owned()),
+        }]);
+        let mut record = sample_record();
+        record.extra_frontmatter.insert(
+            "evaluation".to_owned(),
+            serde_json::json!({
+                "agent_worker_audit": audit_summary,
+                "agent_canary_state": "canary",
+                "produced_by": "cairn-workflows::EvaluationHandler",
+            }),
+        );
+        store.upsert(&record).await.expect("upsert");
+
+        let registry = SqliteIdentityRegistry::open_in_memory().expect("open registry");
+        let cfg = CairnConfig::default();
+        let vault = tempfile::tempdir().expect("tempdir");
+        let result = lint_handler(&store, &registry, None, &cfg, false, vault.path())
+            .await
+            .expect("handler");
+        let report = result
+            .data
+            .agent_worker_audit
+            .expect("lint data includes agent worker audit");
+
+        assert!(report.observed_records);
+        assert_eq!(report.total_runs, 1);
+        assert_eq!(report.failed_runs, 1);
+        assert_eq!(report.cost_units, 99);
+        assert_eq!(
+            report.rollout_state,
+            Some(cairn_core::generated::verbs::lint::AgentWorkerAuditReportRolloutState::Canary)
+        );
+        assert_eq!(report.workers[0].worker_name, "agent_dream");
+        assert_eq!(report.workers[0].turns, 3);
+        assert_eq!(
+            report.failure_modes["provider_unavailable"],
+            serde_json::json!(1)
+        );
     }
 
     #[tokio::test]

--- a/crates/cairn-cli/src/verbs/lint.rs
+++ b/crates/cairn-cli/src/verbs/lint.rs
@@ -3101,6 +3101,7 @@ pub fn run(sub: &ArgMatches, vault_root: Option<&Path>) -> ExitCode {
                 tracking_issue: Some(83),
             };
             let degraded_data = cairn_core::generated::verbs::lint::LintData {
+                agent_worker_audit: None,
                 findings: vec![deferred],
                 report_path: None,
                 summary: cairn_core::generated::verbs::lint::LintDataSummary {
@@ -3394,6 +3395,7 @@ fn lint_data(report: EdgeLintReport) -> LintData {
     let total = usize_to_u64(report.findings.len());
     let summary = edge_summary(&report.findings, total, report.auto_resolved);
     LintData {
+        agent_worker_audit: None,
         findings: report.findings,
         report_path: None,
         summary,
@@ -4010,6 +4012,7 @@ mod tests {
         // - the summary aggregates (total / by_severity / by_kind)
         //   stay consistent so the json/markdown render is correct.
         let mut data = cairn_core::generated::verbs::lint::LintData {
+            agent_worker_audit: None,
             findings: Vec::new(),
             summary: cairn_core::generated::verbs::lint::LintDataSummary {
                 auto_resolved: None,

--- a/crates/cairn-core/src/domain/agent_audit.rs
+++ b/crates/cairn-core/src/domain/agent_audit.rs
@@ -136,10 +136,85 @@ pub struct AgentWorkerGroupSummary {
     pub canary_label: Option<String>,
     /// Number of records in this group.
     pub total_runs: u64,
-    /// Accepted candidates in this group.
-    pub accepted_candidates: u64,
+    /// Runs with `Completed` status.
+    #[serde(default)]
+    pub completed_runs: u64,
+    /// Runs with rejected, aborted, or rolled-back status.
+    #[serde(default)]
+    pub failed_runs: u64,
     /// Generated candidates in this group.
     pub generated_candidates: u64,
+    /// Accepted candidates in this group.
+    pub accepted_candidates: u64,
+    /// `accepted_candidates / generated_candidates`, absent when no candidates were generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_rate: Option<f64>,
+    /// Agent turns consumed in this group.
+    #[serde(default)]
+    pub turns: u64,
+    /// Agent tool calls consumed in this group.
+    #[serde(default)]
+    pub tool_calls: u64,
+    /// Provider-defined cost units consumed in this group.
+    #[serde(default)]
+    pub cost_units: u64,
+    /// Failure counts by stable failure category in this group.
+    #[serde(default)]
+    pub failure_modes: BTreeMap<AgentWorkerFailureMode, u64>,
+}
+
+impl AgentWorkerGroupSummary {
+    fn new(record: &AgentWorkerAuditRecord) -> Self {
+        Self {
+            worker_kind: record.worker_kind,
+            worker_name: record.worker_name.clone(),
+            canary_label: record.canary_label.clone(),
+            total_runs: 0,
+            completed_runs: 0,
+            failed_runs: 0,
+            generated_candidates: 0,
+            accepted_candidates: 0,
+            acceptance_rate: None,
+            turns: 0,
+            tool_calls: 0,
+            cost_units: 0,
+            failure_modes: BTreeMap::new(),
+        }
+    }
+
+    fn observe(
+        &mut self,
+        record: &AgentWorkerAuditRecord,
+        failure_mode: Option<AgentWorkerFailureMode>,
+    ) {
+        self.total_runs = self.total_runs.saturating_add(1);
+        if record.status == AgentWorkerStatus::Completed {
+            self.completed_runs = self.completed_runs.saturating_add(1);
+        }
+        if record.status.is_failure() {
+            self.failed_runs = self.failed_runs.saturating_add(1);
+        }
+        self.accepted_candidates = self
+            .accepted_candidates
+            .saturating_add(record.accepted_candidates);
+        self.generated_candidates = self
+            .generated_candidates
+            .saturating_add(record.generated_candidates);
+        self.acceptance_rate = acceptance_rate(self.accepted_candidates, self.generated_candidates);
+        self.turns = self
+            .turns
+            .saturating_add(u64::from(record.budget_consumed.turns));
+        self.tool_calls = self
+            .tool_calls
+            .saturating_add(u64::from(record.budget_consumed.tool_calls));
+        self.cost_units = self
+            .cost_units
+            .saturating_add(record.budget_consumed.cost_units);
+        if let Some(mode) = failure_mode {
+            let count = self.failure_modes.entry(mode).or_insert(0);
+            *count = count.saturating_add(1);
+        }
+    }
 }
 
 /// Body-free aggregate for operator reports and canary controls.
@@ -194,6 +269,15 @@ impl AgentWorkerAuditSummary {
             if record.status == AgentWorkerStatus::Completed {
                 completed_runs = completed_runs.saturating_add(1);
             }
+            let failure_mode = if record.status.is_failure() {
+                Some(
+                    record
+                        .failure_mode
+                        .unwrap_or(AgentWorkerFailureMode::Unknown),
+                )
+            } else {
+                None
+            };
             if record.status.is_failure() {
                 failed_runs = failed_runs.saturating_add(1);
             }
@@ -203,7 +287,7 @@ impl AgentWorkerAuditSummary {
             tool_calls = tool_calls.saturating_add(u64::from(record.budget_consumed.tool_calls));
             cost_units = cost_units.saturating_add(record.budget_consumed.cost_units);
 
-            if let Some(mode) = record.failure_mode {
+            if let Some(mode) = failure_mode {
                 let count = failure_modes.entry(mode).or_insert(0);
                 *count = count.saturating_add(1);
             }
@@ -213,23 +297,10 @@ impl AgentWorkerAuditSummary {
                 record.worker_name.clone(),
                 record.canary_label.clone(),
             );
-            let group = groups
+            groups
                 .entry(key)
-                .or_insert_with(|| AgentWorkerGroupSummary {
-                    worker_kind: record.worker_kind,
-                    worker_name: record.worker_name.clone(),
-                    canary_label: record.canary_label.clone(),
-                    total_runs: 0,
-                    accepted_candidates: 0,
-                    generated_candidates: 0,
-                });
-            group.total_runs = group.total_runs.saturating_add(1);
-            group.accepted_candidates = group
-                .accepted_candidates
-                .saturating_add(record.accepted_candidates);
-            group.generated_candidates = group
-                .generated_candidates
-                .saturating_add(record.generated_candidates);
+                .or_insert_with(|| AgentWorkerGroupSummary::new(record))
+                .observe(record, failure_mode);
         }
 
         let acceptance_rate = acceptance_rate(accepted_candidates, generated_candidates);
@@ -344,6 +415,54 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_tracks_worker_cost_failures_and_unknown_modes() {
+        let mut dream = record("op-2", AgentWorkerStatus::Aborted, 0, 0, 7, None);
+        dream.worker_kind = AgentWorkerKind::Dream;
+        dream.worker_name = "agent_dream".to_owned();
+        dream.agent_identity = "agt:cairn-dream:v1".to_owned();
+        dream.scope = Some(scope("agt:cairn-dream:v1"));
+        dream.canary_label = Some("canary-10".to_owned());
+        dream.budget_consumed = AgentBudgetConsumed {
+            turns: 5,
+            tool_calls: 9,
+            cost_units: 7,
+        };
+
+        let records = vec![
+            record("op-1", AgentWorkerStatus::Completed, 4, 1, 11, None),
+            dream,
+        ];
+
+        let summary = AgentWorkerAuditSummary::from_records(&records);
+
+        assert_eq!(
+            summary.failure_modes.get(&AgentWorkerFailureMode::Unknown),
+            Some(&1)
+        );
+
+        let dream = summary
+            .workers
+            .iter()
+            .find(|worker| worker.worker_name == "agent_dream")
+            .expect("dream worker group present");
+        assert_eq!(dream.worker_kind, AgentWorkerKind::Dream);
+        assert_eq!(dream.canary_label.as_deref(), Some("canary-10"));
+        assert_eq!(dream.total_runs, 1);
+        assert_eq!(dream.completed_runs, 0);
+        assert_eq!(dream.failed_runs, 1);
+        assert_eq!(dream.generated_candidates, 0);
+        assert_eq!(dream.accepted_candidates, 0);
+        assert_eq!(dream.acceptance_rate, None);
+        assert_eq!(dream.turns, 5);
+        assert_eq!(dream.tool_calls, 9);
+        assert_eq!(dream.cost_units, 7);
+        assert_eq!(
+            dream.failure_modes.get(&AgentWorkerFailureMode::Unknown),
+            Some(&1)
+        );
+    }
+
+    #[test]
     fn aggregate_reports_no_acceptance_rate_without_generated_candidates() {
         let records = vec![record("op-1", AgentWorkerStatus::Completed, 0, 0, 10, None)];
 
@@ -352,6 +471,39 @@ mod tests {
         assert_eq!(summary.generated_candidates, 0);
         assert_eq!(summary.accepted_candidates, 0);
         assert_eq!(summary.acceptance_rate, None);
+    }
+
+    #[test]
+    fn legacy_worker_groups_deserialize_with_new_metric_defaults() {
+        let value = serde_json::json!({
+            "total_runs": 1,
+            "completed_runs": 1,
+            "failed_runs": 0,
+            "generated_candidates": 2,
+            "accepted_candidates": 1,
+            "acceptance_rate": 0.5,
+            "turns": 3,
+            "tool_calls": 4,
+            "cost_units": 5,
+            "failure_modes": {},
+            "workers": [{
+                "worker_kind": "extractor",
+                "worker_name": "agent_extractor",
+                "canary_label": "canary-05",
+                "total_runs": 1,
+                "generated_candidates": 2,
+                "accepted_candidates": 1
+            }]
+        });
+
+        let summary: AgentWorkerAuditSummary =
+            serde_json::from_value(value).expect("legacy summary deserializes");
+
+        assert_eq!(summary.workers[0].completed_runs, 0);
+        assert_eq!(summary.workers[0].failed_runs, 0);
+        assert_eq!(summary.workers[0].acceptance_rate, None);
+        assert_eq!(summary.workers[0].turns, 0);
+        assert_eq!(summary.workers[0].failure_modes.len(), 0);
     }
 
     #[test]

--- a/crates/cairn-core/src/domain/agent_audit.rs
+++ b/crates/cairn-core/src/domain/agent_audit.rs
@@ -62,7 +62,7 @@ pub enum AgentWorkerFailureMode {
 }
 
 impl AgentWorkerFailureMode {
-    /// Map an AgentProvider failure to the reportable audit category.
+    /// Map an `AgentProvider` failure to the reportable audit category.
     #[must_use]
     pub fn from_provider_error(error: &AgentProviderError) -> Self {
         match error {
@@ -113,7 +113,7 @@ pub struct AgentWorkerAuditRecord {
     pub generated_candidates: u64,
     /// Number of generated candidates accepted by the host pipeline.
     pub accepted_candidates: u64,
-    /// AgentProvider budget consumed by the run.
+    /// `AgentProvider` budget consumed by the run.
     pub budget_consumed: AgentBudgetConsumed,
     /// Compact failure mode when the worker failed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -232,11 +232,7 @@ impl AgentWorkerAuditSummary {
                 .saturating_add(record.generated_candidates);
         }
 
-        let acceptance_rate = if generated_candidates == 0 {
-            None
-        } else {
-            Some(accepted_candidates as f64 / generated_candidates as f64)
-        };
+        let acceptance_rate = acceptance_rate(accepted_candidates, generated_candidates);
 
         Self {
             total_runs,
@@ -258,6 +254,17 @@ impl AgentWorkerAuditSummary {
     pub const fn is_empty(&self) -> bool {
         self.total_runs == 0
     }
+}
+
+fn acceptance_rate(accepted_candidates: u64, generated_candidates: u64) -> Option<f64> {
+    if generated_candidates == 0 {
+        return None;
+    }
+
+    // Operator-facing ratio; exact integer counts remain in the same summary.
+    #[allow(clippy::cast_precision_loss)]
+    let rate = accepted_candidates as f64 / generated_candidates as f64;
+    Some(rate)
 }
 
 #[cfg(test)]
@@ -388,5 +395,35 @@ mod tests {
             ),
             AgentWorkerFailureMode::MutatingVerbNotScoped
         );
+    }
+
+    #[test]
+    fn failure_modes_render_stable_snake_case_labels() {
+        let labels = [
+            (AgentWorkerFailureMode::BudgetExceeded, "budget_exceeded"),
+            (
+                AgentWorkerFailureMode::WallClockExceeded,
+                "wall_clock_exceeded",
+            ),
+            (AgentWorkerFailureMode::ToolNotAllowed, "tool_not_allowed"),
+            (
+                AgentWorkerFailureMode::MutatingVerbNotScoped,
+                "mutating_verb_not_scoped",
+            ),
+            (AgentWorkerFailureMode::InvalidOutput, "invalid_output"),
+            (
+                AgentWorkerFailureMode::ProviderUnavailable,
+                "provider_unavailable",
+            ),
+            (
+                AgentWorkerFailureMode::HostRejectedCandidates,
+                "host_rejected_candidates",
+            ),
+            (AgentWorkerFailureMode::Unknown, "unknown"),
+        ];
+
+        for (mode, label) in labels {
+            assert_eq!(mode.as_str(), label);
+        }
     }
 }

--- a/crates/cairn-core/src/domain/agent_audit.rs
+++ b/crates/cairn-core/src/domain/agent_audit.rs
@@ -1,0 +1,392 @@
+//! Body-free agent-worker audit records and aggregates for issue #126.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::contract::agent_provider::{AgentBudgetConsumed, AgentProviderError};
+use crate::domain::ScopeTuple;
+
+/// Agent-mode worker class that produced an audit record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentWorkerKind {
+    /// Agent-mode extractor worker.
+    Extractor,
+    /// Agent-mode dream worker.
+    Dream,
+}
+
+/// Host-visible status for one logical worker invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentWorkerStatus {
+    /// Worker completed and returned control to the host.
+    Completed,
+    /// Host rejected the worker before it could run.
+    Rejected,
+    /// Worker aborted with a typed provider or host failure.
+    Aborted,
+    /// Worker output was rolled back by canary controls.
+    RolledBack,
+}
+
+impl AgentWorkerStatus {
+    /// Returns true when this status counts as a failed run for canary gates.
+    #[must_use]
+    pub const fn is_failure(self) -> bool {
+        matches!(self, Self::Rejected | Self::Aborted | Self::RolledBack)
+    }
+}
+
+/// Compact, body-free agent failure mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentWorkerFailureMode {
+    /// Cost budget was exceeded.
+    BudgetExceeded,
+    /// Wall-clock budget was exceeded.
+    WallClockExceeded,
+    /// Agent tried to invoke a tool outside its allowlist.
+    ToolNotAllowed,
+    /// Agent tried to invoke a mutating verb without mutating scope.
+    MutatingVerbNotScoped,
+    /// Agent output did not match the requested schema.
+    InvalidOutput,
+    /// Provider could not run in this build or configuration.
+    ProviderUnavailable,
+    /// Host rejected every generated candidate.
+    HostRejectedCandidates,
+    /// Failure did not map to a narrower stable category.
+    Unknown,
+}
+
+impl AgentWorkerFailureMode {
+    /// Map an AgentProvider failure to the reportable audit category.
+    #[must_use]
+    pub fn from_provider_error(error: &AgentProviderError) -> Self {
+        match error {
+            AgentProviderError::BudgetExceeded { .. } => Self::BudgetExceeded,
+            AgentProviderError::WallClockExceeded => Self::WallClockExceeded,
+            AgentProviderError::ToolNotAllowed { .. } => Self::ToolNotAllowed,
+            AgentProviderError::MutatingVerbNotScoped { .. } => Self::MutatingVerbNotScoped,
+            AgentProviderError::InvalidOutput { .. } => Self::InvalidOutput,
+            AgentProviderError::ProviderUnavailable { .. } => Self::ProviderUnavailable,
+            AgentProviderError::InvalidRequest { .. } => Self::Unknown,
+        }
+    }
+
+    /// Stable snake-case label for report maps.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::BudgetExceeded => "budget_exceeded",
+            Self::WallClockExceeded => "wall_clock_exceeded",
+            Self::ToolNotAllowed => "tool_not_allowed",
+            Self::MutatingVerbNotScoped => "mutating_verb_not_scoped",
+            Self::InvalidOutput => "invalid_output",
+            Self::ProviderUnavailable => "provider_unavailable",
+            Self::HostRejectedCandidates => "host_rejected_candidates",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// One body-free audit record for one logical agent-worker invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentWorkerAuditRecord {
+    /// Stable operation or workflow id for correlation.
+    pub operation_id: String,
+    /// Agent-mode worker class.
+    pub worker_kind: AgentWorkerKind,
+    /// Stable worker label.
+    pub worker_name: String,
+    /// `agt:` identity used by the worker.
+    pub agent_identity: String,
+    /// Body-free tenant/workspace/user/agent scope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<ScopeTuple>,
+    /// Host-visible status.
+    pub status: AgentWorkerStatus,
+    /// Number of candidates produced by the worker.
+    pub generated_candidates: u64,
+    /// Number of generated candidates accepted by the host pipeline.
+    pub accepted_candidates: u64,
+    /// AgentProvider budget consumed by the run.
+    pub budget_consumed: AgentBudgetConsumed,
+    /// Compact failure mode when the worker failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_mode: Option<AgentWorkerFailureMode>,
+    /// Optional rollout cohort label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canary_label: Option<String>,
+}
+
+/// Aggregate for one `(worker_kind, worker_name, canary_label)` group.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentWorkerGroupSummary {
+    /// Worker class for this group.
+    pub worker_kind: AgentWorkerKind,
+    /// Stable worker label.
+    pub worker_name: String,
+    /// Optional rollout cohort label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canary_label: Option<String>,
+    /// Number of records in this group.
+    pub total_runs: u64,
+    /// Accepted candidates in this group.
+    pub accepted_candidates: u64,
+    /// Generated candidates in this group.
+    pub generated_candidates: u64,
+}
+
+/// Body-free aggregate for operator reports and canary controls.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentWorkerAuditSummary {
+    /// Total observed worker runs.
+    pub total_runs: u64,
+    /// Runs with `Completed` status.
+    pub completed_runs: u64,
+    /// Runs with rejected, aborted, or rolled-back status.
+    pub failed_runs: u64,
+    /// Generated candidates across all records.
+    pub generated_candidates: u64,
+    /// Accepted candidates across all records.
+    pub accepted_candidates: u64,
+    /// `accepted_candidates / generated_candidates`, absent when no candidates were generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_rate: Option<f64>,
+    /// Agent turns consumed.
+    pub turns: u64,
+    /// Agent tool calls consumed.
+    pub tool_calls: u64,
+    /// Provider-defined cost units consumed.
+    pub cost_units: u64,
+    /// Failure counts by stable failure category.
+    pub failure_modes: BTreeMap<AgentWorkerFailureMode, u64>,
+    /// Per-worker and per-cohort summaries.
+    pub workers: Vec<AgentWorkerGroupSummary>,
+}
+
+impl AgentWorkerAuditSummary {
+    /// Build a body-free aggregate from audit records.
+    #[must_use]
+    pub fn from_records(records: &[AgentWorkerAuditRecord]) -> Self {
+        let mut total_runs = 0_u64;
+        let mut completed_runs = 0_u64;
+        let mut failed_runs = 0_u64;
+        let mut generated_candidates = 0_u64;
+        let mut accepted_candidates = 0_u64;
+        let mut turns = 0_u64;
+        let mut tool_calls = 0_u64;
+        let mut cost_units = 0_u64;
+        let mut failure_modes: BTreeMap<AgentWorkerFailureMode, u64> = BTreeMap::new();
+        let mut groups: BTreeMap<
+            (AgentWorkerKind, String, Option<String>),
+            AgentWorkerGroupSummary,
+        > = BTreeMap::new();
+
+        for record in records {
+            total_runs = total_runs.saturating_add(1);
+            if record.status == AgentWorkerStatus::Completed {
+                completed_runs = completed_runs.saturating_add(1);
+            }
+            if record.status.is_failure() {
+                failed_runs = failed_runs.saturating_add(1);
+            }
+            generated_candidates = generated_candidates.saturating_add(record.generated_candidates);
+            accepted_candidates = accepted_candidates.saturating_add(record.accepted_candidates);
+            turns = turns.saturating_add(u64::from(record.budget_consumed.turns));
+            tool_calls = tool_calls.saturating_add(u64::from(record.budget_consumed.tool_calls));
+            cost_units = cost_units.saturating_add(record.budget_consumed.cost_units);
+
+            if let Some(mode) = record.failure_mode {
+                let count = failure_modes.entry(mode).or_insert(0);
+                *count = count.saturating_add(1);
+            }
+
+            let key = (
+                record.worker_kind,
+                record.worker_name.clone(),
+                record.canary_label.clone(),
+            );
+            let group = groups
+                .entry(key)
+                .or_insert_with(|| AgentWorkerGroupSummary {
+                    worker_kind: record.worker_kind,
+                    worker_name: record.worker_name.clone(),
+                    canary_label: record.canary_label.clone(),
+                    total_runs: 0,
+                    accepted_candidates: 0,
+                    generated_candidates: 0,
+                });
+            group.total_runs = group.total_runs.saturating_add(1);
+            group.accepted_candidates = group
+                .accepted_candidates
+                .saturating_add(record.accepted_candidates);
+            group.generated_candidates = group
+                .generated_candidates
+                .saturating_add(record.generated_candidates);
+        }
+
+        let acceptance_rate = if generated_candidates == 0 {
+            None
+        } else {
+            Some(accepted_candidates as f64 / generated_candidates as f64)
+        };
+
+        Self {
+            total_runs,
+            completed_runs,
+            failed_runs,
+            generated_candidates,
+            accepted_candidates,
+            acceptance_rate,
+            turns,
+            tool_calls,
+            cost_units,
+            failure_modes,
+            workers: groups.into_values().collect(),
+        }
+    }
+
+    /// True when no worker audit records were observed.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.total_runs == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::contract::agent_provider::CairnVerb;
+
+    fn scope(agent: &str) -> ScopeTuple {
+        ScopeTuple {
+            tenant: Some("tenant-a".to_owned()),
+            workspace: Some("workspace-a".to_owned()),
+            agent: Some(agent.to_owned()),
+            ..ScopeTuple::default()
+        }
+    }
+
+    fn record(
+        operation_id: &str,
+        status: AgentWorkerStatus,
+        generated_candidates: u64,
+        accepted_candidates: u64,
+        cost_units: u64,
+        failure_mode: Option<AgentWorkerFailureMode>,
+    ) -> AgentWorkerAuditRecord {
+        AgentWorkerAuditRecord {
+            operation_id: operation_id.to_owned(),
+            worker_kind: AgentWorkerKind::Extractor,
+            worker_name: "agent_extractor".to_owned(),
+            agent_identity: "agt:cairn-extractor:v1".to_owned(),
+            scope: Some(scope("agt:cairn-extractor:v1")),
+            status,
+            generated_candidates,
+            accepted_candidates,
+            budget_consumed: AgentBudgetConsumed {
+                turns: 2,
+                tool_calls: 3,
+                cost_units,
+            },
+            failure_mode,
+            canary_label: Some("canary-05".to_owned()),
+        }
+    }
+
+    #[test]
+    fn aggregate_tracks_cost_candidates_acceptance_and_failures() {
+        let records = vec![
+            record("op-1", AgentWorkerStatus::Completed, 4, 2, 100, None),
+            record(
+                "op-2",
+                AgentWorkerStatus::Aborted,
+                0,
+                0,
+                50,
+                Some(AgentWorkerFailureMode::BudgetExceeded),
+            ),
+        ];
+
+        let summary = AgentWorkerAuditSummary::from_records(&records);
+
+        assert_eq!(summary.total_runs, 2);
+        assert_eq!(summary.completed_runs, 1);
+        assert_eq!(summary.failed_runs, 1);
+        assert_eq!(summary.generated_candidates, 4);
+        assert_eq!(summary.accepted_candidates, 2);
+        assert_eq!(summary.acceptance_rate, Some(0.5));
+        assert_eq!(summary.turns, 4);
+        assert_eq!(summary.tool_calls, 6);
+        assert_eq!(summary.cost_units, 150);
+        assert_eq!(
+            summary
+                .failure_modes
+                .get(&AgentWorkerFailureMode::BudgetExceeded),
+            Some(&1)
+        );
+        assert_eq!(summary.workers[0].worker_name, "agent_extractor");
+    }
+
+    #[test]
+    fn aggregate_reports_no_acceptance_rate_without_generated_candidates() {
+        let records = vec![record("op-1", AgentWorkerStatus::Completed, 0, 0, 10, None)];
+
+        let summary = AgentWorkerAuditSummary::from_records(&records);
+
+        assert_eq!(summary.generated_candidates, 0);
+        assert_eq!(summary.accepted_candidates, 0);
+        assert_eq!(summary.acceptance_rate, None);
+    }
+
+    #[test]
+    fn record_preserves_identity_and_scope_for_aborted_runs() {
+        let record = record(
+            "op-1",
+            AgentWorkerStatus::Aborted,
+            0,
+            0,
+            1,
+            Some(AgentWorkerFailureMode::ProviderUnavailable),
+        );
+
+        assert_eq!(record.agent_identity, "agt:cairn-extractor:v1");
+        assert_eq!(
+            record
+                .scope
+                .as_ref()
+                .and_then(|scope| scope.agent.as_deref()),
+            Some("agt:cairn-extractor:v1")
+        );
+        assert_eq!(
+            record.failure_mode,
+            Some(AgentWorkerFailureMode::ProviderUnavailable)
+        );
+    }
+
+    #[test]
+    fn provider_errors_map_to_failure_modes() {
+        assert_eq!(
+            AgentWorkerFailureMode::from_provider_error(&AgentProviderError::ToolNotAllowed {
+                verb: CairnVerb::Forget,
+            }),
+            AgentWorkerFailureMode::ToolNotAllowed
+        );
+        assert_eq!(
+            AgentWorkerFailureMode::from_provider_error(
+                &AgentProviderError::MutatingVerbNotScoped {
+                    verb: CairnVerb::Ingest,
+                },
+            ),
+            AgentWorkerFailureMode::MutatingVerbNotScoped
+        );
+    }
+}

--- a/crates/cairn-core/src/domain/agent_canary.rs
+++ b/crates/cairn-core/src/domain/agent_canary.rs
@@ -1,0 +1,747 @@
+//! Pure canary controls for agent-mode workers.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::AgentWorkerAuditSummary;
+
+/// Operator-visible rollout state for agent-mode workers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentCanaryState {
+    /// Do not dispatch agent-mode workers.
+    Paused,
+    /// Dispatch only for a bounded canary cohort.
+    Canary,
+    /// Dispatch for all configured eligible traffic.
+    Enabled,
+    /// Do not dispatch until an operator resets the rollout.
+    RolledBack,
+}
+
+impl AgentCanaryState {
+    /// Stable snake-case label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Paused => "paused",
+            Self::Canary => "canary",
+            Self::Enabled => "enabled",
+            Self::RolledBack => "rolled_back",
+        }
+    }
+}
+
+/// Pure canary policy evaluated before dispatch and after audit aggregation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentCanaryPolicy {
+    /// Current rollout state.
+    pub state: AgentCanaryState,
+    /// Stable operator-facing cohort label, such as `canary-05`.
+    pub cohort_label: String,
+    /// Percentage of traffic allowed in canary state, from 0 through 100.
+    pub rollout_percent: u8,
+    /// Minimum observed runs before judging canary metrics.
+    pub min_runs: u64,
+    /// Minimum accepted/generated rate required for promotion.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_acceptance_rate: Option<f64>,
+    /// Maximum failed/total rate allowed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_failure_rate: Option<f64>,
+    /// Maximum aggregate provider-defined cost units allowed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_cost_units: Option<u64>,
+    /// Maximum aggregate agent tool calls allowed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tool_calls: Option<u64>,
+    /// Maximum aggregate agent turns allowed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<u64>,
+    /// Maximum cost units per accepted candidate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_cost_units_per_accepted_candidate: Option<u64>,
+    /// Explicit operator pause.
+    pub pause_requested: bool,
+    /// Explicit operator rollback.
+    pub rollback_requested: bool,
+}
+
+/// Stable decision category for reports and tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentCanaryDecisionKind {
+    /// Dispatch can proceed.
+    DispatchAllowed,
+    /// Dispatch denied because agent mode is paused.
+    DispatchDeniedPaused,
+    /// Dispatch denied because agent mode is rolled back.
+    DispatchDeniedRolledBack,
+    /// Dispatch denied because this request is outside the canary cohort.
+    DispatchDeniedOutsideCanary,
+    /// Canary stays in observation mode.
+    RemainCanaryInsufficientData,
+    /// Canary passed configured thresholds.
+    PromoteToEnabled,
+    /// Canary failed a configured threshold.
+    RollbackThresholdFailed,
+    /// Operator requested rollback.
+    RollbackRequested,
+}
+
+/// Stable body-free reason code for a canary decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentCanaryReasonCode {
+    /// Dispatch is allowed by the current state.
+    DispatchAllowed,
+    /// Operator requested pause.
+    OperatorPaused,
+    /// Rollout state is paused.
+    RolloutPaused,
+    /// Operator requested rollback.
+    OperatorRollbackRequested,
+    /// Rollout state is rolled back.
+    RolloutRolledBack,
+    /// Request cohort is outside the current canary sample.
+    OutsideCanaryCohort,
+    /// Not enough audit runs have accumulated to judge canary health.
+    InsufficientAuditRuns,
+    /// Failure rate exceeded the configured threshold.
+    FailureRateExceeded,
+    /// Acceptance rate fell below the configured threshold.
+    AcceptanceRateTooLow,
+    /// Aggregate cost units exceeded the configured cap.
+    CostUnitsExceeded,
+    /// Aggregate tool calls exceeded the configured cap.
+    ToolCallsExceeded,
+    /// Aggregate turns exceeded the configured cap.
+    TurnsExceeded,
+    /// Cost per accepted candidate exceeded the configured cap.
+    CostPerAcceptedCandidateExceeded,
+    /// Canary metrics passed configured thresholds.
+    ThresholdsPassed,
+    /// Aggregate evaluation observed a non-canary state.
+    NonCanaryState,
+}
+
+impl AgentCanaryReasonCode {
+    /// Stable snake-case label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DispatchAllowed => "dispatch_allowed",
+            Self::OperatorPaused => "operator_paused",
+            Self::RolloutPaused => "rollout_paused",
+            Self::OperatorRollbackRequested => "operator_rollback_requested",
+            Self::RolloutRolledBack => "rollout_rolled_back",
+            Self::OutsideCanaryCohort => "outside_canary_cohort",
+            Self::InsufficientAuditRuns => "insufficient_audit_runs",
+            Self::FailureRateExceeded => "failure_rate_exceeded",
+            Self::AcceptanceRateTooLow => "acceptance_rate_too_low",
+            Self::CostUnitsExceeded => "cost_units_exceeded",
+            Self::ToolCallsExceeded => "tool_calls_exceeded",
+            Self::TurnsExceeded => "turns_exceeded",
+            Self::CostPerAcceptedCandidateExceeded => "cost_per_accepted_candidate_exceeded",
+            Self::ThresholdsPassed => "thresholds_passed",
+            Self::NonCanaryState => "non_canary_state",
+        }
+    }
+}
+
+/// Body-free audit counters attached to aggregate canary decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentCanaryDecisionCounters {
+    /// Total observed worker runs.
+    pub total_runs: u64,
+    /// Runs counted as failed by canary gates.
+    pub failed_runs: u64,
+    /// Generated candidates across observed worker runs.
+    pub generated_candidates: u64,
+    /// Accepted candidates across observed worker runs.
+    pub accepted_candidates: u64,
+    /// Agent turns consumed.
+    pub turns: u64,
+    /// Agent tool calls consumed.
+    pub tool_calls: u64,
+    /// Provider-defined cost units consumed.
+    pub cost_units: u64,
+    /// `failed_runs / total_runs`, absent without observed runs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_rate: Option<f64>,
+    /// `accepted_candidates / generated_candidates`, absent without generated candidates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_rate: Option<f64>,
+    /// Integer cost units per accepted candidate, absent without accepted candidates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_units_per_accepted_candidate: Option<u64>,
+}
+
+impl AgentCanaryDecisionCounters {
+    /// Empty counters for dispatch decisions that do not evaluate an audit summary.
+    pub const EMPTY: Self = Self {
+        total_runs: 0,
+        failed_runs: 0,
+        generated_candidates: 0,
+        accepted_candidates: 0,
+        turns: 0,
+        tool_calls: 0,
+        cost_units: 0,
+        failure_rate: None,
+        acceptance_rate: None,
+        cost_units_per_accepted_candidate: None,
+    };
+
+    /// Build counters from a body-free worker audit summary.
+    #[must_use]
+    pub fn from_summary(summary: &AgentWorkerAuditSummary) -> Self {
+        Self {
+            total_runs: summary.total_runs,
+            failed_runs: summary.failed_runs,
+            generated_candidates: summary.generated_candidates,
+            accepted_candidates: summary.accepted_candidates,
+            turns: summary.turns,
+            tool_calls: summary.tool_calls,
+            cost_units: summary.cost_units,
+            failure_rate: rate(summary.failed_runs, summary.total_runs),
+            acceptance_rate: summary.acceptance_rate,
+            cost_units_per_accepted_candidate: cost_per_accepted_candidate(
+                summary.cost_units,
+                summary.accepted_candidates,
+            ),
+        }
+    }
+}
+
+impl Default for AgentCanaryDecisionCounters {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+/// Pure canary decision with state, reason code, and report counters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentCanaryDecision {
+    /// Stable decision kind.
+    pub kind: AgentCanaryDecisionKind,
+    /// State that should be used after applying the decision.
+    pub next_state: AgentCanaryState,
+    /// Stable body-free reason code.
+    pub reason_code: AgentCanaryReasonCode,
+    /// Cohort label copied from the policy for operator reports.
+    pub cohort_label: String,
+    /// Rollout sample percentage copied from the policy.
+    pub rollout_percent: u8,
+    /// Body-free audit counters used for the decision.
+    pub counters: AgentCanaryDecisionCounters,
+}
+
+/// Validation failures for impossible canary policies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum AgentCanaryError {
+    /// Cohort label must not be empty.
+    #[error("agent canary cohort_label must not be empty")]
+    EmptyCohortLabel,
+    /// `rollout_percent` must be from 0 through 100.
+    #[error("agent canary rollout_percent must be between 0 and 100")]
+    RolloutPercentOutOfRange,
+    /// `cohort_percentile` must be from 0 through 99.
+    #[error("agent canary cohort_percentile {cohort_percentile} must be between 0 and 99")]
+    CohortPercentileOutOfRange {
+        /// Invalid cohort percentile.
+        cohort_percentile: u8,
+    },
+    /// `min_runs` must be nonzero.
+    #[error("agent canary min_runs must be nonzero")]
+    ZeroMinRuns,
+    /// A rate field was outside 0.0 through 1.0.
+    #[error("agent canary rate {field} must be between 0.0 and 1.0")]
+    RateOutOfRange {
+        /// Field name.
+        field: &'static str,
+    },
+}
+
+impl AgentCanaryPolicy {
+    /// Validate policy invariants.
+    ///
+    /// # Errors
+    /// Returns [`AgentCanaryError`] when the policy is impossible to evaluate.
+    pub fn validate(&self) -> Result<(), AgentCanaryError> {
+        if self.cohort_label.trim().is_empty() {
+            return Err(AgentCanaryError::EmptyCohortLabel);
+        }
+        if self.rollout_percent > 100 {
+            return Err(AgentCanaryError::RolloutPercentOutOfRange);
+        }
+        if self.min_runs == 0 {
+            return Err(AgentCanaryError::ZeroMinRuns);
+        }
+        validate_rate("min_acceptance_rate", self.min_acceptance_rate)?;
+        validate_rate("max_failure_rate", self.max_failure_rate)?;
+        Ok(())
+    }
+
+    /// Decide whether one request in `cohort_percentile` may dispatch.
+    ///
+    /// `cohort_percentile` is expected to be a deterministic value from 0 through 99
+    /// computed by the caller from body-free request identity.
+    ///
+    /// # Errors
+    /// Returns [`AgentCanaryError`] when the policy or cohort percentile is invalid.
+    pub fn dispatch_decision(
+        &self,
+        cohort_percentile: u8,
+    ) -> Result<AgentCanaryDecision, AgentCanaryError> {
+        self.validate()?;
+        if cohort_percentile >= 100 {
+            return Err(AgentCanaryError::CohortPercentileOutOfRange { cohort_percentile });
+        }
+        if self.rollback_requested {
+            return Ok(self.decision(
+                AgentCanaryDecisionKind::RollbackRequested,
+                AgentCanaryState::RolledBack,
+                AgentCanaryReasonCode::OperatorRollbackRequested,
+                AgentCanaryDecisionCounters::EMPTY,
+            ));
+        }
+        if self.pause_requested {
+            return Ok(self.decision(
+                AgentCanaryDecisionKind::DispatchDeniedPaused,
+                AgentCanaryState::Paused,
+                AgentCanaryReasonCode::OperatorPaused,
+                AgentCanaryDecisionCounters::EMPTY,
+            ));
+        }
+        if self.state == AgentCanaryState::Paused {
+            return Ok(self.decision(
+                AgentCanaryDecisionKind::DispatchDeniedPaused,
+                AgentCanaryState::Paused,
+                AgentCanaryReasonCode::RolloutPaused,
+                AgentCanaryDecisionCounters::EMPTY,
+            ));
+        }
+        if self.state == AgentCanaryState::RolledBack {
+            return Ok(self.decision(
+                AgentCanaryDecisionKind::DispatchDeniedRolledBack,
+                AgentCanaryState::RolledBack,
+                AgentCanaryReasonCode::RolloutRolledBack,
+                AgentCanaryDecisionCounters::EMPTY,
+            ));
+        }
+        if self.state == AgentCanaryState::Canary && cohort_percentile >= self.rollout_percent {
+            return Ok(self.decision(
+                AgentCanaryDecisionKind::DispatchDeniedOutsideCanary,
+                AgentCanaryState::Canary,
+                AgentCanaryReasonCode::OutsideCanaryCohort,
+                AgentCanaryDecisionCounters::EMPTY,
+            ));
+        }
+        Ok(self.decision(
+            AgentCanaryDecisionKind::DispatchAllowed,
+            self.state,
+            AgentCanaryReasonCode::DispatchAllowed,
+            AgentCanaryDecisionCounters::EMPTY,
+        ))
+    }
+
+    /// Evaluate aggregate canary metrics after worker audit records are summarized.
+    ///
+    /// # Errors
+    /// Returns [`AgentCanaryError`] when the policy is invalid.
+    pub fn evaluate_summary(
+        &self,
+        summary: &AgentWorkerAuditSummary,
+    ) -> Result<AgentCanaryDecision, AgentCanaryError> {
+        self.validate()?;
+        let counters = AgentCanaryDecisionCounters::from_summary(summary);
+        if let Some(decision) = self.gated_summary_decision(counters) {
+            return Ok(decision);
+        }
+        if self.state != AgentCanaryState::Canary {
+            return Ok(self.decision(
+                AgentCanaryDecisionKind::DispatchAllowed,
+                self.state,
+                AgentCanaryReasonCode::NonCanaryState,
+                counters,
+            ));
+        }
+        if summary.total_runs < self.min_runs {
+            return Ok(self.decision(
+                AgentCanaryDecisionKind::RemainCanaryInsufficientData,
+                AgentCanaryState::Canary,
+                AgentCanaryReasonCode::InsufficientAuditRuns,
+                counters,
+            ));
+        }
+        if let Some(reason_code) = self.threshold_failure(summary, counters) {
+            return Ok(self.decision(
+                AgentCanaryDecisionKind::RollbackThresholdFailed,
+                AgentCanaryState::RolledBack,
+                reason_code,
+                counters,
+            ));
+        }
+        Ok(self.decision(
+            AgentCanaryDecisionKind::PromoteToEnabled,
+            AgentCanaryState::Enabled,
+            AgentCanaryReasonCode::ThresholdsPassed,
+            counters,
+        ))
+    }
+
+    fn gated_summary_decision(
+        &self,
+        counters: AgentCanaryDecisionCounters,
+    ) -> Option<AgentCanaryDecision> {
+        if self.rollback_requested {
+            return Some(self.decision(
+                AgentCanaryDecisionKind::RollbackRequested,
+                AgentCanaryState::RolledBack,
+                AgentCanaryReasonCode::OperatorRollbackRequested,
+                counters,
+            ));
+        }
+        if self.pause_requested {
+            return Some(self.decision(
+                AgentCanaryDecisionKind::DispatchDeniedPaused,
+                AgentCanaryState::Paused,
+                AgentCanaryReasonCode::OperatorPaused,
+                counters,
+            ));
+        }
+        match self.state {
+            AgentCanaryState::Paused => Some(self.decision(
+                AgentCanaryDecisionKind::DispatchDeniedPaused,
+                AgentCanaryState::Paused,
+                AgentCanaryReasonCode::RolloutPaused,
+                counters,
+            )),
+            AgentCanaryState::RolledBack => Some(self.decision(
+                AgentCanaryDecisionKind::DispatchDeniedRolledBack,
+                AgentCanaryState::RolledBack,
+                AgentCanaryReasonCode::RolloutRolledBack,
+                counters,
+            )),
+            AgentCanaryState::Canary | AgentCanaryState::Enabled => None,
+        }
+    }
+
+    fn threshold_failure(
+        &self,
+        summary: &AgentWorkerAuditSummary,
+        counters: AgentCanaryDecisionCounters,
+    ) -> Option<AgentCanaryReasonCode> {
+        if self
+            .max_failure_rate
+            .is_some_and(|max| counters.failure_rate.is_some_and(|rate| rate > max))
+        {
+            return Some(AgentCanaryReasonCode::FailureRateExceeded);
+        }
+        if self
+            .min_acceptance_rate
+            .is_some_and(|min| counters.acceptance_rate.unwrap_or(0.0) < min)
+        {
+            return Some(AgentCanaryReasonCode::AcceptanceRateTooLow);
+        }
+        if self
+            .max_cost_units
+            .is_some_and(|max| summary.cost_units > max)
+        {
+            return Some(AgentCanaryReasonCode::CostUnitsExceeded);
+        }
+        if self
+            .max_tool_calls
+            .is_some_and(|max| summary.tool_calls > max)
+        {
+            return Some(AgentCanaryReasonCode::ToolCallsExceeded);
+        }
+        if self.max_turns.is_some_and(|max| summary.turns > max) {
+            return Some(AgentCanaryReasonCode::TurnsExceeded);
+        }
+        if self
+            .max_cost_units_per_accepted_candidate
+            .is_some_and(|max| {
+                exceeds_cost_per_accepted_candidate(
+                    summary.cost_units,
+                    summary.accepted_candidates,
+                    max,
+                )
+            })
+        {
+            return Some(AgentCanaryReasonCode::CostPerAcceptedCandidateExceeded);
+        }
+        None
+    }
+
+    fn decision(
+        &self,
+        kind: AgentCanaryDecisionKind,
+        next_state: AgentCanaryState,
+        reason_code: AgentCanaryReasonCode,
+        counters: AgentCanaryDecisionCounters,
+    ) -> AgentCanaryDecision {
+        AgentCanaryDecision {
+            kind,
+            next_state,
+            reason_code,
+            cohort_label: self.cohort_label.clone(),
+            rollout_percent: self.rollout_percent,
+            counters,
+        }
+    }
+}
+
+fn validate_rate(field: &'static str, value: Option<f64>) -> Result<(), AgentCanaryError> {
+    if value.is_some_and(|rate| !(0.0..=1.0).contains(&rate)) {
+        return Err(AgentCanaryError::RateOutOfRange { field });
+    }
+    Ok(())
+}
+
+fn rate(numerator: u64, denominator: u64) -> Option<f64> {
+    if denominator == 0 {
+        return None;
+    }
+
+    // Operator-facing ratio; exact integer counters remain attached to the decision.
+    #[allow(clippy::cast_precision_loss)]
+    Some(numerator as f64 / denominator as f64)
+}
+
+fn cost_per_accepted_candidate(cost_units: u64, accepted_candidates: u64) -> Option<u64> {
+    if accepted_candidates == 0 {
+        return None;
+    }
+    Some(cost_units / accepted_candidates)
+}
+
+fn exceeds_cost_per_accepted_candidate(
+    cost_units: u64,
+    accepted_candidates: u64,
+    max_cost_units_per_accepted_candidate: u64,
+) -> bool {
+    if accepted_candidates == 0 {
+        return true;
+    }
+
+    u128::from(cost_units)
+        > u128::from(max_cost_units_per_accepted_candidate) * u128::from(accepted_candidates)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(
+        total: u64,
+        failed: u64,
+        generated: u64,
+        accepted: u64,
+        cost_units: u64,
+    ) -> AgentWorkerAuditSummary {
+        AgentWorkerAuditSummary {
+            total_runs: total,
+            completed_runs: total.saturating_sub(failed),
+            failed_runs: failed,
+            generated_candidates: generated,
+            accepted_candidates: accepted,
+            acceptance_rate: rate(accepted, generated),
+            turns: 2,
+            tool_calls: 3,
+            cost_units,
+            failure_modes: Default::default(),
+            workers: Vec::new(),
+        }
+    }
+
+    fn policy() -> AgentCanaryPolicy {
+        AgentCanaryPolicy {
+            state: AgentCanaryState::Canary,
+            cohort_label: "canary-05".to_owned(),
+            rollout_percent: 5,
+            min_runs: 4,
+            min_acceptance_rate: Some(0.50),
+            max_failure_rate: Some(0.20),
+            max_cost_units: Some(100),
+            max_tool_calls: None,
+            max_turns: None,
+            max_cost_units_per_accepted_candidate: Some(20),
+            pause_requested: false,
+            rollback_requested: false,
+        }
+    }
+
+    #[test]
+    fn paused_rollout_denies_dispatch_with_stable_reason_code() {
+        let policy = AgentCanaryPolicy {
+            state: AgentCanaryState::Paused,
+            pause_requested: true,
+            ..policy()
+        };
+
+        let decision = policy.dispatch_decision(0).expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::DispatchDeniedPaused);
+        assert_eq!(decision.next_state, AgentCanaryState::Paused);
+        assert_eq!(decision.reason_code, AgentCanaryReasonCode::OperatorPaused);
+        assert_eq!(decision.cohort_label, "canary-05");
+    }
+
+    #[test]
+    fn canary_rollout_denies_outside_cohort() {
+        let decision = policy().dispatch_decision(50).expect("valid policy");
+
+        assert_eq!(
+            decision.kind,
+            AgentCanaryDecisionKind::DispatchDeniedOutsideCanary
+        );
+        assert_eq!(
+            decision.reason_code,
+            AgentCanaryReasonCode::OutsideCanaryCohort
+        );
+        assert_eq!(decision.next_state, AgentCanaryState::Canary);
+    }
+
+    #[test]
+    fn canary_allows_inside_cohort() {
+        let decision = policy().dispatch_decision(4).expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::DispatchAllowed);
+        assert_eq!(decision.reason_code, AgentCanaryReasonCode::DispatchAllowed);
+        assert_eq!(decision.next_state, AgentCanaryState::Canary);
+    }
+
+    #[test]
+    fn canary_remains_when_insufficient_runs() {
+        let decision = policy()
+            .evaluate_summary(&summary(3, 0, 4, 4, 20))
+            .expect("valid policy");
+
+        assert_eq!(
+            decision.kind,
+            AgentCanaryDecisionKind::RemainCanaryInsufficientData
+        );
+        assert_eq!(
+            decision.reason_code,
+            AgentCanaryReasonCode::InsufficientAuditRuns
+        );
+        assert_eq!(decision.next_state, AgentCanaryState::Canary);
+        assert_eq!(decision.counters.total_runs, 3);
+    }
+
+    #[test]
+    fn canary_rolls_back_when_failure_rate_exceeds_threshold() {
+        let decision = policy()
+            .evaluate_summary(&summary(5, 2, 4, 4, 20))
+            .expect("valid policy");
+
+        assert_eq!(
+            decision.kind,
+            AgentCanaryDecisionKind::RollbackThresholdFailed
+        );
+        assert_eq!(
+            decision.reason_code,
+            AgentCanaryReasonCode::FailureRateExceeded
+        );
+        assert_eq!(decision.next_state, AgentCanaryState::RolledBack);
+        assert_eq!(decision.counters.failed_runs, 2);
+        assert_eq!(decision.counters.failure_rate, Some(0.4));
+    }
+
+    #[test]
+    fn canary_rolls_back_when_budget_cap_is_exceeded() {
+        let policy = AgentCanaryPolicy {
+            max_cost_units: Some(30),
+            max_cost_units_per_accepted_candidate: None,
+            ..policy()
+        };
+
+        let decision = policy
+            .evaluate_summary(&summary(5, 0, 10, 8, 80))
+            .expect("valid policy");
+
+        assert_eq!(
+            decision.kind,
+            AgentCanaryDecisionKind::RollbackThresholdFailed
+        );
+        assert_eq!(
+            decision.reason_code,
+            AgentCanaryReasonCode::CostUnitsExceeded
+        );
+        assert_eq!(decision.counters.cost_units, 80);
+    }
+
+    #[test]
+    fn canary_rolls_back_when_cost_per_accepted_candidate_exceeds_threshold() {
+        let policy = AgentCanaryPolicy {
+            max_cost_units: None,
+            max_cost_units_per_accepted_candidate: Some(9),
+            ..policy()
+        };
+
+        let decision = policy
+            .evaluate_summary(&summary(5, 0, 10, 8, 80))
+            .expect("valid policy");
+
+        assert_eq!(
+            decision.kind,
+            AgentCanaryDecisionKind::RollbackThresholdFailed
+        );
+        assert_eq!(
+            decision.reason_code,
+            AgentCanaryReasonCode::CostPerAcceptedCandidateExceeded
+        );
+        assert_eq!(
+            decision.counters.cost_units_per_accepted_candidate,
+            Some(10)
+        );
+    }
+
+    #[test]
+    fn canary_promotes_when_thresholds_pass() {
+        let decision = policy()
+            .evaluate_summary(&summary(5, 0, 10, 8, 80))
+            .expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::PromoteToEnabled);
+        assert_eq!(
+            decision.reason_code,
+            AgentCanaryReasonCode::ThresholdsPassed
+        );
+        assert_eq!(decision.next_state, AgentCanaryState::Enabled);
+        assert_eq!(decision.counters.acceptance_rate, Some(0.8));
+    }
+
+    #[test]
+    fn explicit_rollback_wins_over_promotion() {
+        let policy = AgentCanaryPolicy {
+            rollback_requested: true,
+            ..policy()
+        };
+
+        let decision = policy
+            .evaluate_summary(&summary(5, 0, 10, 10, 10))
+            .expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::RollbackRequested);
+        assert_eq!(
+            decision.reason_code,
+            AgentCanaryReasonCode::OperatorRollbackRequested
+        );
+        assert_eq!(decision.next_state, AgentCanaryState::RolledBack);
+        assert_eq!(decision.counters.total_runs, 5);
+    }
+
+    fn rate(numerator: u64, denominator: u64) -> Option<f64> {
+        if denominator == 0 {
+            return None;
+        }
+
+        #[allow(clippy::cast_precision_loss)]
+        Some(numerator as f64 / denominator as f64)
+    }
+}

--- a/crates/cairn-core/src/domain/agent_canary.rs
+++ b/crates/cairn-core/src/domain/agent_canary.rs
@@ -173,7 +173,7 @@ pub struct AgentCanaryDecisionCounters {
     /// `accepted_candidates / generated_candidates`, absent without generated candidates.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acceptance_rate: Option<f64>,
-    /// Integer cost units per accepted candidate, absent without accepted candidates.
+    /// Ceil-rounded cost units per accepted candidate, absent without accepted candidates.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost_units_per_accepted_candidate: Option<u64>,
 }
@@ -205,7 +205,7 @@ impl AgentCanaryDecisionCounters {
             tool_calls: summary.tool_calls,
             cost_units: summary.cost_units,
             failure_rate: rate(summary.failed_runs, summary.total_runs),
-            acceptance_rate: summary.acceptance_rate,
+            acceptance_rate: rate(summary.accepted_candidates, summary.generated_candidates),
             cost_units_per_accepted_candidate: cost_per_accepted_candidate(
                 summary.cost_units,
                 summary.accepted_candidates,
@@ -257,6 +257,9 @@ pub enum AgentCanaryError {
     /// `min_runs` must be nonzero.
     #[error("agent canary min_runs must be nonzero")]
     ZeroMinRuns,
+    /// A populated audit summary was not pre-filtered to one canary cohort.
+    #[error("agent canary summary must be pre-filtered to the policy cohort")]
+    MixedCohortSummary,
     /// A rate field was outside 0.0 through 1.0.
     #[error("agent canary rate {field} must be between 0.0 and 1.0")]
     RateOutOfRange {
@@ -350,13 +353,20 @@ impl AgentCanaryPolicy {
 
     /// Evaluate aggregate canary metrics after worker audit records are summarized.
     ///
+    /// Callers must pass a summary already filtered to `self.cohort_label`.
+    /// Empty worker-group metadata is accepted for synthetic tests and no-data
+    /// reports. When worker groups are present, every group must carry the
+    /// policy cohort label so mixed-cohort aggregate misuse fails closed.
+    ///
     /// # Errors
-    /// Returns [`AgentCanaryError`] when the policy is invalid.
+    /// Returns [`AgentCanaryError`] when the policy is invalid or the summary
+    /// contains mixed or unlabeled worker cohorts.
     pub fn evaluate_summary(
         &self,
         summary: &AgentWorkerAuditSummary,
     ) -> Result<AgentCanaryDecision, AgentCanaryError> {
         self.validate()?;
+        self.validate_summary_cohort(summary)?;
         let counters = AgentCanaryDecisionCounters::from_summary(summary);
         if let Some(decision) = self.gated_summary_decision(counters) {
             return Ok(decision);
@@ -391,6 +401,25 @@ impl AgentCanaryPolicy {
             AgentCanaryReasonCode::ThresholdsPassed,
             counters,
         ))
+    }
+
+    fn validate_summary_cohort(
+        &self,
+        summary: &AgentWorkerAuditSummary,
+    ) -> Result<(), AgentCanaryError> {
+        if summary.workers.is_empty() {
+            return Ok(());
+        }
+
+        if summary
+            .workers
+            .iter()
+            .all(|worker| worker.canary_label.as_deref() == Some(self.cohort_label.as_str()))
+        {
+            return Ok(());
+        }
+
+        Err(AgentCanaryError::MixedCohortSummary)
     }
 
     fn gated_summary_decision(
@@ -516,7 +545,7 @@ fn cost_per_accepted_candidate(cost_units: u64, accepted_candidates: u64) -> Opt
     if accepted_candidates == 0 {
         return None;
     }
-    Some(cost_units / accepted_candidates)
+    Some(cost_units.div_ceil(accepted_candidates))
 }
 
 fn exceeds_cost_per_accepted_candidate(
@@ -525,7 +554,7 @@ fn exceeds_cost_per_accepted_candidate(
     max_cost_units_per_accepted_candidate: u64,
 ) -> bool {
     if accepted_candidates == 0 {
-        return true;
+        return cost_units > 0;
     }
 
     u128::from(cost_units)
@@ -535,6 +564,8 @@ fn exceeds_cost_per_accepted_candidate(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::domain::{AgentWorkerGroupSummary, AgentWorkerKind};
 
     fn summary(
         total: u64,
@@ -572,6 +603,17 @@ mod tests {
             max_cost_units_per_accepted_candidate: Some(20),
             pause_requested: false,
             rollback_requested: false,
+        }
+    }
+
+    fn group(canary_label: Option<&str>, total_runs: u64) -> AgentWorkerGroupSummary {
+        AgentWorkerGroupSummary {
+            worker_kind: AgentWorkerKind::Extractor,
+            worker_name: "agent_extractor".to_owned(),
+            canary_label: canary_label.map(str::to_owned),
+            total_runs,
+            accepted_candidates: total_runs,
+            generated_candidates: total_runs,
         }
     }
 
@@ -653,6 +695,36 @@ mod tests {
     }
 
     #[test]
+    fn canary_recomputes_acceptance_rate_from_counts() {
+        let mut summary = summary(5, 0, 10, 1, 10);
+        summary.acceptance_rate = Some(1.0);
+
+        let decision = policy().evaluate_summary(&summary).expect("valid policy");
+
+        assert_eq!(
+            decision.kind,
+            AgentCanaryDecisionKind::RollbackThresholdFailed
+        );
+        assert_eq!(
+            decision.reason_code,
+            AgentCanaryReasonCode::AcceptanceRateTooLow
+        );
+        assert_eq!(decision.counters.acceptance_rate, Some(0.1));
+    }
+
+    #[test]
+    fn mixed_cohort_summary_is_rejected_before_thresholds() {
+        let mut summary = summary(5, 0, 10, 8, 80);
+        summary.workers = vec![group(Some("canary-05"), 3), group(Some("canary-10"), 2)];
+
+        let error = policy()
+            .evaluate_summary(&summary)
+            .expect_err("mixed cohort summaries must be rejected");
+
+        assert_eq!(error, AgentCanaryError::MixedCohortSummary);
+    }
+
+    #[test]
     fn canary_rolls_back_when_budget_cap_is_exceeded() {
         let policy = AgentCanaryPolicy {
             max_cost_units: Some(30),
@@ -679,12 +751,12 @@ mod tests {
     fn canary_rolls_back_when_cost_per_accepted_candidate_exceeds_threshold() {
         let policy = AgentCanaryPolicy {
             max_cost_units: None,
-            max_cost_units_per_accepted_candidate: Some(9),
+            max_cost_units_per_accepted_candidate: Some(10),
             ..policy()
         };
 
         let decision = policy
-            .evaluate_summary(&summary(5, 0, 10, 8, 80))
+            .evaluate_summary(&summary(5, 0, 10, 8, 81))
             .expect("valid policy");
 
         assert_eq!(
@@ -697,8 +769,49 @@ mod tests {
         );
         assert_eq!(
             decision.counters.cost_units_per_accepted_candidate,
-            Some(10)
+            Some(11)
         );
+    }
+
+    #[test]
+    fn zero_cost_with_zero_accepted_candidates_does_not_exceed_cost_ratio() {
+        let policy = AgentCanaryPolicy {
+            min_acceptance_rate: None,
+            max_cost_units: None,
+            max_cost_units_per_accepted_candidate: Some(10),
+            ..policy()
+        };
+
+        let decision = policy
+            .evaluate_summary(&summary(5, 0, 0, 0, 0))
+            .expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::PromoteToEnabled);
+        assert_eq!(decision.counters.cost_units_per_accepted_candidate, None);
+    }
+
+    #[test]
+    fn positive_cost_with_zero_accepted_candidates_exceeds_cost_ratio() {
+        let policy = AgentCanaryPolicy {
+            min_acceptance_rate: None,
+            max_cost_units: None,
+            max_cost_units_per_accepted_candidate: Some(10),
+            ..policy()
+        };
+
+        let decision = policy
+            .evaluate_summary(&summary(5, 0, 0, 0, 1))
+            .expect("valid policy");
+
+        assert_eq!(
+            decision.kind,
+            AgentCanaryDecisionKind::RollbackThresholdFailed
+        );
+        assert_eq!(
+            decision.reason_code,
+            AgentCanaryReasonCode::CostPerAcceptedCandidateExceeded
+        );
+        assert_eq!(decision.counters.cost_units_per_accepted_candidate, None);
     }
 
     #[test]

--- a/crates/cairn-core/src/domain/agent_canary.rs
+++ b/crates/cairn-core/src/domain/agent_canary.rs
@@ -569,6 +569,8 @@ fn exceeds_cost_per_accepted_candidate(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
 
     use crate::domain::{AgentWorkerGroupSummary, AgentWorkerKind};
@@ -590,7 +592,7 @@ mod tests {
             turns: 2,
             tool_calls: 3,
             cost_units,
-            failure_modes: Default::default(),
+            failure_modes: BTreeMap::default(),
             workers: if total == 0 {
                 Vec::new()
             } else {
@@ -630,7 +632,7 @@ mod tests {
             turns: total_runs,
             tool_calls: total_runs,
             cost_units: total_runs,
-            failure_modes: Default::default(),
+            failure_modes: BTreeMap::default(),
         }
     }
 

--- a/crates/cairn-core/src/domain/agent_canary.rs
+++ b/crates/cairn-core/src/domain/agent_canary.rs
@@ -354,9 +354,10 @@ impl AgentCanaryPolicy {
     /// Evaluate aggregate canary metrics after worker audit records are summarized.
     ///
     /// Callers must pass a summary already filtered to `self.cohort_label`.
-    /// Empty worker-group metadata is accepted for synthetic tests and no-data
-    /// reports. When worker groups are present, every group must carry the
-    /// policy cohort label so mixed-cohort aggregate misuse fails closed.
+    /// Empty worker-group metadata is accepted only for true no-data summaries.
+    /// When runs are present, every worker group must carry the policy cohort
+    /// label so mixed-cohort aggregate misuse fails closed. Explicit operator
+    /// pause and rollback requests are evaluated before this cohort check.
     ///
     /// # Errors
     /// Returns [`AgentCanaryError`] when the policy is invalid or the summary
@@ -366,11 +367,11 @@ impl AgentCanaryPolicy {
         summary: &AgentWorkerAuditSummary,
     ) -> Result<AgentCanaryDecision, AgentCanaryError> {
         self.validate()?;
-        self.validate_summary_cohort(summary)?;
         let counters = AgentCanaryDecisionCounters::from_summary(summary);
         if let Some(decision) = self.gated_summary_decision(counters) {
             return Ok(decision);
         }
+        self.validate_summary_cohort(summary)?;
         if self.state != AgentCanaryState::Canary {
             return Ok(self.decision(
                 AgentCanaryDecisionKind::DispatchAllowed,
@@ -408,7 +409,11 @@ impl AgentCanaryPolicy {
         summary: &AgentWorkerAuditSummary,
     ) -> Result<(), AgentCanaryError> {
         if summary.workers.is_empty() {
-            return Ok(());
+            return if summary.total_runs == 0 {
+                Ok(())
+            } else {
+                Err(AgentCanaryError::MixedCohortSummary)
+            };
         }
 
         if summary
@@ -585,7 +590,11 @@ mod tests {
             tool_calls: 3,
             cost_units,
             failure_modes: Default::default(),
-            workers: Vec::new(),
+            workers: if total == 0 {
+                Vec::new()
+            } else {
+                vec![group(Some("canary-05"), total)]
+            },
         }
     }
 
@@ -720,6 +729,56 @@ mod tests {
         let error = policy()
             .evaluate_summary(&summary)
             .expect_err("mixed cohort summaries must be rejected");
+
+        assert_eq!(error, AgentCanaryError::MixedCohortSummary);
+    }
+
+    #[test]
+    fn operator_gates_win_over_mixed_cohort_validation() {
+        let mut summary = summary(5, 0, 10, 8, 80);
+        summary.workers = vec![group(Some("canary-05"), 3), group(Some("canary-10"), 2)];
+
+        let rollback = AgentCanaryPolicy {
+            rollback_requested: true,
+            ..policy()
+        };
+        let rollback_decision = rollback
+            .evaluate_summary(&summary)
+            .expect("operator rollback must bypass cohort validation");
+        assert_eq!(
+            rollback_decision.kind,
+            AgentCanaryDecisionKind::RollbackRequested
+        );
+        assert_eq!(
+            rollback_decision.reason_code,
+            AgentCanaryReasonCode::OperatorRollbackRequested
+        );
+
+        let pause = AgentCanaryPolicy {
+            pause_requested: true,
+            ..policy()
+        };
+        let pause_decision = pause
+            .evaluate_summary(&summary)
+            .expect("operator pause must bypass cohort validation");
+        assert_eq!(
+            pause_decision.kind,
+            AgentCanaryDecisionKind::DispatchDeniedPaused
+        );
+        assert_eq!(
+            pause_decision.reason_code,
+            AgentCanaryReasonCode::OperatorPaused
+        );
+    }
+
+    #[test]
+    fn non_empty_summary_without_worker_metadata_is_rejected() {
+        let mut summary = summary(5, 0, 10, 8, 80);
+        summary.workers = Vec::new();
+
+        let error = policy()
+            .evaluate_summary(&summary)
+            .expect_err("non-empty summaries must include cohort metadata");
 
         assert_eq!(error, AgentCanaryError::MixedCohortSummary);
     }

--- a/crates/cairn-core/src/domain/agent_canary.rs
+++ b/crates/cairn-core/src/domain/agent_canary.rs
@@ -353,11 +353,12 @@ impl AgentCanaryPolicy {
 
     /// Evaluate aggregate canary metrics after worker audit records are summarized.
     ///
-    /// Callers must pass a summary already filtered to `self.cohort_label`.
-    /// Empty worker-group metadata is accepted only for true no-data summaries.
-    /// When runs are present, every worker group must carry the policy cohort
-    /// label so mixed-cohort aggregate misuse fails closed. Explicit operator
-    /// pause and rollback requests are evaluated before this cohort check.
+    /// Canary-state callers must pass a summary already filtered to
+    /// `self.cohort_label`. Empty worker-group metadata is accepted only for
+    /// true no-data summaries. When runs are present during canary evaluation,
+    /// every worker group must carry the policy cohort label so mixed-cohort
+    /// aggregate misuse fails closed. Explicit operator pause/rollback requests
+    /// and non-canary states are evaluated before this cohort check.
     ///
     /// # Errors
     /// Returns [`AgentCanaryError`] when the policy is invalid or the summary
@@ -371,7 +372,6 @@ impl AgentCanaryPolicy {
         if let Some(decision) = self.gated_summary_decision(counters) {
             return Ok(decision);
         }
-        self.validate_summary_cohort(summary)?;
         if self.state != AgentCanaryState::Canary {
             return Ok(self.decision(
                 AgentCanaryDecisionKind::DispatchAllowed,
@@ -380,6 +380,7 @@ impl AgentCanaryPolicy {
                 counters,
             ));
         }
+        self.validate_summary_cohort(summary)?;
         if summary.total_runs < self.min_runs {
             return Ok(self.decision(
                 AgentCanaryDecisionKind::RemainCanaryInsufficientData,
@@ -621,9 +622,34 @@ mod tests {
             worker_name: "agent_extractor".to_owned(),
             canary_label: canary_label.map(str::to_owned),
             total_runs,
-            accepted_candidates: total_runs,
+            completed_runs: total_runs,
+            failed_runs: 0,
             generated_candidates: total_runs,
+            accepted_candidates: total_runs,
+            acceptance_rate: rate(total_runs, total_runs),
+            turns: total_runs,
+            tool_calls: total_runs,
+            cost_units: total_runs,
+            failure_modes: Default::default(),
         }
+    }
+
+    #[test]
+    fn enabled_summary_bypasses_canary_cohort_validation() {
+        let mut summary = summary(5, 0, 10, 8, 80);
+        summary.workers = vec![group(Some("canary-05"), 3), group(None, 2)];
+        let policy = AgentCanaryPolicy {
+            state: AgentCanaryState::Enabled,
+            ..policy()
+        };
+
+        let decision = policy
+            .evaluate_summary(&summary)
+            .expect("enabled rollouts accept mixed historical summaries");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::DispatchAllowed);
+        assert_eq!(decision.next_state, AgentCanaryState::Enabled);
+        assert_eq!(decision.reason_code, AgentCanaryReasonCode::NonCanaryState);
     }
 
     #[test]

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -20,6 +20,7 @@
 pub mod actor_chain;
 pub mod admission;
 pub mod agent_audit;
+pub mod agent_canary;
 pub mod backup;
 pub mod body_hash;
 pub mod canonical;
@@ -62,6 +63,10 @@ pub use admission::{AdmissionError, SignedAdmission, WalActionKind};
 pub use agent_audit::{
     AgentWorkerAuditRecord, AgentWorkerAuditSummary, AgentWorkerFailureMode,
     AgentWorkerGroupSummary, AgentWorkerKind, AgentWorkerStatus,
+};
+pub use agent_canary::{
+    AgentCanaryDecision, AgentCanaryDecisionCounters, AgentCanaryDecisionKind, AgentCanaryError,
+    AgentCanaryPolicy, AgentCanaryReasonCode, AgentCanaryState,
 };
 pub use backup::{BackupRegistryEntry, RewritePlan, ShreddedBackupEntry};
 pub use body_hash::BodyHash;

--- a/crates/cairn-core/src/domain/mod.rs
+++ b/crates/cairn-core/src/domain/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod actor_chain;
 pub mod admission;
+pub mod agent_audit;
 pub mod backup;
 pub mod body_hash;
 pub mod canonical;
@@ -58,6 +59,10 @@ pub mod zero_capture;
 
 pub use actor_chain::{ActorChainEntry, ChainRole, validate_chain};
 pub use admission::{AdmissionError, SignedAdmission, WalActionKind};
+pub use agent_audit::{
+    AgentWorkerAuditRecord, AgentWorkerAuditSummary, AgentWorkerFailureMode,
+    AgentWorkerGroupSummary, AgentWorkerKind, AgentWorkerStatus,
+};
 pub use backup::{BackupRegistryEntry, RewritePlan, ShreddedBackupEntry};
 pub use body_hash::BodyHash;
 pub use canonical::CanonicalRecordHash;

--- a/crates/cairn-core/src/generated/schemas/verbs/lint.json
+++ b/crates/cairn-core/src/generated/schemas/verbs/lint.json
@@ -84,6 +84,11 @@
     "AgentWorkerAuditWorker": {
       "additionalProperties": false,
       "properties": {
+        "acceptance_rate": {
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
         "accepted_candidates": {
           "minimum": 0,
           "type": "integer"
@@ -92,11 +97,38 @@
           "minLength": 1,
           "type": "string"
         },
+        "completed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "cost_units": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failure_modes": {
+          "additionalProperties": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "object"
+        },
         "generated_candidates": {
           "minimum": 0,
           "type": "integer"
         },
+        "tool_calls": {
+          "minimum": 0,
+          "type": "integer"
+        },
         "total_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "turns": {
           "minimum": 0,
           "type": "integer"
         },
@@ -116,8 +148,14 @@
         "worker_kind",
         "worker_name",
         "total_runs",
+        "completed_runs",
+        "failed_runs",
         "generated_candidates",
-        "accepted_candidates"
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes"
       ],
       "type": "object"
     },

--- a/crates/cairn-core/src/generated/schemas/verbs/lint.json
+++ b/crates/cairn-core/src/generated/schemas/verbs/lint.json
@@ -1,5 +1,126 @@
 {
   "$defs": {
+    "AgentWorkerAuditReport": {
+      "additionalProperties": false,
+      "properties": {
+        "acceptance_rate": {
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "accepted_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "completed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "cost_units": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failure_modes": {
+          "additionalProperties": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "generated_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_records": {
+          "type": "boolean"
+        },
+        "rollout_state": {
+          "enum": [
+            "paused",
+            "canary",
+            "enabled",
+            "rolled_back"
+          ],
+          "type": "string"
+        },
+        "tool_calls": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "turns": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "workers": {
+          "items": {
+            "$ref": "#/$defs/AgentWorkerAuditWorker"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "observed_records",
+        "total_runs",
+        "completed_runs",
+        "failed_runs",
+        "generated_candidates",
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes",
+        "workers"
+      ],
+      "type": "object"
+    },
+    "AgentWorkerAuditWorker": {
+      "additionalProperties": false,
+      "properties": {
+        "accepted_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "canary_label": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "generated_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "worker_kind": {
+          "enum": [
+            "extractor",
+            "dream"
+          ],
+          "type": "string"
+        },
+        "worker_name": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "worker_kind",
+        "worker_name",
+        "total_runs",
+        "generated_candidates",
+        "accepted_candidates"
+      ],
+      "type": "object"
+    },
     "Args": {
       "additionalProperties": false,
       "properties": {
@@ -28,6 +149,9 @@
     "Data": {
       "additionalProperties": false,
       "properties": {
+        "agent_worker_audit": {
+          "$ref": "#/$defs/AgentWorkerAuditReport"
+        },
         "findings": {
           "items": {
             "$ref": "#/$defs/Finding"

--- a/crates/cairn-core/src/generated/verbs/lint.rs
+++ b/crates/cairn-core/src/generated/verbs/lint.rs
@@ -46,11 +46,19 @@ pub enum AgentWorkerAuditWorkerWorkerKind {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AgentWorkerAuditWorker {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_rate: Option<f64>,
     pub accepted_candidates: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub canary_label: Option<String>,
+    pub completed_runs: u64,
+    pub cost_units: u64,
+    pub failed_runs: u64,
+    pub failure_modes: serde_json::Value,
     pub generated_candidates: u64,
+    pub tool_calls: u64,
     pub total_runs: u64,
+    pub turns: u64,
     pub worker_kind: AgentWorkerAuditWorkerWorkerKind,
     pub worker_name: String,
 }

--- a/crates/cairn-core/src/generated/verbs/lint.rs
+++ b/crates/cairn-core/src/generated/verbs/lint.rs
@@ -5,6 +5,56 @@
 
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentWorkerAuditReportRolloutState {
+    Paused,
+    Canary,
+    Enabled,
+    RolledBack,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentWorkerAuditReport {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_rate: Option<f64>,
+    pub accepted_candidates: u64,
+    pub completed_runs: u64,
+    pub cost_units: u64,
+    pub failed_runs: u64,
+    pub failure_modes: serde_json::Value,
+    pub generated_candidates: u64,
+    pub observed_records: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollout_state: Option<AgentWorkerAuditReportRolloutState>,
+    pub tool_calls: u64,
+    pub total_runs: u64,
+    pub turns: u64,
+    pub workers: Vec<AgentWorkerAuditWorker>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentWorkerAuditWorkerWorkerKind {
+    Extractor,
+    Dream,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentWorkerAuditWorker {
+    pub accepted_candidates: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canary_label: Option<String>,
+    pub generated_candidates: u64,
+    pub total_runs: u64,
+    pub worker_kind: AgentWorkerAuditWorkerWorkerKind,
+    pub worker_name: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Finding {
@@ -131,6 +181,8 @@ pub struct LintDataSummary {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct LintData {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_worker_audit: Option<AgentWorkerAuditReport>,
     pub findings: Vec<Finding>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub report_path: Option<String>,

--- a/crates/cairn-core/src/verbs/lint/checks/actor_chain.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/actor_chain.rs
@@ -207,6 +207,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/consent.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/consent.rs
@@ -284,6 +284,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let findings = run(&inputs).await;
@@ -313,6 +315,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let f = run(&inputs).await;
@@ -343,6 +347,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let f = run(&inputs).await;
@@ -386,6 +392,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let f = run(&inputs).await;
@@ -439,6 +447,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let f = run(&inputs).await;
@@ -495,6 +505,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let f = run(&inputs).await;
@@ -544,6 +556,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let f = run(&inputs).await;
@@ -596,6 +610,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         assert!(run(&inputs).await.is_empty());
@@ -619,6 +635,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let f = run(&inputs).await;
@@ -652,6 +670,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         assert!(run(&inputs).await.is_empty());

--- a/crates/cairn-core/src/verbs/lint/checks/hot_memory.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/hot_memory.rs
@@ -197,6 +197,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let findings = run(&inputs);
@@ -242,6 +244,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let findings = run(&inputs);
@@ -281,6 +285,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let findings = run(&inputs);

--- a/crates/cairn-core/src/verbs/lint/checks/hot_memory_walker.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/hot_memory_walker.rs
@@ -147,6 +147,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         }
     }
@@ -166,6 +168,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/index_drift.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/index_drift.rs
@@ -61,6 +61,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         assert!(run(&li).is_empty());
@@ -83,6 +85,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let f = run(&li);
@@ -115,6 +119,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let f = run(&li);
@@ -139,6 +145,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         assert!(run(&li).is_empty());

--- a/crates/cairn-core/src/verbs/lint/checks/malformed.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/malformed.rs
@@ -68,6 +68,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/provenance.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/provenance.rs
@@ -667,6 +667,8 @@ mod tests {
             source_resolver: resolver,
             consent_journal: journal,
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/salience.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/salience.rs
@@ -54,6 +54,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/schema.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/schema.rs
@@ -157,6 +157,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/taxonomy_conventions.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/taxonomy_conventions.rs
@@ -190,6 +190,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/trace_reasoning.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/trace_reasoning.rs
@@ -166,6 +166,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         }
     }

--- a/crates/cairn-core/src/verbs/lint/checks/workflow_health.rs
+++ b/crates/cairn-core/src/verbs/lint/checks/workflow_health.rs
@@ -479,6 +479,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         assert!(super::run(&inputs).is_empty());

--- a/crates/cairn-core/src/verbs/lint/mod.rs
+++ b/crates/cairn-core/src/verbs/lint/mod.rs
@@ -11,9 +11,13 @@ use crate::contract::consent_lookup::ConsentLookup;
 use crate::contract::memory_store::{IndexStats, StoredRecord};
 use crate::contract::source_resolver::SourceResolver;
 use crate::domain::record::RecordId;
-use crate::domain::{Identity, SourceId};
+use crate::domain::{
+    AgentCanaryState, AgentWorkerAuditSummary, AgentWorkerKind, Identity, SourceId,
+};
 use crate::generated::verbs::lint::{
-    Finding, Kind, LintData, LintDataSummary, LintDataSummaryBySeverity, Severity, Target,
+    AgentWorkerAuditReport, AgentWorkerAuditReportRolloutState, AgentWorkerAuditWorker,
+    AgentWorkerAuditWorkerWorkerKind, Finding, Kind, LintData, LintDataSummary,
+    LintDataSummaryBySeverity, Severity, Target,
 };
 use crate::pipeline::lint::author_lifecycle::AuthorLifecycle;
 
@@ -365,7 +369,10 @@ pub async fn run_checks(inputs: &LintInputs<'_>) -> LintData {
     findings.extend(checks::workflow_health::run(inputs));
     findings.extend(checks::consent::run(inputs).await);
     let summary = summarize(&findings);
+    let agent_worker_audit =
+        agent_worker_audit_report(&AgentWorkerAuditSummary::from_records(&[]), None);
     LintData {
+        agent_worker_audit: Some(agent_worker_audit),
         findings,
         summary,
         report_path: None,
@@ -450,6 +457,64 @@ fn kind_key(k: Kind) -> String {
         Kind::SkillRollbackBroken => "skill_rollback_broken",
     }
     .to_owned()
+}
+
+/// Project a core agent-worker summary into the generated lint DTO.
+#[must_use]
+pub fn agent_worker_audit_report(
+    summary: &AgentWorkerAuditSummary,
+    rollout_state: Option<AgentCanaryState>,
+) -> AgentWorkerAuditReport {
+    let mut failure_modes = serde_json::Map::new();
+    for (mode, count) in &summary.failure_modes {
+        failure_modes.insert(
+            mode.as_str().to_owned(),
+            serde_json::Value::Number(serde_json::Number::from(*count)),
+        );
+    }
+
+    AgentWorkerAuditReport {
+        observed_records: !summary.is_empty(),
+        rollout_state: rollout_state.map(agent_rollout_state),
+        total_runs: summary.total_runs,
+        completed_runs: summary.completed_runs,
+        failed_runs: summary.failed_runs,
+        generated_candidates: summary.generated_candidates,
+        accepted_candidates: summary.accepted_candidates,
+        acceptance_rate: summary.acceptance_rate,
+        turns: summary.turns,
+        tool_calls: summary.tool_calls,
+        cost_units: summary.cost_units,
+        failure_modes: serde_json::Value::Object(failure_modes),
+        workers: summary
+            .workers
+            .iter()
+            .map(|worker| AgentWorkerAuditWorker {
+                worker_kind: agent_worker_kind(worker.worker_kind),
+                worker_name: worker.worker_name.clone(),
+                canary_label: worker.canary_label.clone(),
+                total_runs: worker.total_runs,
+                generated_candidates: worker.generated_candidates,
+                accepted_candidates: worker.accepted_candidates,
+            })
+            .collect(),
+    }
+}
+
+fn agent_rollout_state(state: AgentCanaryState) -> AgentWorkerAuditReportRolloutState {
+    match state {
+        AgentCanaryState::Paused => AgentWorkerAuditReportRolloutState::Paused,
+        AgentCanaryState::Canary => AgentWorkerAuditReportRolloutState::Canary,
+        AgentCanaryState::Enabled => AgentWorkerAuditReportRolloutState::Enabled,
+        AgentCanaryState::RolledBack => AgentWorkerAuditReportRolloutState::RolledBack,
+    }
+}
+
+fn agent_worker_kind(kind: AgentWorkerKind) -> AgentWorkerAuditWorkerWorkerKind {
+    match kind {
+        AgentWorkerKind::Extractor => AgentWorkerAuditWorkerWorkerKind::Extractor,
+        AgentWorkerKind::Dream => AgentWorkerAuditWorkerWorkerKind::Dream,
+    }
 }
 
 /// Construct a finding with no target / fix / tracking issue.
@@ -661,6 +726,64 @@ mod tests {
         assert_eq!(
             super::kind_key(Kind::SensorBudgetExceeded),
             "sensor_budget_exceeded"
+        );
+    }
+
+    #[test]
+    fn agent_worker_audit_report_projects_summary() {
+        use crate::domain::{
+            AgentCanaryState, AgentWorkerAuditSummary, AgentWorkerFailureMode,
+            AgentWorkerGroupSummary, AgentWorkerKind,
+        };
+
+        let mut failure_modes = std::collections::BTreeMap::new();
+        failure_modes.insert(AgentWorkerFailureMode::BudgetExceeded, 2);
+        let summary = AgentWorkerAuditSummary {
+            total_runs: 4,
+            completed_runs: 2,
+            failed_runs: 2,
+            generated_candidates: 10,
+            accepted_candidates: 5,
+            acceptance_rate: Some(0.5),
+            turns: 8,
+            tool_calls: 12,
+            cost_units: 200,
+            failure_modes,
+            workers: vec![AgentWorkerGroupSummary {
+                worker_kind: AgentWorkerKind::Extractor,
+                worker_name: "agent_extractor".to_owned(),
+                canary_label: Some("canary-05".to_owned()),
+                total_runs: 4,
+                accepted_candidates: 5,
+                generated_candidates: 10,
+            }],
+        };
+
+        let report = agent_worker_audit_report(&summary, Some(AgentCanaryState::Canary));
+
+        assert!(report.observed_records);
+        assert_eq!(
+            report.rollout_state,
+            Some(crate::generated::verbs::lint::AgentWorkerAuditReportRolloutState::Canary)
+        );
+        assert_eq!(report.total_runs, 4);
+        assert_eq!(report.completed_runs, 2);
+        assert_eq!(report.failed_runs, 2);
+        assert_eq!(report.generated_candidates, 10);
+        assert_eq!(report.accepted_candidates, 5);
+        assert_eq!(report.acceptance_rate, Some(0.5));
+        assert_eq!(report.turns, 8);
+        assert_eq!(report.tool_calls, 12);
+        assert_eq!(report.cost_units, 200);
+        assert_eq!(
+            report.failure_modes["budget_exceeded"],
+            serde_json::json!(2)
+        );
+        assert_eq!(report.workers.len(), 1);
+        assert_eq!(
+            serde_json::to_value(report.workers[0].worker_kind)
+                .expect("generated worker kind serializes"),
+            serde_json::json!("extractor")
         );
     }
 

--- a/crates/cairn-core/src/verbs/lint/mod.rs
+++ b/crates/cairn-core/src/verbs/lint/mod.rs
@@ -138,6 +138,13 @@ pub struct LintInputs<'a> {
     /// `None` keeps the `workflow_health` check on the no-op path so
     /// fixture-only tests of unrelated checks stay green.
     pub workflow_jobs: Option<&'a (dyn crate::contract::workflow_jobs::WorkflowJobsReader + 'a)>,
+    /// Optional body-free agent-worker audit aggregate to expose in
+    /// JSON and markdown lint reports. `None` means the caller had no
+    /// audit source to provide, not that agent-mode workers are healthy.
+    pub agent_worker_audit: Option<&'a AgentWorkerAuditSummary>,
+    /// Optional current rollout state associated with
+    /// `agent_worker_audit`.
+    pub agent_canary_state: Option<AgentCanaryState>,
     /// Wall-clock for time-based lint checks. The CLI passes
     /// `SystemClock::now_ms()`; tests pass a synthetic value.
     pub now_ms: i64,
@@ -159,6 +166,8 @@ impl std::fmt::Debug for LintInputs<'_> {
             .field("source_resolver", &"<dyn SourceResolver>")
             .field("consent_journal", &"<dyn ConsentJournalReader>")
             .field("workflow_jobs", &self.workflow_jobs.is_some())
+            .field("agent_worker_audit", &self.agent_worker_audit.is_some())
+            .field("agent_canary_state", &self.agent_canary_state)
             .field("now_ms", &self.now_ms)
             .finish()
     }
@@ -350,6 +359,8 @@ pub(crate) fn empty_lint_inputs_with_reader(
         source_resolver: empty_source_resolver(),
         consent_journal: empty_consent_journal(),
         workflow_jobs: Some(reader),
+        agent_worker_audit: None,
+        agent_canary_state: None,
         now_ms,
     }
 }
@@ -369,8 +380,13 @@ pub async fn run_checks(inputs: &LintInputs<'_>) -> LintData {
     findings.extend(checks::workflow_health::run(inputs));
     findings.extend(checks::consent::run(inputs).await);
     let summary = summarize(&findings);
-    let agent_worker_audit =
-        agent_worker_audit_report(&AgentWorkerAuditSummary::from_records(&[]), None);
+    let empty_agent_worker_audit = AgentWorkerAuditSummary::from_records(&[]);
+    let agent_worker_audit = agent_worker_audit_report(
+        inputs
+            .agent_worker_audit
+            .unwrap_or(&empty_agent_worker_audit),
+        inputs.agent_canary_state,
+    );
     LintData {
         agent_worker_audit: Some(agent_worker_audit),
         findings,
@@ -489,13 +505,30 @@ pub fn agent_worker_audit_report(
         workers: summary
             .workers
             .iter()
-            .map(|worker| AgentWorkerAuditWorker {
-                worker_kind: agent_worker_kind(worker.worker_kind),
-                worker_name: worker.worker_name.clone(),
-                canary_label: worker.canary_label.clone(),
-                total_runs: worker.total_runs,
-                generated_candidates: worker.generated_candidates,
-                accepted_candidates: worker.accepted_candidates,
+            .map(|worker| {
+                let mut worker_failure_modes = serde_json::Map::new();
+                for (mode, count) in &worker.failure_modes {
+                    worker_failure_modes.insert(
+                        mode.as_str().to_owned(),
+                        serde_json::Value::Number(serde_json::Number::from(*count)),
+                    );
+                }
+
+                AgentWorkerAuditWorker {
+                    worker_kind: agent_worker_kind(worker.worker_kind),
+                    worker_name: worker.worker_name.clone(),
+                    canary_label: worker.canary_label.clone(),
+                    total_runs: worker.total_runs,
+                    completed_runs: worker.completed_runs,
+                    failed_runs: worker.failed_runs,
+                    generated_candidates: worker.generated_candidates,
+                    accepted_candidates: worker.accepted_candidates,
+                    acceptance_rate: worker.acceptance_rate,
+                    turns: worker.turns,
+                    tool_calls: worker.tool_calls,
+                    cost_units: worker.cost_units,
+                    failure_modes: serde_json::Value::Object(worker_failure_modes),
+                }
             })
             .collect(),
     }
@@ -609,6 +642,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let data = run_checks(&inputs).await;
@@ -680,6 +715,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let inputs_rev = LintInputs {
@@ -696,6 +733,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
 
@@ -748,14 +787,21 @@ mod tests {
             turns: 8,
             tool_calls: 12,
             cost_units: 200,
-            failure_modes,
+            failure_modes: failure_modes.clone(),
             workers: vec![AgentWorkerGroupSummary {
                 worker_kind: AgentWorkerKind::Extractor,
                 worker_name: "agent_extractor".to_owned(),
                 canary_label: Some("canary-05".to_owned()),
                 total_runs: 4,
+                completed_runs: 2,
+                failed_runs: 2,
                 accepted_candidates: 5,
                 generated_candidates: 10,
+                acceptance_rate: Some(0.5),
+                turns: 8,
+                tool_calls: 12,
+                cost_units: 200,
+                failure_modes: failure_modes.clone(),
             }],
         };
 
@@ -785,6 +831,90 @@ mod tests {
                 .expect("generated worker kind serializes"),
             serde_json::json!("extractor")
         );
+        assert_eq!(report.workers[0].completed_runs, 2);
+        assert_eq!(report.workers[0].failed_runs, 2);
+        assert_eq!(report.workers[0].acceptance_rate, Some(0.5));
+        assert_eq!(report.workers[0].turns, 8);
+        assert_eq!(report.workers[0].tool_calls, 12);
+        assert_eq!(report.workers[0].cost_units, 200);
+        assert_eq!(
+            report.workers[0].failure_modes["budget_exceeded"],
+            serde_json::json!(2)
+        );
+    }
+
+    #[tokio::test]
+    async fn run_checks_projects_agent_worker_audit_input() {
+        use crate::domain::{
+            AgentCanaryState, AgentWorkerAuditSummary, AgentWorkerFailureMode,
+            AgentWorkerGroupSummary, AgentWorkerKind,
+        };
+
+        let mut failure_modes = std::collections::BTreeMap::new();
+        failure_modes.insert(AgentWorkerFailureMode::Unknown, 1);
+        let summary = AgentWorkerAuditSummary {
+            total_runs: 1,
+            completed_runs: 0,
+            failed_runs: 1,
+            generated_candidates: 0,
+            accepted_candidates: 0,
+            acceptance_rate: None,
+            turns: 3,
+            tool_calls: 4,
+            cost_units: 5,
+            failure_modes: failure_modes.clone(),
+            workers: vec![AgentWorkerGroupSummary {
+                worker_kind: AgentWorkerKind::Dream,
+                worker_name: "agent_dream".to_owned(),
+                canary_label: Some("canary-05".to_owned()),
+                total_runs: 1,
+                completed_runs: 0,
+                failed_runs: 1,
+                accepted_candidates: 0,
+                generated_candidates: 0,
+                acceptance_rate: None,
+                turns: 3,
+                tool_calls: 4,
+                cost_units: 5,
+                failure_modes,
+            }],
+        };
+        let cfg = CairnConfig::default();
+        let inputs = LintInputs {
+            records: &[],
+            config: &cfg,
+            index_stats: IndexStats::new(0, 0),
+            author_states: crate::verbs::lint::empty_author_states(),
+            unresolvable_authors: crate::verbs::lint::empty_unresolvable_authors(),
+            consent_lookup: None,
+            source_artifacts: crate::verbs::lint::empty_source_artifacts(),
+            source_forgets: crate::verbs::lint::empty_source_forgets(),
+            vault_root: None,
+            hot_body_loader: None,
+            source_resolver: crate::verbs::lint::empty_source_resolver(),
+            consent_journal: crate::verbs::lint::empty_consent_journal(),
+            workflow_jobs: None,
+            agent_worker_audit: Some(&summary),
+            agent_canary_state: Some(AgentCanaryState::Canary),
+            now_ms: 0,
+        };
+
+        let data = run_checks(&inputs).await;
+        let report = data
+            .agent_worker_audit
+            .expect("lint data includes agent worker audit");
+
+        assert!(report.observed_records);
+        assert_eq!(
+            report.rollout_state,
+            Some(crate::generated::verbs::lint::AgentWorkerAuditReportRolloutState::Canary)
+        );
+        assert_eq!(report.total_runs, 1);
+        assert_eq!(report.failed_runs, 1);
+        assert_eq!(report.failure_modes["unknown"], serde_json::json!(1));
+        assert_eq!(report.workers[0].worker_name, "agent_dream");
+        assert_eq!(report.workers[0].failed_runs, 1);
+        assert_eq!(report.workers[0].tool_calls, 4);
     }
 
     #[tokio::test]
@@ -806,6 +936,8 @@ mod tests {
             source_resolver: crate::verbs::lint::empty_source_resolver(),
             consent_journal: crate::verbs::lint::empty_consent_journal(),
             workflow_jobs: None,
+            agent_worker_audit: None,
+            agent_canary_state: None,
             now_ms: 0,
         };
         let data = run_checks(&inputs).await;

--- a/crates/cairn-core/src/verbs/lint/report.rs
+++ b/crates/cairn-core/src/verbs/lint/report.rs
@@ -113,10 +113,16 @@ fn render_failure_modes(value: &serde_json::Value) -> String {
     if map.is_empty() {
         return "none".to_owned();
     }
-    map.iter()
+    let rendered = map
+        .iter()
         .filter_map(|(key, value)| value.as_u64().map(|count| format!("{key}={count}")))
         .collect::<Vec<_>>()
-        .join(", ")
+        .join(", ");
+    if rendered.is_empty() {
+        "none".to_owned()
+    } else {
+        rendered
+    }
 }
 
 #[cfg(test)]
@@ -243,5 +249,14 @@ mod tests {
         assert!(rendered.contains("- failures: budget_exceeded=2"));
         assert!(!rendered.contains("prompt"));
         assert!(!rendered.contains("candidate body"));
+    }
+
+    #[test]
+    fn malformed_agent_failure_mode_counts_render_none() {
+        let rendered = render_failure_modes(&serde_json::json!({
+            "budget_exceeded": "2",
+        }));
+
+        assert_eq!(rendered, "none");
     }
 }

--- a/crates/cairn-core/src/verbs/lint/report.rs
+++ b/crates/cairn-core/src/verbs/lint/report.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::Write as _;
 
-use crate::generated::verbs::lint::{Kind, LintData, Severity};
+use crate::generated::verbs::lint::{AgentWorkerAuditReportRolloutState, Kind, LintData, Severity};
 
 /// Render `data` as the canonical lint-report markdown body.
 ///
@@ -25,6 +25,29 @@ pub fn render(data: &LintData) -> String {
     let _ = writeln!(out, "- error: {}", data.summary.by_severity.error);
     let _ = writeln!(out, "- warning: {}", data.summary.by_severity.warning);
     let _ = writeln!(out, "- info: {}\n", data.summary.by_severity.info);
+
+    if let Some(agent) = &data.agent_worker_audit {
+        out.push_str("## Agent worker audit\n\n");
+        if agent.observed_records {
+            let state = agent
+                .rollout_state
+                .map_or("unconfigured", render_rollout_state);
+            let _ = writeln!(out, "- state: {state}");
+            let _ = writeln!(out, "- runs: {}", agent.total_runs);
+            let _ = writeln!(
+                out,
+                "- accepted candidates: {} / {}",
+                agent.accepted_candidates, agent.generated_candidates
+            );
+            let _ = writeln!(out, "- cost units: {}", agent.cost_units);
+            let _ = writeln!(out, "- tool calls: {}", agent.tool_calls);
+            let failures = render_failure_modes(&agent.failure_modes);
+            let _ = writeln!(out, "- failures: {failures}");
+            out.push('\n');
+        } else {
+            out.push_str("- no agent-worker audit records observed\n\n");
+        }
+    }
 
     let deferred = data
         .findings
@@ -74,6 +97,28 @@ pub fn render(data: &LintData) -> String {
     out
 }
 
+fn render_rollout_state(state: AgentWorkerAuditReportRolloutState) -> &'static str {
+    match state {
+        AgentWorkerAuditReportRolloutState::Paused => "paused",
+        AgentWorkerAuditReportRolloutState::Canary => "canary",
+        AgentWorkerAuditReportRolloutState::Enabled => "enabled",
+        AgentWorkerAuditReportRolloutState::RolledBack => "rolled_back",
+    }
+}
+
+fn render_failure_modes(value: &serde_json::Value) -> String {
+    let Some(map) = value.as_object() else {
+        return "none".to_owned();
+    };
+    if map.is_empty() {
+        return "none".to_owned();
+    }
+    map.iter()
+        .filter_map(|(key, value)| value.as_u64().map(|count| format!("{key}={count}")))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,6 +142,7 @@ mod tests {
     #[test]
     fn empty_data_renders_no_findings_block() {
         let data = LintData {
+            agent_worker_audit: None,
             findings: vec![],
             summary: empty_summary(),
             report_path: None,
@@ -127,6 +173,7 @@ mod tests {
         by_kind.insert("index_drift".into(), serde_json::Value::Number(1.into()));
         summary.by_kind = serde_json::Value::Object(by_kind);
         let data = LintData {
+            agent_worker_audit: None,
             findings: vec![f],
             summary,
             report_path: None,
@@ -154,11 +201,47 @@ mod tests {
         by_kind.insert("deferred_check".into(), serde_json::Value::Number(1.into()));
         summary.by_kind = serde_json::Value::Object(by_kind);
         let data = LintData {
+            agent_worker_audit: None,
             findings: vec![f],
             summary,
             report_path: None,
         };
         let s = render(&data);
         insta::assert_snapshot!(s);
+    }
+
+    #[test]
+    fn agent_worker_audit_section_renders_without_body_text() {
+        let data = LintData {
+            agent_worker_audit: Some(crate::generated::verbs::lint::AgentWorkerAuditReport {
+                rollout_state: Some(
+                    crate::generated::verbs::lint::AgentWorkerAuditReportRolloutState::Canary,
+                ),
+                failure_modes: serde_json::json!({"budget_exceeded": 2}),
+                workers: Vec::new(),
+                observed_records: true,
+                total_runs: 4,
+                completed_runs: 2,
+                failed_runs: 2,
+                generated_candidates: 10,
+                accepted_candidates: 5,
+                acceptance_rate: Some(0.5),
+                turns: 8,
+                tool_calls: 12,
+                cost_units: 200,
+            }),
+            findings: vec![],
+            summary: empty_summary(),
+            report_path: None,
+        };
+
+        let rendered = render(&data);
+
+        assert!(rendered.contains("## Agent worker audit"));
+        assert!(rendered.contains("- state: canary"));
+        assert!(rendered.contains("- accepted candidates: 5 / 10"));
+        assert!(rendered.contains("- failures: budget_exceeded=2"));
+        assert!(!rendered.contains("prompt"));
+        assert!(!rendered.contains("candidate body"));
     }
 }

--- a/crates/cairn-core/src/verbs/lint/report.rs
+++ b/crates/cairn-core/src/verbs/lint/report.rs
@@ -6,7 +6,9 @@
 
 use std::fmt::Write as _;
 
-use crate::generated::verbs::lint::{AgentWorkerAuditReportRolloutState, Kind, LintData, Severity};
+use crate::generated::verbs::lint::{
+    AgentWorkerAuditReportRolloutState, AgentWorkerAuditWorkerWorkerKind, Kind, LintData, Severity,
+};
 
 /// Render `data` as the canonical lint-report markdown body.
 ///
@@ -43,6 +45,28 @@ pub fn render(data: &LintData) -> String {
             let _ = writeln!(out, "- tool calls: {}", agent.tool_calls);
             let failures = render_failure_modes(&agent.failure_modes);
             let _ = writeln!(out, "- failures: {failures}");
+            if !agent.workers.is_empty() {
+                out.push_str("- workers:\n");
+                for worker in &agent.workers {
+                    let canary_label = worker.canary_label.as_deref().unwrap_or("unlabeled");
+                    let failures = render_failure_modes(&worker.failure_modes);
+                    let acceptance_rate = render_rate(worker.acceptance_rate);
+                    let _ = writeln!(
+                        out,
+                        "  - {} `{}` ({canary_label}): runs {} (completed {}, failed {}), accepted candidates {} / {} (rate {acceptance_rate}), turns {}, cost units {}, tool calls {}, failures {failures}",
+                        render_worker_kind(worker.worker_kind),
+                        worker.worker_name,
+                        worker.total_runs,
+                        worker.completed_runs,
+                        worker.failed_runs,
+                        worker.accepted_candidates,
+                        worker.generated_candidates,
+                        worker.turns,
+                        worker.cost_units,
+                        worker.tool_calls,
+                    );
+                }
+            }
             out.push('\n');
         } else {
             out.push_str("- no agent-worker audit records observed\n\n");
@@ -104,6 +128,17 @@ fn render_rollout_state(state: AgentWorkerAuditReportRolloutState) -> &'static s
         AgentWorkerAuditReportRolloutState::Enabled => "enabled",
         AgentWorkerAuditReportRolloutState::RolledBack => "rolled_back",
     }
+}
+
+fn render_worker_kind(kind: AgentWorkerAuditWorkerWorkerKind) -> &'static str {
+    match kind {
+        AgentWorkerAuditWorkerWorkerKind::Extractor => "extractor",
+        AgentWorkerAuditWorkerWorkerKind::Dream => "dream",
+    }
+}
+
+fn render_rate(rate: Option<f64>) -> String {
+    rate.map_or_else(|| "n/a".to_owned(), |value| format!("{value:.3}"))
 }
 
 fn render_failure_modes(value: &serde_json::Value) -> String {
@@ -224,7 +259,22 @@ mod tests {
                     crate::generated::verbs::lint::AgentWorkerAuditReportRolloutState::Canary,
                 ),
                 failure_modes: serde_json::json!({"budget_exceeded": 2}),
-                workers: Vec::new(),
+                workers: vec![crate::generated::verbs::lint::AgentWorkerAuditWorker {
+                    worker_kind:
+                        crate::generated::verbs::lint::AgentWorkerAuditWorkerWorkerKind::Extractor,
+                    worker_name: "agent_extractor".to_owned(),
+                    canary_label: Some("canary-05".to_owned()),
+                    total_runs: 4,
+                    completed_runs: 2,
+                    failed_runs: 2,
+                    generated_candidates: 10,
+                    accepted_candidates: 5,
+                    acceptance_rate: Some(0.5),
+                    turns: 8,
+                    tool_calls: 12,
+                    cost_units: 200,
+                    failure_modes: serde_json::json!({"budget_exceeded": 2}),
+                }],
                 observed_records: true,
                 total_runs: 4,
                 completed_runs: 2,
@@ -247,6 +297,10 @@ mod tests {
         assert!(rendered.contains("- state: canary"));
         assert!(rendered.contains("- accepted candidates: 5 / 10"));
         assert!(rendered.contains("- failures: budget_exceeded=2"));
+        assert!(rendered.contains("- workers:"));
+        assert!(rendered.contains(
+            "- extractor `agent_extractor` (canary-05): runs 4 (completed 2, failed 2), accepted candidates 5 / 10 (rate 0.500), turns 8, cost units 200, tool calls 12, failures budget_exceeded=2"
+        ));
         assert!(!rendered.contains("prompt"));
         assert!(!rendered.contains("candidate body"));
     }

--- a/crates/cairn-idl/schema/verbs/lint.json
+++ b/crates/cairn-idl/schema/verbs/lint.json
@@ -115,6 +115,113 @@
         "path":         { "type": "string", "minLength": 1 }
       }
     },
+    "AgentWorkerAuditWorker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["worker_kind", "worker_name", "total_runs", "generated_candidates", "accepted_candidates"],
+      "properties": {
+        "worker_kind": {
+          "type": "string",
+          "enum": ["extractor", "dream"]
+        },
+        "worker_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canary_label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "total_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "generated_candidates": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "accepted_candidates": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "AgentWorkerAuditReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observed_records",
+        "total_runs",
+        "completed_runs",
+        "failed_runs",
+        "generated_candidates",
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes",
+        "workers"
+      ],
+      "properties": {
+        "observed_records": {
+          "type": "boolean"
+        },
+        "rollout_state": {
+          "type": "string",
+          "enum": ["paused", "canary", "enabled", "rolled_back"]
+        },
+        "total_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "completed_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "generated_candidates": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "accepted_candidates": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "acceptance_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "turns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tool_calls": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cost_units": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failure_modes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "workers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AgentWorkerAuditWorker"
+          }
+        }
+      }
+    },
     "Finding": {
       "type": "object",
       "additionalProperties": false,
@@ -164,7 +271,10 @@
           "type": "array",
           "items": { "$ref": "#/$defs/Finding" }
         },
-        "report_path": { "type": "string", "minLength": 1 }
+        "report_path": { "type": "string", "minLength": 1 },
+        "agent_worker_audit": {
+          "$ref": "#/$defs/AgentWorkerAuditReport"
+        }
       }
     }
   }

--- a/crates/cairn-idl/schema/verbs/lint.json
+++ b/crates/cairn-idl/schema/verbs/lint.json
@@ -118,7 +118,19 @@
     "AgentWorkerAuditWorker": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["worker_kind", "worker_name", "total_runs", "generated_candidates", "accepted_candidates"],
+      "required": [
+        "worker_kind",
+        "worker_name",
+        "total_runs",
+        "completed_runs",
+        "failed_runs",
+        "generated_candidates",
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes"
+      ],
       "properties": {
         "worker_kind": {
           "type": "string",
@@ -136,6 +148,14 @@
           "type": "integer",
           "minimum": 0
         },
+        "completed_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
         "generated_candidates": {
           "type": "integer",
           "minimum": 0
@@ -143,6 +163,30 @@
         "accepted_candidates": {
           "type": "integer",
           "minimum": 0
+        },
+        "acceptance_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "turns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tool_calls": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cost_units": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failure_modes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
         }
       }
     },

--- a/crates/cairn-idl/tests/snapshots/wire_compat_v1__file__verbs_lint_json.snap
+++ b/crates/cairn-idl/tests/snapshots/wire_compat_v1__file__verbs_lint_json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cairn-idl/tests/wire_compat_v1.rs
+assertion_line: 95
 expression: body
 ---
 {
@@ -119,6 +120,157 @@ expression: body
         "path":         { "type": "string", "minLength": 1 }
       }
     },
+    "AgentWorkerAuditWorker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "worker_kind",
+        "worker_name",
+        "total_runs",
+        "completed_runs",
+        "failed_runs",
+        "generated_candidates",
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes"
+      ],
+      "properties": {
+        "worker_kind": {
+          "type": "string",
+          "enum": ["extractor", "dream"]
+        },
+        "worker_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "canary_label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "total_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "completed_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "generated_candidates": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "accepted_candidates": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "acceptance_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "turns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tool_calls": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cost_units": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failure_modes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "AgentWorkerAuditReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "observed_records",
+        "total_runs",
+        "completed_runs",
+        "failed_runs",
+        "generated_candidates",
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes",
+        "workers"
+      ],
+      "properties": {
+        "observed_records": {
+          "type": "boolean"
+        },
+        "rollout_state": {
+          "type": "string",
+          "enum": ["paused", "canary", "enabled", "rolled_back"]
+        },
+        "total_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "completed_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed_runs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "generated_candidates": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "accepted_candidates": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "acceptance_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "turns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tool_calls": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "cost_units": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failure_modes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "workers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AgentWorkerAuditWorker"
+          }
+        }
+      }
+    },
     "Finding": {
       "type": "object",
       "additionalProperties": false,
@@ -168,7 +320,10 @@ expression: body
           "type": "array",
           "items": { "$ref": "#/$defs/Finding" }
         },
-        "report_path": { "type": "string", "minLength": 1 }
+        "report_path": { "type": "string", "minLength": 1 },
+        "agent_worker_audit": {
+          "$ref": "#/$defs/AgentWorkerAuditReport"
+        }
       }
     }
   }

--- a/crates/cairn-idl/tests/snapshots/wire_compat_v1__manifest_fingerprint.snap
+++ b/crates/cairn-idl/tests/snapshots/wire_compat_v1__manifest_fingerprint.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/cairn-idl/tests/wire_compat_v1.rs
+assertion_line: 84
 expression: digest
 ---
-ddc0964551c86aea6754fbffd7192af398d59572c8ca798c0f5d18c4a2b6fd9a
+f23a00be587415ee22bbd4135be55e2ce35c665264a139c1f9cfed80f5da54de

--- a/crates/cairn-mcp/src/generated/schemas/verbs/lint.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/lint.input.json
@@ -84,6 +84,11 @@
     "AgentWorkerAuditWorker": {
       "additionalProperties": false,
       "properties": {
+        "acceptance_rate": {
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
         "accepted_candidates": {
           "minimum": 0,
           "type": "integer"
@@ -92,11 +97,38 @@
           "minLength": 1,
           "type": "string"
         },
+        "completed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "cost_units": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failure_modes": {
+          "additionalProperties": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "object"
+        },
         "generated_candidates": {
           "minimum": 0,
           "type": "integer"
         },
+        "tool_calls": {
+          "minimum": 0,
+          "type": "integer"
+        },
         "total_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "turns": {
           "minimum": 0,
           "type": "integer"
         },
@@ -116,8 +148,14 @@
         "worker_kind",
         "worker_name",
         "total_runs",
+        "completed_runs",
+        "failed_runs",
         "generated_candidates",
-        "accepted_candidates"
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes"
       ],
       "type": "object"
     },

--- a/crates/cairn-mcp/src/generated/schemas/verbs/lint.input.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/lint.input.json
@@ -1,5 +1,126 @@
 {
   "$defs": {
+    "AgentWorkerAuditReport": {
+      "additionalProperties": false,
+      "properties": {
+        "acceptance_rate": {
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "accepted_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "completed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "cost_units": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failure_modes": {
+          "additionalProperties": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "generated_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_records": {
+          "type": "boolean"
+        },
+        "rollout_state": {
+          "enum": [
+            "paused",
+            "canary",
+            "enabled",
+            "rolled_back"
+          ],
+          "type": "string"
+        },
+        "tool_calls": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "turns": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "workers": {
+          "items": {
+            "$ref": "#/$defs/AgentWorkerAuditWorker"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "observed_records",
+        "total_runs",
+        "completed_runs",
+        "failed_runs",
+        "generated_candidates",
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes",
+        "workers"
+      ],
+      "type": "object"
+    },
+    "AgentWorkerAuditWorker": {
+      "additionalProperties": false,
+      "properties": {
+        "accepted_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "canary_label": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "generated_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "worker_kind": {
+          "enum": [
+            "extractor",
+            "dream"
+          ],
+          "type": "string"
+        },
+        "worker_name": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "worker_kind",
+        "worker_name",
+        "total_runs",
+        "generated_candidates",
+        "accepted_candidates"
+      ],
+      "type": "object"
+    },
     "Args": {
       "additionalProperties": false,
       "properties": {
@@ -28,6 +149,9 @@
     "Data": {
       "additionalProperties": false,
       "properties": {
+        "agent_worker_audit": {
+          "$ref": "#/$defs/AgentWorkerAuditReport"
+        },
         "findings": {
           "items": {
             "$ref": "#/$defs/Finding"

--- a/crates/cairn-mcp/src/generated/schemas/verbs/lint.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/lint.json
@@ -84,6 +84,11 @@
     "AgentWorkerAuditWorker": {
       "additionalProperties": false,
       "properties": {
+        "acceptance_rate": {
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
         "accepted_candidates": {
           "minimum": 0,
           "type": "integer"
@@ -92,11 +97,38 @@
           "minLength": 1,
           "type": "string"
         },
+        "completed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "cost_units": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failure_modes": {
+          "additionalProperties": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "object"
+        },
         "generated_candidates": {
           "minimum": 0,
           "type": "integer"
         },
+        "tool_calls": {
+          "minimum": 0,
+          "type": "integer"
+        },
         "total_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "turns": {
           "minimum": 0,
           "type": "integer"
         },
@@ -116,8 +148,14 @@
         "worker_kind",
         "worker_name",
         "total_runs",
+        "completed_runs",
+        "failed_runs",
         "generated_candidates",
-        "accepted_candidates"
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes"
       ],
       "type": "object"
     },

--- a/crates/cairn-mcp/src/generated/schemas/verbs/lint.json
+++ b/crates/cairn-mcp/src/generated/schemas/verbs/lint.json
@@ -1,5 +1,126 @@
 {
   "$defs": {
+    "AgentWorkerAuditReport": {
+      "additionalProperties": false,
+      "properties": {
+        "acceptance_rate": {
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "accepted_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "completed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "cost_units": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failed_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "failure_modes": {
+          "additionalProperties": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "generated_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "observed_records": {
+          "type": "boolean"
+        },
+        "rollout_state": {
+          "enum": [
+            "paused",
+            "canary",
+            "enabled",
+            "rolled_back"
+          ],
+          "type": "string"
+        },
+        "tool_calls": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "turns": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "workers": {
+          "items": {
+            "$ref": "#/$defs/AgentWorkerAuditWorker"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "observed_records",
+        "total_runs",
+        "completed_runs",
+        "failed_runs",
+        "generated_candidates",
+        "accepted_candidates",
+        "turns",
+        "tool_calls",
+        "cost_units",
+        "failure_modes",
+        "workers"
+      ],
+      "type": "object"
+    },
+    "AgentWorkerAuditWorker": {
+      "additionalProperties": false,
+      "properties": {
+        "accepted_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "canary_label": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "generated_candidates": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total_runs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "worker_kind": {
+          "enum": [
+            "extractor",
+            "dream"
+          ],
+          "type": "string"
+        },
+        "worker_name": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "worker_kind",
+        "worker_name",
+        "total_runs",
+        "generated_candidates",
+        "accepted_candidates"
+      ],
+      "type": "object"
+    },
     "Args": {
       "additionalProperties": false,
       "properties": {
@@ -28,6 +149,9 @@
     "Data": {
       "additionalProperties": false,
       "properties": {
+        "agent_worker_audit": {
+          "$ref": "#/$defs/AgentWorkerAuditReport"
+        },
         "findings": {
           "items": {
             "$ref": "#/$defs/Finding"

--- a/crates/cairn-store-sqlite/tests/lint_author_lifecycle.rs
+++ b/crates/cairn-store-sqlite/tests/lint_author_lifecycle.rs
@@ -573,6 +573,8 @@ async fn run_checks_emits_broken_actor_chain_warning_for_revoked_author() {
         source_resolver: &resolver,
         consent_journal: &journal,
         workflow_jobs: None,
+        agent_worker_audit: None,
+        agent_canary_state: None,
         now_ms: 0,
     };
 

--- a/crates/cairn-store-sqlite/tests/lint_author_lifecycle.rs
+++ b/crates/cairn-store-sqlite/tests/lint_author_lifecycle.rs
@@ -43,10 +43,13 @@ use cairn_core::domain::identity::receipts::{ReceiptOpKind, ReceiptPayload, Revo
 use cairn_core::domain::identity::records::{
     IdentityKeyEntry, ProvisioningState, PublicIdentityRecord, ReceiptId,
 };
-use cairn_core::domain::{ChainRole, Identity, IdentityKind, MemoryRecord, RecordId, TargetId};
+use cairn_core::domain::{
+    ChainRole, Identity, IdentityKind, MemoryRecord, RecordId, SourceId, TargetId,
+};
 use cairn_core::pipeline::lint::author_lifecycle::{
     AuthorLifecycle, AuthorLifecycleFinding, AuthorState, ChainStatus, check_author_lifecycle,
 };
+use cairn_core::verbs::lint::{LintRecord, SourceArtifact, SourceArtifactState};
 use cairn_store_sqlite::{SqliteIdentityRegistry, SqliteMemoryStore, open_in_memory};
 
 /// Open a store + registry pair that share no state. Production wires
@@ -503,14 +506,38 @@ async fn prefetch_author_states(
     map
 }
 
+fn source_artifacts_for_records(lint_records: &[LintRecord]) -> HashMap<SourceId, SourceArtifact> {
+    lint_records
+        .iter()
+        .flat_map(|record| {
+            record
+                .stored
+                .record
+                .provenance
+                .source_ids
+                .iter()
+                .cloned()
+                .map(move |source_id| {
+                    (
+                        source_id,
+                        SourceArtifact {
+                            path: "sources/test/sample.txt".to_owned(),
+                            state: SourceArtifactState::Present {
+                                sha256: record.stored.record.provenance.source_hash.clone(),
+                            },
+                        },
+                    )
+                })
+        })
+        .collect()
+}
+
 #[tokio::test]
 async fn run_checks_emits_broken_actor_chain_warning_for_revoked_author() {
     use cairn_core::config::CairnConfig;
     use cairn_core::contract::memory_store::IndexStats;
     use cairn_core::generated::verbs::lint::{Kind, Severity};
-    use cairn_core::verbs::lint::{
-        ConsentModel, LintInputs, LintRecord, SourceArtifact, SourceArtifactState, run_checks,
-    };
+    use cairn_core::verbs::lint::{ConsentModel, LintInputs, run_checks};
 
     let (store, registry, _dir) = setup().await;
 
@@ -535,29 +562,7 @@ async fn run_checks_emits_broken_actor_chain_warning_for_revoked_author() {
     let cfg = CairnConfig::default();
     let resolver = stub_resolver::EmptySourceResolver;
     let journal = stub_resolver::EmptyConsentJournal;
-    let source_artifacts: HashMap<_, _> = lint_records
-        .iter()
-        .flat_map(|record| {
-            record
-                .stored
-                .record
-                .provenance
-                .source_ids
-                .iter()
-                .cloned()
-                .map(move |source_id| {
-                    (
-                        source_id,
-                        SourceArtifact {
-                            path: "sources/test/sample.txt".to_owned(),
-                            state: SourceArtifactState::Present {
-                                sha256: record.stored.record.provenance.source_hash.clone(),
-                            },
-                        },
-                    )
-                })
-        })
-        .collect();
+    let source_artifacts = source_artifacts_for_records(&lint_records);
     let source_forgets = HashMap::new();
     let inputs = LintInputs {
         records: &lint_records,

--- a/crates/cairn-workflows/src/evaluation/handler.rs
+++ b/crates/cairn-workflows/src/evaluation/handler.rs
@@ -3,6 +3,7 @@
 //! `MetricEvent::EvaluationCompleted` to the configured `MetricsSink`
 //! (issue #91, brief §15).
 
+use std::fmt::Write as _;
 use std::sync::Arc;
 
 use cairn_core::config::EvaluationConfig;
@@ -284,25 +285,7 @@ impl EvaluationHandler {
             }
             body.push('\n');
         }
-        body.push_str("\n## Agent worker audit\n\n");
-        if agent_worker_audit.is_empty() {
-            body.push_str("- no agent-worker audit records observed\n");
-        } else {
-            body.push_str("- runs: ");
-            body.push_str(&agent_worker_audit.total_runs.to_string());
-            body.push('\n');
-            body.push_str("- accepted candidates: ");
-            body.push_str(&agent_worker_audit.accepted_candidates.to_string());
-            body.push_str(" / ");
-            body.push_str(&agent_worker_audit.generated_candidates.to_string());
-            body.push('\n');
-            body.push_str("- cost units: ");
-            body.push_str(&agent_worker_audit.cost_units.to_string());
-            body.push('\n');
-            body.push_str("- tool calls: ");
-            body.push_str(&agent_worker_audit.tool_calls.to_string());
-            body.push('\n');
-        }
+        append_agent_worker_audit_section(&mut body, agent_worker_audit);
 
         let target_id = stable_target_id(target_key)?;
         let target_id_str = target_id.as_str().to_owned();
@@ -383,6 +366,72 @@ fn outcome_hash_basis(
     let audit_basis = serde_json::to_string(agent_worker_audit)
         .unwrap_or_else(|_| "agent_worker_audit_unserializable".to_owned());
     format!("{outcome_basis}|agent_worker_audit={audit_basis}")
+}
+
+fn append_agent_worker_audit_section(body: &mut String, audit: &AgentWorkerAuditSummary) {
+    body.push_str("\n## Agent worker audit\n\n");
+    if audit.is_empty() {
+        body.push_str("- no agent-worker audit records observed\n");
+        return;
+    }
+
+    let _ = writeln!(body, "- runs: {}", audit.total_runs);
+    let _ = writeln!(
+        body,
+        "- accepted candidates: {} / {}",
+        audit.accepted_candidates, audit.generated_candidates
+    );
+    let _ = writeln!(body, "- cost units: {}", audit.cost_units);
+    let _ = writeln!(body, "- tool calls: {}", audit.tool_calls);
+    if audit.workers.is_empty() {
+        return;
+    }
+
+    body.push_str("- workers:\n");
+    for worker in &audit.workers {
+        let canary_label = worker.canary_label.as_deref().unwrap_or("unlabeled");
+        let acceptance_rate = render_rate(worker.acceptance_rate);
+        let failures = render_failure_modes(&worker.failure_modes);
+        let _ = writeln!(
+            body,
+            "  - {} `{}` ({canary_label}): runs {} (completed {}, failed {}), accepted candidates {} / {} (rate {acceptance_rate}), turns {}, cost units {}, tool calls {}, failures {failures}",
+            render_worker_kind(worker.worker_kind),
+            worker.worker_name,
+            worker.total_runs,
+            worker.completed_runs,
+            worker.failed_runs,
+            worker.accepted_candidates,
+            worker.generated_candidates,
+            worker.turns,
+            worker.cost_units,
+            worker.tool_calls,
+        );
+    }
+}
+
+fn render_worker_kind(kind: cairn_core::domain::AgentWorkerKind) -> &'static str {
+    match kind {
+        cairn_core::domain::AgentWorkerKind::Extractor => "extractor",
+        cairn_core::domain::AgentWorkerKind::Dream => "dream",
+    }
+}
+
+fn render_rate(rate: Option<f64>) -> String {
+    rate.map_or_else(|| "n/a".to_owned(), |value| format!("{value:.3}"))
+}
+
+fn render_failure_modes(
+    modes: &std::collections::BTreeMap<cairn_core::domain::AgentWorkerFailureMode, u64>,
+) -> String {
+    if modes.is_empty() {
+        return "none".to_owned();
+    }
+
+    modes
+        .iter()
+        .map(|(mode, count)| format!("{}={count}", mode.as_str()))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 #[async_trait::async_trait]

--- a/crates/cairn-workflows/src/evaluation/handler.rs
+++ b/crates/cairn-workflows/src/evaluation/handler.rs
@@ -10,7 +10,7 @@ use cairn_core::contract::job_store::{FailureClass, JobKind, JobPayload};
 use cairn_core::contract::memory_store::MemoryStore;
 use cairn_core::contract::metrics::MetricsSink;
 use cairn_core::domain::{
-    ScopeTuple,
+    AgentWorkerAuditRecord, AgentWorkerAuditSummary, ScopeTuple,
     metrics::MetricEvent,
     taxonomy::{MemoryClass, MemoryKind},
 };
@@ -30,7 +30,7 @@ const EVAL_CONSENT_REF: &str = "consent:system:evaluation-workflow";
 
 /// Per-sweep summary surfaced to callers and tests so they can assert
 /// the workflow's behaviour without parsing the report record.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EvaluationReport {
     /// Total number of `GoldenCheck`s executed this sweep.
     pub checks_run: u32,
@@ -41,6 +41,8 @@ pub struct EvaluationReport {
     /// Stable `target_id` of the upserted report record (when
     /// `write_report_record = true`).
     pub report_target_id: Option<String>,
+    /// Body-free aggregate for agent-mode worker audit records observed by this sweep.
+    pub agent_worker_audit: AgentWorkerAuditSummary,
 }
 
 /// Minimum-path `EvaluationWorkflow` handler.
@@ -49,6 +51,7 @@ pub struct EvaluationHandler {
     metrics: Arc<dyn MetricsSink>,
     checks: Vec<Arc<dyn GoldenCheck>>,
     config: EvaluationConfig,
+    agent_worker_audit: Vec<AgentWorkerAuditRecord>,
 }
 
 impl EvaluationHandler {
@@ -67,7 +70,15 @@ impl EvaluationHandler {
             metrics,
             checks,
             config,
+            agent_worker_audit: Vec::new(),
         }
+    }
+
+    /// Attach body-free agent-worker audit records for this handler instance.
+    #[must_use]
+    pub fn with_agent_worker_audit(mut self, records: Vec<AgentWorkerAuditRecord>) -> Self {
+        self.agent_worker_audit = records;
+        self
     }
 
     /// Resolve the check allow-list against the registered set.
@@ -154,6 +165,7 @@ impl EvaluationHandler {
         // byte-stable replays.
         findings.sort_by(|a, b| a.0.cmp(&b.0));
 
+        let agent_worker_audit = AgentWorkerAuditSummary::from_records(&self.agent_worker_audit);
         let checks_run = u32::try_from(findings.len()).unwrap_or(u32::MAX);
 
         // Compute the stable `report_target_id` unconditionally so
@@ -162,13 +174,13 @@ impl EvaluationHandler {
         // unrelated no-report sweeps at the same `ts_ms` would
         // collapse in downstream `(report_target_id, ts_ms)`
         // queries (round-3 adversarial review #2).
-        let target_key = Self::report_target_key(payload, &findings);
+        let target_key = Self::report_target_key(payload, &findings, &agent_worker_audit);
         let target_id = stable_target_id(&target_key)
             .map_err(|e| Box::<dyn std::error::Error + Send + Sync>::from(e.to_string()))?;
         let report_target_id = target_id.as_str().to_owned();
 
         let _report_was_new = if self.config.write_report_record {
-            self.upsert_report_record(payload, &findings, &target_key)
+            self.upsert_report_record(payload, &findings, &target_key, &agent_worker_audit)
                 .await?
         } else {
             true
@@ -200,6 +212,7 @@ impl EvaluationHandler {
             passed,
             failed,
             report_target_id: Some(report_target_id),
+            agent_worker_audit,
         })
     }
 
@@ -214,6 +227,7 @@ impl EvaluationHandler {
     fn report_target_key(
         payload: &EvaluationPayload,
         findings: &[(String, CheckOutcome)],
+        agent_worker_audit: &AgentWorkerAuditSummary,
     ) -> String {
         let check_ids = findings
             .iter()
@@ -238,6 +252,9 @@ impl EvaluationHandler {
             })
             .collect::<Vec<_>>()
             .join("|");
+        let audit_basis = serde_json::to_string(agent_worker_audit)
+            .unwrap_or_else(|_| "agent_worker_audit_unserializable".to_owned());
+        let outcome_basis = format!("{outcome_basis}|agent_worker_audit={audit_basis}");
         let outcome_hash = crate::synthetic::sha256_hex(outcome_basis.as_bytes());
         // Use only the first 16 hex chars of the digest to keep the
         // key short; collisions at that prefix are vanishingly
@@ -261,6 +278,7 @@ impl EvaluationHandler {
         payload: &EvaluationPayload,
         findings: &[(String, CheckOutcome)],
         target_key: &str,
+        agent_worker_audit: &AgentWorkerAuditSummary,
     ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
         // Build a deterministic Markdown body. Same findings → same
         // bytes → same body hash → store dedupes on idempotent
@@ -278,6 +296,25 @@ impl EvaluationHandler {
                     body.push_str(details);
                 }
             }
+            body.push('\n');
+        }
+        body.push_str("\n## Agent worker audit\n\n");
+        if agent_worker_audit.is_empty() {
+            body.push_str("- no agent-worker audit records observed\n");
+        } else {
+            body.push_str("- runs: ");
+            body.push_str(&agent_worker_audit.total_runs.to_string());
+            body.push('\n');
+            body.push_str("- accepted candidates: ");
+            body.push_str(&agent_worker_audit.accepted_candidates.to_string());
+            body.push_str(" / ");
+            body.push_str(&agent_worker_audit.generated_candidates.to_string());
+            body.push('\n');
+            body.push_str("- cost units: ");
+            body.push_str(&agent_worker_audit.cost_units.to_string());
+            body.push('\n');
+            body.push_str("- tool calls: ");
+            body.push_str(&agent_worker_audit.tool_calls.to_string());
             body.push('\n');
         }
 
@@ -301,6 +338,7 @@ impl EvaluationHandler {
                 "checks": findings.iter().map(|(id, _)| id).collect::<Vec<_>>(),
                 "ts_ms":  payload.ts_ms,
                 "outcome_hash": outcome_hash,
+                "agent_worker_audit": agent_worker_audit,
                 "produced_by": "cairn-workflows::EvaluationHandler",
             }),
         );
@@ -466,5 +504,66 @@ mod tests {
             }
             _ => panic!("expected EvaluationCompleted"),
         }
+    }
+
+    #[tokio::test]
+    async fn evaluation_report_includes_agent_worker_audit_summary() {
+        use cairn_core::contract::agent_provider::AgentBudgetConsumed;
+        use cairn_core::domain::{
+            AgentWorkerAuditRecord, AgentWorkerFailureMode, AgentWorkerKind, AgentWorkerStatus,
+        };
+
+        let store: Arc<dyn MemoryStore> = Arc::new(NoopMemoryStore::default());
+        let sink = metrics();
+        let audit_records = vec![AgentWorkerAuditRecord {
+            operation_id: "op-agent-1".to_owned(),
+            worker_kind: AgentWorkerKind::Dream,
+            worker_name: "agent_dream".to_owned(),
+            agent_identity: "agt:cairn-dream:v1".to_owned(),
+            scope: Some(ScopeTuple {
+                tenant: Some("tenant-a".to_owned()),
+                agent: Some("agt:cairn-dream:v1".to_owned()),
+                ..ScopeTuple::default()
+            }),
+            status: AgentWorkerStatus::Aborted,
+            generated_candidates: 2,
+            accepted_candidates: 1,
+            budget_consumed: AgentBudgetConsumed {
+                turns: 1,
+                tool_calls: 2,
+                cost_units: 99,
+            },
+            failure_mode: Some(AgentWorkerFailureMode::ProviderUnavailable),
+            canary_label: Some("canary-05".to_owned()),
+        }];
+        let h = EvaluationHandler::new(
+            store,
+            sink.clone() as Arc<dyn MetricsSink>,
+            default_checks(),
+            EvaluationConfig {
+                enabled: true,
+                write_report_record: false,
+                ..EvaluationConfig::default()
+            },
+        )
+        .with_agent_worker_audit(audit_records);
+        let payload = EvaluationPayload {
+            ts_ms: 1_700_000_000_000,
+            check_ids: vec![],
+            bound_scope: None,
+        };
+
+        let report = h.run_once(&payload).await.expect("run_once");
+
+        assert_eq!(report.agent_worker_audit.total_runs, 1);
+        assert_eq!(report.agent_worker_audit.accepted_candidates, 1);
+        assert_eq!(report.agent_worker_audit.cost_units, 99);
+        assert_eq!(
+            report
+                .agent_worker_audit
+                .failure_modes
+                .get(&AgentWorkerFailureMode::ProviderUnavailable),
+            Some(&1)
+        );
     }
 }

--- a/crates/cairn-workflows/src/evaluation/handler.rs
+++ b/crates/cairn-workflows/src/evaluation/handler.rs
@@ -240,21 +240,7 @@ impl EvaluationHandler {
             .map(ScopeTuple::canonical_wire)
             .unwrap_or_default();
         let day = payload.ts_ms / 86_400_000;
-        // Outcome digest: stable serialization of pass/fail per
-        // check id. `CheckOutcome::Failed { details }` participates
-        // in the hash so a failure detail change also splits the
-        // target.
-        let outcome_basis: String = findings
-            .iter()
-            .map(|(id, outcome)| match outcome {
-                CheckOutcome::Passed => format!("{id}=P"),
-                CheckOutcome::Failed { details } => format!("{id}=F:{details}"),
-            })
-            .collect::<Vec<_>>()
-            .join("|");
-        let audit_basis = serde_json::to_string(agent_worker_audit)
-            .unwrap_or_else(|_| "agent_worker_audit_unserializable".to_owned());
-        let outcome_basis = format!("{outcome_basis}|agent_worker_audit={audit_basis}");
+        let outcome_basis = outcome_hash_basis(findings, agent_worker_audit);
         let outcome_hash = crate::synthetic::sha256_hex(outcome_basis.as_bytes());
         // Use only the first 16 hex chars of the digest to keep the
         // key short; collisions at that prefix are vanishingly
@@ -321,14 +307,7 @@ impl EvaluationHandler {
         let target_id = stable_target_id(target_key)?;
         let target_id_str = target_id.as_str().to_owned();
 
-        let outcome_basis: String = findings
-            .iter()
-            .map(|(id, outcome)| match outcome {
-                CheckOutcome::Passed => format!("{id}=P"),
-                CheckOutcome::Failed { details } => format!("{id}=F:{details}"),
-            })
-            .collect::<Vec<_>>()
-            .join("|");
+        let outcome_basis = outcome_hash_basis(findings, agent_worker_audit);
         let outcome_hash = crate::synthetic::sha256_hex(outcome_basis.as_bytes());
 
         let mut extras = std::collections::BTreeMap::new();
@@ -385,6 +364,25 @@ impl EvaluationHandler {
         }
         Ok(outcome.content_changed)
     }
+}
+
+fn outcome_hash_basis(
+    findings: &[(String, CheckOutcome)],
+    agent_worker_audit: &AgentWorkerAuditSummary,
+) -> String {
+    // Stable serialization of pass/fail per check id. `CheckOutcome::Failed { details }`
+    // participates in the hash so a failure detail change also splits the target.
+    let outcome_basis = findings
+        .iter()
+        .map(|(id, outcome)| match outcome {
+            CheckOutcome::Passed => format!("{id}=P"),
+            CheckOutcome::Failed { details } => format!("{id}=F:{details}"),
+        })
+        .collect::<Vec<_>>()
+        .join("|");
+    let audit_basis = serde_json::to_string(agent_worker_audit)
+        .unwrap_or_else(|_| "agent_worker_audit_unserializable".to_owned());
+    format!("{outcome_basis}|agent_worker_audit={audit_basis}")
 }
 
 #[async_trait::async_trait]

--- a/crates/cairn-workflows/tests/evaluation.rs
+++ b/crates/cairn-workflows/tests/evaluation.rs
@@ -222,6 +222,15 @@ async fn audit_state_changes_persisted_outcome_hash() {
         2,
         "audit state must participate in persisted outcome_hash"
     );
+
+    let audit_report = listed
+        .records
+        .iter()
+        .find(|r| r.body.contains("agent_dream"))
+        .expect("audit report body includes per-worker details");
+    assert!(audit_report.body.contains(
+        "- dream `agent_dream` (canary-05): runs 1 (completed 0, failed 1), accepted candidates 1 / 2 (rate 0.500), turns 1, cost units 99, tool calls 2, failures provider_unavailable=1"
+    ));
 }
 
 #[tokio::test]

--- a/crates/cairn-workflows/tests/evaluation.rs
+++ b/crates/cairn-workflows/tests/evaluation.rs
@@ -6,10 +6,14 @@
 use std::sync::Arc;
 
 use cairn_core::config::EvaluationConfig;
+use cairn_core::contract::agent_provider::AgentBudgetConsumed;
 use cairn_core::contract::memory_store::{ListArgs, MemoryStore};
 use cairn_core::contract::metrics::{CapturingMetricsSink, MetricsSink};
 use cairn_core::domain::metrics::MetricEvent;
 use cairn_core::domain::taxonomy::MemoryKind;
+use cairn_core::domain::{
+    AgentWorkerAuditRecord, AgentWorkerFailureMode, AgentWorkerKind, AgentWorkerStatus, ScopeTuple,
+};
 use cairn_test_fixtures::{memstore, sample_record};
 use cairn_workflows::scheduler::{HandlerOutcome, JobHandler};
 use cairn_workflows::{EvaluationHandler, EvaluationPayload, default_golden_checks};
@@ -133,6 +137,90 @@ async fn replays_produce_byte_identical_report() {
         target_ids.len(),
         1,
         "both replays carry the same report_target_id so downstream can dedupe"
+    );
+}
+
+#[tokio::test]
+async fn audit_state_changes_persisted_outcome_hash() {
+    let store = Arc::new(memstore().await);
+    let sink = Arc::new(CapturingMetricsSink::new());
+    let dyn_store: Arc<dyn MemoryStore> = store.clone();
+    let payload = EvaluationPayload {
+        ts_ms: 1_700_000_000_000,
+        check_ids: vec![],
+        bound_scope: None,
+    };
+
+    let without_audit = EvaluationHandler::new(
+        dyn_store.clone(),
+        sink.clone() as Arc<dyn MetricsSink>,
+        default_golden_checks(),
+        EvaluationConfig {
+            enabled: true,
+            write_report_record: true,
+            ..EvaluationConfig::default()
+        },
+    );
+    let with_audit = EvaluationHandler::new(
+        dyn_store,
+        sink.clone() as Arc<dyn MetricsSink>,
+        default_golden_checks(),
+        EvaluationConfig {
+            enabled: true,
+            write_report_record: true,
+            ..EvaluationConfig::default()
+        },
+    )
+    .with_agent_worker_audit(vec![AgentWorkerAuditRecord {
+        operation_id: "op-agent-1".to_owned(),
+        worker_kind: AgentWorkerKind::Dream,
+        worker_name: "agent_dream".to_owned(),
+        agent_identity: "agt:cairn-dream:v1".to_owned(),
+        scope: Some(ScopeTuple {
+            tenant: Some("tenant-a".to_owned()),
+            agent: Some("agt:cairn-dream:v1".to_owned()),
+            ..ScopeTuple::default()
+        }),
+        status: AgentWorkerStatus::Aborted,
+        generated_candidates: 2,
+        accepted_candidates: 1,
+        budget_consumed: AgentBudgetConsumed {
+            turns: 1,
+            tool_calls: 2,
+            cost_units: 99,
+        },
+        failure_mode: Some(AgentWorkerFailureMode::ProviderUnavailable),
+        canary_label: Some("canary-05".to_owned()),
+    }]);
+
+    let a = without_audit.run_once(&payload).await.expect("first sweep");
+    let b = with_audit.run_once(&payload).await.expect("second sweep");
+    assert_ne!(a.report_target_id, b.report_target_id);
+
+    let listed = store
+        .list(&ListArgs {
+            limit: 100,
+            ..ListArgs::default()
+        })
+        .await
+        .expect("list");
+    let hashes: std::collections::BTreeSet<String> = listed
+        .records
+        .iter()
+        .filter(|r| r.kind == MemoryKind::Reasoning && r.body.starts_with("# Evaluation report"))
+        .filter_map(|r| {
+            r.extra_frontmatter
+                .get("evaluation")
+                .and_then(|v| v.get("outcome_hash"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .collect();
+
+    assert_eq!(
+        hashes.len(),
+        2,
+        "audit state must participate in persisted outcome_hash"
     );
 }
 

--- a/docs/superpowers/plans/2026-05-23-issue-126-agent-worker-audit-canary.md
+++ b/docs/superpowers/plans/2026-05-23-issue-126-agent-worker-audit-canary.md
@@ -1,0 +1,1697 @@
+# Agent Worker Audit And Canary Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add body-free agent-worker audit metrics, deterministic canary controls, and lint/evaluation report projection for issue #126.
+
+**Architecture:** Keep the first implementation pure and deterministic. `cairn-core::domain` owns audit aggregation and canary decisions, the generated `lint` DTO gets an optional machine-readable audit report field through IDL/codegen, and `cairn-workflows::evaluation` includes the same audit aggregate in report records through an in-memory injection point for tests and host wiring.
+
+**Tech Stack:** Rust 2024, serde, serde_json, existing Cairn generated IDL/codegen, existing lint report renderer, existing EvaluationWorkflow handler, Cargo tests.
+
+---
+
+## File Structure
+
+- Create `crates/cairn-core/src/domain/agent_audit.rs`
+  - Body-free agent-worker audit records, typed failure modes, aggregate summaries, and mapping from `AgentProviderError`.
+- Create `crates/cairn-core/src/domain/agent_canary.rs`
+  - Pure canary policy validation, dispatch decisions, and aggregate-threshold decisions.
+- Modify `crates/cairn-core/src/domain/mod.rs`
+  - Export `agent_audit`, `agent_canary`, and the public audit/canary types.
+- Modify `crates/cairn-idl/schema/verbs/lint.json`
+  - Add generated JSON shape for `Data.agent_worker_audit`.
+- Regenerate generated artifacts with `cargo run -p cairn-idl --bin cairn-codegen`.
+- Modify generated output from codegen under:
+  - `crates/cairn-core/src/generated/verbs/lint.rs`
+  - `crates/cairn-core/src/generated/schemas/verbs/lint.json`
+  - `crates/cairn-mcp/src/generated/schemas/verbs/lint.json`
+  - `skills/cairn/.version` if codegen refreshes it
+- Modify `crates/cairn-core/src/verbs/lint/mod.rs`
+  - Build the generated audit report from an `AgentWorkerAuditSummary`; attach a no-data report to ordinary `run_checks` output.
+- Modify `crates/cairn-core/src/verbs/lint/report.rs`
+  - Render an `Agent worker audit` markdown section when `agent_worker_audit` is present.
+- Modify `crates/cairn-workflows/src/evaluation/handler.rs`
+  - Add an in-memory audit-record injection point, include the aggregate in `EvaluationReport`, include it in report target keys, and render it in the report body.
+
+## Task 1: Core Agent Worker Audit Model
+
+**Files:**
+- Create: `crates/cairn-core/src/domain/agent_audit.rs`
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+- Test: `crates/cairn-core/src/domain/agent_audit.rs`
+
+- [ ] **Step 1: Write failing audit aggregation tests**
+
+Create `crates/cairn-core/src/domain/agent_audit.rs` with tests first:
+
+```rust
+use std::collections::BTreeMap;
+
+use crate::contract::agent_provider::{AgentBudgetConsumed, AgentProviderError, CairnVerb};
+use crate::domain::ScopeTuple;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scope(agent: &str) -> ScopeTuple {
+        ScopeTuple {
+            tenant: Some("tenant-a".to_owned()),
+            workspace: Some("workspace-a".to_owned()),
+            agent: Some(agent.to_owned()),
+            ..ScopeTuple::default()
+        }
+    }
+
+    fn record(
+        operation_id: &str,
+        status: AgentWorkerStatus,
+        generated_candidates: u64,
+        accepted_candidates: u64,
+        cost_units: u64,
+        failure_mode: Option<AgentWorkerFailureMode>,
+    ) -> AgentWorkerAuditRecord {
+        AgentWorkerAuditRecord {
+            operation_id: operation_id.to_owned(),
+            worker_kind: AgentWorkerKind::Extractor,
+            worker_name: "agent_extractor".to_owned(),
+            agent_identity: "agt:cairn-extractor:v1".to_owned(),
+            scope: Some(scope("agt:cairn-extractor:v1")),
+            status,
+            generated_candidates,
+            accepted_candidates,
+            budget_consumed: AgentBudgetConsumed {
+                turns: 2,
+                tool_calls: 3,
+                cost_units,
+            },
+            failure_mode,
+            canary_label: Some("canary-05".to_owned()),
+        }
+    }
+
+    #[test]
+    fn aggregate_tracks_cost_candidates_acceptance_and_failures() {
+        let records = vec![
+            record("op-1", AgentWorkerStatus::Completed, 4, 2, 100, None),
+            record(
+                "op-2",
+                AgentWorkerStatus::Aborted,
+                0,
+                0,
+                50,
+                Some(AgentWorkerFailureMode::BudgetExceeded),
+            ),
+        ];
+
+        let summary = AgentWorkerAuditSummary::from_records(&records);
+
+        assert_eq!(summary.total_runs, 2);
+        assert_eq!(summary.completed_runs, 1);
+        assert_eq!(summary.failed_runs, 1);
+        assert_eq!(summary.generated_candidates, 4);
+        assert_eq!(summary.accepted_candidates, 2);
+        assert_eq!(summary.acceptance_rate, Some(0.5));
+        assert_eq!(summary.turns, 4);
+        assert_eq!(summary.tool_calls, 6);
+        assert_eq!(summary.cost_units, 150);
+        assert_eq!(
+            summary.failure_modes.get(&AgentWorkerFailureMode::BudgetExceeded),
+            Some(&1)
+        );
+        assert_eq!(summary.workers[0].worker_name, "agent_extractor");
+    }
+
+    #[test]
+    fn aggregate_reports_no_acceptance_rate_without_generated_candidates() {
+        let records = vec![record("op-1", AgentWorkerStatus::Completed, 0, 0, 10, None)];
+
+        let summary = AgentWorkerAuditSummary::from_records(&records);
+
+        assert_eq!(summary.generated_candidates, 0);
+        assert_eq!(summary.accepted_candidates, 0);
+        assert_eq!(summary.acceptance_rate, None);
+    }
+
+    #[test]
+    fn record_preserves_identity_and_scope_for_aborted_runs() {
+        let record = record(
+            "op-1",
+            AgentWorkerStatus::Aborted,
+            0,
+            0,
+            1,
+            Some(AgentWorkerFailureMode::ProviderUnavailable),
+        );
+
+        assert_eq!(record.agent_identity, "agt:cairn-extractor:v1");
+        assert_eq!(
+            record.scope.as_ref().and_then(|scope| scope.agent.as_deref()),
+            Some("agt:cairn-extractor:v1")
+        );
+        assert_eq!(record.failure_mode, Some(AgentWorkerFailureMode::ProviderUnavailable));
+    }
+
+    #[test]
+    fn provider_errors_map_to_failure_modes() {
+        assert_eq!(
+            AgentWorkerFailureMode::from_provider_error(&AgentProviderError::ToolNotAllowed {
+                verb: CairnVerb::Forget,
+            }),
+            AgentWorkerFailureMode::ToolNotAllowed
+        );
+        assert_eq!(
+            AgentWorkerFailureMode::from_provider_error(
+                &AgentProviderError::MutatingVerbNotScoped {
+                    verb: CairnVerb::Ingest,
+                },
+            ),
+            AgentWorkerFailureMode::MutatingVerbNotScoped
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run audit tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p cairn-core domain::agent_audit --lib
+```
+
+Expected: FAIL with unresolved items such as `AgentWorkerStatus`, `AgentWorkerAuditRecord`, and `AgentWorkerAuditSummary`.
+
+- [ ] **Step 3: Implement the audit domain model**
+
+Replace the top of `crates/cairn-core/src/domain/agent_audit.rs` above the test module with:
+
+```rust
+//! Body-free agent-worker audit records and aggregates for issue #126.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::contract::agent_provider::{AgentBudgetConsumed, AgentProviderError};
+use crate::domain::ScopeTuple;
+
+/// Agent-mode worker class that produced an audit record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentWorkerKind {
+    /// Agent-mode extractor worker.
+    Extractor,
+    /// Agent-mode dream worker.
+    Dream,
+}
+
+/// Host-visible status for one logical worker invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentWorkerStatus {
+    /// Worker completed and returned control to the host.
+    Completed,
+    /// Host rejected the worker before it could run.
+    Rejected,
+    /// Worker aborted with a typed provider or host failure.
+    Aborted,
+    /// Worker output was rolled back by canary controls.
+    RolledBack,
+}
+
+impl AgentWorkerStatus {
+    /// Returns true when this status counts as a failed run for canary gates.
+    #[must_use]
+    pub const fn is_failure(self) -> bool {
+        matches!(self, Self::Rejected | Self::Aborted | Self::RolledBack)
+    }
+}
+
+/// Compact, body-free agent failure mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentWorkerFailureMode {
+    /// Cost budget was exceeded.
+    BudgetExceeded,
+    /// Wall-clock budget was exceeded.
+    WallClockExceeded,
+    /// Agent tried to invoke a tool outside its allowlist.
+    ToolNotAllowed,
+    /// Agent tried to invoke a mutating verb without mutating scope.
+    MutatingVerbNotScoped,
+    /// Agent output did not match the requested schema.
+    InvalidOutput,
+    /// Provider could not run in this build or configuration.
+    ProviderUnavailable,
+    /// Host rejected every generated candidate.
+    HostRejectedCandidates,
+    /// Failure did not map to a narrower stable category.
+    Unknown,
+}
+
+impl AgentWorkerFailureMode {
+    /// Map an AgentProvider failure to the reportable audit category.
+    #[must_use]
+    pub fn from_provider_error(error: &AgentProviderError) -> Self {
+        match error {
+            AgentProviderError::BudgetExceeded { .. } => Self::BudgetExceeded,
+            AgentProviderError::WallClockExceeded => Self::WallClockExceeded,
+            AgentProviderError::ToolNotAllowed { .. } => Self::ToolNotAllowed,
+            AgentProviderError::MutatingVerbNotScoped { .. } => Self::MutatingVerbNotScoped,
+            AgentProviderError::InvalidOutput { .. } => Self::InvalidOutput,
+            AgentProviderError::ProviderUnavailable { .. } => Self::ProviderUnavailable,
+            AgentProviderError::InvalidRequest { .. } => Self::Unknown,
+        }
+    }
+
+    /// Stable snake-case label for report maps.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::BudgetExceeded => "budget_exceeded",
+            Self::WallClockExceeded => "wall_clock_exceeded",
+            Self::ToolNotAllowed => "tool_not_allowed",
+            Self::MutatingVerbNotScoped => "mutating_verb_not_scoped",
+            Self::InvalidOutput => "invalid_output",
+            Self::ProviderUnavailable => "provider_unavailable",
+            Self::HostRejectedCandidates => "host_rejected_candidates",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// One body-free audit record for one logical agent-worker invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentWorkerAuditRecord {
+    /// Stable operation or workflow id for correlation.
+    pub operation_id: String,
+    /// Agent-mode worker class.
+    pub worker_kind: AgentWorkerKind,
+    /// Stable worker label.
+    pub worker_name: String,
+    /// `agt:` identity used by the worker.
+    pub agent_identity: String,
+    /// Body-free tenant/workspace/user/agent scope.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<ScopeTuple>,
+    /// Host-visible status.
+    pub status: AgentWorkerStatus,
+    /// Number of candidates produced by the worker.
+    pub generated_candidates: u64,
+    /// Number of generated candidates accepted by the host pipeline.
+    pub accepted_candidates: u64,
+    /// AgentProvider budget consumed by the run.
+    pub budget_consumed: AgentBudgetConsumed,
+    /// Compact failure mode when the worker failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_mode: Option<AgentWorkerFailureMode>,
+    /// Optional rollout cohort label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canary_label: Option<String>,
+}
+
+/// Aggregate for one `(worker_kind, worker_name, canary_label)` group.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentWorkerGroupSummary {
+    /// Worker class for this group.
+    pub worker_kind: AgentWorkerKind,
+    /// Stable worker label.
+    pub worker_name: String,
+    /// Optional rollout cohort label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canary_label: Option<String>,
+    /// Number of records in this group.
+    pub total_runs: u64,
+    /// Accepted candidates in this group.
+    pub accepted_candidates: u64,
+    /// Generated candidates in this group.
+    pub generated_candidates: u64,
+}
+
+/// Body-free aggregate for operator reports and canary controls.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentWorkerAuditSummary {
+    /// Total observed worker runs.
+    pub total_runs: u64,
+    /// Runs with `Completed` status.
+    pub completed_runs: u64,
+    /// Runs with rejected, aborted, or rolled-back status.
+    pub failed_runs: u64,
+    /// Generated candidates across all records.
+    pub generated_candidates: u64,
+    /// Accepted candidates across all records.
+    pub accepted_candidates: u64,
+    /// `accepted_candidates / generated_candidates`, absent when no candidates were generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acceptance_rate: Option<f64>,
+    /// Agent turns consumed.
+    pub turns: u64,
+    /// Agent tool calls consumed.
+    pub tool_calls: u64,
+    /// Provider-defined cost units consumed.
+    pub cost_units: u64,
+    /// Failure counts by stable failure category.
+    pub failure_modes: BTreeMap<AgentWorkerFailureMode, u64>,
+    /// Per-worker and per-cohort summaries.
+    pub workers: Vec<AgentWorkerGroupSummary>,
+}
+```
+
+Add the `impl AgentWorkerAuditSummary` block:
+
+```rust
+impl AgentWorkerAuditSummary {
+    /// Build a body-free aggregate from audit records.
+    #[must_use]
+    pub fn from_records(records: &[AgentWorkerAuditRecord]) -> Self {
+        let mut total_runs = 0_u64;
+        let mut completed_runs = 0_u64;
+        let mut failed_runs = 0_u64;
+        let mut generated_candidates = 0_u64;
+        let mut accepted_candidates = 0_u64;
+        let mut turns = 0_u64;
+        let mut tool_calls = 0_u64;
+        let mut cost_units = 0_u64;
+        let mut failure_modes: BTreeMap<AgentWorkerFailureMode, u64> = BTreeMap::new();
+        let mut groups: BTreeMap<(AgentWorkerKind, String, Option<String>), AgentWorkerGroupSummary> =
+            BTreeMap::new();
+
+        for record in records {
+            total_runs = total_runs.saturating_add(1);
+            if record.status == AgentWorkerStatus::Completed {
+                completed_runs = completed_runs.saturating_add(1);
+            }
+            if record.status.is_failure() {
+                failed_runs = failed_runs.saturating_add(1);
+            }
+            generated_candidates =
+                generated_candidates.saturating_add(record.generated_candidates);
+            accepted_candidates = accepted_candidates.saturating_add(record.accepted_candidates);
+            turns = turns.saturating_add(u64::from(record.budget_consumed.turns));
+            tool_calls = tool_calls.saturating_add(u64::from(record.budget_consumed.tool_calls));
+            cost_units = cost_units.saturating_add(record.budget_consumed.cost_units);
+
+            if let Some(mode) = record.failure_mode {
+                let count = failure_modes.entry(mode).or_insert(0);
+                *count = count.saturating_add(1);
+            }
+
+            let key = (
+                record.worker_kind,
+                record.worker_name.clone(),
+                record.canary_label.clone(),
+            );
+            let group = groups.entry(key).or_insert_with(|| AgentWorkerGroupSummary {
+                worker_kind: record.worker_kind,
+                worker_name: record.worker_name.clone(),
+                canary_label: record.canary_label.clone(),
+                total_runs: 0,
+                accepted_candidates: 0,
+                generated_candidates: 0,
+            });
+            group.total_runs = group.total_runs.saturating_add(1);
+            group.accepted_candidates =
+                group.accepted_candidates.saturating_add(record.accepted_candidates);
+            group.generated_candidates =
+                group.generated_candidates.saturating_add(record.generated_candidates);
+        }
+
+        let acceptance_rate = if generated_candidates == 0 {
+            None
+        } else {
+            Some(accepted_candidates as f64 / generated_candidates as f64)
+        };
+
+        Self {
+            total_runs,
+            completed_runs,
+            failed_runs,
+            generated_candidates,
+            accepted_candidates,
+            acceptance_rate,
+            turns,
+            tool_calls,
+            cost_units,
+            failure_modes,
+            workers: groups.into_values().collect(),
+        }
+    }
+
+    /// True when no worker audit records were observed.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.total_runs == 0
+    }
+}
+```
+
+- [ ] **Step 4: Export the audit module**
+
+Modify `crates/cairn-core/src/domain/mod.rs`:
+
+```rust
+pub mod agent_audit;
+```
+
+Add exports with the other `pub use` lines:
+
+```rust
+pub use agent_audit::{
+    AgentWorkerAuditRecord, AgentWorkerAuditSummary, AgentWorkerFailureMode,
+    AgentWorkerGroupSummary, AgentWorkerKind, AgentWorkerStatus,
+};
+```
+
+- [ ] **Step 5: Run audit tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p cairn-core domain::agent_audit --lib
+```
+
+Expected: PASS for all `agent_audit` tests.
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```bash
+git add crates/cairn-core/src/domain/agent_audit.rs crates/cairn-core/src/domain/mod.rs
+git commit -m "feat(core): add agent worker audit aggregate"
+```
+
+## Task 2: Core Agent Canary Controls
+
+**Files:**
+- Create: `crates/cairn-core/src/domain/agent_canary.rs`
+- Modify: `crates/cairn-core/src/domain/mod.rs`
+- Test: `crates/cairn-core/src/domain/agent_canary.rs`
+
+- [ ] **Step 1: Write failing canary tests**
+
+Create `crates/cairn-core/src/domain/agent_canary.rs` with tests first:
+
+```rust
+use crate::domain::AgentWorkerAuditSummary;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(total: u64, failed: u64, generated: u64, accepted: u64, cost: u64) -> AgentWorkerAuditSummary {
+        AgentWorkerAuditSummary {
+            total_runs: total,
+            completed_runs: total.saturating_sub(failed),
+            failed_runs: failed,
+            generated_candidates: generated,
+            accepted_candidates: accepted,
+            acceptance_rate: if generated == 0 {
+                None
+            } else {
+                Some(accepted as f64 / generated as f64)
+            },
+            turns: 0,
+            tool_calls: 0,
+            cost_units: cost,
+            failure_modes: Default::default(),
+            workers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn paused_rollout_denies_dispatch() {
+        let policy = AgentCanaryPolicy {
+            state: AgentCanaryState::Paused,
+            rollout_percent: 5,
+            min_runs: 10,
+            min_acceptance_rate: None,
+            max_failure_rate: None,
+            max_cost_units_per_accepted_candidate: None,
+            pause_requested: false,
+            rollback_requested: false,
+        };
+
+        let decision = policy.dispatch_decision(0).expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::DispatchDeniedPaused);
+    }
+
+    #[test]
+    fn canary_rollout_denies_outside_cohort() {
+        let policy = AgentCanaryPolicy {
+            state: AgentCanaryState::Canary,
+            rollout_percent: 5,
+            min_runs: 10,
+            min_acceptance_rate: None,
+            max_failure_rate: None,
+            max_cost_units_per_accepted_candidate: None,
+            pause_requested: false,
+            rollback_requested: false,
+        };
+
+        let decision = policy.dispatch_decision(50).expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::DispatchDeniedOutsideCanary);
+    }
+
+    #[test]
+    fn canary_remains_when_insufficient_runs() {
+        let policy = AgentCanaryPolicy {
+            state: AgentCanaryState::Canary,
+            rollout_percent: 5,
+            min_runs: 10,
+            min_acceptance_rate: Some(0.50),
+            max_failure_rate: Some(0.20),
+            max_cost_units_per_accepted_candidate: None,
+            pause_requested: false,
+            rollback_requested: false,
+        };
+
+        let decision = policy.evaluate_summary(&summary(3, 0, 4, 4, 20)).expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::RemainCanaryInsufficientData);
+    }
+
+    #[test]
+    fn canary_rolls_back_when_failure_rate_exceeds_threshold() {
+        let policy = AgentCanaryPolicy {
+            state: AgentCanaryState::Canary,
+            rollout_percent: 5,
+            min_runs: 4,
+            min_acceptance_rate: Some(0.50),
+            max_failure_rate: Some(0.20),
+            max_cost_units_per_accepted_candidate: None,
+            pause_requested: false,
+            rollback_requested: false,
+        };
+
+        let decision = policy.evaluate_summary(&summary(5, 2, 4, 4, 20)).expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::RollbackThresholdFailed);
+        assert_eq!(decision.next_state, AgentCanaryState::RolledBack);
+    }
+
+    #[test]
+    fn canary_promotes_when_thresholds_pass() {
+        let policy = AgentCanaryPolicy {
+            state: AgentCanaryState::Canary,
+            rollout_percent: 5,
+            min_runs: 4,
+            min_acceptance_rate: Some(0.50),
+            max_failure_rate: Some(0.20),
+            max_cost_units_per_accepted_candidate: Some(20),
+            pause_requested: false,
+            rollback_requested: false,
+        };
+
+        let decision = policy.evaluate_summary(&summary(5, 0, 10, 8, 80)).expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::PromoteToEnabled);
+        assert_eq!(decision.next_state, AgentCanaryState::Enabled);
+    }
+
+    #[test]
+    fn explicit_rollback_wins_over_promotion() {
+        let policy = AgentCanaryPolicy {
+            state: AgentCanaryState::Canary,
+            rollout_percent: 5,
+            min_runs: 1,
+            min_acceptance_rate: None,
+            max_failure_rate: None,
+            max_cost_units_per_accepted_candidate: None,
+            pause_requested: false,
+            rollback_requested: true,
+        };
+
+        let decision = policy.evaluate_summary(&summary(5, 0, 10, 10, 10)).expect("valid policy");
+
+        assert_eq!(decision.kind, AgentCanaryDecisionKind::RollbackRequested);
+        assert_eq!(decision.next_state, AgentCanaryState::RolledBack);
+    }
+}
+```
+
+- [ ] **Step 2: Run canary tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p cairn-core domain::agent_canary --lib
+```
+
+Expected: FAIL with unresolved items such as `AgentCanaryPolicy`, `AgentCanaryState`, and `AgentCanaryDecisionKind`.
+
+- [ ] **Step 3: Implement canary state and decisions**
+
+Replace the top of `crates/cairn-core/src/domain/agent_canary.rs` above the test module with:
+
+```rust
+//! Pure canary controls for agent-mode workers.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::AgentWorkerAuditSummary;
+
+/// Operator-visible rollout state for agent-mode workers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentCanaryState {
+    /// Do not dispatch agent-mode workers.
+    Paused,
+    /// Dispatch only for a bounded canary cohort.
+    Canary,
+    /// Dispatch for all configured eligible traffic.
+    Enabled,
+    /// Do not dispatch until explicitly reset.
+    RolledBack,
+}
+
+impl AgentCanaryState {
+    /// Stable snake-case label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Paused => "paused",
+            Self::Canary => "canary",
+            Self::Enabled => "enabled",
+            Self::RolledBack => "rolled_back",
+        }
+    }
+}
+
+/// Pure canary policy evaluated before dispatch and after audit aggregation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentCanaryPolicy {
+    /// Current rollout state.
+    pub state: AgentCanaryState,
+    /// Percentage of traffic allowed in canary state, 0 through 100.
+    pub rollout_percent: u8,
+    /// Minimum observed runs before judging canary metrics.
+    pub min_runs: u64,
+    /// Minimum accepted/generated rate required for promotion.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_acceptance_rate: Option<f64>,
+    /// Maximum failed/total rate allowed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_failure_rate: Option<f64>,
+    /// Maximum cost units per accepted candidate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_cost_units_per_accepted_candidate: Option<u64>,
+    /// Explicit operator pause.
+    pub pause_requested: bool,
+    /// Explicit operator rollback.
+    pub rollback_requested: bool,
+}
+
+/// Stable decision category for reports and tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentCanaryDecisionKind {
+    /// Dispatch can proceed.
+    DispatchAllowed,
+    /// Dispatch denied because agent mode is paused.
+    DispatchDeniedPaused,
+    /// Dispatch denied because agent mode is rolled back.
+    DispatchDeniedRolledBack,
+    /// Dispatch denied because this request is outside the canary cohort.
+    DispatchDeniedOutsideCanary,
+    /// Canary stays in observation mode.
+    RemainCanaryInsufficientData,
+    /// Canary passed configured thresholds.
+    PromoteToEnabled,
+    /// Canary failed a configured threshold.
+    RollbackThresholdFailed,
+    /// Operator requested rollback.
+    RollbackRequested,
+}
+
+/// Pure canary decision with the next rollout state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentCanaryDecision {
+    /// Stable decision kind.
+    pub kind: AgentCanaryDecisionKind,
+    /// State that should be used after applying the decision.
+    pub next_state: AgentCanaryState,
+    /// Compact body-free reason.
+    pub reason: String,
+}
+
+/// Validation failures for impossible canary policies.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum AgentCanaryError {
+    /// `min_runs` must be nonzero.
+    #[error("agent canary min_runs must be nonzero")]
+    ZeroMinRuns,
+    /// A rate field was outside 0.0 through 1.0.
+    #[error("agent canary rate {field} must be between 0.0 and 1.0")]
+    RateOutOfRange {
+        /// Field name.
+        field: &'static str,
+    },
+}
+```
+
+Add the policy implementation:
+
+```rust
+impl AgentCanaryPolicy {
+    /// Validate policy invariants.
+    ///
+    /// # Errors
+    /// Returns [`AgentCanaryError`] when a threshold is impossible.
+    pub fn validate(&self) -> Result<(), AgentCanaryError> {
+        if self.min_runs == 0 {
+            return Err(AgentCanaryError::ZeroMinRuns);
+        }
+        validate_rate("min_acceptance_rate", self.min_acceptance_rate)?;
+        validate_rate("max_failure_rate", self.max_failure_rate)?;
+        Ok(())
+    }
+
+    /// Decide whether one request in `cohort_percentile` may dispatch.
+    ///
+    /// # Errors
+    /// Returns [`AgentCanaryError`] when the policy is invalid.
+    pub fn dispatch_decision(
+        &self,
+        cohort_percentile: u8,
+    ) -> Result<AgentCanaryDecision, AgentCanaryError> {
+        self.validate()?;
+        if self.rollback_requested {
+            return Ok(decision(
+                AgentCanaryDecisionKind::RollbackRequested,
+                AgentCanaryState::RolledBack,
+                "operator requested rollback",
+            ));
+        }
+        if self.pause_requested || self.state == AgentCanaryState::Paused {
+            return Ok(decision(
+                AgentCanaryDecisionKind::DispatchDeniedPaused,
+                AgentCanaryState::Paused,
+                "agent mode is paused",
+            ));
+        }
+        if self.state == AgentCanaryState::RolledBack {
+            return Ok(decision(
+                AgentCanaryDecisionKind::DispatchDeniedRolledBack,
+                AgentCanaryState::RolledBack,
+                "agent mode is rolled back",
+            ));
+        }
+        if self.state == AgentCanaryState::Canary
+            && cohort_percentile >= self.rollout_percent
+        {
+            return Ok(decision(
+                AgentCanaryDecisionKind::DispatchDeniedOutsideCanary,
+                AgentCanaryState::Canary,
+                "request is outside the canary cohort",
+            ));
+        }
+        Ok(decision(
+            AgentCanaryDecisionKind::DispatchAllowed,
+            self.state,
+            "dispatch allowed",
+        ))
+    }
+
+    /// Evaluate aggregate canary metrics after worker audit records are summarized.
+    ///
+    /// # Errors
+    /// Returns [`AgentCanaryError`] when the policy is invalid.
+    pub fn evaluate_summary(
+        &self,
+        summary: &AgentWorkerAuditSummary,
+    ) -> Result<AgentCanaryDecision, AgentCanaryError> {
+        self.validate()?;
+        if self.rollback_requested {
+            return Ok(decision(
+                AgentCanaryDecisionKind::RollbackRequested,
+                AgentCanaryState::RolledBack,
+                "operator requested rollback",
+            ));
+        }
+        if self.pause_requested || self.state == AgentCanaryState::Paused {
+            return Ok(decision(
+                AgentCanaryDecisionKind::DispatchDeniedPaused,
+                AgentCanaryState::Paused,
+                "agent mode is paused",
+            ));
+        }
+        if self.state == AgentCanaryState::RolledBack {
+            return Ok(decision(
+                AgentCanaryDecisionKind::DispatchDeniedRolledBack,
+                AgentCanaryState::RolledBack,
+                "agent mode is rolled back",
+            ));
+        }
+        if self.state != AgentCanaryState::Canary {
+            return Ok(decision(
+                AgentCanaryDecisionKind::DispatchAllowed,
+                self.state,
+                "non-canary state has no aggregate transition",
+            ));
+        }
+        if summary.total_runs < self.min_runs {
+            return Ok(decision(
+                AgentCanaryDecisionKind::RemainCanaryInsufficientData,
+                AgentCanaryState::Canary,
+                "not enough audit records to judge canary",
+            ));
+        }
+        if let Some(max_failure_rate) = self.max_failure_rate {
+            let failure_rate = summary.failed_runs as f64 / summary.total_runs as f64;
+            if failure_rate > max_failure_rate {
+                return Ok(decision(
+                    AgentCanaryDecisionKind::RollbackThresholdFailed,
+                    AgentCanaryState::RolledBack,
+                    "failure rate exceeded canary threshold",
+                ));
+            }
+        }
+        if let Some(min_acceptance_rate) = self.min_acceptance_rate {
+            if summary.acceptance_rate.unwrap_or(0.0) < min_acceptance_rate {
+                return Ok(decision(
+                    AgentCanaryDecisionKind::RollbackThresholdFailed,
+                    AgentCanaryState::RolledBack,
+                    "acceptance rate fell below canary threshold",
+                ));
+            }
+        }
+        if let Some(max_cost) = self.max_cost_units_per_accepted_candidate {
+            if summary.accepted_candidates == 0
+                || summary.cost_units / summary.accepted_candidates > max_cost
+            {
+                return Ok(decision(
+                    AgentCanaryDecisionKind::RollbackThresholdFailed,
+                    AgentCanaryState::RolledBack,
+                    "cost per accepted candidate exceeded canary threshold",
+                ));
+            }
+        }
+        Ok(decision(
+            AgentCanaryDecisionKind::PromoteToEnabled,
+            AgentCanaryState::Enabled,
+            "canary thresholds passed",
+        ))
+    }
+}
+
+fn validate_rate(field: &'static str, value: Option<f64>) -> Result<(), AgentCanaryError> {
+    if value.is_some_and(|rate| !(0.0..=1.0).contains(&rate)) {
+        return Err(AgentCanaryError::RateOutOfRange { field });
+    }
+    Ok(())
+}
+
+fn decision(
+    kind: AgentCanaryDecisionKind,
+    next_state: AgentCanaryState,
+    reason: &str,
+) -> AgentCanaryDecision {
+    AgentCanaryDecision {
+        kind,
+        next_state,
+        reason: reason.to_owned(),
+    }
+}
+```
+
+- [ ] **Step 4: Export the canary module**
+
+Modify `crates/cairn-core/src/domain/mod.rs`:
+
+```rust
+pub mod agent_canary;
+```
+
+Add exports:
+
+```rust
+pub use agent_canary::{
+    AgentCanaryDecision, AgentCanaryDecisionKind, AgentCanaryError, AgentCanaryPolicy,
+    AgentCanaryState,
+};
+```
+
+- [ ] **Step 5: Run canary tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p cairn-core domain::agent_canary --lib
+```
+
+Expected: PASS for all `agent_canary` tests.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git add crates/cairn-core/src/domain/agent_canary.rs crates/cairn-core/src/domain/mod.rs
+git commit -m "feat(core): add agent canary controls"
+```
+
+## Task 3: Lint JSON And Markdown Report Projection
+
+**Files:**
+- Modify: `crates/cairn-idl/schema/verbs/lint.json`
+- Modify after codegen: `crates/cairn-core/src/generated/verbs/lint.rs`
+- Modify after codegen: `crates/cairn-core/src/generated/schemas/verbs/lint.json`
+- Modify after codegen: `crates/cairn-mcp/src/generated/schemas/verbs/lint.json`
+- Modify after codegen: generated skill files if codegen refreshes them
+- Modify: `crates/cairn-core/src/verbs/lint/mod.rs`
+- Modify: `crates/cairn-core/src/verbs/lint/report.rs`
+- Test: `crates/cairn-core/src/verbs/lint/mod.rs`
+- Test: `crates/cairn-core/src/verbs/lint/report.rs`
+
+- [ ] **Step 1: Write failing lint projection tests**
+
+In `crates/cairn-core/src/verbs/lint/mod.rs`, add this test inside the existing `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn agent_worker_audit_report_projects_summary() {
+    use crate::domain::{
+        AgentCanaryState, AgentWorkerAuditSummary, AgentWorkerFailureMode,
+        AgentWorkerGroupSummary, AgentWorkerKind,
+    };
+
+    let mut failure_modes = std::collections::BTreeMap::new();
+    failure_modes.insert(AgentWorkerFailureMode::BudgetExceeded, 2);
+    let summary = AgentWorkerAuditSummary {
+        total_runs: 4,
+        completed_runs: 2,
+        failed_runs: 2,
+        generated_candidates: 10,
+        accepted_candidates: 5,
+        acceptance_rate: Some(0.5),
+        turns: 8,
+        tool_calls: 12,
+        cost_units: 200,
+        failure_modes,
+        workers: vec![AgentWorkerGroupSummary {
+            worker_kind: AgentWorkerKind::Extractor,
+            worker_name: "agent_extractor".to_owned(),
+            canary_label: Some("canary-05".to_owned()),
+            total_runs: 4,
+            accepted_candidates: 5,
+            generated_candidates: 10,
+        }],
+    };
+
+    let report = agent_worker_audit_report(&summary, Some(AgentCanaryState::Canary));
+
+    assert!(report.observed_records);
+    assert_eq!(report.rollout_state.as_deref(), Some("canary"));
+    assert_eq!(report.total_runs, 4);
+    assert_eq!(report.accepted_candidates, 5);
+    assert_eq!(report.acceptance_rate, Some(0.5));
+    assert_eq!(report.failure_modes["budget_exceeded"], serde_json::json!(2));
+    assert_eq!(report.workers.len(), 1);
+}
+```
+
+In `crates/cairn-core/src/verbs/lint/report.rs`, add this test:
+
+```rust
+#[test]
+fn agent_worker_audit_section_renders_without_body_text() {
+    let data = LintData {
+        findings: vec![],
+        summary: empty_summary(),
+        report_path: None,
+        agent_worker_audit: Some(crate::generated::verbs::lint::AgentWorkerAuditReport {
+            observed_records: true,
+            rollout_state: Some("canary".to_owned()),
+            total_runs: 4,
+            completed_runs: 2,
+            failed_runs: 2,
+            generated_candidates: 10,
+            accepted_candidates: 5,
+            acceptance_rate: Some(0.5),
+            turns: 8,
+            tool_calls: 12,
+            cost_units: 200,
+            failure_modes: serde_json::json!({"budget_exceeded": 2}),
+            workers: Vec::new(),
+        }),
+    };
+
+    let rendered = render(&data);
+
+    assert!(rendered.contains("## Agent worker audit"));
+    assert!(rendered.contains("- state: canary"));
+    assert!(rendered.contains("- accepted candidates: 5 / 10"));
+    assert!(rendered.contains("- failures: budget_exceeded=2"));
+    assert!(!rendered.contains("prompt"));
+    assert!(!rendered.contains("candidate body"));
+}
+```
+
+- [ ] **Step 2: Run lint tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p cairn-core agent_worker_audit --lib
+```
+
+Expected: FAIL with missing generated type or field errors for `AgentWorkerAuditReport` and `LintData.agent_worker_audit`.
+
+- [ ] **Step 3: Update lint IDL schema**
+
+Modify `crates/cairn-idl/schema/verbs/lint.json`.
+
+Add these definitions under `$defs` after `Target`:
+
+```json
+"AgentWorkerAuditWorker": {
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["worker_kind", "worker_name", "total_runs", "generated_candidates", "accepted_candidates"],
+  "properties": {
+    "worker_kind": {
+      "type": "string",
+      "enum": ["extractor", "dream"]
+    },
+    "worker_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "canary_label": {
+      "type": "string",
+      "minLength": 1
+    },
+    "total_runs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "generated_candidates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "accepted_candidates": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+},
+"AgentWorkerAuditReport": {
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "observed_records",
+    "total_runs",
+    "completed_runs",
+    "failed_runs",
+    "generated_candidates",
+    "accepted_candidates",
+    "turns",
+    "tool_calls",
+    "cost_units",
+    "failure_modes",
+    "workers"
+  ],
+  "properties": {
+    "observed_records": {
+      "type": "boolean"
+    },
+    "rollout_state": {
+      "type": "string",
+      "enum": ["paused", "canary", "enabled", "rolled_back"]
+    },
+    "total_runs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "completed_runs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed_runs": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "generated_candidates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "accepted_candidates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "acceptance_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "turns": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "tool_calls": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cost_units": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failure_modes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "workers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/AgentWorkerAuditWorker"
+      }
+    }
+  }
+}
+```
+
+Add this optional field to `$defs.Data.properties`:
+
+```json
+"agent_worker_audit": {
+  "$ref": "#/$defs/AgentWorkerAuditReport"
+}
+```
+
+- [ ] **Step 4: Regenerate IDL artifacts**
+
+Run:
+
+```bash
+cargo run -p cairn-idl --bin cairn-codegen --locked
+```
+
+Expected: command exits 0 and rewrites generated artifacts. Inspect generated `crates/cairn-core/src/generated/verbs/lint.rs`; it should include `AgentWorkerAuditReport`, `AgentWorkerAuditWorker`, and `LintData { agent_worker_audit: Option<AgentWorkerAuditReport>, ... }`.
+
+- [ ] **Step 5: Implement lint projection helper and default no-data report**
+
+In `crates/cairn-core/src/verbs/lint/mod.rs`, add imports:
+
+```rust
+use crate::domain::{AgentCanaryState, AgentWorkerAuditSummary};
+```
+
+In `run_checks`, build the no-data report:
+
+```rust
+let agent_worker_audit = agent_worker_audit_report(
+    &AgentWorkerAuditSummary::from_records(&[]),
+    None,
+);
+LintData {
+    findings,
+    summary,
+    report_path: None,
+    agent_worker_audit: Some(agent_worker_audit),
+}
+```
+
+Add this public helper near `kind_key`:
+
+```rust
+/// Project a core agent-worker summary into the generated lint DTO.
+#[must_use]
+pub fn agent_worker_audit_report(
+    summary: &AgentWorkerAuditSummary,
+    rollout_state: Option<AgentCanaryState>,
+) -> crate::generated::verbs::lint::AgentWorkerAuditReport {
+    let mut failure_modes = serde_json::Map::new();
+    for (mode, count) in &summary.failure_modes {
+        failure_modes.insert(mode.as_str().to_owned(), serde_json::json!(count));
+    }
+    crate::generated::verbs::lint::AgentWorkerAuditReport {
+        observed_records: !summary.is_empty(),
+        rollout_state: rollout_state.map(|state| state.as_str().to_owned()),
+        total_runs: summary.total_runs,
+        completed_runs: summary.completed_runs,
+        failed_runs: summary.failed_runs,
+        generated_candidates: summary.generated_candidates,
+        accepted_candidates: summary.accepted_candidates,
+        acceptance_rate: summary.acceptance_rate,
+        turns: summary.turns,
+        tool_calls: summary.tool_calls,
+        cost_units: summary.cost_units,
+        failure_modes: serde_json::Value::Object(failure_modes),
+        workers: summary
+            .workers
+            .iter()
+            .map(|worker| crate::generated::verbs::lint::AgentWorkerAuditWorker {
+                worker_kind: match worker.worker_kind {
+                    crate::domain::AgentWorkerKind::Extractor => "extractor".to_owned(),
+                    crate::domain::AgentWorkerKind::Dream => "dream".to_owned(),
+                },
+                worker_name: worker.worker_name.clone(),
+                canary_label: worker.canary_label.clone(),
+                total_runs: worker.total_runs,
+                generated_candidates: worker.generated_candidates,
+                accepted_candidates: worker.accepted_candidates,
+            })
+            .collect(),
+    }
+}
+```
+
+Update all direct `LintData { ... }` initializers in `crates/cairn-core/src/verbs/lint/report.rs` and `crates/cairn-cli/src/verbs/lint.rs` to include:
+
+```rust
+agent_worker_audit: None,
+```
+
+- [ ] **Step 6: Render markdown agent audit section**
+
+In `crates/cairn-core/src/verbs/lint/report.rs`, after the severity summary and before the coverage section, add:
+
+```rust
+if let Some(agent) = &data.agent_worker_audit {
+    out.push_str("## Agent worker audit\n\n");
+    if !agent.observed_records {
+        out.push_str("- no agent-worker audit records observed\n\n");
+    } else {
+        let state = agent.rollout_state.as_deref().unwrap_or("unconfigured");
+        let _ = writeln!(out, "- state: {state}");
+        let _ = writeln!(out, "- runs: {}", agent.total_runs);
+        let _ = writeln!(
+            out,
+            "- accepted candidates: {} / {}",
+            agent.accepted_candidates, agent.generated_candidates
+        );
+        let _ = writeln!(out, "- cost units: {}", agent.cost_units);
+        let _ = writeln!(out, "- tool calls: {}", agent.tool_calls);
+        let failures = render_failure_modes(&agent.failure_modes);
+        let _ = writeln!(out, "- failures: {failures}");
+        out.push('\n');
+    }
+}
+```
+
+Add helper:
+
+```rust
+fn render_failure_modes(value: &serde_json::Value) -> String {
+    let Some(map) = value.as_object() else {
+        return "none".to_owned();
+    };
+    if map.is_empty() {
+        return "none".to_owned();
+    }
+    map.iter()
+        .filter_map(|(key, value)| value.as_u64().map(|count| format!("{key}={count}")))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+```
+
+- [ ] **Step 7: Run lint tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p cairn-core agent_worker_audit --lib
+cargo test -p cairn-core verbs::lint::report --lib
+```
+
+Expected: PASS. Snapshot tests may create `.snap.new`; inspect them and accept intentional markdown changes with:
+
+```bash
+cargo insta accept -p cairn-core
+```
+
+- [ ] **Step 8: Verify generated artifacts are clean**
+
+Run:
+
+```bash
+cargo run -p cairn-idl --bin cairn-codegen --locked -- --check
+```
+
+Expected: PASS with `cairn-codegen: clean`.
+
+- [ ] **Step 9: Commit Task 3**
+
+Run:
+
+```bash
+git add crates/cairn-idl/schema/verbs/lint.json crates/cairn-core/src/generated crates/cairn-mcp/src/generated skills/cairn crates/cairn-core/src/verbs/lint/mod.rs crates/cairn-core/src/verbs/lint/report.rs crates/cairn-cli/src/verbs/lint.rs
+git commit -m "feat(lint): report agent worker audit metrics"
+```
+
+## Task 4: Evaluation Report Projection
+
+**Files:**
+- Modify: `crates/cairn-workflows/src/evaluation/handler.rs`
+- Test: `crates/cairn-workflows/src/evaluation/handler.rs`
+
+- [ ] **Step 1: Write failing evaluation tests**
+
+In `crates/cairn-workflows/src/evaluation/handler.rs`, add this test in the existing `#[cfg(test)] mod tests`:
+
+```rust
+#[tokio::test]
+async fn evaluation_report_includes_agent_worker_audit_summary() {
+    use cairn_core::contract::agent_provider::AgentBudgetConsumed;
+    use cairn_core::domain::{
+        AgentWorkerAuditRecord, AgentWorkerFailureMode, AgentWorkerKind, AgentWorkerStatus,
+        ScopeTuple,
+    };
+
+    let store: Arc<dyn MemoryStore> = Arc::new(NoopMemoryStore::default());
+    let sink = metrics();
+    let audit_records = vec![AgentWorkerAuditRecord {
+        operation_id: "op-agent-1".to_owned(),
+        worker_kind: AgentWorkerKind::Dream,
+        worker_name: "agent_dream".to_owned(),
+        agent_identity: "agt:cairn-dream:v1".to_owned(),
+        scope: Some(ScopeTuple {
+            tenant: Some("tenant-a".to_owned()),
+            agent: Some("agt:cairn-dream:v1".to_owned()),
+            ..ScopeTuple::default()
+        }),
+        status: AgentWorkerStatus::Aborted,
+        generated_candidates: 2,
+        accepted_candidates: 1,
+        budget_consumed: AgentBudgetConsumed {
+            turns: 1,
+            tool_calls: 2,
+            cost_units: 99,
+        },
+        failure_mode: Some(AgentWorkerFailureMode::ProviderUnavailable),
+        canary_label: Some("canary-05".to_owned()),
+    }];
+    let h = EvaluationHandler::new(
+        store,
+        sink.clone() as Arc<dyn MetricsSink>,
+        default_checks(),
+        EvaluationConfig {
+            enabled: true,
+            write_report_record: false,
+            ..EvaluationConfig::default()
+        },
+    )
+    .with_agent_worker_audit(audit_records);
+    let payload = EvaluationPayload {
+        ts_ms: 1_700_000_000_000,
+        check_ids: vec![],
+        bound_scope: None,
+    };
+
+    let report = h.run_once(&payload).await.expect("run_once");
+
+    assert_eq!(report.agent_worker_audit.total_runs, 1);
+    assert_eq!(report.agent_worker_audit.accepted_candidates, 1);
+    assert_eq!(report.agent_worker_audit.cost_units, 99);
+    assert_eq!(
+        report
+            .agent_worker_audit
+            .failure_modes
+            .get(&AgentWorkerFailureMode::ProviderUnavailable),
+        Some(&1)
+    );
+}
+```
+
+- [ ] **Step 2: Run evaluation test to verify RED**
+
+Run:
+
+```bash
+cargo test -p cairn-workflows evaluation_report_includes_agent_worker_audit_summary
+```
+
+Expected: FAIL because `EvaluationHandler::with_agent_worker_audit` and `EvaluationReport.agent_worker_audit` do not exist.
+
+- [ ] **Step 3: Add handler audit storage and report field**
+
+In `crates/cairn-workflows/src/evaluation/handler.rs`, update imports:
+
+```rust
+use cairn_core::domain::{
+    AgentWorkerAuditRecord, AgentWorkerAuditSummary, ScopeTuple,
+    metrics::MetricEvent,
+    taxonomy::{MemoryClass, MemoryKind},
+};
+```
+
+Add to `EvaluationReport`:
+
+```rust
+/// Body-free aggregate for agent-mode worker audit records observed by this sweep.
+pub agent_worker_audit: AgentWorkerAuditSummary,
+```
+
+Add to `EvaluationHandler`:
+
+```rust
+agent_worker_audit: Vec<AgentWorkerAuditRecord>,
+```
+
+In `EvaluationHandler::new`, initialize:
+
+```rust
+agent_worker_audit: Vec::new(),
+```
+
+Add builder:
+
+```rust
+/// Attach body-free agent-worker audit records for this handler instance.
+#[must_use]
+pub fn with_agent_worker_audit(mut self, records: Vec<AgentWorkerAuditRecord>) -> Self {
+    self.agent_worker_audit = records;
+    self
+}
+```
+
+In `run_once`, compute after sorting findings:
+
+```rust
+let agent_worker_audit = AgentWorkerAuditSummary::from_records(&self.agent_worker_audit);
+```
+
+Pass `&agent_worker_audit` to `report_target_key` and `upsert_report_record`, and include it in the returned report:
+
+```rust
+Ok(EvaluationReport {
+    checks_run,
+    passed,
+    failed,
+    report_target_id: Some(report_target_id),
+    agent_worker_audit,
+})
+```
+
+- [ ] **Step 4: Make evaluation target keys include audit state**
+
+Change the signature:
+
+```rust
+fn report_target_key(
+    payload: &EvaluationPayload,
+    findings: &[(String, CheckOutcome)],
+    agent_worker_audit: &AgentWorkerAuditSummary,
+) -> String
+```
+
+Before computing `outcome_hash`, append the audit summary JSON into `outcome_basis`:
+
+```rust
+let audit_basis = serde_json::to_string(agent_worker_audit)
+    .unwrap_or_else(|_| "agent_worker_audit_unserializable".to_owned());
+let outcome_basis = format!("{outcome_basis}|agent_worker_audit={audit_basis}");
+let outcome_hash = crate::synthetic::sha256_hex(outcome_basis.as_bytes());
+```
+
+Update the call site:
+
+```rust
+let target_key = Self::report_target_key(payload, &findings, &agent_worker_audit);
+```
+
+- [ ] **Step 5: Render evaluation report audit section**
+
+Change `upsert_report_record` signature:
+
+```rust
+async fn upsert_report_record(
+    &self,
+    payload: &EvaluationPayload,
+    findings: &[(String, CheckOutcome)],
+    target_key: &str,
+    agent_worker_audit: &AgentWorkerAuditSummary,
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>>
+```
+
+After rendering check findings, add:
+
+```rust
+body.push_str("\n## Agent worker audit\n\n");
+if agent_worker_audit.is_empty() {
+    body.push_str("- no agent-worker audit records observed\n");
+} else {
+    body.push_str("- runs: ");
+    body.push_str(&agent_worker_audit.total_runs.to_string());
+    body.push('\n');
+    body.push_str("- accepted candidates: ");
+    body.push_str(&agent_worker_audit.accepted_candidates.to_string());
+    body.push_str(" / ");
+    body.push_str(&agent_worker_audit.generated_candidates.to_string());
+    body.push('\n');
+    body.push_str("- cost units: ");
+    body.push_str(&agent_worker_audit.cost_units.to_string());
+    body.push('\n');
+    body.push_str("- tool calls: ");
+    body.push_str(&agent_worker_audit.tool_calls.to_string());
+    body.push('\n');
+}
+```
+
+Add audit summary to `extras`:
+
+```rust
+"agent_worker_audit": agent_worker_audit,
+```
+
+inside the existing `"evaluation"` JSON object.
+
+Update `upsert_report_record` call:
+
+```rust
+self.upsert_report_record(payload, &findings, &target_key, &agent_worker_audit)
+    .await?
+```
+
+- [ ] **Step 6: Update existing evaluation report construction assertions**
+
+Existing tests that assert `EvaluationReport` fields can continue to use direct field access. No literal `EvaluationReport { ... }` initializers exist outside the handler return path, so no other compile updates are expected.
+
+- [ ] **Step 7: Run evaluation tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p cairn-workflows evaluation_report_includes_agent_worker_audit_summary
+cargo test -p cairn-workflows evaluation --lib
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 4**
+
+Run:
+
+```bash
+git add crates/cairn-workflows/src/evaluation/handler.rs
+git commit -m "feat(workflows): include agent audit in evaluation reports"
+```
+
+## Task 5: Focused Verification And Drift Checks
+
+**Files:**
+- No new files.
+- Verify all files changed by Tasks 1 through 4.
+
+- [ ] **Step 1: Run focused core tests**
+
+Run:
+
+```bash
+cargo test -p cairn-core domain::agent_audit --lib
+cargo test -p cairn-core domain::agent_canary --lib
+cargo test -p cairn-core agent_worker_audit --lib
+cargo test -p cairn-core verbs::lint::report --lib
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 2: Run workflow tests**
+
+Run:
+
+```bash
+cargo test -p cairn-workflows evaluation --lib
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify generated IDL artifacts**
+
+Run:
+
+```bash
+cargo run -p cairn-idl --bin cairn-codegen --locked -- --check
+```
+
+Expected: PASS with `cairn-codegen: clean`.
+
+- [ ] **Step 4: Verify core boundary**
+
+Run:
+
+```bash
+./scripts/check-core-boundary.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run formatting**
+
+Run:
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: PASS. If formatting fails, run `cargo fmt --all`, inspect the diff, then rerun `cargo fmt --all --check`.
+
+- [ ] **Step 6: Run compile check for touched crates**
+
+Run:
+
+```bash
+cargo check -p cairn-core -p cairn-workflows -p cairn-cli -p cairn-mcp --all-targets --locked
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit verification-only generated or snapshot changes**
+
+If Step 5 formatting or intentional snapshot acceptance changed files, commit them:
+
+```bash
+git add crates/cairn-core crates/cairn-workflows crates/cairn-cli crates/cairn-mcp crates/cairn-idl skills/cairn
+git commit -m "test: update agent audit report snapshots"
+```
+
+Skip this commit when there are no files to commit.
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Audit record identity, scope, cost, tool call, candidate, acceptance, and failure fields are covered by Task 1.
+  - Canary pause, cohort dispatch, metric rollback, explicit rollback, and promotion are covered by Task 2.
+  - Lint JSON and markdown report projection are covered by Task 3.
+  - Evaluation report projection is covered by Task 4.
+  - Verification commands are covered by Task 5.
+- Placeholder scan:
+  - The plan contains no unresolved marker text or omitted code blocks.
+- Type consistency:
+  - `AgentWorkerAuditSummary` is the single aggregate type shared by lint and evaluation.
+  - `AgentCanaryState::as_str()` supplies the generated lint `rollout_state` string.
+  - `AgentWorkerFailureMode::as_str()` supplies stable JSON keys for report maps.

--- a/docs/superpowers/specs/2026-05-23-issue-126-agent-worker-audit-canary-design.md
+++ b/docs/superpowers/specs/2026-05-23-issue-126-agent-worker-audit-canary-design.md
@@ -1,0 +1,291 @@
+# Agent Worker Audit And Canary Controls Design - Issue #126
+
+**Date:** 2026-05-23
+**Issue:** [#126 - Add agent worker audit, cost, and canary controls](https://github.com/windoliver/cairn/issues/126)
+**Brief sections:** section 11.3 Constraint gates; section 15 Evaluation
+**Related sections:** section 4 AgentProvider; section 5.2.a AgentExtractor; section 10.2 DreamWorker
+**Status:** Approved direction, pending written-spec review
+
+---
+
+## 1. Scope
+
+Implement issue #126 as the control and reporting layer that sits above the
+AgentProvider contract from issue #124 and the agent-mode extractor/dream
+workers from issue #125.
+
+This PR adds:
+
+- A body-free agent-worker audit model that records per-worker cost, tool calls,
+  generated candidates, accepted candidates, acceptance rate, failure modes,
+  identity, and scope.
+- Pure aggregation helpers that summarize multiple agent-worker audit records
+  for operator-facing reports.
+- Canary rollout controls that can keep agent-mode workers paused, enable them
+  for a bounded canary percentage, promote them to enabled, or roll them back
+  when audit-derived thresholds fail.
+- Lint and evaluation report data that exposes agent-mode cost and benefit
+  without leaking record bodies or tool output bodies.
+- Tests covering audit metrics, canary pause/rollback behavior, and report
+  projection.
+
+Out of scope:
+
+- Production rollout automation, schedulers, remote control planes, or
+  fleet-wide deployment automation.
+- New external agent runtime adapters.
+- Changing how the AgentProvider executes tools or models.
+- Broadening agent-mode worker enablement beyond the already configured
+  extractor/dream worker paths.
+
+## 2. Current Context
+
+Issue #124 has already established the pure AgentProvider spawn contract in
+`cairn-core::contract::agent_provider`. That contract records run status,
+typed abort errors, budget consumed, attempted tool calls, and policy trace.
+
+Issue #125 is closed and has unblocked issue #126. The remaining gap is not
+whether a single agent run can be constrained; it is whether operators can see
+the cost and benefit of agent-mode workers over time and whether agent mode can
+be paused or rolled back before it becomes broadly active.
+
+The design should preserve the current AgentProvider result shape instead of
+adding issue-specific reporting fields directly to `AgentRun`. `AgentRun`
+remains the per-spawn contract artifact. Issue #126 adds host-owned audit and
+rollout projections over those runs.
+
+## 3. Architecture
+
+Keep this work in deterministic, pure layers first.
+
+| Layer | Location | Responsibility |
+|---|---|---|
+| Audit model | `cairn-core::domain::agent_audit` | Body-free event and aggregate types for agent-worker outcomes. |
+| Canary model | `cairn-core::domain::agent_canary` | Pure rollout state, threshold evaluation, pause, promote, and rollback decisions. |
+| Agent run mapping | `cairn-core::domain::agent_audit` | Convert AgentProvider run facts plus worker metadata into audit records. |
+| Lint projection | `cairn-core::verbs::lint` and CLI lint report rendering | Include agent audit summary in JSON and markdown report data. |
+| Evaluation projection | `cairn-workflows::evaluation` | Include agent audit summary in deterministic evaluation reports. |
+
+The first implementation should not require a database migration. Existing
+report paths can consume in-memory audit records in tests. Persistent metrics
+or workflow event wiring belongs to production automation follow-up work.
+
+## 4. Audit Record Shape
+
+An agent-worker audit record represents one logical worker invocation, not an
+entire deployment window.
+
+Required fields:
+
+- `operation_id`: stable operation or workflow id for correlation.
+- `worker_kind`: `extractor` or `dream`.
+- `worker_name`: stable worker label, such as `agent_extractor` or
+  `agent_dream`.
+- `agent_identity`: the `agt:` identity used by the worker.
+- `scope`: tenant, workspace, user, and agent dimensions available to the
+  caller, represented with the existing body-free scope shape where possible.
+- `status`: completed, rejected, aborted, or rolled back.
+- `generated_candidates`: number of candidates produced by the worker.
+- `accepted_candidates`: number of candidates accepted by the host pipeline.
+- `budget_consumed`: turns, tool calls, and cost units.
+- `failure_mode`: optional typed failure mode for failed runs.
+- `canary_label`: optional rollout cohort label used for canary accounting.
+
+The model must not include:
+
+- Raw prompt text.
+- Raw record body text.
+- Tool output bodies.
+- Generated candidate bodies.
+
+Candidate counts are sufficient for issue #126. Quality and body-level review
+belong to existing evidence, flush-plan, and evaluation fixtures.
+
+## 5. Aggregate Metrics
+
+The aggregate view computes operator-facing cost and benefit.
+
+Per worker and per canary cohort, report:
+
+- total runs
+- completed runs
+- rejected or aborted runs
+- generated candidates
+- accepted candidates
+- acceptance rate
+- turns consumed
+- tool calls consumed
+- cost units consumed
+- failure mode counts
+
+Acceptance rate is:
+
+```text
+accepted_candidates / generated_candidates
+```
+
+When `generated_candidates == 0`, the aggregate reports `None` instead of `0`.
+That avoids implying poor quality when the worker never had an opportunity to
+produce candidates.
+
+Failure modes should stay typed and compact. Initial values should map cleanly
+from `AgentProviderError` and host outcomes:
+
+- `budget_exceeded`
+- `wall_clock_exceeded`
+- `tool_not_allowed`
+- `mutating_verb_not_scoped`
+- `invalid_output`
+- `provider_unavailable`
+- `host_rejected_candidates`
+- `unknown`
+
+## 6. Canary Controls
+
+Canary control is a pure state machine used by hosts before dispatching an
+agent-mode worker and after summarizing its audit records.
+
+States:
+
+- `paused`: do not dispatch agent-mode workers.
+- `canary`: dispatch only for a bounded percentage or explicit cohort.
+- `enabled`: dispatch for all configured eligible traffic.
+- `rolled_back`: do not dispatch until an operator explicitly resets the state.
+
+Inputs:
+
+- `rollout_percent`: integer 0 through 100.
+- `min_runs`: minimum completed or failed runs before judging the canary.
+- `min_acceptance_rate`: optional minimum acceptance rate.
+- `max_failure_rate`: optional maximum failed-run ratio.
+- `max_cost_units_per_accepted_candidate`: optional cost ceiling.
+- `pause_requested`: explicit operator pause.
+- `rollback_requested`: explicit operator rollback.
+
+Decisions:
+
+- `paused` and `rolled_back` always deny dispatch.
+- `canary` allows dispatch only when the candidate is in cohort.
+- `enabled` allows dispatch for all eligible agent-mode traffic.
+- Explicit rollback wins over all metric decisions.
+- Explicit pause wins over metric promotion.
+- A canary with insufficient runs remains in canary.
+- A canary that violates any threshold rolls back with a compact reason.
+- A canary that satisfies every configured threshold may promote to enabled.
+
+The state machine should be deterministic and side-effect free. Persistence and
+automatic scheduling are future production automation.
+
+## 7. Report Surfaces
+
+Lint reports should expose the audit aggregate so local operators can answer:
+
+- How much did agent mode cost?
+- How many tool calls did it use?
+- How many candidates did it generate?
+- How many were accepted?
+- What failure modes occurred?
+- Is agent mode paused, canarying, enabled, or rolled back?
+
+Evaluation reports should expose the same aggregate because brief section 15
+requires every new workflow, adapter, or contract behavior to ship with
+evaluation. Evaluation output should use deterministic, body-free data so it is
+safe for CI snapshots and local operator review.
+
+The JSON shape should favor stable machine-readable fields. Markdown rendering
+can be concise, for example:
+
+```text
+## Agent worker audit
+
+- state: canary
+- runs: 10
+- accepted candidates: 7 / 12
+- cost units: 850
+- tool calls: 18
+- failures: budget_exceeded=1, provider_unavailable=1
+```
+
+If no agent audit data exists, reports should state that no agent-worker audit
+records were observed rather than treating that as success or failure.
+
+## 8. Identity And Scope
+
+Audit records must preserve both identity and scope:
+
+- The worker identity must remain an `agt:` identity.
+- Scope must be body-free and suitable for report rendering.
+- Scope must be included even on rejected and aborted runs.
+- Canary cohort labels must not replace identity or scope; they are an
+  additional rollout dimension.
+
+This keeps issue #126 aligned with the acceptance criterion that audit records
+preserve identity and scope.
+
+## 9. Error Handling
+
+Audit construction should be infallible where possible. Invalid identities,
+invalid canary percentages, and impossible thresholds should be rejected when
+building the policy configuration.
+
+Report rendering should not fail because audit data is empty. Empty input
+returns an empty aggregate with `acceptance_rate = None`.
+
+Canary evaluation should return a typed decision that includes a short reason:
+
+- `dispatch_allowed`
+- `dispatch_denied_paused`
+- `dispatch_denied_rolled_back`
+- `dispatch_denied_outside_canary`
+- `remain_canary_insufficient_data`
+- `promote_to_enabled`
+- `rollback_threshold_failed`
+
+Reasons must be safe to include in lint and evaluation reports.
+
+## 10. Testing
+
+The implementation should use test-first coverage at the smallest layer that
+captures each behavior.
+
+Core audit tests:
+
+- Aggregates cost, tool calls, generated candidates, accepted candidates, and
+  failure modes per worker.
+- Computes acceptance rate when generated candidates are nonzero.
+- Reports no acceptance rate when no candidates were generated.
+- Preserves agent identity and scope for completed and aborted runs.
+
+Core canary tests:
+
+- Paused rollout denies dispatch.
+- Rolled-back rollout denies dispatch.
+- Canary rollout denies traffic outside the cohort.
+- Canary rollout remains in canary before `min_runs`.
+- Canary rollout rolls back when failure rate exceeds threshold.
+- Canary rollout promotes when all thresholds pass.
+- Explicit rollback wins over promotion.
+
+Report tests:
+
+- Lint JSON includes the agent audit summary.
+- Lint markdown renders the agent audit summary without record bodies.
+- Evaluation report includes the agent audit summary.
+- Empty audit input renders an explicit no-data state.
+
+## 11. Non-Goals And Follow-Ups
+
+This issue should not add production rollout automation. A P3 task can
+persist canary state, schedule canary windows, integrate with a remote control
+plane, and connect rollback to fleet deployment workflows.
+
+This issue also should not add a new agent runtime. It should consume the
+existing AgentProvider run data and host-level candidate acceptance outcomes.
+
+Future work can add:
+
+- Persistent metrics rows for agent-worker audit records.
+- CLI operator commands for viewing and changing canary state.
+- SRE dashboard panels over the same aggregate.
+- Workflow automation that flips canary state after a configured observation
+  window.


### PR DESCRIPTION
## Summary
- Add the agent worker audit aggregate and canary rollout state model in core.
- Surface audit and canary status through lint reports, generated schemas, and workflow evaluation output.
- Project persisted evaluation audit details into the CLI lint path, including per-worker metrics and failure modes.

Closes #126.

## Validation
- `cargo test -p cairn-core agent_ --lib`
- `cargo test -p cairn-core verbs::lint::report --lib`
- `cargo test -p cairn-cli lint_handler_projects_persisted_agent_worker_audit --lib --locked`
- `cargo test -p cairn-cli --all-targets --locked`
- `cargo test -p cairn-workflows evaluation --lib`
- `cargo test -p cairn-workflows audit_state_changes_persisted_outcome_hash --test evaluation`
- `cargo fmt --all --check`
- `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check`
- `./scripts/check-core-boundary.sh`
- `cargo clippy -p cairn-core --lib --locked -- -D warnings`
- `cargo clippy -p cairn-workflows --all-targets --locked -- -D warnings`
- `cargo clippy -p cairn-cli --lib --locked -- -D warnings`
- `cargo check -p cairn-core -p cairn-workflows -p cairn-cli -p cairn-mcp --all-targets --locked`
- `git diff --check`
- Binary smoke: `cairn bootstrap`, `cairn handshake`, and `cairn lint --json` on a temp vault.