### PR TITLE
[codex] Implement evolution workflow state machine

### DIFF
--- a/crates/cairn-cli/src/command.rs
+++ b/crates/cairn-cli/src/command.rs
@@ -635,6 +635,18 @@ fn admin_workflow_subcommand() -> clap::Command {
                         .help("Polling deadline before reporting a timeout (default: 15)"),
                 ),
         )
+        .subcommand(
+            clap::Command::new("run-evolution")
+                .about("Run one evolution workflow payload and materialize its audit files")
+                .arg(
+                    clap::Arg::new("payload")
+                        .long("payload")
+                        .required(true)
+                        .value_name("PATH")
+                        .value_parser(clap::value_parser!(std::path::PathBuf))
+                        .help("Path to an EvolutionPayload JSON file"),
+                ),
+        )
         .subcommand(clap::Command::new("recover").about(
             "Boot Scheduler with worker_count=0 so the startup reap runs once; \
                      reports how many leased rows were reclaimed.",

--- a/crates/cairn-cli/src/main.rs
+++ b/crates/cairn-cli/src/main.rs
@@ -991,6 +991,7 @@ fn run_admin(matches: &ArgMatches, explicit_vault: Option<&str>) -> ExitCode {
         Some(("workflow", sub)) => match sub.subcommand() {
             Some(("run-failing", s)) => verbs::admin_workflow::run_failing(s, &vault_root),
             Some(("run-succeeding", s)) => verbs::admin_workflow::run_succeeding(s, &vault_root),
+            Some(("run-evolution", s)) => verbs::admin_workflow::run_evolution(s, &vault_root),
             Some(("simulate-crash", s)) => verbs::admin_workflow::simulate_crash(s, &vault_root),
             Some(("recover", s)) => verbs::admin_workflow::recover(s, &vault_root),
             _ => unreachable!(

--- a/crates/cairn-cli/src/mcp.rs
+++ b/crates/cairn-cli/src/mcp.rs
@@ -16,8 +16,8 @@ use cairn_core::mcp_auth::{ConfigBackedScope, McpSessionScope};
 use cairn_workflows::scheduler::HandlerRegistryBuilder;
 use cairn_workflows::{
     ConsolidationForgetCleanupHandler, ConsolidationHandler, DreamHandler, EvaluationHandler,
-    ExpirationHandler, Scheduler, SchedulerConfig, SkillifyHandler, SqliteJobStore, SystemClock,
-    default_golden_checks,
+    EvolutionHandler, ExpirationHandler, Scheduler, SchedulerConfig, SkillifyHandler,
+    SqliteJobStore, SystemClock, default_golden_checks,
 };
 
 /// Outcome of resolving the `[mcp.stdio]` block into runtime components.
@@ -244,6 +244,7 @@ pub fn run(
                     default_golden_checks(),
                     config.evaluation.clone(),
                 );
+                let evolution_handler = EvolutionHandler::new(vault_root.to_path_buf());
 
                 let registry = HandlerRegistryBuilder::default()
                     .with(Arc::new(consolidation_handler))
@@ -252,6 +253,7 @@ pub fn run(
                     .with(Arc::new(skillify_handler))
                     .with(Arc::new(expiration_handler))
                     .with(Arc::new(evaluation_handler))
+                    .with(Arc::new(evolution_handler))
                     .build();
 
                 // Start the scheduler. `Scheduler::start` spawns tokio tasks

--- a/crates/cairn-cli/src/verbs/admin_workflow.rs
+++ b/crates/cairn-cli/src/verbs/admin_workflow.rs
@@ -31,7 +31,7 @@
 //! row. The `JsonlMetricsSink` wiring matches `cairn mcp`.
 //! Hidden from default `--help`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
@@ -41,9 +41,11 @@ use cairn_core::contract::job_store::{
 };
 use cairn_core::contract::metrics::{MetricsSink, NoopMetricsSink};
 use cairn_core::domain::metrics::MetricEvent;
-use cairn_workflows::SqliteJobStore;
 use cairn_workflows::scheduler::{
     Clock, ReaperConfig, Scheduler, SchedulerConfig, SystemClock, WorkerConfig,
+};
+use cairn_workflows::{
+    EvolutionHandler, EvolutionPayload, MaterializedEvolutionDecision, SqliteJobStore,
 };
 use clap::ArgMatches;
 use rusqlite::Connection;
@@ -940,6 +942,61 @@ pub fn run_succeeding(sub: &ArgMatches, vault_root: &Path) -> ExitCode {
         println!("job_id={job_id_str}");
         ExitCode::SUCCESS
     })
+}
+
+/// `cairn admin workflow run-evolution` — decode one `EvolutionPayload`
+/// JSON file, run the workflow handler, and report the terminal decision.
+#[must_use]
+pub fn run_evolution(sub: &ArgMatches, vault_root: &Path) -> ExitCode {
+    let Some(payload_path) = sub.get_one::<PathBuf>("payload") else {
+        eprintln!("cairn admin workflow run-evolution: missing --payload");
+        return ExitCode::from(64);
+    };
+
+    let bytes = match std::fs::read(payload_path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            eprintln!(
+                "cairn admin workflow run-evolution: read {}: {e}",
+                payload_path.display()
+            );
+            return ExitCode::from(69);
+        }
+    };
+    let payload: EvolutionPayload = match serde_json::from_slice(&bytes) {
+        Ok(payload) => payload,
+        Err(e) => {
+            eprintln!(
+                "cairn admin workflow run-evolution: parse {}: {e}",
+                payload_path.display()
+            );
+            return ExitCode::from(69);
+        }
+    };
+    let proposal_id = payload.proposal_id.clone();
+
+    let handler = EvolutionHandler::new(vault_root.to_path_buf());
+    match handler.run_once(payload) {
+        Ok(decision) => {
+            println!(
+                "evolution: proposal_id={proposal_id} decision={}",
+                materialized_evolution_decision(decision)
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("cairn admin workflow run-evolution: {e}");
+            ExitCode::from(69)
+        }
+    }
+}
+
+fn materialized_evolution_decision(decision: MaterializedEvolutionDecision) -> &'static str {
+    match decision {
+        MaterializedEvolutionDecision::Promoted => "promoted",
+        MaterializedEvolutionDecision::RolledBack => "rolled_back",
+        MaterializedEvolutionDecision::Rejected => "rejected",
+    }
 }
 
 #[cfg(test)]

--- a/crates/cairn-cli/tests/admin_workflow_evolution_cli.rs
+++ b/crates/cairn-cli/tests/admin_workflow_evolution_cli.rs
@@ -1,0 +1,153 @@
+//! CLI E2E coverage for `cairn admin workflow run-evolution`.
+//!
+//! This drives the real `cairn` binary against a bootstrapped vault and
+//! verifies the evolution workflow's persisted audit files, not just the
+//! in-process handler.
+
+use assert_cmd::Command;
+use serde_json::json;
+use std::path::Path;
+
+fn bootstrap_vault(vault: &Path) {
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: vault.to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+}
+
+fn artifact(version: u32, digest_byte: char) -> serde_json::Value {
+    json!({
+        "kind": "skill",
+        "artifact_id": "skill:deploy-hotfix",
+        "version": version,
+        "content_sha256": format!(
+            "sha256:{}",
+            std::iter::repeat_n(digest_byte, 64).collect::<String>()
+        )
+    })
+}
+
+fn gate(kind: &str, status: &str, evidence: &str) -> serde_json::Value {
+    json!({
+        "kind": kind,
+        "status": status,
+        "evidence_refs": [evidence]
+    })
+}
+
+fn passing_payload(proposal_id: &str) -> serde_json::Value {
+    json!({
+        "proposal_id": proposal_id,
+        "previous_artifact": artifact(3, 'a'),
+        "candidate_artifact": artifact(4, 'b'),
+        "rollback_plan": {
+            "plan_id": "rollback:deploy-hotfix:v4",
+            "restores_artifact": artifact(3, 'a'),
+            "evidence_refs": ["eval:rollback-dry-run"]
+        },
+        "gates": [
+            gate("eval", "passed", "eval:main"),
+            gate("privacy", "passed", "privacy:trace"),
+            gate("version", "passed", "version:compat"),
+            gate("rollback_plan", "passed", "rollback:dry-run"),
+            gate("canary", "passed", "canary:24h-pass")
+        ],
+        "canary_ref": "canary:24h-pass",
+        "reviewer": "hmn:reviewer:v1",
+        "decision_ref": "decision:approve"
+    })
+}
+
+fn run_evolution(vault: &Path, payload_path: &Path) -> std::process::Output {
+    Command::cargo_bin("cairn")
+        .expect("cairn binary")
+        .env("CAIRN_VAULT", vault)
+        .env_remove("CAIRN_REGISTRY")
+        .args([
+            "admin",
+            "workflow",
+            "run-evolution",
+            "--payload",
+            payload_path.to_str().expect("payload path utf-8"),
+        ])
+        .output()
+        .expect("run cli")
+}
+
+#[test]
+fn run_evolution_promotes_and_rolls_back_from_cli_payloads() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    bootstrap_vault(temp.path());
+
+    let promote_path = temp.path().join("promote.json");
+    std::fs::write(
+        &promote_path,
+        serde_json::to_vec_pretty(&passing_payload("evo_cli_promote")).expect("payload json"),
+    )
+    .expect("write promote payload");
+
+    let promote = run_evolution(temp.path(), &promote_path);
+    assert!(
+        promote.status.success(),
+        "stdout: {} stderr: {}",
+        String::from_utf8_lossy(&promote.stdout),
+        String::from_utf8_lossy(&promote.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&promote.stdout).contains("decision=promoted"),
+        "stdout should report promoted decision: {}",
+        String::from_utf8_lossy(&promote.stdout)
+    );
+
+    let promote_root = temp.path().join(".cairn/evolution/evolve/evo_cli_promote");
+    let lineage: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(promote_root.join("lineage.json")).expect("lineage"))
+            .expect("lineage json");
+    assert_eq!(lineage["previous_artifact"]["version"], 3);
+    assert_eq!(lineage["promoted_artifact"]["version"], 4);
+    assert_eq!(
+        lineage["eval_result_refs"],
+        json!(["eval:main", "canary:24h-pass"])
+    );
+
+    let rollback_path = temp.path().join("rollback.json");
+    let mut rollback_payload = passing_payload("evo_cli_rollback");
+    rollback_payload["gates"] = json!([
+        gate("eval", "passed", "eval:main"),
+        gate("privacy", "passed", "privacy:trace"),
+        gate("version", "passed", "version:compat"),
+        gate("rollback_plan", "passed", "rollback:dry-run")
+    ]);
+    rollback_payload["canary_ref"] = json!("canary:5pct");
+    rollback_payload["canary_failure_ref"] = json!("slo:latency-regression");
+    std::fs::write(
+        &rollback_path,
+        serde_json::to_vec_pretty(&rollback_payload).expect("payload json"),
+    )
+    .expect("write rollback payload");
+
+    let rollback = run_evolution(temp.path(), &rollback_path);
+    assert!(
+        rollback.status.success(),
+        "stdout: {} stderr: {}",
+        String::from_utf8_lossy(&rollback.stdout),
+        String::from_utf8_lossy(&rollback.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&rollback.stdout).contains("decision=rolled_back"),
+        "stdout should report rolled_back decision: {}",
+        String::from_utf8_lossy(&rollback.stdout)
+    );
+
+    let rollback_root = temp.path().join(".cairn/evolution/evolve/evo_cli_rollback");
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(rollback_root.join("state.json")).expect("state"))
+            .expect("state json");
+    assert_eq!(state["state"], "rolled_back");
+    assert_eq!(state["active_artifact"]["version"], 3);
+    assert_eq!(
+        state["decision_evidence"],
+        json!(["canary:5pct", "slo:latency-regression"])
+    );
+}

--- a/crates/cairn-cli/tests/admin_workflow_evolution_cli.rs
+++ b/crates/cairn-cli/tests/admin_workflow_evolution_cli.rs
@@ -5,8 +5,12 @@
 //! in-process handler.
 
 use assert_cmd::Command;
+use cairn_core::contract::job_store::{EnqueueRequest, JobId, JobKind, JobStore, RetryPolicy};
+use cairn_workflows::{EVOLUTION_KIND, SqliteJobStore};
 use serde_json::json;
 use std::path::Path;
+use std::process::{Command as ProcessCommand, Stdio};
+use std::time::{Duration, Instant};
 
 fn bootstrap_vault(vault: &Path) {
     cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
@@ -14,6 +18,18 @@ fn bootstrap_vault(vault: &Path) {
         force: false,
     })
     .expect("bootstrap vault");
+}
+
+fn enable_mcp_single_tenant(vault: &Path) {
+    let config_path = vault.join(".cairn/config.yaml");
+    let mut cfg = std::fs::read_to_string(&config_path).expect("read config");
+    if let Some(idx) = cfg.find("\nmcp:") {
+        cfg.truncate(idx);
+    }
+    cfg.push_str(
+        "\nmcp:\n  stdio:\n    single_tenant: true\n    principal:\n      tenant: evolution-e2e\n",
+    );
+    std::fs::write(&config_path, cfg).expect("write config");
 }
 
 fn artifact(version: u32, digest_byte: char) -> serde_json::Value {
@@ -73,6 +89,68 @@ fn run_evolution(vault: &Path, payload_path: &Path) -> std::process::Output {
         ])
         .output()
         .expect("run cli")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcp_scheduler_drains_queued_evolution_job() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    bootstrap_vault(temp.path());
+    enable_mcp_single_tenant(temp.path());
+
+    let db_path = temp.path().join(".cairn/cairn.db");
+    let jobs_conn = cairn_store_sqlite::open_sync(&db_path).expect("open jobs db");
+    let jobs = SqliteJobStore::new(jobs_conn).expect("jobs");
+    jobs.enqueue(EnqueueRequest {
+        job_id: JobId::new("evo-cli-mcp-scheduler"),
+        kind: JobKind::new(EVOLUTION_KIND),
+        payload: serde_json::to_vec(&passing_payload("evo_cli_mcp_scheduler"))
+            .expect("payload json"),
+        queue_key: None,
+        dedupe_key: None,
+        not_before_ms: 0,
+        retry: RetryPolicy::DEFAULT,
+    })
+    .await
+    .expect("enqueue evolution job");
+
+    let mut child = ProcessCommand::new(env!("CARGO_BIN_EXE_cairn"))
+        .arg("--vault")
+        .arg(temp.path())
+        .arg("mcp")
+        .env_remove("CAIRN_VAULT")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn cairn mcp");
+    let child_stdin = child.stdin.take().expect("stdin pipe");
+
+    let state_path = temp
+        .path()
+        .join(".cairn/evolution/evolve/evo_cli_mcp_scheduler/state.json");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline && !state_path.exists() {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    drop(child_stdin);
+    let shutdown_deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < shutdown_deadline {
+        match child.try_wait() {
+            Ok(None) => tokio::time::sleep(Duration::from_millis(50)).await,
+            Ok(Some(_)) | Err(_) => break,
+        }
+    }
+    if child.try_wait().expect("try wait").is_none() {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("cairn mcp did not exit after stdin EOF");
+    }
+
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&state_path).expect("state materialized"))
+            .expect("state json");
+    assert_eq!(state["state"], "promoted");
 }
 
 #[test]

--- a/crates/cairn-core/src/pipeline/evolution.rs
+++ b/crates/cairn-core/src/pipeline/evolution.rs
@@ -149,6 +149,18 @@ impl EvolutionGateReport {
             }
         }
 
+        for gate in &self.gates {
+            if Self::REQUIRED_FOR_PROMOTION.contains(&gate.kind) {
+                continue;
+            }
+            if matches!(
+                gate.status,
+                EvolutionGateStatus::Failed | EvolutionGateStatus::Blocked
+            ) {
+                failed.push(gate.kind);
+            }
+        }
+
         (missing, failed)
     }
 

--- a/crates/cairn-core/src/pipeline/evolution.rs
+++ b/crates/cairn-core/src/pipeline/evolution.rs
@@ -1,0 +1,497 @@
+//! Evolution workflow primitives (brief §11 and §11.3).
+//!
+//! This module is pure data plus state-transition validation. Workflow and
+//! store crates own I/O, durable job dispatch, and side-effect application.
+
+use serde::{Deserialize, Serialize};
+
+/// Evolvable artifact classes from brief §11.1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum EvolutionArtifactKind {
+    /// `skills/<skill>.md`.
+    Skill,
+    /// Tool registry metadata / descriptions.
+    ToolDescription,
+    /// System prompt fragments.
+    Prompt,
+    /// Classifiers or routing rules.
+    Classifier,
+    /// Pipeline configuration files.
+    PipelineConfig,
+}
+
+/// Versioned artifact reference carried through proposal lineage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvolutionArtifactRef {
+    /// Artifact class.
+    pub kind: EvolutionArtifactKind,
+    /// Stable artifact id.
+    pub artifact_id: String,
+    /// Monotonic artifact version.
+    pub version: u32,
+    /// Content digest of the referenced version.
+    pub content_sha256: String,
+}
+
+/// Rollback plan required before a candidate may be promoted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RollbackPlan {
+    /// Stable rollback plan id.
+    pub plan_id: String,
+    /// Artifact restored when the candidate is abandoned.
+    pub restores_artifact: EvolutionArtifactRef,
+    /// Evidence proving rollback was planned or dry-run.
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+}
+
+/// Required and optional promotion gates for evolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum EvolutionGateKind {
+    /// Evaluation result gate.
+    Eval,
+    /// Privacy and consent gate.
+    Privacy,
+    /// Version compatibility gate.
+    Version,
+    /// Rollback plan gate.
+    RollbackPlan,
+    /// Canary rollout gate.
+    Canary,
+    /// Human or autonomous review gate.
+    Review,
+    /// Held-out adversarial dataset gate.
+    HeldOutAdversarial,
+    /// Shared-tier consent gate.
+    SharedTier,
+}
+
+/// Status for one evolution gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvolutionGateStatus {
+    /// Gate passed.
+    Passed,
+    /// Gate failed.
+    Failed,
+    /// Gate could not run because another gate blocked it.
+    Blocked,
+    /// Gate was intentionally skipped for this contract phase.
+    Skipped,
+}
+
+/// One gate result and its supporting evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvolutionGateResult {
+    /// Gate kind.
+    pub kind: EvolutionGateKind,
+    /// Gate status.
+    pub status: EvolutionGateStatus,
+    /// Optional operator-facing detail.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Evidence references supporting this gate result.
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+}
+
+/// Gate report for one proposal.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvolutionGateReport {
+    /// Gate results.
+    #[serde(default)]
+    pub gates: Vec<EvolutionGateResult>,
+}
+
+impl EvolutionGateReport {
+    /// Gate subset #127 requires before promotion.
+    pub const REQUIRED_FOR_PROMOTION: &'static [EvolutionGateKind] = &[
+        EvolutionGateKind::Eval,
+        EvolutionGateKind::Privacy,
+        EvolutionGateKind::Version,
+        EvolutionGateKind::RollbackPlan,
+        EvolutionGateKind::Canary,
+    ];
+
+    /// Add or replace a gate result by kind.
+    pub fn record(&mut self, gate: EvolutionGateResult) {
+        if let Some(existing) = self
+            .gates
+            .iter_mut()
+            .find(|existing| existing.kind == gate.kind)
+        {
+            *existing = gate;
+        } else {
+            self.gates.push(gate);
+        }
+        self.gates.sort_by_key(|gate| gate.kind);
+    }
+
+    /// Promotion blockers split into missing and present-but-not-passing gates.
+    #[must_use]
+    pub fn promotion_blockers(&self) -> (Vec<EvolutionGateKind>, Vec<EvolutionGateKind>) {
+        let mut missing = Vec::new();
+        let mut failed = Vec::new();
+
+        for required in Self::REQUIRED_FOR_PROMOTION {
+            match self.gates.iter().find(|gate| gate.kind == *required) {
+                Some(gate) if gate.status == EvolutionGateStatus::Passed => {}
+                Some(_) => failed.push(*required),
+                None => missing.push(*required),
+            }
+        }
+
+        (missing, failed)
+    }
+
+    /// Returns true when every configured promotion gate passed.
+    #[must_use]
+    pub fn ready_for_promotion(&self) -> bool {
+        let (missing, failed) = self.promotion_blockers();
+        missing.is_empty() && failed.is_empty()
+    }
+
+    fn evidence_for(&self, kinds: &[EvolutionGateKind]) -> Vec<String> {
+        let mut evidence = Vec::new();
+        for gate in &self.gates {
+            if kinds.contains(&gate.kind) {
+                evidence.extend(gate.evidence_refs.iter().cloned());
+            }
+        }
+        evidence
+    }
+}
+
+/// Evolution workflow lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvolutionState {
+    /// Proposal has been staged but not evaluated.
+    Proposed,
+    /// Proposal is being evaluated.
+    Evaluating,
+    /// Candidate is live only in a canary window.
+    Canarying,
+    /// Candidate was promoted.
+    Promoted,
+    /// Candidate failed canary or apply and was rolled back.
+    RolledBack,
+    /// Candidate failed pre-canary gates.
+    Rejected,
+}
+
+/// Durable lineage for an evolution proposal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvolutionLineage {
+    /// Stable proposal id.
+    pub proposal_id: String,
+    /// Artifact version before the proposal.
+    pub previous_artifact: EvolutionArtifactRef,
+    /// Proposed artifact version.
+    pub proposed_artifact: EvolutionArtifactRef,
+    /// Eval and canary result evidence.
+    #[serde(default)]
+    pub eval_result_refs: Vec<String>,
+    /// Promoted artifact, if promotion happened.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub promoted_artifact: Option<EvolutionArtifactRef>,
+    /// Decision references such as approval, rejection, or rollback evidence.
+    #[serde(default)]
+    pub decision_evidence: Vec<String>,
+}
+
+/// In-memory evolution state machine for one proposal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvolutionRun {
+    proposal_id: String,
+    previous_artifact: EvolutionArtifactRef,
+    candidate_artifact: EvolutionArtifactRef,
+    rollback_plan: RollbackPlan,
+    gate_report: EvolutionGateReport,
+    state: EvolutionState,
+    active_artifact: EvolutionArtifactRef,
+    promoted_artifact: Option<EvolutionArtifactRef>,
+    decision_evidence: Vec<String>,
+}
+
+impl EvolutionRun {
+    /// Create a staged proposal.
+    ///
+    /// # Errors
+    /// Returns when required identity fields are empty, the candidate is not
+    /// a new version of the same artifact, or the rollback plan restores a
+    /// different previous artifact.
+    pub fn new(
+        proposal_id: impl Into<String>,
+        previous_artifact: EvolutionArtifactRef,
+        candidate_artifact: EvolutionArtifactRef,
+        rollback_plan: RollbackPlan,
+    ) -> Result<Self, EvolutionTransitionError> {
+        let proposal_id = proposal_id.into();
+        validate_not_empty("proposal_id", &proposal_id)?;
+        validate_artifact_ref(&previous_artifact)?;
+        validate_artifact_ref(&candidate_artifact)?;
+        validate_not_empty("rollback_plan.plan_id", &rollback_plan.plan_id)?;
+        if previous_artifact.kind != candidate_artifact.kind
+            || previous_artifact.artifact_id != candidate_artifact.artifact_id
+        {
+            return Err(EvolutionTransitionError::InvalidProposal {
+                field: "candidate_artifact".to_owned(),
+                reason: "candidate must evolve the same artifact id and kind".to_owned(),
+            });
+        }
+        if candidate_artifact.version <= previous_artifact.version {
+            return Err(EvolutionTransitionError::InvalidProposal {
+                field: "candidate_artifact.version".to_owned(),
+                reason: "candidate version must be greater than previous version".to_owned(),
+            });
+        }
+        if rollback_plan.restores_artifact != previous_artifact {
+            return Err(EvolutionTransitionError::InvalidProposal {
+                field: "rollback_plan.restores_artifact".to_owned(),
+                reason: "rollback plan must restore the previous artifact".to_owned(),
+            });
+        }
+
+        Ok(Self {
+            proposal_id,
+            active_artifact: previous_artifact.clone(),
+            previous_artifact,
+            candidate_artifact,
+            rollback_plan,
+            gate_report: EvolutionGateReport::default(),
+            state: EvolutionState::Proposed,
+            promoted_artifact: None,
+            decision_evidence: Vec::new(),
+        })
+    }
+
+    /// Current state.
+    #[must_use]
+    pub const fn state(&self) -> EvolutionState {
+        self.state
+    }
+
+    /// Artifact currently visible to non-canary traffic.
+    #[must_use]
+    pub const fn active_artifact(&self) -> &EvolutionArtifactRef {
+        &self.active_artifact
+    }
+
+    /// Decision evidence accumulated by transitions.
+    #[must_use]
+    pub fn decision_evidence(&self) -> &[String] {
+        &self.decision_evidence
+    }
+
+    /// Gate report accumulated so far.
+    #[must_use]
+    pub const fn gate_report(&self) -> &EvolutionGateReport {
+        &self.gate_report
+    }
+
+    /// Rollback plan for this proposal.
+    #[must_use]
+    pub const fn rollback_plan(&self) -> &RollbackPlan {
+        &self.rollback_plan
+    }
+
+    /// Promoted artifact, if any.
+    #[must_use]
+    pub const fn promoted_artifact(&self) -> Option<&EvolutionArtifactRef> {
+        self.promoted_artifact.as_ref()
+    }
+
+    /// Proposal id.
+    #[must_use]
+    pub fn proposal_id(&self) -> &str {
+        &self.proposal_id
+    }
+
+    /// Add or replace one gate result.
+    pub fn record_gate(&mut self, gate: EvolutionGateResult) {
+        self.gate_report.record(gate);
+    }
+
+    /// Add or replace all gate results from `report`.
+    pub fn extend_gates(&mut self, report: EvolutionGateReport) {
+        for gate in report.gates {
+            self.record_gate(gate);
+        }
+    }
+
+    /// Return missing and failed promotion gates.
+    #[must_use]
+    pub fn promotion_blockers(&self) -> (Vec<EvolutionGateKind>, Vec<EvolutionGateKind>) {
+        self.gate_report.promotion_blockers()
+    }
+
+    /// Start the canary window.
+    ///
+    /// # Errors
+    /// Returns if the run is already terminal.
+    pub fn start_canary(&mut self, evidence_ref: &str) -> Result<(), EvolutionTransitionError> {
+        self.ensure_not_terminal(EvolutionState::Canarying)?;
+        validate_not_empty("canary evidence", evidence_ref)?;
+        self.state = EvolutionState::Canarying;
+        push_unique(&mut self.decision_evidence, evidence_ref);
+        Ok(())
+    }
+
+    /// Roll back after a canary failure.
+    ///
+    /// # Errors
+    /// Returns if the run is not currently canarying or evidence is empty.
+    pub fn fail_canary(&mut self, evidence_ref: &str) -> Result<(), EvolutionTransitionError> {
+        if self.state != EvolutionState::Canarying {
+            return Err(EvolutionTransitionError::InvalidTransition {
+                from: self.state,
+                to: EvolutionState::RolledBack,
+            });
+        }
+        validate_not_empty("canary failure evidence", evidence_ref)?;
+        self.state = EvolutionState::RolledBack;
+        self.active_artifact = self.rollback_plan.restores_artifact.clone();
+        self.promoted_artifact = None;
+        push_unique(&mut self.decision_evidence, evidence_ref);
+        Ok(())
+    }
+
+    /// Reject a proposal before promotion.
+    ///
+    /// # Errors
+    /// Returns if the run is already terminal or evidence is empty.
+    pub fn reject(&mut self, evidence_ref: &str) -> Result<(), EvolutionTransitionError> {
+        self.ensure_not_terminal(EvolutionState::Rejected)?;
+        validate_not_empty("rejection evidence", evidence_ref)?;
+        self.state = EvolutionState::Rejected;
+        self.active_artifact = self.rollback_plan.restores_artifact.clone();
+        self.promoted_artifact = None;
+        push_unique(&mut self.decision_evidence, evidence_ref);
+        Ok(())
+    }
+
+    /// Promote the candidate artifact.
+    ///
+    /// # Errors
+    /// Returns if configured gates are missing or failed, if this run is
+    /// terminal, or if decision evidence is empty.
+    pub fn promote(
+        &mut self,
+        reviewer: &str,
+        decision_ref: &str,
+    ) -> Result<(), EvolutionTransitionError> {
+        self.ensure_not_terminal(EvolutionState::Promoted)?;
+        validate_not_empty("reviewer", reviewer)?;
+        validate_not_empty("decision evidence", decision_ref)?;
+        let (missing, failed) = self.gate_report.promotion_blockers();
+        if !missing.is_empty() || !failed.is_empty() {
+            return Err(EvolutionTransitionError::PromotionBlocked { missing, failed });
+        }
+
+        for evidence_ref in self.gate_report.evidence_for(&[EvolutionGateKind::Canary]) {
+            push_unique(&mut self.decision_evidence, &evidence_ref);
+        }
+        push_unique(&mut self.decision_evidence, decision_ref);
+        self.state = EvolutionState::Promoted;
+        self.active_artifact = self.candidate_artifact.clone();
+        self.promoted_artifact = Some(self.candidate_artifact.clone());
+        Ok(())
+    }
+
+    /// Build durable lineage for persistence.
+    #[must_use]
+    pub fn lineage(&self) -> EvolutionLineage {
+        EvolutionLineage {
+            proposal_id: self.proposal_id.clone(),
+            previous_artifact: self.previous_artifact.clone(),
+            proposed_artifact: self.candidate_artifact.clone(),
+            eval_result_refs: self
+                .gate_report
+                .evidence_for(&[EvolutionGateKind::Eval, EvolutionGateKind::Canary]),
+            promoted_artifact: self.promoted_artifact.clone(),
+            decision_evidence: self.decision_evidence.clone(),
+        }
+    }
+
+    fn ensure_not_terminal(&self, to: EvolutionState) -> Result<(), EvolutionTransitionError> {
+        if matches!(
+            self.state,
+            EvolutionState::Promoted | EvolutionState::RolledBack | EvolutionState::Rejected
+        ) {
+            return Err(EvolutionTransitionError::InvalidTransition {
+                from: self.state,
+                to,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Transition or validation error for one evolution run.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum EvolutionTransitionError {
+    /// Proposal data was malformed.
+    #[error("invalid evolution proposal field `{field}`: {reason}")]
+    InvalidProposal {
+        /// Field name.
+        field: String,
+        /// Rejection reason.
+        reason: String,
+    },
+    /// Promotion gates are not satisfied.
+    #[error("evolution promotion blocked: missing={missing:?} failed={failed:?}")]
+    PromotionBlocked {
+        /// Required gates with no result.
+        missing: Vec<EvolutionGateKind>,
+        /// Required gates with a non-passing result.
+        failed: Vec<EvolutionGateKind>,
+    },
+    /// State transition is not legal.
+    #[error("invalid evolution transition {from:?} -> {to:?}")]
+    InvalidTransition {
+        /// Current state.
+        from: EvolutionState,
+        /// Requested state.
+        to: EvolutionState,
+    },
+}
+
+fn validate_artifact_ref(artifact: &EvolutionArtifactRef) -> Result<(), EvolutionTransitionError> {
+    validate_not_empty("artifact_id", &artifact.artifact_id)?;
+    validate_not_empty("content_sha256", &artifact.content_sha256)?;
+    if !artifact.content_sha256.starts_with("sha256:") {
+        return Err(EvolutionTransitionError::InvalidProposal {
+            field: "content_sha256".to_owned(),
+            reason: "digest must start with sha256:".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_not_empty(field: &'static str, value: &str) -> Result<(), EvolutionTransitionError> {
+    if value.trim().is_empty() {
+        Err(EvolutionTransitionError::InvalidProposal {
+            field: field.to_owned(),
+            reason: "must not be empty".to_owned(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn push_unique(target: &mut Vec<String>, value: &str) {
+    if !target.iter().any(|existing| existing == value) {
+        target.push(value.to_owned());
+    }
+}

--- a/crates/cairn-core/src/pipeline/mod.rs
+++ b/crates/cairn-core/src/pipeline/mod.rs
@@ -37,6 +37,7 @@ pub mod capture_trace;
 pub mod consolidation;
 pub mod dispatch;
 pub mod entity_resolve;
+pub mod evolution;
 pub mod expiration;
 pub mod explain;
 pub mod extract;

--- a/crates/cairn-core/src/wal/mod.rs
+++ b/crates/cairn-core/src/wal/mod.rs
@@ -25,5 +25,6 @@ pub use fsm::{
 pub use idempotency::{OperationId, OperationIdError, StepKey, StepLog, StepLogError};
 pub use recover::{MAX_STEP_ATTEMPTS, OpSnapshot, RecoveryDecision, StepRow, decide_recovery};
 pub use step_graph::{
-    EXPIRE_STEPS, FORGET_RECORD_STEPS, StepDef, StepGraph, UPSERT_STEPS, WalKind, graph_for,
+    EVOLVE_STEPS, EXPIRE_STEPS, FORGET_RECORD_STEPS, StepDef, StepGraph, UPSERT_STEPS, WalKind,
+    graph_for,
 };

--- a/crates/cairn-core/src/wal/step_graph.rs
+++ b/crates/cairn-core/src/wal/step_graph.rs
@@ -4,9 +4,9 @@
 //! `wal_steps.step_kind` and are wire-stable: renaming a step requires a
 //! schema migration to map old names forward.
 
-/// P0 mutation kinds whose step graphs this module defines. Marked
-/// `#[non_exhaustive]` so `Promote`, `ForgetSession`, `Evolve`, and the
-/// graph kinds can be added later without breaking matchers.
+/// P0/P2 mutation kinds whose step graphs this module defines. Marked
+/// `#[non_exhaustive]` so `Promote`, `ForgetSession`, and the graph kinds can
+/// be added later without breaking matchers.
 ///
 /// The existing `lint_repair` kind (in
 /// `cairn-store-sqlite/src/wal/lint_repair.rs`) is intentionally not part
@@ -20,6 +20,8 @@ pub enum WalKind {
     ForgetRecord,
     /// `expire` — soft-expire (brief §5.6 row 5).
     Expire,
+    /// `evolve` — gated proposal/eval/canary promotion (brief §11.3).
+    Evolve,
 }
 
 impl WalKind {
@@ -30,6 +32,7 @@ impl WalKind {
             Self::Upsert => "upsert",
             Self::ForgetRecord => "forget_record",
             Self::Expire => "expire",
+            Self::Evolve => "evolve",
         }
     }
 }
@@ -203,6 +206,49 @@ const EXPIRE_GRAPH: StepGraph = StepGraph {
     steps: EXPIRE_STEPS,
 };
 
+/// Step graph for `evolve` — brief §5.6 row 6 and §11.3 canary rollout.
+///
+/// Rollback is handled by compensation against the staged proposal/canary
+/// steps. The final `artifact.promote` step is the linearization point for
+/// non-canary readers.
+pub const EVOLVE_STEPS: &[StepDef] = &[
+    StepDef {
+        ord: 0,
+        name: "proposal.stage",
+        idempotent: false,
+    },
+    StepDef {
+        ord: 1,
+        name: "eval.run",
+        idempotent: true,
+    },
+    StepDef {
+        ord: 2,
+        name: "gates.verify",
+        idempotent: true,
+    },
+    StepDef {
+        ord: 3,
+        name: "canary.start",
+        idempotent: true,
+    },
+    StepDef {
+        ord: 4,
+        name: "canary.observe",
+        idempotent: true,
+    },
+    StepDef {
+        ord: 5,
+        name: "artifact.promote",
+        idempotent: true,
+    },
+];
+
+const EVOLVE_GRAPH: StepGraph = StepGraph {
+    kind: WalKind::Evolve,
+    steps: EVOLVE_STEPS,
+};
+
 /// Resolves a [`WalKind`] to its static step graph.
 #[must_use]
 pub fn graph_for(kind: WalKind) -> &'static StepGraph {
@@ -210,6 +256,7 @@ pub fn graph_for(kind: WalKind) -> &'static StepGraph {
         WalKind::Upsert => &UPSERT_GRAPH,
         WalKind::ForgetRecord => &FORGET_RECORD_GRAPH,
         WalKind::Expire => &EXPIRE_GRAPH,
+        WalKind::Evolve => &EVOLVE_GRAPH,
     }
 }
 
@@ -219,7 +266,12 @@ mod tests {
 
     #[test]
     fn step_ords_match_slice_indices() {
-        for graph in [&UPSERT_GRAPH, &FORGET_RECORD_GRAPH, &EXPIRE_GRAPH] {
+        for graph in [
+            &UPSERT_GRAPH,
+            &FORGET_RECORD_GRAPH,
+            &EXPIRE_GRAPH,
+            &EVOLVE_GRAPH,
+        ] {
             for (idx, step) in graph.steps.iter().enumerate() {
                 assert_eq!(
                     step.ord as usize, idx,
@@ -232,7 +284,12 @@ mod tests {
 
     #[test]
     fn step_names_unique_within_graph() {
-        for graph in [&UPSERT_GRAPH, &FORGET_RECORD_GRAPH, &EXPIRE_GRAPH] {
+        for graph in [
+            &UPSERT_GRAPH,
+            &FORGET_RECORD_GRAPH,
+            &EXPIRE_GRAPH,
+            &EVOLVE_GRAPH,
+        ] {
             let mut seen: Vec<&str> = Vec::with_capacity(graph.steps.len());
             for step in graph.steps {
                 assert!(
@@ -251,6 +308,7 @@ mod tests {
         assert_eq!(graph_for(WalKind::Upsert).kind, WalKind::Upsert);
         assert_eq!(graph_for(WalKind::ForgetRecord).kind, WalKind::ForgetRecord);
         assert_eq!(graph_for(WalKind::Expire).kind, WalKind::Expire);
+        assert_eq!(graph_for(WalKind::Evolve).kind, WalKind::Evolve);
     }
 
     #[test]

--- a/crates/cairn-core/tests/evolution_state.rs
+++ b/crates/cairn-core/tests/evolution_state.rs
@@ -1,0 +1,169 @@
+#![allow(missing_docs)]
+
+use cairn_core::pipeline::evolution::{
+    EvolutionArtifactKind, EvolutionArtifactRef, EvolutionGateKind, EvolutionGateReport,
+    EvolutionGateResult, EvolutionGateStatus, EvolutionRun, EvolutionState,
+    EvolutionTransitionError, RollbackPlan,
+};
+use cairn_core::wal::{WalKind, graph_for};
+
+fn previous_skill() -> EvolutionArtifactRef {
+    EvolutionArtifactRef {
+        kind: EvolutionArtifactKind::Skill,
+        artifact_id: "skill:deploy-hotfix".to_owned(),
+        version: 3,
+        content_sha256: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            .to_owned(),
+    }
+}
+
+fn candidate_skill() -> EvolutionArtifactRef {
+    EvolutionArtifactRef {
+        kind: EvolutionArtifactKind::Skill,
+        artifact_id: "skill:deploy-hotfix".to_owned(),
+        version: 4,
+        content_sha256: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            .to_owned(),
+    }
+}
+
+fn rollback_plan() -> RollbackPlan {
+    RollbackPlan {
+        plan_id: "rollback:deploy-hotfix:v4".to_owned(),
+        restores_artifact: previous_skill(),
+        evidence_refs: vec!["eval:rollback-dry-run".to_owned()],
+    }
+}
+
+fn passing_gate(kind: EvolutionGateKind, evidence: &str) -> EvolutionGateResult {
+    EvolutionGateResult {
+        kind,
+        status: EvolutionGateStatus::Passed,
+        message: None,
+        evidence_refs: vec![evidence.to_owned()],
+    }
+}
+
+#[test]
+fn promotion_requires_eval_privacy_version_and_rollback_gates() {
+    let mut run = EvolutionRun::new(
+        "evo_proposal_1",
+        previous_skill(),
+        candidate_skill(),
+        rollback_plan(),
+    )
+    .expect("valid run");
+
+    run.record_gate(passing_gate(EvolutionGateKind::Eval, "eval:main"));
+    run.record_gate(passing_gate(EvolutionGateKind::Privacy, "privacy:trace"));
+    run.record_gate(passing_gate(EvolutionGateKind::Version, "version:compat"));
+
+    let err = run
+        .promote("hmn:reviewer:v1", "decision:promote")
+        .expect_err("missing rollback and canary gates must block promotion");
+
+    match err {
+        EvolutionTransitionError::PromotionBlocked { missing, failed } => {
+            assert!(failed.is_empty());
+            assert!(missing.contains(&EvolutionGateKind::RollbackPlan));
+            assert!(missing.contains(&EvolutionGateKind::Canary));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+    assert_eq!(run.state(), EvolutionState::Proposed);
+}
+
+#[test]
+fn canary_failure_rolls_back_to_previous_artifact_and_records_evidence() {
+    let mut run = EvolutionRun::new(
+        "evo_proposal_2",
+        previous_skill(),
+        candidate_skill(),
+        rollback_plan(),
+    )
+    .expect("valid run");
+    run.record_gate(passing_gate(EvolutionGateKind::Eval, "eval:main"));
+    run.record_gate(passing_gate(EvolutionGateKind::Privacy, "privacy:trace"));
+    run.record_gate(passing_gate(EvolutionGateKind::Version, "version:compat"));
+    run.record_gate(passing_gate(
+        EvolutionGateKind::RollbackPlan,
+        "rollback:dry-run",
+    ));
+
+    run.start_canary("canary:5pct").expect("start canary");
+    run.fail_canary("slo:latency-regression")
+        .expect("rollback canary");
+
+    assert_eq!(run.state(), EvolutionState::RolledBack);
+    assert_eq!(run.active_artifact(), &previous_skill());
+    assert_eq!(
+        run.decision_evidence(),
+        &[
+            "canary:5pct".to_owned(),
+            "slo:latency-regression".to_owned()
+        ]
+    );
+}
+
+#[test]
+fn promoted_lineage_links_old_proposal_eval_and_promoted_artifacts() {
+    let mut run = EvolutionRun::new(
+        "evo_proposal_3",
+        previous_skill(),
+        candidate_skill(),
+        rollback_plan(),
+    )
+    .expect("valid run");
+    let report = EvolutionGateReport {
+        gates: vec![
+            passing_gate(EvolutionGateKind::Eval, "eval:main"),
+            passing_gate(EvolutionGateKind::Privacy, "privacy:trace"),
+            passing_gate(EvolutionGateKind::Version, "version:compat"),
+            passing_gate(EvolutionGateKind::RollbackPlan, "rollback:dry-run"),
+            passing_gate(EvolutionGateKind::Canary, "canary:24h-pass"),
+        ],
+    };
+    run.extend_gates(report);
+
+    run.promote("hmn:reviewer:v1", "decision:approve")
+        .expect("promote");
+    let lineage = run.lineage();
+
+    assert_eq!(lineage.previous_artifact, previous_skill());
+    assert_eq!(lineage.proposal_id, "evo_proposal_3");
+    assert_eq!(
+        lineage.eval_result_refs,
+        vec!["eval:main".to_owned(), "canary:24h-pass".to_owned()]
+    );
+    assert_eq!(lineage.promoted_artifact.as_ref(), Some(&candidate_skill()));
+    assert!(
+        lineage
+            .decision_evidence
+            .contains(&"decision:approve".to_owned())
+    );
+}
+
+#[test]
+fn evolve_wal_graph_has_gated_canary_promotion_steps() {
+    let graph = graph_for(WalKind::Evolve);
+    let names: Vec<&str> = graph.steps.iter().map(|step| step.name).collect();
+
+    assert_eq!(
+        names,
+        vec![
+            "proposal.stage",
+            "eval.run",
+            "gates.verify",
+            "canary.start",
+            "canary.observe",
+            "artifact.promote",
+        ]
+    );
+    assert!(
+        graph
+            .steps
+            .iter()
+            .all(|step| step.name == "proposal.stage" || step.idempotent),
+        "all retryable side-effect steps after proposal staging must be idempotent"
+    );
+}

--- a/crates/cairn-core/tests/evolution_state.rs
+++ b/crates/cairn-core/tests/evolution_state.rs
@@ -144,6 +144,46 @@ fn promoted_lineage_links_old_proposal_eval_and_promoted_artifacts() {
 }
 
 #[test]
+fn failed_configured_optional_gate_blocks_promotion() {
+    let mut run = EvolutionRun::new(
+        "evo_proposal_4",
+        previous_skill(),
+        candidate_skill(),
+        rollback_plan(),
+    )
+    .expect("valid run");
+    let report = EvolutionGateReport {
+        gates: vec![
+            passing_gate(EvolutionGateKind::Eval, "eval:main"),
+            passing_gate(EvolutionGateKind::Privacy, "privacy:trace"),
+            passing_gate(EvolutionGateKind::Version, "version:compat"),
+            passing_gate(EvolutionGateKind::RollbackPlan, "rollback:dry-run"),
+            passing_gate(EvolutionGateKind::Canary, "canary:24h-pass"),
+            EvolutionGateResult {
+                kind: EvolutionGateKind::Review,
+                status: EvolutionGateStatus::Failed,
+                message: Some("human review rejected the candidate".to_owned()),
+                evidence_refs: vec!["review:reject".to_owned()],
+            },
+        ],
+    };
+    run.extend_gates(report);
+
+    let err = run
+        .promote("hmn:reviewer:v1", "decision:approve")
+        .expect_err("failed configured review gate must block promotion");
+
+    match err {
+        EvolutionTransitionError::PromotionBlocked { missing, failed } => {
+            assert!(missing.is_empty());
+            assert_eq!(failed, vec![EvolutionGateKind::Review]);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+    assert_eq!(run.state(), EvolutionState::Proposed);
+}
+
+#[test]
 fn evolve_wal_graph_has_gated_canary_promotion_steps() {
     let graph = graph_for(WalKind::Evolve);
     let names: Vec<&str> = graph.steps.iter().map(|step| step.name).collect();

--- a/crates/cairn-workflows/src/evolution/handler.rs
+++ b/crates/cairn-workflows/src/evolution/handler.rs
@@ -1,0 +1,133 @@
+//! Scheduler handler for evolution proposal decisions.
+
+use std::path::PathBuf;
+
+use cairn_core::contract::job_store::{FailureClass, JobKind, JobPayload};
+use cairn_core::pipeline::evolution::{
+    EvolutionGateKind, EvolutionGateReport, EvolutionRun, EvolutionTransitionError,
+};
+
+use crate::scheduler::{HandlerOutcome, JobHandler};
+
+use super::materialize::{
+    EvolutionMaterializeError, MaterializedEvolutionDecision, materialize_run,
+};
+use super::payload::EvolutionPayload;
+
+/// The `JobKind` discriminator stored in `workflow_jobs.kind`.
+pub const EVOLUTION_KIND: &str = "evolution.evolve";
+
+/// File-backed evolution state-machine handler.
+pub struct EvolutionHandler {
+    vault_root: PathBuf,
+}
+
+/// Error from one decoded evolution handler run.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EvolutionRunError {
+    /// Core state transition rejected the payload.
+    #[error(transparent)]
+    Transition(#[from] EvolutionTransitionError),
+    /// Persistence failed.
+    #[error(transparent)]
+    Materialize(#[from] EvolutionMaterializeError),
+}
+
+impl EvolutionRunError {
+    fn is_permanent(&self) -> bool {
+        matches!(self, Self::Transition(_))
+            || matches!(
+                self,
+                Self::Materialize(
+                    EvolutionMaterializeError::InvalidProposalId { .. }
+                        | EvolutionMaterializeError::NonTerminal { .. }
+                        | EvolutionMaterializeError::Json(_)
+                )
+            )
+    }
+}
+
+impl EvolutionHandler {
+    /// Construct a handler rooted at a vault directory.
+    #[must_use]
+    pub const fn new(vault_root: PathBuf) -> Self {
+        Self { vault_root }
+    }
+
+    /// Run one decoded evolution proposal.
+    ///
+    /// # Errors
+    /// Returns when the payload violates the evolution state machine or the
+    /// terminal audit files cannot be written.
+    pub fn run_once(
+        &self,
+        payload: EvolutionPayload,
+    ) -> Result<MaterializedEvolutionDecision, EvolutionRunError> {
+        let mut run = EvolutionRun::new(
+            payload.proposal_id,
+            payload.previous_artifact,
+            payload.candidate_artifact,
+            payload.rollback_plan,
+        )?;
+        run.extend_gates(EvolutionGateReport {
+            gates: payload.gates,
+        });
+
+        let (missing, failed) = run.promotion_blockers();
+        let pre_canary_blocked = missing
+            .iter()
+            .chain(failed.iter())
+            .any(|gate| *gate != EvolutionGateKind::Canary);
+        if pre_canary_blocked {
+            run.reject(&payload.decision_ref)?;
+            return Ok(materialize_run(&self.vault_root, &run)?);
+        }
+
+        if let Some(canary_ref) = payload.canary_ref.as_deref() {
+            run.start_canary(canary_ref)?;
+        }
+        if let Some(failure_ref) = payload.canary_failure_ref.as_deref() {
+            run.fail_canary(failure_ref)?;
+            return Ok(materialize_run(&self.vault_root, &run)?);
+        }
+
+        let (missing, failed) = run.promotion_blockers();
+        if !missing.is_empty() || !failed.is_empty() {
+            run.reject(&payload.decision_ref)?;
+            return Ok(materialize_run(&self.vault_root, &run)?);
+        }
+
+        let reviewer = payload.reviewer.as_deref().unwrap_or("autonomous");
+        run.promote(reviewer, &payload.decision_ref)?;
+        Ok(materialize_run(&self.vault_root, &run)?)
+    }
+}
+
+#[async_trait::async_trait]
+impl JobHandler for EvolutionHandler {
+    fn kind(&self) -> JobKind {
+        JobKind::new(EVOLUTION_KIND)
+    }
+
+    async fn handle(&self, payload: &JobPayload) -> HandlerOutcome {
+        let payload = match EvolutionPayload::from_bytes(payload) {
+            Ok(payload) => payload,
+            Err(e) => {
+                return HandlerOutcome::Permanent {
+                    class: FailureClass::Validation,
+                    reason: format!("invalid evolution payload: {e}"),
+                };
+            }
+        };
+
+        match self.run_once(payload) {
+            Ok(_) => HandlerOutcome::Done,
+            Err(e) if e.is_permanent() => HandlerOutcome::Permanent {
+                class: FailureClass::Validation,
+                reason: e.to_string(),
+            },
+            Err(e) => HandlerOutcome::transient_retry(e.to_string()),
+        }
+    }
+}

--- a/crates/cairn-workflows/src/evolution/materialize.rs
+++ b/crates/cairn-workflows/src/evolution/materialize.rs
@@ -1,0 +1,126 @@
+//! File-backed audit materialization for `EvolutionWorkflow`.
+
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use cairn_core::pipeline::evolution::{EvolutionArtifactRef, EvolutionRun, EvolutionState};
+use serde::Serialize;
+
+/// Materialized terminal decision for one proposal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaterializedEvolutionDecision {
+    /// Candidate promoted.
+    Promoted,
+    /// Candidate rolled back after canary failure.
+    RolledBack,
+    /// Candidate rejected before promotion.
+    Rejected,
+}
+
+impl MaterializedEvolutionDecision {
+    /// Map an evolution state to its terminal materialized decision.
+    #[must_use]
+    pub const fn from_state(state: EvolutionState) -> Option<Self> {
+        match state {
+            EvolutionState::Promoted => Some(Self::Promoted),
+            EvolutionState::RolledBack => Some(Self::RolledBack),
+            EvolutionState::Rejected => Some(Self::Rejected),
+            EvolutionState::Proposed | EvolutionState::Evaluating | EvolutionState::Canarying => {
+                None
+            }
+        }
+    }
+}
+
+/// Persistence error for `.cairn/evolution/evolve`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EvolutionMaterializeError {
+    /// Proposal id cannot be safely used as a path segment.
+    #[error("invalid proposal id `{value}`")]
+    InvalidProposalId {
+        /// Rejected value.
+        value: String,
+    },
+    /// JSON serialization failed.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    /// Filesystem operation failed.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// Tried to persist a non-terminal state.
+    #[error("evolution state {state:?} is not terminal")]
+    NonTerminal {
+        /// State that was not terminal.
+        state: EvolutionState,
+    },
+}
+
+/// Persist the terminal state, gate report, rollback plan, and lineage.
+///
+/// # Errors
+/// Returns when the proposal id is unsafe, the state is non-terminal, or JSON
+/// or filesystem writes fail.
+pub fn materialize_run(
+    vault_root: &Path,
+    run: &EvolutionRun,
+) -> Result<MaterializedEvolutionDecision, EvolutionMaterializeError> {
+    let decision = MaterializedEvolutionDecision::from_state(run.state())
+        .ok_or(EvolutionMaterializeError::NonTerminal { state: run.state() })?;
+    validate_path_token(run.proposal_id())?;
+
+    let root = vault_root
+        .join(".cairn/evolution/evolve")
+        .join(run.proposal_id());
+    fs::create_dir_all(&root)?;
+
+    write_pretty(root.join("state.json"), &EvolutionStateSnapshot::from(run))?;
+    write_pretty(root.join("gate-report.json"), run.gate_report())?;
+    write_pretty(root.join("rollback-plan.json"), run.rollback_plan())?;
+    write_pretty(root.join("lineage.json"), &run.lineage())?;
+
+    Ok(decision)
+}
+
+#[derive(Serialize)]
+struct EvolutionStateSnapshot<'a> {
+    proposal_id: &'a str,
+    state: EvolutionState,
+    active_artifact: &'a EvolutionArtifactRef,
+    promoted_artifact: Option<&'a EvolutionArtifactRef>,
+    decision_evidence: &'a [String],
+}
+
+impl<'a> From<&'a EvolutionRun> for EvolutionStateSnapshot<'a> {
+    fn from(run: &'a EvolutionRun) -> Self {
+        Self {
+            proposal_id: run.proposal_id(),
+            state: run.state(),
+            active_artifact: run.active_artifact(),
+            promoted_artifact: run.promoted_artifact(),
+            decision_evidence: run.decision_evidence(),
+        }
+    }
+}
+
+fn write_pretty<T: Serialize>(path: PathBuf, value: &T) -> Result<(), EvolutionMaterializeError> {
+    fs::write(path, serde_json::to_vec_pretty(value)?)?;
+    Ok(())
+}
+
+fn validate_path_token(value: &str) -> Result<(), EvolutionMaterializeError> {
+    let path = Path::new(value);
+    let components = path.components().collect::<Vec<_>>();
+    if value.trim().is_empty()
+        || path.is_absolute()
+        || components.len() != 1
+        || !components
+            .iter()
+            .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return Err(EvolutionMaterializeError::InvalidProposalId {
+            value: value.to_owned(),
+        });
+    }
+    Ok(())
+}

--- a/crates/cairn-workflows/src/evolution/mod.rs
+++ b/crates/cairn-workflows/src/evolution/mod.rs
@@ -1,0 +1,9 @@
+//! Evolution workflow support (brief §11 and §11.3).
+
+pub mod handler;
+pub mod materialize;
+pub mod payload;
+
+pub use handler::{EVOLUTION_KIND, EvolutionHandler};
+pub use materialize::{EvolutionMaterializeError, MaterializedEvolutionDecision, materialize_run};
+pub use payload::EvolutionPayload;

--- a/crates/cairn-workflows/src/evolution/payload.rs
+++ b/crates/cairn-workflows/src/evolution/payload.rs
@@ -1,0 +1,51 @@
+//! `EvolutionPayload` — input for one evolution state-machine run.
+
+use cairn_core::contract::job_store::JobPayload;
+use cairn_core::pipeline::evolution::{EvolutionArtifactRef, EvolutionGateResult, RollbackPlan};
+use serde::{Deserialize, Serialize};
+
+/// One enqueued evolution proposal decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvolutionPayload {
+    /// Stable proposal id.
+    pub proposal_id: String,
+    /// Artifact currently live before this proposal.
+    pub previous_artifact: EvolutionArtifactRef,
+    /// Candidate artifact being evaluated.
+    pub candidate_artifact: EvolutionArtifactRef,
+    /// Rollback plan that restores the previous artifact.
+    pub rollback_plan: RollbackPlan,
+    /// Gate results already produced by eval/privacy/version/canary workers.
+    #[serde(default)]
+    pub gates: Vec<EvolutionGateResult>,
+    /// Canary rollout evidence, if a canary window was started.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canary_ref: Option<String>,
+    /// Failure evidence; when present the handler rolls back instead of promoting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canary_failure_ref: Option<String>,
+    /// Reviewer identity for successful promotion. `None` means autonomous gate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reviewer: Option<String>,
+    /// Final decision evidence reference.
+    pub decision_ref: String,
+}
+
+impl EvolutionPayload {
+    /// Serialize to `JobPayload`.
+    ///
+    /// # Errors
+    /// JSON encoding failure.
+    pub fn to_bytes(&self) -> Result<JobPayload, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+
+    /// Deserialize from `JobPayload`.
+    ///
+    /// # Errors
+    /// JSON decoding failure.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
+    }
+}

--- a/crates/cairn-workflows/src/lib.rs
+++ b/crates/cairn-workflows/src/lib.rs
@@ -13,6 +13,7 @@ pub mod consolidation;
 pub mod drainer;
 pub mod dream;
 pub mod evaluation;
+pub mod evolution;
 pub mod expiration;
 pub mod planners;
 pub mod salience_decay;
@@ -45,6 +46,9 @@ pub use evaluation::{
     CheckOutcome, EVALUATION_KIND, EvaluationHandler, EvaluationPayload, EvaluationReport,
     GoldenCheck, OrphanCheck, TombstoneConsistencyCheck, default_checks as default_golden_checks,
 };
+pub use evolution::{
+    EVOLUTION_KIND, EvolutionHandler, EvolutionPayload, MaterializedEvolutionDecision,
+};
 pub use expiration::{
     EXPIRATION_KIND, ExpirationHandler, ExpirationPayload, ExpirationSweepReport,
 };
@@ -63,7 +67,8 @@ pub use trace_canvas::{
     TraceCanvasPayload, TraceCanvasProjection, enqueue_trace_canvas_step,
 };
 pub use workflows::{
-    ConsolidateWorkflow, ExpireWorkflow, PromoteWorkflow, ReflectionWorkflow, WorkflowPlanSource,
+    ConsolidateWorkflow, EvolutionWorkflow, ExpireWorkflow, PromoteWorkflow, ReflectionWorkflow,
+    WorkflowPlanSource,
 };
 
 use cairn_core::contract::version::{ContractVersion, VersionRange};

--- a/crates/cairn-workflows/src/workflows.rs
+++ b/crates/cairn-workflows/src/workflows.rs
@@ -70,3 +70,8 @@ workflow_type!(
     "reflect",
     "Reflection workflow class: emits candidate-record `FlushPlan` batches from repeated recent patterns."
 );
+workflow_type!(
+    EvolutionWorkflow,
+    "evolve",
+    "Evolution workflow class: emits gated `FlushPlan` batches for proposal, canary, and promotion decisions."
+);

--- a/crates/cairn-workflows/tests/evolution_handler.rs
+++ b/crates/cairn-workflows/tests/evolution_handler.rs
@@ -1,0 +1,168 @@
+#![allow(missing_docs)]
+
+use cairn_core::pipeline::evolution::{
+    EvolutionArtifactKind, EvolutionArtifactRef, EvolutionGateKind, EvolutionGateResult,
+    EvolutionGateStatus, RollbackPlan,
+};
+use cairn_workflows::evolution::{
+    EvolutionHandler, EvolutionPayload, MaterializedEvolutionDecision,
+};
+use serde_json::json;
+use tempfile::TempDir;
+
+fn artifact(version: u32, digest_byte: char) -> EvolutionArtifactRef {
+    EvolutionArtifactRef {
+        kind: EvolutionArtifactKind::Skill,
+        artifact_id: "skill:deploy-hotfix".to_owned(),
+        version,
+        content_sha256: format!(
+            "sha256:{}",
+            std::iter::repeat_n(digest_byte, 64).collect::<String>()
+        ),
+    }
+}
+
+fn rollback_plan() -> RollbackPlan {
+    RollbackPlan {
+        plan_id: "rollback:deploy-hotfix:v4".to_owned(),
+        restores_artifact: artifact(3, 'a'),
+        evidence_refs: vec!["eval:rollback-dry-run".to_owned()],
+    }
+}
+
+fn gate(
+    kind: EvolutionGateKind,
+    status: EvolutionGateStatus,
+    evidence: &str,
+) -> EvolutionGateResult {
+    EvolutionGateResult {
+        kind,
+        status,
+        message: None,
+        evidence_refs: vec![evidence.to_owned()],
+    }
+}
+
+fn passing_payload(proposal_id: &str) -> EvolutionPayload {
+    EvolutionPayload {
+        proposal_id: proposal_id.to_owned(),
+        previous_artifact: artifact(3, 'a'),
+        candidate_artifact: artifact(4, 'b'),
+        rollback_plan: rollback_plan(),
+        gates: vec![
+            gate(
+                EvolutionGateKind::Eval,
+                EvolutionGateStatus::Passed,
+                "eval:main",
+            ),
+            gate(
+                EvolutionGateKind::Privacy,
+                EvolutionGateStatus::Passed,
+                "privacy:trace",
+            ),
+            gate(
+                EvolutionGateKind::Version,
+                EvolutionGateStatus::Passed,
+                "version:compat",
+            ),
+            gate(
+                EvolutionGateKind::RollbackPlan,
+                EvolutionGateStatus::Passed,
+                "rollback:dry-run",
+            ),
+            gate(
+                EvolutionGateKind::Canary,
+                EvolutionGateStatus::Passed,
+                "canary:24h-pass",
+            ),
+        ],
+        canary_ref: Some("canary:24h-pass".to_owned()),
+        canary_failure_ref: None,
+        reviewer: Some("hmn:reviewer:v1".to_owned()),
+        decision_ref: "decision:approve".to_owned(),
+    }
+}
+
+#[test]
+fn handler_persists_promoted_lineage_and_decision_evidence() {
+    let temp = TempDir::new().expect("temp");
+    let handler = EvolutionHandler::new(temp.path().to_path_buf());
+
+    let decision = handler
+        .run_once(passing_payload("evo_promote"))
+        .expect("run");
+    assert_eq!(decision, MaterializedEvolutionDecision::Promoted);
+
+    let root = temp.path().join(".cairn/evolution/evolve/evo_promote");
+    let lineage: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(root.join("lineage.json")).expect("lineage"))
+            .expect("lineage json");
+    assert_eq!(lineage["proposal_id"], "evo_promote");
+    assert_eq!(lineage["previous_artifact"]["version"], 3);
+    assert_eq!(lineage["promoted_artifact"]["version"], 4);
+    assert_eq!(
+        lineage["eval_result_refs"],
+        json!(["eval:main", "canary:24h-pass"])
+    );
+    assert_eq!(
+        lineage["decision_evidence"],
+        json!(["canary:24h-pass", "decision:approve"])
+    );
+
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(root.join("state.json")).expect("state"))
+            .expect("state json");
+    assert_eq!(state["state"], "promoted");
+}
+
+#[test]
+fn handler_rolls_back_and_persists_failed_canary_evidence() {
+    let temp = TempDir::new().expect("temp");
+    let handler = EvolutionHandler::new(temp.path().to_path_buf());
+    let mut payload = passing_payload("evo_rollback");
+    payload
+        .gates
+        .retain(|gate| gate.kind != EvolutionGateKind::Canary);
+    payload.canary_ref = Some("canary:5pct".to_owned());
+    payload.canary_failure_ref = Some("slo:latency-regression".to_owned());
+
+    let decision = handler.run_once(payload).expect("run");
+    assert_eq!(decision, MaterializedEvolutionDecision::RolledBack);
+
+    let root = temp.path().join(".cairn/evolution/evolve/evo_rollback");
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(root.join("state.json")).expect("state"))
+            .expect("state json");
+    assert_eq!(state["state"], "rolled_back");
+    assert_eq!(state["active_artifact"]["version"], 3);
+    assert_eq!(
+        state["decision_evidence"],
+        json!(["canary:5pct", "slo:latency-regression"])
+    );
+}
+
+#[test]
+fn handler_rejects_gate_failure_without_promoting_candidate() {
+    let temp = TempDir::new().expect("temp");
+    let handler = EvolutionHandler::new(temp.path().to_path_buf());
+    let mut payload = passing_payload("evo_rejected");
+    payload
+        .gates
+        .retain(|gate| gate.kind != EvolutionGateKind::Privacy);
+    payload.gates.push(gate(
+        EvolutionGateKind::Privacy,
+        EvolutionGateStatus::Failed,
+        "privacy:raw-body-leak",
+    ));
+
+    let decision = handler.run_once(payload).expect("run");
+    assert_eq!(decision, MaterializedEvolutionDecision::Rejected);
+
+    let root = temp.path().join(".cairn/evolution/evolve/evo_rejected");
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(root.join("state.json")).expect("state"))
+            .expect("state json");
+    assert_eq!(state["state"], "rejected");
+    assert_eq!(state["active_artifact"]["version"], 3);
+    assert_eq!(state["promoted_artifact"], serde_json::Value::Null);
+}


### PR DESCRIPTION
## Summary

Closes #127.

Implements the evolution workflow state machine for proposal evaluation, gate enforcement, canary rollback, and promotion lineage. Adds file-backed materialization under `.cairn/evolution/evolve/<proposal_id>/` for terminal decisions, gate reports, rollback plans, and lineage.

Adds the hidden `cairn admin workflow run-evolution --payload <PATH>` diagnostic CLI path and an end-to-end CLI test that drives the real binary through both promotion and canary rollback.

## Validation

- `cargo-nextest nextest run --workspace --locked --no-fail-fast` -> 5191 passed, 20 skipped
- `cargo test --doc --workspace --locked` -> passed
- `cargo fmt --all --check` -> passed
- `cargo check --workspace --all-targets --locked` -> passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings` -> passed
- `cargo run -p cairn-cli --bin cairn-docgen --locked -- --check` -> clean, 90 files match
- `cargo run -p cairn-idl --bin cairn-codegen --locked -- --check` -> clean, 74 files match
- `git diff --check` -> passed
