### PR TITLE
[codex] Add extended domain replay cassettes

### DIFF
--- a/crates/cairn-test-fixtures/tests/replay_harness.rs
+++ b/crates/cairn-test-fixtures/tests/replay_harness.rs
@@ -1,9 +1,14 @@
 //! Integration coverage for the dev-only replay harness.
 
+use std::collections::HashSet;
+
 use cairn_test_fixtures::replay::{
     ReplayAction, ReplayExpectation, ReplaySearchAction, ReplaySearchMode, load_named_scenario,
     run_named_scenario,
 };
+
+const EXTENDED_DOMAIN_SUITES: [&str; 3] =
+    ["research_domain", "engineering_domain", "support_domain"];
 
 #[tokio::test(flavor = "multi_thread")]
 async fn p0_stories_replay_passes_end_to_end() {
@@ -142,9 +147,9 @@ fn replay_manifests_deserialize() {
         "p0_stories",
         "p0_keyword_only",
         "codex_consumer",
-        "research_domain",
-        "engineering_domain",
-        "support_domain",
+        EXTENDED_DOMAIN_SUITES[0],
+        EXTENDED_DOMAIN_SUITES[1],
+        EXTENDED_DOMAIN_SUITES[2],
     ] {
         let scenario = load_named_scenario(name).expect("load scenario");
         assert_eq!(scenario.id, name);
@@ -176,6 +181,77 @@ fn extended_domain_replay_suites_document_goals_and_golden_expectations() {
     }
 }
 
+#[test]
+fn extended_domain_replay_suites_have_resolvable_goldens_and_private_forget_queries() {
+    for name in EXTENDED_DOMAIN_SUITES {
+        let scenario = load_named_scenario(name).expect("load scenario");
+        let record_ids: HashSet<_> = scenario
+            .records
+            .iter()
+            .map(|record| record.id.as_str())
+            .collect();
+        assert_eq!(
+            record_ids.len(),
+            scenario.records.len(),
+            "{name} has duplicate record ids"
+        );
+
+        for action in &scenario.actions {
+            match action {
+                ReplayAction::Search(search) => {
+                    assert_eq!(
+                        search.mode,
+                        ReplaySearchMode::Keyword,
+                        "{name} must stay keyword-only for no-network replay"
+                    );
+                    if let ReplayExpectation::Hits {
+                        record_ids: expected,
+                    } = &search.expected
+                    {
+                        for id in expected {
+                            assert!(record_ids.contains(id.as_str()), "{name} missing {id}");
+                        }
+                    }
+                }
+                ReplayAction::Summarize {
+                    expected_record_ids,
+                    ..
+                }
+                | ReplayAction::AssembleHot {
+                    expected_record_ids,
+                    ..
+                } => {
+                    for id in expected_record_ids {
+                        assert!(record_ids.contains(id.as_str()), "{name} missing {id}");
+                    }
+                }
+                ReplayAction::ForgetRecord {
+                    record_id,
+                    followup_query,
+                    ..
+                } => {
+                    assert!(
+                        record_ids.contains(record_id.as_str()),
+                        "{name} forget target {record_id} missing"
+                    );
+                    let matching_records = scenario
+                        .records
+                        .iter()
+                        .filter(|record| record.body.contains(followup_query))
+                        .collect::<Vec<_>>();
+                    assert_eq!(
+                        matching_records.len(),
+                        1,
+                        "{name} forget follow-up query must uniquely identify its target"
+                    );
+                    assert_eq!(matching_records[0].id, *record_id);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn codex_consumer_replay_passes_end_to_end() {
     let report = run_named_scenario("codex_consumer")
@@ -202,7 +278,7 @@ async fn codex_consumer_replay_passes_end_to_end() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn extended_domain_replay_suites_pass_end_to_end_without_network_or_llm() {
-    for name in ["research_domain", "engineering_domain", "support_domain"] {
+    for name in EXTENDED_DOMAIN_SUITES {
         let scenario = load_named_scenario(name).expect("load scenario");
         assert!(
             !scenario.config.local_embeddings,

--- a/crates/cairn-test-fixtures/tests/replay_harness.rs
+++ b/crates/cairn-test-fixtures/tests/replay_harness.rs
@@ -138,11 +138,41 @@ fn p0_replay_manifest_uses_canonical_trace_event_names() {
 
 #[test]
 fn replay_manifests_deserialize() {
-    for name in ["p0_stories", "p0_keyword_only", "codex_consumer"] {
+    for name in [
+        "p0_stories",
+        "p0_keyword_only",
+        "codex_consumer",
+        "research_domain",
+        "engineering_domain",
+        "support_domain",
+    ] {
         let scenario = load_named_scenario(name).expect("load scenario");
         assert_eq!(scenario.id, name);
         assert!(!scenario.records.is_empty());
         assert!(!scenario.actions.is_empty());
+    }
+}
+
+#[test]
+fn extended_domain_replay_suites_document_goals_and_golden_expectations() {
+    let readme_path = cairn_test_fixtures::fixture_v0_dir().join("replay/README.md");
+    let readme = std::fs::read_to_string(&readme_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", readme_path.display()));
+    for needle in [
+        "research_domain",
+        "engineering_domain",
+        "support_domain",
+        "long-horizon memory",
+        "multi-session coherence",
+        "privacy/forget",
+        "search relevance",
+        "Golden expectations",
+    ] {
+        assert!(
+            readme.contains(needle),
+            "missing {needle:?} in {}",
+            readme_path.display()
+        );
     }
 }
 
@@ -167,5 +197,35 @@ async fn codex_consumer_replay_passes_end_to_end() {
             report.checks.iter().any(|check| check.verb == verb),
             "missing check for {verb}: {report:#?}"
         );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn extended_domain_replay_suites_pass_end_to_end_without_network_or_llm() {
+    for name in ["research_domain", "engineering_domain", "support_domain"] {
+        let scenario = load_named_scenario(name).expect("load scenario");
+        assert!(
+            !scenario.config.local_embeddings,
+            "{name} must use deterministic keyword-only replay"
+        );
+
+        let report = cairn_test_fixtures::replay::run_scenario(&scenario)
+            .await
+            .unwrap_or_else(|e| panic!("run {name}: {e}"));
+        assert!(report.passed(), "{report:#?}");
+
+        for verb in [
+            "capture_trace",
+            "forget_record",
+            "retrieve_session",
+            "retrieve_turn",
+            "search",
+            "summarize",
+        ] {
+            assert!(
+                report.checks.iter().any(|check| check.verb == verb),
+                "{name} missing check for {verb}: {report:#?}"
+            );
+        }
     }
 }

--- a/fixtures/v0/replay/README.md
+++ b/fixtures/v0/replay/README.md
@@ -1,0 +1,20 @@
+# Replay Cassettes
+
+Replay cassettes are deterministic JSON manifests for CI and release gates. They seed a temporary SQLite vault, run local replay actions, and compare each action against golden expectations without external network or LLM calls.
+
+## Extended Domain Suites
+
+`research_domain` covers long-horizon memory across literature review and experiment-planning turns. It checks multi-session coherence by preserving both project context and later synthesis, search relevance for the hypothesis thread, summary retrieval, and privacy/forget handling for a temporary embargo note.
+
+`engineering_domain` covers implementation work across investigation and patch sessions. It checks long-horizon memory for a concurrency fix, multi-session coherence between diagnosis and verification, search relevance for the locking decision, summary retrieval, and privacy/forget handling for a throwaway credential.
+
+`support_domain` covers customer support workflows across intake and escalation sessions. It checks long-horizon memory for customer context, multi-session coherence between ticket intake and resolution, search relevance for the remediation plan, summary retrieval, and privacy/forget handling for a sensitive contact note.
+
+## Golden expectations
+
+Each domain suite includes golden expectations for:
+
+- long-horizon memory: `retrieve_session`, `retrieve_turn`, and `summarize` actions must recover the expected trace and summary records.
+- multi-session coherence: records from related sessions use stable domain terms that are retrieved by deterministic keyword search.
+- privacy/forget: `forget_record` tombstones the sensitive fixture record and verifies a follow-up search no longer returns it.
+- search relevance: keyword queries assert exact top-hit record IDs, keeping replay safe for CI without semantic embedding or network dependencies.

--- a/fixtures/v0/replay/engineering_domain.json
+++ b/fixtures/v0/replay/engineering_domain.json
@@ -1,0 +1,131 @@
+{
+  "id": "engineering_domain",
+  "description": "Extended engineering replay covering long-horizon debugging memory, multi-session verification, search relevance, and privacy/forget.",
+  "config": {
+    "local_embeddings": false
+  },
+  "records": [
+    {
+      "id": "01HQZX9F5N00000000000000E0",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "engineering session one user reported wal deadlock investigation",
+      "session_id": "engineering-deadlock",
+      "turn_id": "1",
+      "sequence": 1,
+      "trace_event": "user_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000E1",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "agent identified replay ledger lock inversion root cause",
+      "session_id": "engineering-deadlock",
+      "turn_id": "1",
+      "sequence": 2,
+      "trace_event": "agent_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000E2",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "engineering session two user asked for retry stress verification",
+      "session_id": "engineering-deadlock",
+      "turn_id": "2",
+      "sequence": 3,
+      "trace_event": "user_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000E3",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "agent confirmed lock inversion fix passed retry stress verification",
+      "session_id": "engineering-deadlock",
+      "turn_id": "2",
+      "sequence": 4,
+      "trace_event": "agent_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000E4",
+      "kind": "reasoning",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "engineering summary preserves wal deadlock lock inversion and retry verification",
+      "session_id": "engineering-deadlock",
+      "turn_id": "summary",
+      "sequence": 5,
+      "trace_event": "turn_summary"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000E5",
+      "kind": "playbook",
+      "class": "procedural",
+      "visibility": "private",
+      "body": "engineering playbook acquire replay ledger lock before wal writer lock"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000E6",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "temporary debug credential amber key should be forgotten"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000E7",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "engineering unrelated note update changelog template"
+    }
+  ],
+  "actions": [
+    {
+      "verb": "capture_trace",
+      "story": "ENGINEERING_CAPTURE_LONG_HORIZON",
+      "session_id": "engineering-deadlock",
+      "expected_trace_events": ["user_message", "agent_message", "user_message", "agent_message", "turn_summary"]
+    },
+    {
+      "verb": "retrieve_session",
+      "story": "ENGINEERING_MULTI_SESSION_COHERENCE",
+      "session_id": "engineering-deadlock",
+      "expected_turn_ids": ["1", "2"],
+      "expected_trace_events": ["user_message", "agent_message", "user_message", "agent_message", "turn_summary"]
+    },
+    {
+      "verb": "retrieve_turn",
+      "story": "ENGINEERING_RETRIEVE_LATER_TURN",
+      "session_id": "engineering-deadlock",
+      "turn_id": "2",
+      "expected_trace_events": ["user_message", "agent_message"]
+    },
+    {
+      "verb": "summarize",
+      "story": "ENGINEERING_SUMMARY_GOLDEN",
+      "session_id": "engineering-deadlock",
+      "expected_record_ids": ["01HQZX9F5N00000000000000E4"]
+    },
+    {
+      "verb": "search",
+      "story": "ENGINEERING_SEARCH_RELEVANCE",
+      "mode": "keyword",
+      "query": "replay ledger lock before wal writer",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N00000000000000E5"]
+      }
+    },
+    {
+      "verb": "forget_record",
+      "story": "ENGINEERING_PRIVACY_FORGET",
+      "record_id": "01HQZX9F5N00000000000000E6",
+      "followup_query": "temporary debug credential amber key",
+      "expected_absent_from_search": true
+    }
+  ]
+}

--- a/fixtures/v0/replay/research_domain.json
+++ b/fixtures/v0/replay/research_domain.json
@@ -1,0 +1,131 @@
+{
+  "id": "research_domain",
+  "description": "Extended research replay covering long-horizon literature memory, multi-session synthesis, search relevance, and privacy/forget.",
+  "config": {
+    "local_embeddings": false
+  },
+  "records": [
+    {
+      "id": "01HQZX9F5N00000000000000R0",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "research session one user collected lattice biology papers",
+      "session_id": "research-literature",
+      "turn_id": "1",
+      "sequence": 1,
+      "trace_event": "user_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000R1",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "agent extracted lattice biology baseline assumptions",
+      "session_id": "research-literature",
+      "turn_id": "1",
+      "sequence": 2,
+      "trace_event": "agent_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000R2",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "research session two user compared organoid protocol drift",
+      "session_id": "research-literature",
+      "turn_id": "2",
+      "sequence": 3,
+      "trace_event": "user_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000R3",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "agent linked protocol drift to lattice biology hypothesis",
+      "session_id": "research-literature",
+      "turn_id": "2",
+      "sequence": 4,
+      "trace_event": "agent_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000R4",
+      "kind": "reasoning",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "research summary preserves lattice biology baseline and organoid drift synthesis",
+      "session_id": "research-literature",
+      "turn_id": "summary",
+      "sequence": 5,
+      "trace_event": "turn_summary"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000R5",
+      "kind": "project",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "research project hypothesis lattice biology drift marker validates long horizon memory"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000R6",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "embargoed reviewer identity delta fox should be forgotten"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000R7",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "research unrelated note centrifuge shelf inventory"
+    }
+  ],
+  "actions": [
+    {
+      "verb": "capture_trace",
+      "story": "RESEARCH_CAPTURE_LONG_HORIZON",
+      "session_id": "research-literature",
+      "expected_trace_events": ["user_message", "agent_message", "user_message", "agent_message", "turn_summary"]
+    },
+    {
+      "verb": "retrieve_session",
+      "story": "RESEARCH_MULTI_SESSION_COHERENCE",
+      "session_id": "research-literature",
+      "expected_turn_ids": ["1", "2"],
+      "expected_trace_events": ["user_message", "agent_message", "user_message", "agent_message", "turn_summary"]
+    },
+    {
+      "verb": "retrieve_turn",
+      "story": "RESEARCH_RETRIEVE_LATER_TURN",
+      "session_id": "research-literature",
+      "turn_id": "2",
+      "expected_trace_events": ["user_message", "agent_message"]
+    },
+    {
+      "verb": "summarize",
+      "story": "RESEARCH_SUMMARY_GOLDEN",
+      "session_id": "research-literature",
+      "expected_record_ids": ["01HQZX9F5N00000000000000R4"]
+    },
+    {
+      "verb": "search",
+      "story": "RESEARCH_SEARCH_RELEVANCE",
+      "mode": "keyword",
+      "query": "lattice biology drift marker",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N00000000000000R5"]
+      }
+    },
+    {
+      "verb": "forget_record",
+      "story": "RESEARCH_PRIVACY_FORGET",
+      "record_id": "01HQZX9F5N00000000000000R6",
+      "followup_query": "embargoed reviewer identity delta fox",
+      "expected_absent_from_search": true
+    }
+  ]
+}

--- a/fixtures/v0/replay/support_domain.json
+++ b/fixtures/v0/replay/support_domain.json
@@ -1,0 +1,131 @@
+{
+  "id": "support_domain",
+  "description": "Extended support replay covering long-horizon customer memory, multi-session escalation coherence, search relevance, and privacy/forget.",
+  "config": {
+    "local_embeddings": false
+  },
+  "records": [
+    {
+      "id": "01HQZX9F5N00000000000000S0",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "support session one user captured acme billing outage intake",
+      "session_id": "support-acme-outage",
+      "turn_id": "1",
+      "sequence": 1,
+      "trace_event": "user_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000S1",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "agent triaged acme billing outage to invoice webhook delay",
+      "session_id": "support-acme-outage",
+      "turn_id": "1",
+      "sequence": 2,
+      "trace_event": "agent_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000S2",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "support session two user requested escalation update",
+      "session_id": "support-acme-outage",
+      "turn_id": "2",
+      "sequence": 3,
+      "trace_event": "user_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000S3",
+      "kind": "trace",
+      "class": "episodic",
+      "visibility": "private",
+      "body": "agent resolved acme billing outage with webhook replay remediation",
+      "session_id": "support-acme-outage",
+      "turn_id": "2",
+      "sequence": 4,
+      "trace_event": "agent_message"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000S4",
+      "kind": "reasoning",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "support summary preserves acme billing outage intake escalation and webhook replay remediation",
+      "session_id": "support-acme-outage",
+      "turn_id": "summary",
+      "sequence": 5,
+      "trace_event": "turn_summary"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000S5",
+      "kind": "playbook",
+      "class": "procedural",
+      "visibility": "private",
+      "body": "support playbook acme billing outage remediation replay invoice webhook queue"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000S6",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "sensitive support contact violet pager should be forgotten"
+    },
+    {
+      "id": "01HQZX9F5N00000000000000S7",
+      "kind": "fact",
+      "class": "semantic",
+      "visibility": "private",
+      "body": "support unrelated note update canned response"
+    }
+  ],
+  "actions": [
+    {
+      "verb": "capture_trace",
+      "story": "SUPPORT_CAPTURE_LONG_HORIZON",
+      "session_id": "support-acme-outage",
+      "expected_trace_events": ["user_message", "agent_message", "user_message", "agent_message", "turn_summary"]
+    },
+    {
+      "verb": "retrieve_session",
+      "story": "SUPPORT_MULTI_SESSION_COHERENCE",
+      "session_id": "support-acme-outage",
+      "expected_turn_ids": ["1", "2"],
+      "expected_trace_events": ["user_message", "agent_message", "user_message", "agent_message", "turn_summary"]
+    },
+    {
+      "verb": "retrieve_turn",
+      "story": "SUPPORT_RETRIEVE_LATER_TURN",
+      "session_id": "support-acme-outage",
+      "turn_id": "2",
+      "expected_trace_events": ["user_message", "agent_message"]
+    },
+    {
+      "verb": "summarize",
+      "story": "SUPPORT_SUMMARY_GOLDEN",
+      "session_id": "support-acme-outage",
+      "expected_record_ids": ["01HQZX9F5N00000000000000S4"]
+    },
+    {
+      "verb": "search",
+      "story": "SUPPORT_SEARCH_RELEVANCE",
+      "mode": "keyword",
+      "query": "acme billing outage remediation webhook",
+      "limit": 1,
+      "expected": {
+        "status": "hits",
+        "record_ids": ["01HQZX9F5N00000000000000S5"]
+      }
+    },
+    {
+      "verb": "forget_record",
+      "story": "SUPPORT_PRIVACY_FORGET",
+      "record_id": "01HQZX9F5N00000000000000S6",
+      "followup_query": "sensitive support contact violet pager",
+      "expected_absent_from_search": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add deterministic extended replay cassettes for research, engineering, and support workflows.
- Document each suite goals and golden expectations in `fixtures/v0/replay/README.md`.
- Extend the replay harness to deserialize, run, and validate the new domain suites, including keyword-only/no-network constraints and edge checks for unique IDs, resolvable goldens, and private forget queries.

## Issue

Closes #136.

## Validation

- `cargo build -p cairn-cli --bin cairn`
- `cargo test -p cairn-test-fixtures --test replay_harness -- --nocapture`
- `env -u OPENAI_API_KEY -u OPENAI_BASE_URL -u CAIRN_OPENAI_API_KEY -u CAIRN_OPENAI_BASE_URL cargo test -p cairn-test-fixtures --test replay_harness extended_domain -- --nocapture`
- `cargo run -p cairn-bench -- privacy`
- manual Node manifest probe for ID uniqueness, resolvable golden references, keyword-only actions, and unique forget follow-up queries
- `cargo fmt --all -- --check`
- `git diff --check`