### PR TITLE
[codex] Fix source-forget receipt parsing

### DIFF
--- a/crates/cairn-cli/tests/openclaw_import.rs
+++ b/crates/cairn-cli/tests/openclaw_import.rs
@@ -173,6 +173,13 @@ fn openclaw_import_plan_applies_to_search_retrieve_lint_and_forget() {
         hit_record_ids(vault.path(), "quartz").is_empty(),
         "forgotten import should leave keyword search"
     );
+
+    let lint_after_forget_out = run_in_vault(vault.path(), &["lint", "--json"]);
+    let lint_after_forget = json_output(&lint_after_forget_out, &["lint", "--json"]);
+    assert_eq!(
+        lint_after_forget["data"]["summary"]["by_severity"]["error"], 0,
+        "forgetting OpenClaw imports should not leave malformed source_forget rows: {lint_after_forget}"
+    );
 }
 
 #[test]

--- a/crates/cairn-store-sqlite/src/consent.rs
+++ b/crates/cairn-store-sqlite/src/consent.rs
@@ -264,6 +264,7 @@ fn parse_source_forget_row(
         .map_or_else(|| subject.unwrap_or_default(), ToOwned::to_owned);
     let source_bytes_hash = payload
         .get("source_bytes_hash")
+        .or_else(|| payload.get("target_id_hash"))
         .and_then(serde_json::Value::as_str)
         .map(ToOwned::to_owned);
 

--- a/crates/cairn-store-sqlite/tests/consent_reader.rs
+++ b/crates/cairn-store-sqlite/tests/consent_reader.rs
@@ -102,3 +102,40 @@ fn snapshot_reader_parses_source_forget_rows_and_surfaces_malformed_versions() {
                 ))
     );
 }
+
+#[test]
+fn snapshot_reader_accepts_source_forget_intent_receipt_payloads() {
+    let conn = Connection::open_in_memory().expect("open");
+    conn.execute_batch(
+        "CREATE TABLE consent_journal (
+            rowid INTEGER PRIMARY KEY,
+            kind TEXT NOT NULL,
+            op_id TEXT,
+            subject TEXT NOT NULL,
+            payload_json TEXT
+        );",
+    )
+    .expect("schema");
+    conn.execute(
+        "INSERT INTO consent_journal (kind, op_id, subject, payload_json)
+         VALUES (?1, ?2, ?3, ?4)",
+        (
+            "source_forget",
+            "forget-op-receipt",
+            "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            r#"{"shape":"intent_receipt","target_id_hash":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","scope_tier":"private","reason_code":"record_forget"}"#,
+        ),
+    )
+    .expect("insert valid");
+
+    let reader = SqliteConsentJournalReader::from_connection(&conn).expect("snapshot");
+    let source_forgets = reader.forgotten_source_forgets();
+
+    assert_eq!(source_forgets.len(), 1);
+    assert_eq!(source_forgets[0].op_id, "forget-op-receipt");
+    assert_eq!(
+        source_forgets[0].source_bytes_hash,
+        "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    );
+    assert!(reader.malformed_source_forget_rows().is_empty());
+}


### PR DESCRIPTION
## Summary
- rebase on current main and drop the now-upstream OpenClaw bridge commit
- parse current source_forget IntentReceipt payloads via target_id_hash as source-byte hashes
- add store and OpenClaw e2e regression coverage for post-forget lint

Closes #151

## Verification
- cargo fmt --check
- cargo test -p cairn-cli --test openclaw_import
- cargo test -p cairn-store-sqlite --test consent_reader
- cargo run -p cairn-cli --bin cairn-docgen -- --check
- cargo clippy -p cairn-cli --tests -- -D warnings
- git diff --check origin/main...HEAD