### PR TITLE
feat(connectors-webclip): generic web-clipper connector adapter (#131 slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -846,6 +846,28 @@ dependencies = [
  "ulid",
  "url",
  "wiremock",
+]
+
+[[package]]
+name = "cairn-connectors-webclip"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "axum",
+ "cairn-connectors-core",
+ "cairn-core",
+ "hex",
+ "proptest",
+ "rstest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "ulid",
+ "url",
 ]
 
 [[package]]
@@ -1252,14 +1274,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1279,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -1417,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -1954,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2837,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2882,9 +2904,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3421,14 +3443,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.0",
 ]
 
 [[package]]
@@ -3600,9 +3622,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -3663,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -4493,7 +4515,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -4789,9 +4811,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -5498,6 +5520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5570,9 +5598,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5736,9 +5764,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "temp-env"
@@ -6093,9 +6121,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -6289,9 +6317,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -6306,11 +6334,11 @@ dependencies = [
 
 [[package]]
 name = "ulid"
-version = "1.1.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f294bff79170ed1c5633812aff1e565c35d993a36e757f9bc0accf5eec4e6045"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.8.6",
+ "rand 0.9.4",
  "web-time",
 ]
 
@@ -6473,9 +6501,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7474,9 +7502,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -7509,9 +7537,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7535,18 +7563,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7647,9 +7675,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
@@ -7661,9 +7689,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7674,9 +7702,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ cairn-frontend-vscode = { path = "crates/cairn-frontend-vscode", version = "0.0.
 cairn-frontend-logseq = { path = "crates/cairn-frontend-logseq", version = "0.0.1" }
 cairn-connectors-core = { path = "crates/cairn-connectors-core", version = "0.0.1" }
 cairn-connectors-github = { path = "crates/cairn-connectors-github", version = "0.0.1" }
+cairn-connectors-webclip = { path = "crates/cairn-connectors-webclip", version = "0.0.1" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/cairn-connectors-webclip/Cargo.toml
+++ b/crates/cairn-connectors-webclip/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "cairn-connectors-webclip"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Generic web-clipper connector adapter (webhook-only) for cairn-connectors-core."
+
+[lints]
+workspace = true
+
+[features]
+default = ["testkit"]
+testkit = []
+
+[dependencies]
+cairn-connectors-core = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+ulid = { workspace = true }
+hex = { workspace = true }
+url = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+cairn-connectors-core = { workspace = true, features = ["fixture"] }
+cairn-core = { workspace = true }
+axum = { workspace = true }
+tower = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+rstest = { workspace = true }
+proptest = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/cairn-connectors-webclip/connector.toml
+++ b/crates/cairn-connectors-webclip/connector.toml
@@ -1,0 +1,47 @@
+[connector]
+name              = "webclip"
+contract          = "Connector"
+contract_version  = "0.1.0"
+sensor_identity   = "snr:local:connector:webclip:v1"
+
+[capabilities]
+poll     = false
+webhook  = true
+backfill = false
+
+# Inert: the web clipper authenticates via the per-connector HMAC webhook
+# secret (CredentialStore key "connector/webclip/webhook_secret"), not OAuth.
+# The block is required by the manifest schema; the values are unused.
+[oauth]
+required_scopes = []
+token_lifetime  = "0s"
+refresh         = false
+
+[budget]
+max_items_per_hour = 600
+max_bytes_per_day  = "100MiB"
+
+[labels]
+allowed = ["source:web", "kind:clip"]
+
+[[scopes.declared]]
+kind    = "domain"
+pattern = "*"
+
+[webhook]
+"signature.algorithm" = "hmac-sha256"
+"signature.header"    = "X-Cairn-Signature-256"
+"signature.prefix"    = "sha256="
+allowed_mimes         = ["application/json", "text/markdown", "text/plain"]
+delivery_id_header    = "X-Cairn-Delivery"
+
+# Inert: poll = false means the registry never spawns a poll task. The block
+# is required by the manifest schema; the values are placeholders.
+[poll]
+cursor_kind      = "opaque-string"
+min_interval     = "60s"
+default_interval = "5m"
+
+[payload]
+max_bytes = "1MiB"
+max_depth = 16

--- a/crates/cairn-connectors-webclip/src/clip.rs
+++ b/crates/cairn-connectors-webclip/src/clip.rs
@@ -5,10 +5,6 @@
 //! - `text/markdown` | `text/plain` -> raw body + `X-Cairn-Clip-*` headers ->
 //!   `ConnectorPayload::Text`.
 
-// Items in this module will be consumed by `WebClipConnector::ingest_webhook`
-// in Task 5; they are crate-private and unused at the library level until then.
-#![allow(dead_code)]
-
 use std::collections::BTreeSet;
 
 use cairn_connectors_core::{

--- a/crates/cairn-connectors-webclip/src/clip.rs
+++ b/crates/cairn-connectors-webclip/src/clip.rs
@@ -1,0 +1,269 @@
+//! Parse a verified web-clip webhook request into a `ConnectorEvent`.
+//!
+//! Content negotiation on `Content-Type`:
+//! - `application/json` -> structured [`ClipEnvelope`] -> `ConnectorPayload::Json`.
+//! - `text/markdown` | `text/plain` -> raw body + `X-Cairn-Clip-*` headers ->
+//!   `ConnectorPayload::Text`.
+
+// Items in this module will be consumed by `WebClipConnector::ingest_webhook`
+// in Task 5; they are crate-private and unused at the library level until then.
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+use cairn_connectors_core::{
+    ConnectorEvent, ConnectorPayload, ConnectorScope, DeliveryMode, SourceRef, WebhookRequest,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::error::WebClipError;
+use crate::event_id;
+
+/// Connector name — must match the manifest `[connector] name`.
+const CONNECTOR_NAME: &str = "webclip";
+
+/// Structured clip envelope accepted in `application/json` mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ClipEnvelope {
+    /// Source page URL. Required; its host becomes the consent scope.
+    pub url: String,
+    /// Optional page title (rides in the payload for downstream use).
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Capture time, Unix seconds. Required.
+    pub captured_at: i64,
+    /// Selected text/HTML, if the user clipped a selection.
+    #[serde(default)]
+    pub selection: Option<String>,
+    /// Markdown form of the clip body.
+    #[serde(default)]
+    pub markdown: Option<String>,
+    /// Optional free-form user note.
+    #[serde(default)]
+    pub note: Option<String>,
+    /// Optional user tags. Preserved in the payload; NOT promoted to labels.
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+/// Accepted clip media types after `Content-Type` normalization.
+enum Media {
+    /// `application/json` structured envelope.
+    Json,
+    /// `text/markdown` or `text/plain`; the carried `String` is the concrete
+    /// MIME echoed into `ConnectorPayload::Text`.
+    Text(String),
+}
+
+/// Resolve and normalize the request `Content-Type` into a [`Media`].
+fn media_type(req: &WebhookRequest) -> Result<Media, WebClipError> {
+    let raw = req
+        .header("Content-Type")
+        .ok_or(WebClipError::MissingContentType)?;
+    // Strip parameters (`; charset=utf-8`) and normalize case/whitespace.
+    let base = raw
+        .split(';')
+        .next()
+        .unwrap_or(raw)
+        .trim()
+        .to_ascii_lowercase();
+    match base.as_str() {
+        "application/json" => Ok(Media::Json),
+        "text/markdown" | "text/plain" => Ok(Media::Text(base)),
+        other => Err(WebClipError::UnsupportedContentType(other.to_owned())),
+    }
+}
+
+/// Read a required header, erroring with [`WebClipError::MissingField`] if absent.
+fn header_required(req: &WebhookRequest, name: &'static str) -> Result<String, WebClipError> {
+    req.header(name)
+        .map(str::to_owned)
+        .ok_or(WebClipError::MissingField(name))
+}
+
+/// Parse a `captured_at` string as Unix seconds.
+fn parse_captured_at(s: &str) -> Result<i64, WebClipError> {
+    s.trim()
+        .parse::<i64>()
+        .map_err(|_| WebClipError::BadCapturedAt(s.to_owned()))
+}
+
+/// Parse a verified webhook request into exactly one [`ConnectorEvent`].
+///
+/// The substrate has already verified the HMAC signature; `signature_id` is the
+/// verified signature header value, recorded in `DeliveryMode::Webhook`.
+pub(crate) fn parse_request(
+    req: &WebhookRequest,
+    signature_id: &str,
+) -> Result<ConnectorEvent, WebClipError> {
+    let (url, captured_at, payload, hash_input) = match media_type(req)? {
+        Media::Json => {
+            let env: ClipEnvelope = serde_json::from_slice(&req.body)?;
+            if env.selection.is_none() && env.markdown.is_none() {
+                return Err(WebClipError::MissingField("selection|markdown"));
+            }
+            let body = serde_json::to_value(&env)?;
+            let hash_input = serde_json::to_vec(&body)?;
+            (
+                env.url.clone(),
+                env.captured_at,
+                ConnectorPayload::Json {
+                    mime: "application/json".to_owned(),
+                    body,
+                },
+                hash_input,
+            )
+        }
+        Media::Text(mime) => {
+            let url = header_required(req, "X-Cairn-Clip-Url")?;
+            let captured_at =
+                parse_captured_at(&header_required(req, "X-Cairn-Clip-Captured-At")?)?;
+            let text = String::from_utf8_lossy(&req.body).into_owned();
+            let hash_input = req.body.clone();
+            (
+                url,
+                captured_at,
+                ConnectorPayload::Text { mime, body: text },
+                hash_input,
+            )
+        }
+    };
+
+    // Per-domain consent scope from the URL host.
+    let host = Url::parse(&url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_owned))
+        .ok_or_else(|| WebClipError::BadUrl(url.clone()))?;
+
+    let captured_str = captured_at.to_string();
+    let hash = event_id::payload_hash(&hash_input);
+    let event_id = event_id::from_parts("clip", &url, &[&captured_str, &hash]);
+
+    let mut labels = BTreeSet::new();
+    labels.insert("source:web".to_owned());
+    labels.insert("kind:clip".to_owned());
+
+    Ok(ConnectorEvent::new(
+        event_id,
+        CONNECTOR_NAME,
+        SourceRef::new("clip", url, None),
+        captured_at,
+        labels,
+        ConnectorScope::new("domain", host),
+        payload,
+        DeliveryMode::Webhook {
+            signature_id: signature_id.to_owned(),
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(headers: Vec<(&str, &str)>, body: &[u8]) -> WebhookRequest {
+        WebhookRequest {
+            connector: "webclip".into(),
+            body: body.to_vec(),
+            headers: headers
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn json_clip_builds_scoped_event() {
+        let body =
+            br#"{"url":"https://en.wikipedia.org/wiki/Cairn","captured_at":100,"markdown":"hi"}"#;
+        let r = req(vec![("Content-Type", "application/json")], body);
+        let ev = parse_request(&r, "sig").expect("parses");
+        assert_eq!(ev.connector, "webclip");
+        assert_eq!(ev.scope.kind, "domain");
+        assert_eq!(ev.scope.value, "en.wikipedia.org");
+        assert_eq!(ev.source_ref.kind, "clip");
+        assert!(ev.labels.contains("source:web") && ev.labels.contains("kind:clip"));
+        assert!(matches!(ev.payload, ConnectorPayload::Json { .. }));
+    }
+
+    #[test]
+    fn json_charset_param_is_accepted() {
+        let body = br#"{"url":"https://e.com/a","captured_at":1,"selection":"x"}"#;
+        let r = req(
+            vec![("Content-Type", "application/json; charset=utf-8")],
+            body,
+        );
+        assert!(parse_request(&r, "sig").is_ok());
+    }
+
+    #[test]
+    fn text_markdown_uses_headers_for_metadata() {
+        let r = req(
+            vec![
+                ("Content-Type", "text/markdown"),
+                ("X-Cairn-Clip-Url", "https://example.com/post/42"),
+                ("X-Cairn-Clip-Captured-At", "1748563200"),
+            ],
+            b"## Heading\nbody",
+        );
+        let ev = parse_request(&r, "sig").expect("parses");
+        assert_eq!(ev.scope.value, "example.com");
+        assert_eq!(ev.occurred_at, 1_748_563_200);
+        assert!(matches!(ev.payload, ConnectorPayload::Text { .. }));
+    }
+
+    #[test]
+    fn missing_content_type_is_error() {
+        let r = req(vec![], b"{}");
+        assert!(matches!(
+            parse_request(&r, "s"),
+            Err(WebClipError::MissingContentType)
+        ));
+    }
+
+    #[test]
+    fn unsupported_content_type_is_error() {
+        let r = req(vec![("Content-Type", "text/html")], b"<p>x</p>");
+        assert!(matches!(
+            parse_request(&r, "s"),
+            Err(WebClipError::UnsupportedContentType(_))
+        ));
+    }
+
+    #[test]
+    fn json_without_body_field_is_error() {
+        let body = br#"{"url":"https://e.com/a","captured_at":1}"#;
+        let r = req(vec![("Content-Type", "application/json")], body);
+        assert!(matches!(
+            parse_request(&r, "s"),
+            Err(WebClipError::MissingField(_))
+        ));
+    }
+
+    #[test]
+    fn hostless_url_is_error() {
+        let body = br#"{"url":"file:///etc/passwd","captured_at":1,"markdown":"x"}"#;
+        let r = req(vec![("Content-Type", "application/json")], body);
+        assert!(matches!(
+            parse_request(&r, "s"),
+            Err(WebClipError::BadUrl(_))
+        ));
+    }
+
+    #[test]
+    fn text_missing_url_header_is_error() {
+        let r = req(
+            vec![
+                ("Content-Type", "text/plain"),
+                ("X-Cairn-Clip-Captured-At", "1"),
+            ],
+            b"body",
+        );
+        assert!(matches!(
+            parse_request(&r, "s"),
+            Err(WebClipError::MissingField(_))
+        ));
+    }
+}

--- a/crates/cairn-connectors-webclip/src/connector.rs
+++ b/crates/cairn-connectors-webclip/src/connector.rs
@@ -1,0 +1,118 @@
+//! `WebClipConnector` — `Connector` + `ConnectorPlugin` for web clips.
+//!
+//! Webhook-only and stateless: `poll` is never called (the manifest declares
+//! `poll = false`) and there is no credential cache or HTTP client.
+
+use async_trait::async_trait;
+use cairn_connectors_core::{
+    CONTRACT_VERSION, Connector, ConnectorCapabilities, ConnectorError, ConnectorEvent,
+    ConnectorManifest, ConnectorPlugin, ContractVersion, Identity, PollContext, PollOutcome,
+    VersionRange, WebhookContext, WebhookRequest,
+};
+
+use crate::MANIFEST_TOML;
+use crate::clip;
+
+/// Generic web-clipper connector. Construct once per Cairn process.
+pub struct WebClipConnector {
+    manifest: ConnectorManifest,
+    sensor: Identity,
+}
+
+impl WebClipConnector {
+    /// Construct a new web-clipper connector from the bundled manifest.
+    ///
+    /// # Errors
+    /// Returns [`ConnectorError::Fatal`] if the bundled manifest or sensor
+    /// identity fails to parse (a compile-time invariant, covered by tests).
+    pub fn new() -> Result<Self, ConnectorError> {
+        let manifest = ConnectorManifest::parse_toml(MANIFEST_TOML)
+            .map_err(|e| ConnectorError::fatal_msg(format!("webclip manifest: {e}")))?;
+        let sensor = Identity::parse("snr:local:connector:webclip:v1")
+            .map_err(|e| ConnectorError::fatal_msg(format!("webclip sensor identity: {e:?}")))?;
+        Ok(Self { manifest, sensor })
+    }
+}
+
+#[async_trait]
+impl Connector for WebClipConnector {
+    fn name(&self) -> &str {
+        self.manifest.name()
+    }
+
+    fn manifest(&self) -> &ConnectorManifest {
+        &self.manifest
+    }
+
+    fn capabilities(&self) -> &ConnectorCapabilities {
+        static C: ConnectorCapabilities = ConnectorCapabilities {
+            poll: false,
+            webhook: true,
+            backfill: false,
+        };
+        &C
+    }
+
+    fn sensor_identity(&self) -> &Identity {
+        &self.sensor
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        <Self as ConnectorPlugin>::SUPPORTED_VERSIONS
+    }
+
+    // `poll = false` in the manifest, so the registry never calls this. The
+    // trait still requires a body; return an empty outcome.
+    async fn poll(&self, _cx: &PollContext) -> Result<PollOutcome, ConnectorError> {
+        Ok(PollOutcome::default())
+    }
+
+    async fn ingest_webhook(
+        &self,
+        req: &WebhookRequest,
+        _cx: &WebhookContext,
+    ) -> Result<Vec<ConnectorEvent>, ConnectorError> {
+        // The substrate has already verified the HMAC signature; we use the
+        // header value as the surrogate signature_id (same pattern as GitHub).
+        let signature_id = req
+            .header("X-Cairn-Signature-256")
+            .unwrap_or("unverified")
+            .to_owned();
+        Ok(vec![clip::parse_request(req, &signature_id)?])
+    }
+}
+
+impl ConnectorPlugin for WebClipConnector {
+    const NAME: &'static str = "webclip";
+    const SUPPORTED_VERSIONS: VersionRange =
+        VersionRange::new(CONTRACT_VERSION, ContractVersion::new(0, 2, 0));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn constructs_with_expected_identity() {
+        let c = WebClipConnector::new().expect("constructs");
+        assert_eq!(c.name(), "webclip");
+        assert_eq!(
+            c.sensor_identity().as_str(),
+            "snr:local:connector:webclip:v1"
+        );
+    }
+
+    #[test]
+    fn capabilities_are_webhook_only() {
+        let c = WebClipConnector::new().unwrap();
+        let caps = c.capabilities();
+        assert!(!caps.poll && caps.webhook && !caps.backfill);
+    }
+
+    #[test]
+    fn is_arc_dyn_connector() {
+        let c: Arc<dyn Connector> = Arc::new(WebClipConnector::new().unwrap());
+        assert_eq!(c.name(), "webclip");
+    }
+}

--- a/crates/cairn-connectors-webclip/src/error.rs
+++ b/crates/cairn-connectors-webclip/src/error.rs
@@ -1,0 +1,59 @@
+//! `WebClipError` — adapter-local parse errors, mapped to `ConnectorError`.
+
+use cairn_connectors_core::ConnectorError;
+
+/// Errors produced while parsing a web-clip webhook request into a
+/// [`cairn_connectors_core::ConnectorEvent`].
+///
+/// Every variant maps to [`ConnectorError::MalformedPayload`] so the substrate
+/// webhook handler returns `400 Bad Request`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WebClipError {
+    /// The request carried no `Content-Type` header.
+    #[error("missing Content-Type header")]
+    MissingContentType,
+    /// The `Content-Type` is not an accepted clip media type.
+    #[error("unsupported Content-Type: {0}")]
+    UnsupportedContentType(String),
+    /// A required field was absent (url, `captured_at`, or clip body).
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+    /// The clip URL could not be parsed or had no host component.
+    #[error("invalid clip url: {0}")]
+    BadUrl(String),
+    /// `captured_at` was not a valid Unix-seconds integer.
+    #[error("invalid captured_at: {0}")]
+    BadCapturedAt(String),
+    /// The JSON envelope failed to deserialize.
+    #[error("invalid json clip envelope: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl From<WebClipError> for ConnectorError {
+    fn from(err: WebClipError) -> Self {
+        ConnectorError::MalformedPayload(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_to_malformed_payload() {
+        let e: ConnectorError = WebClipError::BadUrl("file:///x".into()).into();
+        assert!(matches!(e, ConnectorError::MalformedPayload(_)));
+        assert_eq!(
+            e.to_string(),
+            "malformed payload: invalid clip url: file:///x"
+        );
+    }
+
+    #[test]
+    fn json_error_converts_via_from() {
+        let json_err = serde_json::from_str::<serde_json::Value>("{bad").unwrap_err();
+        let e: WebClipError = json_err.into();
+        assert!(matches!(e, WebClipError::Json(_)));
+    }
+}

--- a/crates/cairn-connectors-webclip/src/event_id.rs
+++ b/crates/cairn-connectors-webclip/src/event_id.rs
@@ -1,0 +1,77 @@
+//! Deterministic `ConnectorEventId` minting for web clips.
+//!
+//! Identical re-deliveries of the same clip must collapse to one record at the
+//! substrate's event-id dedup gate. We hash the clip identity tuple
+//! `(url, captured_at, payload_hash)` into the 16 bytes of a ULID, so the same
+//! clip always yields the same id while two distinct clips of the same URL at
+//! the same second differ via `payload_hash`.
+
+use cairn_connectors_core::ConnectorEventId;
+use sha2::{Digest, Sha256};
+use ulid::Ulid;
+
+/// Mint a deterministic ULID from the clip identity components.
+///
+/// All components are NUL-separated in the hash input so they cannot collide
+/// across boundaries (e.g. `["ab","c"]` != `["abc"]`).
+pub(crate) fn from_parts(kind: &str, url: &str, components: &[&str]) -> ConnectorEventId {
+    let mut hasher = Sha256::new();
+    hasher.update(b"cairn-connectors-webclip/v1\0");
+    hasher.update(kind.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(url.as_bytes());
+    for c in components {
+        hasher.update(b"\0");
+        hasher.update(c.as_bytes());
+    }
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    ConnectorEventId::new(Ulid::from_bytes(bytes).to_string())
+}
+
+/// Hash arbitrary wire bytes into a short hex revision component.
+pub(crate) fn payload_hash(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(&hasher.finalize()[..8])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cairn_connectors_core::ConnectorEventId;
+    use proptest::prelude::*;
+
+    #[test]
+    fn same_inputs_yield_same_id() {
+        let a = from_parts("clip", "https://e.com/a", &["100", "deadbeef"]);
+        let b = from_parts("clip", "https://e.com/a", &["100", "deadbeef"]);
+        assert_eq!(a.as_str(), b.as_str());
+    }
+
+    #[test]
+    fn different_payload_hash_yields_different_id() {
+        let a = from_parts("clip", "https://e.com/a", &["100", "aaaa"]);
+        let b = from_parts("clip", "https://e.com/a", &["100", "bbbb"]);
+        assert_ne!(a.as_str(), b.as_str());
+    }
+
+    #[test]
+    fn output_is_valid_ulid_for_substrate_parse() {
+        let id = from_parts("clip", "https://e.com/a", &["100", "rev"]);
+        let parsed = ConnectorEventId::parse(id.as_str()).expect("substrate accepts ULID");
+        assert_eq!(parsed.as_str(), id.as_str());
+    }
+
+    proptest! {
+        #[test]
+        fn from_parts_is_deterministic(url in "[a-z]{1,12}", ts in any::<i64>(), body in ".{0,40}") {
+            let h = payload_hash(body.as_bytes());
+            let ts_s = ts.to_string();
+            let a = from_parts("clip", &url, &[&ts_s, &h]);
+            let b = from_parts("clip", &url, &[&ts_s, &h]);
+            prop_assert_eq!(a.as_str(), b.as_str());
+        }
+    }
+}

--- a/crates/cairn-connectors-webclip/src/lib.rs
+++ b/crates/cairn-connectors-webclip/src/lib.rs
@@ -17,6 +17,7 @@
 /// constructing a `ConsentGrant` for the registry end-to-end test.
 pub const MANIFEST_TOML: &str = include_str!("../connector.toml");
 
+mod clip;
 mod error;
 mod event_id;
 

--- a/crates/cairn-connectors-webclip/src/lib.rs
+++ b/crates/cairn-connectors-webclip/src/lib.rs
@@ -18,6 +18,7 @@
 pub const MANIFEST_TOML: &str = include_str!("../connector.toml");
 
 mod error;
+mod event_id;
 
 pub use error::WebClipError;
 

--- a/crates/cairn-connectors-webclip/src/lib.rs
+++ b/crates/cairn-connectors-webclip/src/lib.rs
@@ -1,0 +1,39 @@
+//! Generic web-clipper connector adapter for `cairn-connectors-core`.
+//!
+//! Issue #131 (slice 2), brief §19 v0.3 connector set, §9.1 source sensors.
+//!
+//! A **webhook-only**, stateless adapter: a browser extension HMAC-signs and
+//! POSTs a captured clip to `POST /webhooks/webclip`. The substrate verifies
+//! the signature, then this adapter parses the request into exactly one
+//! [`cairn_connectors_core::ConnectorEvent`]. There is no upstream to poll, so
+//! `capabilities = { poll: false, webhook: true, backfill: false }`.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+/// Embedded `connector.toml` bytes, parsed at `WebClipConnector::new` time.
+///
+/// Exposed so integration tests can derive the expected `manifest_hash` when
+/// constructing a `ConsentGrant` for the registry end-to-end test.
+pub const MANIFEST_TOML: &str = include_str!("../connector.toml");
+
+#[cfg(test)]
+mod manifest_tests {
+    use super::MANIFEST_TOML;
+    use cairn_connectors_core::ConnectorManifest;
+
+    #[test]
+    fn manifest_parses_and_declares_webhook_only() {
+        let m = ConnectorManifest::parse_toml(MANIFEST_TOML).expect("manifest parses");
+        assert_eq!(m.name(), "webclip");
+        assert!(!m.capabilities.poll, "web clipper does not poll");
+        assert!(m.capabilities.webhook, "web clipper accepts webhooks");
+        assert!(!m.capabilities.backfill, "web clipper has no backfill");
+        assert!(m.allowed_label("source:web"));
+        assert!(m.allowed_label("kind:clip"));
+        assert!(m.scope_matches("domain", "en.wikipedia.org"));
+        assert!(m.allowed_mime("application/json"));
+        assert!(m.allowed_mime("text/markdown"));
+        assert!(m.allowed_mime("text/plain"));
+    }
+}

--- a/crates/cairn-connectors-webclip/src/lib.rs
+++ b/crates/cairn-connectors-webclip/src/lib.rs
@@ -18,9 +18,11 @@
 pub const MANIFEST_TOML: &str = include_str!("../connector.toml");
 
 mod clip;
+mod connector;
 mod error;
 mod event_id;
 
+pub use connector::WebClipConnector;
 pub use error::WebClipError;
 
 #[cfg(test)]

--- a/crates/cairn-connectors-webclip/src/lib.rs
+++ b/crates/cairn-connectors-webclip/src/lib.rs
@@ -25,6 +25,11 @@ mod event_id;
 pub use connector::WebClipConnector;
 pub use error::WebClipError;
 
+/// Test-only helpers exposed for integration tests. Cfg-gated; not part of the
+/// production API.
+#[cfg(any(test, feature = "testkit"))]
+pub mod testkit;
+
 #[cfg(test)]
 mod manifest_tests {
     use super::MANIFEST_TOML;

--- a/crates/cairn-connectors-webclip/src/lib.rs
+++ b/crates/cairn-connectors-webclip/src/lib.rs
@@ -17,6 +17,10 @@
 /// constructing a `ConsentGrant` for the registry end-to-end test.
 pub const MANIFEST_TOML: &str = include_str!("../connector.toml");
 
+mod error;
+
+pub use error::WebClipError;
+
 #[cfg(test)]
 mod manifest_tests {
     use super::MANIFEST_TOML;

--- a/crates/cairn-connectors-webclip/src/testkit.rs
+++ b/crates/cairn-connectors-webclip/src/testkit.rs
@@ -1,0 +1,45 @@
+//! Test-only helpers for building signed web-clip webhook requests.
+//!
+//! Cfg-gated; not part of the production API surface. Integration tests in
+//! `tests/` use these to construct `WebhookRequest`s for direct
+//! `ingest_webhook` calls.
+
+use cairn_connectors_core::WebhookRequest;
+use cairn_connectors_core::webhook::hex_hmac_sha256;
+
+/// Build a signed `application/json` clip request from a raw JSON body.
+#[must_use]
+pub fn json_clip_request(secret: &[u8], json_body: &str) -> WebhookRequest {
+    let sig = format!("sha256={}", hex_hmac_sha256(secret, json_body.as_bytes()));
+    WebhookRequest {
+        connector: "webclip".into(),
+        body: json_body.as_bytes().to_vec(),
+        headers: vec![
+            ("Content-Type".into(), "application/json".into()),
+            ("X-Cairn-Signature-256".into(), sig),
+        ],
+    }
+}
+
+/// Build a signed text-mode clip request (`mime` = `text/markdown` or
+/// `text/plain`) with the `X-Cairn-Clip-*` metadata headers.
+#[must_use]
+pub fn text_clip_request(
+    secret: &[u8],
+    mime: &str,
+    url: &str,
+    captured_at: i64,
+    body: &str,
+) -> WebhookRequest {
+    let sig = format!("sha256={}", hex_hmac_sha256(secret, body.as_bytes()));
+    WebhookRequest {
+        connector: "webclip".into(),
+        body: body.as_bytes().to_vec(),
+        headers: vec![
+            ("Content-Type".into(), mime.to_owned()),
+            ("X-Cairn-Signature-256".into(), sig),
+            ("X-Cairn-Clip-Url".into(), url.to_owned()),
+            ("X-Cairn-Clip-Captured-At".into(), captured_at.to_string()),
+        ],
+    }
+}

--- a/crates/cairn-connectors-webclip/tests/content_negotiation.rs
+++ b/crates/cairn-connectors-webclip/tests/content_negotiation.rs
@@ -1,0 +1,51 @@
+//! Content-Type acceptance / rejection table.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{
+    Connector, ConnectorError, CredentialHandle, WebhookContext, WebhookRequest,
+};
+use cairn_connectors_webclip::WebClipConnector;
+use rstest::rstest;
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+fn raw_request(content_type: &str, body: &[u8]) -> WebhookRequest {
+    WebhookRequest {
+        connector: "webclip".into(),
+        body: body.to_vec(),
+        headers: vec![("Content-Type".into(), content_type.into())],
+    }
+}
+
+#[rstest]
+#[case("text/html")]
+#[case("application/xml")]
+#[case("image/png")]
+#[tokio::test]
+async fn rejects_unsupported_content_type(#[case] content_type: &str) {
+    let connector = WebClipConnector::new().unwrap();
+    let req = raw_request(content_type, b"whatever");
+    let result = connector.ingest_webhook(&req, &ctx()).await;
+    assert!(
+        matches!(result, Err(ConnectorError::MalformedPayload(_))),
+        "expected MalformedPayload for {content_type}, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn accepts_json_with_charset_parameter() {
+    let connector = WebClipConnector::new().unwrap();
+    let body = br#"{"url":"https://e.com/a","captured_at":1,"selection":"x"}"#;
+    let req = WebhookRequest {
+        connector: "webclip".into(),
+        body: body.to_vec(),
+        headers: vec![(
+            "Content-Type".into(),
+            "application/json; charset=utf-8".into(),
+        )],
+    };
+    assert!(connector.ingest_webhook(&req, &ctx()).await.is_ok());
+}

--- a/crates/cairn-connectors-webclip/tests/fixtures/clip_json.json
+++ b/crates/cairn-connectors-webclip/tests/fixtures/clip_json.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://en.wikipedia.org/wiki/Cairn",
+  "title": "Cairn - Wikipedia",
+  "captured_at": 1748563200,
+  "markdown": "## Cairn\nA cairn is a human-made pile of stones.",
+  "note": "trail markers",
+  "tags": ["hiking", "reference"]
+}

--- a/crates/cairn-connectors-webclip/tests/fixtures/clip_markdown.md
+++ b/crates/cairn-connectors-webclip/tests/fixtures/clip_markdown.md
@@ -1,0 +1,3 @@
+## Cairn
+
+A cairn is a human-made pile (or stack) of stones raised for a purpose.

--- a/crates/cairn-connectors-webclip/tests/idempotent_event_id.rs
+++ b/crates/cairn-connectors-webclip/tests/idempotent_event_id.rs
@@ -1,0 +1,41 @@
+//! Re-delivery idempotency + content-sensitivity of the event id.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{Connector, CredentialHandle, WebhookContext};
+use cairn_connectors_webclip::{WebClipConnector, testkit};
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+#[tokio::test]
+async fn same_clip_twice_yields_same_event_id() {
+    let c = WebClipConnector::new().unwrap();
+    let body = include_str!("fixtures/clip_json.json");
+    let e1 = c
+        .ingest_webhook(&testkit::json_clip_request(b"s", body), &ctx())
+        .await
+        .unwrap();
+    let e2 = c
+        .ingest_webhook(&testkit::json_clip_request(b"s", body), &ctx())
+        .await
+        .unwrap();
+    assert_eq!(e1[0].event_id.as_str(), e2[0].event_id.as_str());
+}
+
+#[tokio::test]
+async fn same_url_same_second_different_body_differs() {
+    let c = WebClipConnector::new().unwrap();
+    let b1 = r#"{"url":"https://e.com/a","captured_at":100,"markdown":"one"}"#;
+    let b2 = r#"{"url":"https://e.com/a","captured_at":100,"markdown":"two"}"#;
+    let e1 = c
+        .ingest_webhook(&testkit::json_clip_request(b"s", b1), &ctx())
+        .await
+        .unwrap();
+    let e2 = c
+        .ingest_webhook(&testkit::json_clip_request(b"s", b2), &ctx())
+        .await
+        .unwrap();
+    assert_ne!(e1[0].event_id.as_str(), e2[0].event_id.as_str());
+}

--- a/crates/cairn-connectors-webclip/tests/ingest_json_clip.rs
+++ b/crates/cairn-connectors-webclip/tests/ingest_json_clip.rs
@@ -1,0 +1,32 @@
+//! JSON clip -> one per-domain-scoped `ConnectorEvent`.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{Connector, ConnectorPayload, CredentialHandle, WebhookContext};
+use cairn_connectors_webclip::{WebClipConnector, testkit};
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+#[tokio::test]
+async fn json_clip_produces_one_scoped_event() {
+    let connector = WebClipConnector::new().expect("construct");
+    let body = include_str!("fixtures/clip_json.json");
+    let req = testkit::json_clip_request(b"secret", body);
+
+    let events = connector
+        .ingest_webhook(&req, &ctx())
+        .await
+        .expect("ingest");
+    assert_eq!(events.len(), 1);
+    let e = &events[0];
+    assert_eq!(e.connector, "webclip");
+    assert_eq!(e.source_ref.kind, "clip");
+    assert_eq!(e.scope.kind, "domain");
+    assert_eq!(e.scope.value, "en.wikipedia.org");
+    assert_eq!(e.occurred_at, 1_748_563_200);
+    assert!(e.labels.contains("source:web"));
+    assert!(e.labels.contains("kind:clip"));
+    assert!(matches!(e.payload, ConnectorPayload::Json { .. }));
+}

--- a/crates/cairn-connectors-webclip/tests/ingest_markdown_clip.rs
+++ b/crates/cairn-connectors-webclip/tests/ingest_markdown_clip.rs
@@ -1,0 +1,31 @@
+//! text/markdown clip body + X-Cairn-Clip-* headers -> Text-payload event.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{Connector, ConnectorPayload, CredentialHandle, WebhookContext};
+use cairn_connectors_webclip::{WebClipConnector, testkit};
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+#[tokio::test]
+async fn markdown_clip_produces_text_payload_event() {
+    let connector = WebClipConnector::new().expect("construct");
+    let body = include_str!("fixtures/clip_markdown.md");
+    let req = testkit::text_clip_request(
+        b"secret",
+        "text/markdown",
+        "https://example.com/post/42",
+        1_748_563_200,
+        body,
+    );
+
+    let events = connector
+        .ingest_webhook(&req, &ctx())
+        .await
+        .expect("ingest");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].scope.value, "example.com");
+    assert!(matches!(events[0].payload, ConnectorPayload::Text { .. }));
+}

--- a/crates/cairn-connectors-webclip/tests/malformed_payload.rs
+++ b/crates/cairn-connectors-webclip/tests/malformed_payload.rs
@@ -1,0 +1,75 @@
+//! Adapter-side rejections all surface as `ConnectorError::MalformedPayload`.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{
+    Connector, ConnectorError, CredentialHandle, WebhookContext, WebhookRequest,
+};
+use cairn_connectors_webclip::WebClipConnector;
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+async fn assert_malformed(req: WebhookRequest) {
+    let connector = WebClipConnector::new().unwrap();
+    let result = connector.ingest_webhook(&req, &ctx()).await;
+    assert!(
+        matches!(result, Err(ConnectorError::MalformedPayload(_))),
+        "expected MalformedPayload, got {result:?}"
+    );
+}
+
+fn json_req(body: &[u8]) -> WebhookRequest {
+    WebhookRequest {
+        connector: "webclip".into(),
+        body: body.to_vec(),
+        headers: vec![("Content-Type".into(), "application/json".into())],
+    }
+}
+
+#[tokio::test]
+async fn json_missing_url_is_malformed() {
+    assert_malformed(json_req(br#"{"captured_at":1,"markdown":"x"}"#)).await;
+}
+
+#[tokio::test]
+async fn json_missing_captured_at_is_malformed() {
+    assert_malformed(json_req(br#"{"url":"https://e.com/a","markdown":"x"}"#)).await;
+}
+
+#[tokio::test]
+async fn json_no_body_field_is_malformed() {
+    assert_malformed(json_req(br#"{"url":"https://e.com/a","captured_at":1}"#)).await;
+}
+
+#[tokio::test]
+async fn hostless_url_is_malformed() {
+    assert_malformed(json_req(
+        br#"{"url":"file:///x","captured_at":1,"markdown":"x"}"#,
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn missing_content_type_is_malformed() {
+    assert_malformed(WebhookRequest {
+        connector: "webclip".into(),
+        body: b"{}".to_vec(),
+        headers: vec![],
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn text_mode_missing_url_header_is_malformed() {
+    assert_malformed(WebhookRequest {
+        connector: "webclip".into(),
+        body: b"body".to_vec(),
+        headers: vec![
+            ("Content-Type".into(), "text/plain".into()),
+            ("X-Cairn-Clip-Captured-At".into(), "1".into()),
+        ],
+    })
+    .await;
+}

--- a/crates/cairn-connectors-webclip/tests/registry_end_to_end.rs
+++ b/crates/cairn-connectors-webclip/tests/registry_end_to_end.rs
@@ -1,4 +1,4 @@
-//! End-to-end: signed clip -> real ConnectorRegistry webhook router -> PipelineEmit.
+//! End-to-end: signed clip -> real `ConnectorRegistry` webhook router -> `PipelineEmit`.
 //!
 //! Proves the adapter's event passes the substrate's full gate (HMAC verify ->
 //! consent -> label -> scope -> redaction -> spool -> emit) with the real
@@ -37,7 +37,7 @@ impl PipelineEmit for Capturer {
     }
 }
 
-/// Build a grant whose manifest_hash matches the compiled-in connector.toml.
+/// Build a grant whose `manifest_hash` matches the compiled-in connector.toml.
 fn webclip_grant() -> ConsentGrant {
     let manifest_hash = ConnectorManifest::parse_toml(MANIFEST_TOML)
         .expect("webclip manifest valid")

--- a/crates/cairn-connectors-webclip/tests/registry_end_to_end.rs
+++ b/crates/cairn-connectors-webclip/tests/registry_end_to_end.rs
@@ -1,0 +1,133 @@
+//! End-to-end: signed clip -> real ConnectorRegistry webhook router -> PipelineEmit.
+//!
+//! Proves the adapter's event passes the substrate's full gate (HMAC verify ->
+//! consent -> label -> scope -> redaction -> spool -> emit) with the real
+//! per-domain scope, and that a registered-but-not-enabled connector has no route.
+
+#![allow(missing_docs)]
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use tower::ServiceExt as _;
+
+use cairn_connectors_core::fixture::AcceptAllConsent;
+use cairn_connectors_core::manifest::ConnectorManifest;
+use cairn_connectors_core::webhook::hex_hmac_sha256;
+use cairn_connectors_core::{
+    ConnectorError, ConnectorRegistry, CredentialStore, InMemoryCredentialStore, PipelineEmit,
+};
+use cairn_connectors_webclip::{MANIFEST_TOML, WebClipConnector};
+use cairn_core::contract::connector_consent::ConsentGrant;
+use cairn_core::domain::Identity;
+use cairn_core::domain::capture::CaptureEvent;
+
+const SECRET: &[u8] = b"clip-secret";
+
+#[derive(Default)]
+struct Capturer(Mutex<Vec<CaptureEvent>>);
+
+#[async_trait::async_trait]
+impl PipelineEmit for Capturer {
+    async fn emit(&self, ev: CaptureEvent) -> Result<(), ConnectorError> {
+        self.0.lock().expect("mutex unpoisoned").push(ev);
+        Ok(())
+    }
+}
+
+/// Build a grant whose manifest_hash matches the compiled-in connector.toml.
+fn webclip_grant() -> ConsentGrant {
+    let manifest_hash = ConnectorManifest::parse_toml(MANIFEST_TOML)
+        .expect("webclip manifest valid")
+        .hash();
+    ConsentGrant::new(
+        "webclip",
+        manifest_hash,
+        BTreeSet::from(["source:web".to_string(), "kind:clip".to_string()]),
+        vec!["domain:*".to_string()],
+        1_700_000_000,
+        Identity::parse("hmn:alice").expect("valid identity"),
+    )
+}
+
+#[tokio::test]
+async fn signed_clip_reaches_pipeline_emit() {
+    let capturer = Arc::new(Capturer::default());
+    let creds = Arc::new(InMemoryCredentialStore::default());
+    creds
+        .put("connector/webclip/webhook_secret", SECRET.to_vec())
+        .await
+        .expect("secret put succeeds");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut reg = ConnectorRegistry::builder()
+        .credentials(Arc::clone(&creds) as Arc<dyn CredentialStore>)
+        .consent(Arc::new(AcceptAllConsent::default()))
+        .emit(capturer.clone() as Arc<dyn PipelineEmit>)
+        .spool_root(tmp.path().to_path_buf())
+        .build();
+
+    reg.register(WebClipConnector::new().expect("construct"))
+        .expect("register succeeds");
+    reg.enable("webclip", webclip_grant())
+        .await
+        .expect("enable succeeds");
+
+    let router = reg.webhook_router();
+
+    let body = include_str!("fixtures/clip_json.json");
+    let sig = format!("sha256={}", hex_hmac_sha256(SECRET, body.as_bytes()));
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/webhooks/webclip")
+        .header("content-type", "application/json")
+        .header("X-Cairn-Signature-256", &sig)
+        .body(Body::from(body))
+        .expect("request builds");
+
+    let resp = router.oneshot(req).await.expect("router responds");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "valid clip -> 204");
+
+    {
+        let events = capturer.0.lock().expect("mutex unpoisoned");
+        assert_eq!(events.len(), 1, "exactly one CaptureEvent emitted");
+        assert_eq!(
+            events[0].source_family,
+            cairn_core::domain::capture::SourceFamily::External,
+            "clip event must be source_family External",
+        );
+    }
+
+    reg.shutdown().await;
+}
+
+#[tokio::test]
+async fn not_enabled_connector_has_no_route() {
+    let mut reg = ConnectorRegistry::builder()
+        .credentials(Arc::new(InMemoryCredentialStore::default()))
+        .consent(Arc::new(AcceptAllConsent::default()))
+        .emit(Arc::new(Capturer::default()) as Arc<dyn PipelineEmit>)
+        .build();
+
+    // Register but do NOT enable.
+    reg.register(WebClipConnector::new().unwrap())
+        .expect("register succeeds");
+
+    let router = reg.webhook_router();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/webhooks/webclip")
+        .body(Body::from(b"{}".as_slice()))
+        .expect("request builds");
+
+    let resp = router.oneshot(req).await.expect("router responds");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "disabled connector must not have a webhook route (fail-closed)"
+    );
+
+    reg.shutdown().await;
+}

--- a/crates/cairn-connectors-webclip/tests/tags_not_promoted_to_labels.rs
+++ b/crates/cairn-connectors-webclip/tests/tags_not_promoted_to_labels.rs
@@ -1,0 +1,36 @@
+//! User tags stay inside the payload; emitted labels are fixed.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{Connector, ConnectorPayload, CredentialHandle, WebhookContext};
+use cairn_connectors_webclip::{WebClipConnector, testkit};
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+#[tokio::test]
+async fn tags_stay_in_payload_not_labels() {
+    let c = WebClipConnector::new().unwrap();
+    let body = include_str!("fixtures/clip_json.json"); // contains "tags"
+    let events = c
+        .ingest_webhook(&testkit::json_clip_request(b"s", body), &ctx())
+        .await
+        .unwrap();
+    let e = &events[0];
+
+    // Exactly the two manifest-declared labels — tags are NOT promoted.
+    assert_eq!(e.labels.len(), 2);
+    assert!(e.labels.contains("source:web") && e.labels.contains("kind:clip"));
+
+    // Tags survive inside the JSON payload as data.
+    match &e.payload {
+        ConnectorPayload::Json { body, .. } => {
+            assert!(
+                body.get("tags").is_some(),
+                "tags must be preserved in payload"
+            );
+        }
+        other => panic!("expected Json payload, got {other:?}"),
+    }
+}

--- a/docs/site/docs-coverage.toml
+++ b/docs/site/docs-coverage.toml
@@ -18,6 +18,11 @@ audience = "operator"
 page = "usage/plugins.md"
 generated_reference = "reference/generated/plugins.md"
 
+[packages.cairn-connectors-webclip]
+audience = "operator"
+page = "usage/plugins.md"
+generated_reference = "reference/generated/plugins.md"
+
 [packages.cairn-embeddings-local]
 audience = "internal"
 page = ""

--- a/docs/site/src/reference/generated/packages.md
+++ b/docs/site/src/reference/generated/packages.md
@@ -11,6 +11,7 @@ Generated from workspace package metadata and `docs-coverage.toml`.
 | `cairn-cli` | `user` | `usage/cli.md` | `reference/generated/cli.md` |
 | `cairn-connectors-core` | `operator` | `usage/plugins.md` | `reference/generated/plugins.md` |
 | `cairn-connectors-github` | `operator` | `usage/plugins.md` | `reference/generated/plugins.md` |
+| `cairn-connectors-webclip` | `operator` | `usage/plugins.md` | `reference/generated/plugins.md` |
 | `cairn-core` | `sdk-author` | `reference/rust-api.md` | - |
 | `cairn-desktop` | `operator` | `usage/cli.md` | - |
 | `cairn-embeddings-local` | `internal` | - | - |

--- a/docs/superpowers/plans/2026-05-30-issue-131-webclip-connector.md
+++ b/docs/superpowers/plans/2026-05-30-issue-131-webclip-connector.md
@@ -1,0 +1,1459 @@
+# Web-clipper Connector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `cairn-connectors-webclip`, a webhook-only connector that turns HMAC-signed web-clip POSTs into pipeline `ConnectorEvent`s, scoped per domain.
+
+**Architecture:** A new leaf crate implementing `cairn_connectors_core::Connector` + `ConnectorPlugin`. It advertises `poll=false, webhook=true, backfill=false`. `ingest_webhook` content-negotiates on `Content-Type` (`application/json` envelope vs `text/markdown`|`text/plain` body) and returns exactly one `ConnectorEvent`. The substrate verifies the HMAC and runs redaction/consent/budget/spool/emit; the adapter only parses request → event. Re-deliveries dedup via a deterministic ULID.
+
+**Tech Stack:** Rust 2024, `cairn-connectors-core`, `serde`/`serde_json`, `url`, `sha2`/`ulid`/`hex`, `async-trait`, `thiserror`. Tests: `tokio`, `rstest`, `proptest`, `axum`+`tower` (router e2e), `tempfile`, `cairn-core` + the `fixture` feature of the substrate.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-30-issue-131-webclip-connector-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `crates/cairn-connectors-webclip/Cargo.toml` | Crate manifest; deps are a strict subset of the GitHub adapter (no HTTP/OAuth/state). |
+| `crates/cairn-connectors-webclip/connector.toml` | Bundled `ConnectorManifest`; webhook-only; per-domain scope. |
+| `src/lib.rs` | Crate root: module wiring, `MANIFEST_TOML` const, `pub use`, testkit gate. |
+| `src/error.rs` | `WebClipError` + `From<WebClipError> for ConnectorError`. |
+| `src/event_id.rs` | Deterministic ULID minting from clip identity + payload hash. |
+| `src/clip.rs` | `ClipEnvelope`, `Content-Type` negotiation, `parse_request` → `ConnectorEvent`. The core logic. |
+| `src/connector.rs` | `WebClipConnector` — `Connector` + `ConnectorPlugin` impls; inert `poll`. |
+| `src/testkit.rs` | Test-only signed-request builders. |
+| `tests/fixtures/clip_json.json`, `clip_markdown.md` | Golden clip bodies. |
+| `tests/ingest_json_clip.rs`, `ingest_markdown_clip.rs`, `content_negotiation.rs`, `idempotent_event_id.rs`, `malformed_payload.rs`, `tags_not_promoted_to_labels.rs` | Direct `ingest_webhook` integration tests. |
+| `tests/registry_end_to_end.rs` | Full router → pipeline emit + disabled-route-404. |
+| Root `Cargo.toml` | Add `cairn-connectors-webclip` to `[workspace.dependencies]`. |
+
+---
+
+### Task 1: Crate scaffold + manifest
+
+**Files:**
+- Create: `crates/cairn-connectors-webclip/Cargo.toml`
+- Create: `crates/cairn-connectors-webclip/connector.toml`
+- Create: `crates/cairn-connectors-webclip/src/lib.rs`
+- Modify: `Cargo.toml` (root — add workspace dependency entry)
+
+- [ ] **Step 1: Write `Cargo.toml`**
+
+```toml
+[package]
+name = "cairn-connectors-webclip"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Generic web-clipper connector adapter (webhook-only) for cairn-connectors-core."
+
+[lints]
+workspace = true
+
+[features]
+default = ["testkit"]
+testkit = []
+
+[dependencies]
+cairn-connectors-core = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+ulid = { workspace = true }
+hex = { workspace = true }
+url = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+cairn-connectors-core = { workspace = true, features = ["fixture"] }
+cairn-core = { workspace = true }
+axum = { workspace = true }
+tower = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+rstest = { workspace = true }
+proptest = { workspace = true }
+tempfile = { workspace = true }
+```
+
+- [ ] **Step 2: Write `connector.toml`**
+
+```toml
+[connector]
+name              = "webclip"
+contract          = "Connector"
+contract_version  = "0.1.0"
+sensor_identity   = "snr:local:connector:webclip:v1"
+
+[capabilities]
+poll     = false
+webhook  = true
+backfill = false
+
+# Inert: the web clipper authenticates via the per-connector HMAC webhook
+# secret (CredentialStore key "connector/webclip/webhook_secret"), not OAuth.
+# The block is required by the manifest schema; the values are unused.
+[oauth]
+required_scopes = []
+token_lifetime  = "0s"
+refresh         = false
+
+[budget]
+max_items_per_hour = 600
+max_bytes_per_day  = "100MiB"
+
+[labels]
+allowed = ["source:web", "kind:clip"]
+
+[[scopes.declared]]
+kind    = "domain"
+pattern = "*"
+
+[webhook]
+"signature.algorithm" = "hmac-sha256"
+"signature.header"    = "X-Cairn-Signature-256"
+"signature.prefix"    = "sha256="
+allowed_mimes         = ["application/json", "text/markdown", "text/plain"]
+delivery_id_header    = "X-Cairn-Delivery"
+
+# Inert: poll = false means the registry never spawns a poll task. The block
+# is required by the manifest schema; the values are placeholders.
+[poll]
+cursor_kind      = "opaque-string"
+min_interval     = "60s"
+default_interval = "5m"
+
+[payload]
+max_bytes = "1MiB"
+max_depth = 16
+```
+
+- [ ] **Step 3: Write `src/lib.rs`** (minimal root + manifest-parse test)
+
+```rust
+//! Generic web-clipper connector adapter for `cairn-connectors-core`.
+//!
+//! Issue #131 (slice 2), brief §19 v0.3 connector set, §9.1 source sensors.
+//!
+//! A **webhook-only**, stateless adapter: a browser extension HMAC-signs and
+//! POSTs a captured clip to `POST /webhooks/webclip`. The substrate verifies
+//! the signature, then this adapter parses the request into exactly one
+//! [`cairn_connectors_core::ConnectorEvent`]. There is no upstream to poll, so
+//! `capabilities = { poll: false, webhook: true, backfill: false }`.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+/// Embedded `connector.toml` bytes, parsed at `WebClipConnector::new` time.
+///
+/// Exposed so integration tests can derive the expected `manifest_hash` when
+/// constructing a `ConsentGrant` for the registry end-to-end test.
+pub const MANIFEST_TOML: &str = include_str!("../connector.toml");
+
+#[cfg(test)]
+mod manifest_tests {
+    use super::MANIFEST_TOML;
+    use cairn_connectors_core::ConnectorManifest;
+
+    #[test]
+    fn manifest_parses_and_declares_webhook_only() {
+        let m = ConnectorManifest::parse_toml(MANIFEST_TOML).expect("manifest parses");
+        assert_eq!(m.name(), "webclip");
+        assert!(!m.capabilities.poll, "web clipper does not poll");
+        assert!(m.capabilities.webhook, "web clipper accepts webhooks");
+        assert!(!m.capabilities.backfill, "web clipper has no backfill");
+        assert!(m.allowed_label("source:web"));
+        assert!(m.allowed_label("kind:clip"));
+        assert!(m.scope_matches("domain", "en.wikipedia.org"));
+        assert!(m.allowed_mime("application/json"));
+        assert!(m.allowed_mime("text/markdown"));
+        assert!(m.allowed_mime("text/plain"));
+    }
+}
+```
+
+- [ ] **Step 4: Add the workspace dependency entry to root `Cargo.toml`**
+
+Find the line:
+```toml
+cairn-connectors-github = { path = "crates/cairn-connectors-github", version = "0.0.1" }
+```
+Add immediately after it:
+```toml
+cairn-connectors-webclip = { path = "crates/cairn-connectors-webclip", version = "0.0.1" }
+```
+(`members = ["crates/*"]` already includes the new crate; no members edit needed.)
+
+- [ ] **Step 5: Run the manifest test — verify it passes**
+
+Run: `cargo nextest run -p cairn-connectors-webclip --locked`
+Expected: PASS (`manifest_parses_and_declares_webhook_only`). If the manifest fails to parse, the error names the offending block.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/cairn-connectors-webclip/Cargo.toml \
+        crates/cairn-connectors-webclip/connector.toml \
+        crates/cairn-connectors-webclip/src/lib.rs \
+        Cargo.toml
+git commit -m "feat(connectors-webclip): crate scaffold + manifest (#131 slice 2)"
+```
+
+---
+
+### Task 2: `WebClipError`
+
+**Files:**
+- Create: `crates/cairn-connectors-webclip/src/error.rs`
+- Modify: `crates/cairn-connectors-webclip/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test** — append to `src/error.rs`:
+
+```rust
+//! `WebClipError` — adapter-local parse errors, mapped to `ConnectorError`.
+
+use cairn_connectors_core::ConnectorError;
+
+/// Errors produced while parsing a web-clip webhook request into a
+/// [`cairn_connectors_core::ConnectorEvent`].
+///
+/// Every variant maps to [`ConnectorError::MalformedPayload`] so the substrate
+/// webhook handler returns `400 Bad Request`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WebClipError {
+    /// The request carried no `Content-Type` header.
+    #[error("missing Content-Type header")]
+    MissingContentType,
+    /// The `Content-Type` is not an accepted clip media type.
+    #[error("unsupported Content-Type: {0}")]
+    UnsupportedContentType(String),
+    /// A required field was absent (url, captured_at, or clip body).
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+    /// The clip URL could not be parsed or had no host component.
+    #[error("invalid clip url: {0}")]
+    BadUrl(String),
+    /// `captured_at` was not a valid Unix-seconds integer.
+    #[error("invalid captured_at: {0}")]
+    BadCapturedAt(String),
+    /// The JSON envelope failed to deserialize.
+    #[error("invalid json clip envelope: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl From<WebClipError> for ConnectorError {
+    fn from(err: WebClipError) -> Self {
+        ConnectorError::MalformedPayload(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_to_malformed_payload() {
+        let e: ConnectorError = WebClipError::BadUrl("file:///x".into()).into();
+        assert!(matches!(e, ConnectorError::MalformedPayload(_)));
+        assert_eq!(e.to_string(), "malformed payload: invalid clip url: file:///x");
+    }
+
+    #[test]
+    fn json_error_converts_via_from() {
+        let json_err = serde_json::from_str::<serde_json::Value>("{bad").unwrap_err();
+        let e: WebClipError = json_err.into();
+        assert!(matches!(e, WebClipError::Json(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module** — in `src/lib.rs`, add after the `MANIFEST_TOML` const:
+
+```rust
+mod error;
+
+pub use error::WebClipError;
+```
+
+- [ ] **Step 3: Run the test — verify it passes**
+
+Run: `cargo nextest run -p cairn-connectors-webclip --locked error`
+Expected: PASS (`maps_to_malformed_payload`, `json_error_converts_via_from`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-connectors-webclip/src/error.rs crates/cairn-connectors-webclip/src/lib.rs
+git commit -m "feat(connectors-webclip): WebClipError -> ConnectorError mapping (#131)"
+```
+
+---
+
+### Task 3: Deterministic event IDs
+
+**Files:**
+- Create: `crates/cairn-connectors-webclip/src/event_id.rs`
+- Modify: `crates/cairn-connectors-webclip/src/lib.rs`
+
+- [ ] **Step 1: Write `src/event_id.rs`** (implementation + tests together — this is a pure leaf module)
+
+```rust
+//! Deterministic `ConnectorEventId` minting for web clips.
+//!
+//! Identical re-deliveries of the same clip must collapse to one record at the
+//! substrate's event-id dedup gate. We hash the clip identity tuple
+//! `(url, captured_at, payload_hash)` into the 16 bytes of a ULID, so the same
+//! clip always yields the same id while two distinct clips of the same URL at
+//! the same second differ via `payload_hash`.
+
+use cairn_connectors_core::ConnectorEventId;
+use sha2::{Digest, Sha256};
+use ulid::Ulid;
+
+/// Mint a deterministic ULID from the clip identity components.
+///
+/// All components are NUL-separated in the hash input so they cannot collide
+/// across boundaries (e.g. `["ab","c"]` ≠ `["abc"]`).
+pub(crate) fn from_parts(kind: &str, url: &str, components: &[&str]) -> ConnectorEventId {
+    let mut hasher = Sha256::new();
+    hasher.update(b"cairn-connectors-webclip/v1\0");
+    hasher.update(kind.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(url.as_bytes());
+    for c in components {
+        hasher.update(b"\0");
+        hasher.update(c.as_bytes());
+    }
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    ConnectorEventId::new(Ulid::from_bytes(bytes).to_string())
+}
+
+/// Hash arbitrary wire bytes into a short hex revision component.
+pub(crate) fn payload_hash(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(&hasher.finalize()[..8])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cairn_connectors_core::ConnectorEventId;
+    use proptest::prelude::*;
+
+    #[test]
+    fn same_inputs_yield_same_id() {
+        let a = from_parts("clip", "https://e.com/a", &["100", "deadbeef"]);
+        let b = from_parts("clip", "https://e.com/a", &["100", "deadbeef"]);
+        assert_eq!(a.as_str(), b.as_str());
+    }
+
+    #[test]
+    fn different_payload_hash_yields_different_id() {
+        let a = from_parts("clip", "https://e.com/a", &["100", "aaaa"]);
+        let b = from_parts("clip", "https://e.com/a", &["100", "bbbb"]);
+        assert_ne!(a.as_str(), b.as_str());
+    }
+
+    #[test]
+    fn output_is_valid_ulid_for_substrate_parse() {
+        let id = from_parts("clip", "https://e.com/a", &["100", "rev"]);
+        let parsed = ConnectorEventId::parse(id.as_str()).expect("substrate accepts ULID");
+        assert_eq!(parsed.as_str(), id.as_str());
+    }
+
+    proptest! {
+        #[test]
+        fn from_parts_is_deterministic(url in "[a-z]{1,12}", ts in any::<i64>(), body in ".{0,40}") {
+            let h = payload_hash(body.as_bytes());
+            let ts_s = ts.to_string();
+            let a = from_parts("clip", &url, &[&ts_s, &h]);
+            let b = from_parts("clip", &url, &[&ts_s, &h]);
+            prop_assert_eq!(a.as_str(), b.as_str());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module** — in `src/lib.rs`, add after `mod error;`:
+
+```rust
+mod event_id;
+```
+
+- [ ] **Step 3: Run the tests — verify they pass**
+
+Run: `cargo nextest run -p cairn-connectors-webclip --locked event_id`
+Expected: PASS (4 tests incl. the proptest).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-connectors-webclip/src/event_id.rs crates/cairn-connectors-webclip/src/lib.rs
+git commit -m "feat(connectors-webclip): deterministic clip event IDs (#131)"
+```
+
+---
+
+### Task 4: Clip parsing + content negotiation
+
+**Files:**
+- Create: `crates/cairn-connectors-webclip/src/clip.rs`
+- Modify: `crates/cairn-connectors-webclip/src/lib.rs`
+
+- [ ] **Step 1: Write `src/clip.rs`** (implementation + unit tests)
+
+```rust
+//! Parse a verified web-clip webhook request into a `ConnectorEvent`.
+//!
+//! Content negotiation on `Content-Type`:
+//! - `application/json` → structured [`ClipEnvelope`] → `ConnectorPayload::Json`.
+//! - `text/markdown` | `text/plain` → raw body + `X-Cairn-Clip-*` headers →
+//!   `ConnectorPayload::Text`.
+
+use std::collections::BTreeSet;
+
+use cairn_connectors_core::{
+    ConnectorEvent, ConnectorPayload, ConnectorScope, DeliveryMode, SourceRef, WebhookRequest,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::error::WebClipError;
+use crate::event_id;
+
+/// Connector name — must match the manifest `[connector] name`.
+const CONNECTOR_NAME: &str = "webclip";
+
+/// Structured clip envelope accepted in `application/json` mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ClipEnvelope {
+    /// Source page URL. Required; its host becomes the consent scope.
+    pub url: String,
+    /// Optional page title (rides in the payload for downstream use).
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Capture time, Unix seconds. Required.
+    pub captured_at: i64,
+    /// Selected text/HTML, if the user clipped a selection.
+    #[serde(default)]
+    pub selection: Option<String>,
+    /// Markdown form of the clip body.
+    #[serde(default)]
+    pub markdown: Option<String>,
+    /// Optional free-form user note.
+    #[serde(default)]
+    pub note: Option<String>,
+    /// Optional user tags. Preserved in the payload; NOT promoted to labels.
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+/// Accepted clip media types after `Content-Type` normalization.
+enum Media {
+    /// `application/json` structured envelope.
+    Json,
+    /// `text/markdown` or `text/plain`; the carried `String` is the concrete
+    /// MIME echoed into `ConnectorPayload::Text`.
+    Text(String),
+}
+
+/// Resolve and normalize the request `Content-Type` into a [`Media`].
+fn media_type(req: &WebhookRequest) -> Result<Media, WebClipError> {
+    let raw = req
+        .header("Content-Type")
+        .ok_or(WebClipError::MissingContentType)?;
+    // Strip parameters (`; charset=utf-8`) and normalize case/whitespace.
+    let base = raw
+        .split(';')
+        .next()
+        .unwrap_or(raw)
+        .trim()
+        .to_ascii_lowercase();
+    match base.as_str() {
+        "application/json" => Ok(Media::Json),
+        "text/markdown" | "text/plain" => Ok(Media::Text(base)),
+        other => Err(WebClipError::UnsupportedContentType(other.to_owned())),
+    }
+}
+
+/// Read a required header, erroring with [`WebClipError::MissingField`] if absent.
+fn header_required(req: &WebhookRequest, name: &'static str) -> Result<String, WebClipError> {
+    req.header(name)
+        .map(str::to_owned)
+        .ok_or(WebClipError::MissingField(name))
+}
+
+/// Parse a `captured_at` string as Unix seconds.
+fn parse_captured_at(s: &str) -> Result<i64, WebClipError> {
+    s.trim()
+        .parse::<i64>()
+        .map_err(|_| WebClipError::BadCapturedAt(s.to_owned()))
+}
+
+/// Parse a verified webhook request into exactly one [`ConnectorEvent`].
+///
+/// The substrate has already verified the HMAC signature; `signature_id` is the
+/// verified signature header value, recorded in `DeliveryMode::Webhook`.
+pub(crate) fn parse_request(
+    req: &WebhookRequest,
+    signature_id: &str,
+) -> Result<ConnectorEvent, WebClipError> {
+    let (url, captured_at, payload, hash_input) = match media_type(req)? {
+        Media::Json => {
+            let env: ClipEnvelope = serde_json::from_slice(&req.body)?;
+            if env.selection.is_none() && env.markdown.is_none() {
+                return Err(WebClipError::MissingField("selection|markdown"));
+            }
+            let body = serde_json::to_value(&env)?;
+            let hash_input = serde_json::to_vec(&body)?;
+            (
+                env.url.clone(),
+                env.captured_at,
+                ConnectorPayload::Json {
+                    mime: "application/json".to_owned(),
+                    body,
+                },
+                hash_input,
+            )
+        }
+        Media::Text(mime) => {
+            let url = header_required(req, "X-Cairn-Clip-Url")?;
+            let captured_at = parse_captured_at(&header_required(req, "X-Cairn-Clip-Captured-At")?)?;
+            let text = String::from_utf8_lossy(&req.body).into_owned();
+            let hash_input = req.body.clone();
+            (
+                url,
+                captured_at,
+                ConnectorPayload::Text { mime, body: text },
+                hash_input,
+            )
+        }
+    };
+
+    // Per-domain consent scope from the URL host.
+    let host = Url::parse(&url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_owned))
+        .ok_or_else(|| WebClipError::BadUrl(url.clone()))?;
+
+    let captured_str = captured_at.to_string();
+    let hash = event_id::payload_hash(&hash_input);
+    let event_id = event_id::from_parts("clip", &url, &[&captured_str, &hash]);
+
+    let mut labels = BTreeSet::new();
+    labels.insert("source:web".to_owned());
+    labels.insert("kind:clip".to_owned());
+
+    Ok(ConnectorEvent::new(
+        event_id,
+        CONNECTOR_NAME,
+        SourceRef::new("clip", url, None),
+        captured_at,
+        labels,
+        ConnectorScope::new("domain", host),
+        payload,
+        DeliveryMode::Webhook {
+            signature_id: signature_id.to_owned(),
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(headers: Vec<(&str, &str)>, body: &[u8]) -> WebhookRequest {
+        WebhookRequest {
+            connector: "webclip".into(),
+            body: body.to_vec(),
+            headers: headers
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn json_clip_builds_scoped_event() {
+        let body = br#"{"url":"https://en.wikipedia.org/wiki/Cairn","captured_at":100,"markdown":"hi"}"#;
+        let r = req(vec![("Content-Type", "application/json")], body);
+        let ev = parse_request(&r, "sig").expect("parses");
+        assert_eq!(ev.connector, "webclip");
+        assert_eq!(ev.scope.kind, "domain");
+        assert_eq!(ev.scope.value, "en.wikipedia.org");
+        assert_eq!(ev.source_ref.kind, "clip");
+        assert!(ev.labels.contains("source:web") && ev.labels.contains("kind:clip"));
+        assert!(matches!(ev.payload, ConnectorPayload::Json { .. }));
+    }
+
+    #[test]
+    fn json_charset_param_is_accepted() {
+        let body = br#"{"url":"https://e.com/a","captured_at":1,"selection":"x"}"#;
+        let r = req(vec![("Content-Type", "application/json; charset=utf-8")], body);
+        assert!(parse_request(&r, "sig").is_ok());
+    }
+
+    #[test]
+    fn text_markdown_uses_headers_for_metadata() {
+        let r = req(
+            vec![
+                ("Content-Type", "text/markdown"),
+                ("X-Cairn-Clip-Url", "https://example.com/post/42"),
+                ("X-Cairn-Clip-Captured-At", "1748563200"),
+            ],
+            b"## Heading\nbody",
+        );
+        let ev = parse_request(&r, "sig").expect("parses");
+        assert_eq!(ev.scope.value, "example.com");
+        assert_eq!(ev.occurred_at, 1_748_563_200);
+        assert!(matches!(ev.payload, ConnectorPayload::Text { .. }));
+    }
+
+    #[test]
+    fn missing_content_type_is_error() {
+        let r = req(vec![], b"{}");
+        assert!(matches!(parse_request(&r, "s"), Err(WebClipError::MissingContentType)));
+    }
+
+    #[test]
+    fn unsupported_content_type_is_error() {
+        let r = req(vec![("Content-Type", "text/html")], b"<p>x</p>");
+        assert!(matches!(
+            parse_request(&r, "s"),
+            Err(WebClipError::UnsupportedContentType(_))
+        ));
+    }
+
+    #[test]
+    fn json_without_body_field_is_error() {
+        let body = br#"{"url":"https://e.com/a","captured_at":1}"#;
+        let r = req(vec![("Content-Type", "application/json")], body);
+        assert!(matches!(parse_request(&r, "s"), Err(WebClipError::MissingField(_))));
+    }
+
+    #[test]
+    fn hostless_url_is_error() {
+        let body = br#"{"url":"file:///etc/passwd","captured_at":1,"markdown":"x"}"#;
+        let r = req(vec![("Content-Type", "application/json")], body);
+        assert!(matches!(parse_request(&r, "s"), Err(WebClipError::BadUrl(_))));
+    }
+
+    #[test]
+    fn text_missing_url_header_is_error() {
+        let r = req(
+            vec![
+                ("Content-Type", "text/plain"),
+                ("X-Cairn-Clip-Captured-At", "1"),
+            ],
+            b"body",
+        );
+        assert!(matches!(parse_request(&r, "s"), Err(WebClipError::MissingField(_))));
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module** — in `src/lib.rs`, add after `mod event_id;`:
+
+```rust
+mod clip;
+```
+
+- [ ] **Step 3: Run the tests — verify they pass**
+
+Run: `cargo nextest run -p cairn-connectors-webclip --locked clip`
+Expected: PASS (8 unit tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-connectors-webclip/src/clip.rs crates/cairn-connectors-webclip/src/lib.rs
+git commit -m "feat(connectors-webclip): clip envelope + content negotiation (#131)"
+```
+
+---
+
+### Task 5: `WebClipConnector`
+
+**Files:**
+- Create: `crates/cairn-connectors-webclip/src/connector.rs`
+- Modify: `crates/cairn-connectors-webclip/src/lib.rs`
+
+- [ ] **Step 1: Write `src/connector.rs`** (impl + unit tests)
+
+```rust
+//! `WebClipConnector` — `Connector` + `ConnectorPlugin` for web clips.
+//!
+//! Webhook-only and stateless: `poll` is never called (the manifest declares
+//! `poll = false`) and there is no credential cache or HTTP client.
+
+use async_trait::async_trait;
+use cairn_connectors_core::{
+    CONTRACT_VERSION, Connector, ConnectorCapabilities, ConnectorError, ConnectorEvent,
+    ConnectorManifest, ConnectorPlugin, ContractVersion, Identity, PollContext, PollOutcome,
+    VersionRange, WebhookContext, WebhookRequest,
+};
+
+use crate::MANIFEST_TOML;
+use crate::clip;
+
+/// Generic web-clipper connector. Construct once per Cairn process.
+pub struct WebClipConnector {
+    manifest: ConnectorManifest,
+    sensor: Identity,
+}
+
+impl WebClipConnector {
+    /// Construct a new web-clipper connector from the bundled manifest.
+    ///
+    /// # Errors
+    /// Returns [`ConnectorError::Fatal`] if the bundled manifest or sensor
+    /// identity fails to parse (a compile-time invariant, covered by tests).
+    pub fn new() -> Result<Self, ConnectorError> {
+        let manifest = ConnectorManifest::parse_toml(MANIFEST_TOML)
+            .map_err(|e| ConnectorError::fatal_msg(format!("webclip manifest: {e}")))?;
+        let sensor = Identity::parse("snr:local:connector:webclip:v1")
+            .map_err(|e| ConnectorError::fatal_msg(format!("webclip sensor identity: {e:?}")))?;
+        Ok(Self { manifest, sensor })
+    }
+}
+
+#[async_trait]
+impl Connector for WebClipConnector {
+    fn name(&self) -> &str {
+        self.manifest.name()
+    }
+
+    fn manifest(&self) -> &ConnectorManifest {
+        &self.manifest
+    }
+
+    fn capabilities(&self) -> &ConnectorCapabilities {
+        static C: ConnectorCapabilities = ConnectorCapabilities {
+            poll: false,
+            webhook: true,
+            backfill: false,
+        };
+        &C
+    }
+
+    fn sensor_identity(&self) -> &Identity {
+        &self.sensor
+    }
+
+    fn supported_contract_versions(&self) -> VersionRange {
+        <Self as ConnectorPlugin>::SUPPORTED_VERSIONS
+    }
+
+    // `poll = false` in the manifest, so the registry never calls this. The
+    // trait still requires a body; return an empty outcome.
+    async fn poll(&self, _cx: &PollContext) -> Result<PollOutcome, ConnectorError> {
+        Ok(PollOutcome::default())
+    }
+
+    async fn ingest_webhook(
+        &self,
+        req: &WebhookRequest,
+        _cx: &WebhookContext,
+    ) -> Result<Vec<ConnectorEvent>, ConnectorError> {
+        // The substrate has already verified the HMAC signature; we use the
+        // header value as the surrogate signature_id (same pattern as GitHub).
+        let signature_id = req
+            .header("X-Cairn-Signature-256")
+            .unwrap_or("unverified")
+            .to_owned();
+        Ok(vec![clip::parse_request(req, &signature_id)?])
+    }
+}
+
+impl ConnectorPlugin for WebClipConnector {
+    const NAME: &'static str = "webclip";
+    const SUPPORTED_VERSIONS: VersionRange =
+        VersionRange::new(CONTRACT_VERSION, ContractVersion::new(0, 2, 0));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn constructs_with_expected_identity() {
+        let c = WebClipConnector::new().expect("constructs");
+        assert_eq!(c.name(), "webclip");
+        assert_eq!(c.sensor_identity().as_str(), "snr:local:connector:webclip:v1");
+    }
+
+    #[test]
+    fn capabilities_are_webhook_only() {
+        let c = WebClipConnector::new().unwrap();
+        let caps = c.capabilities();
+        assert!(!caps.poll && caps.webhook && !caps.backfill);
+    }
+
+    #[test]
+    fn is_arc_dyn_connector() {
+        let c: Arc<dyn Connector> = Arc::new(WebClipConnector::new().unwrap());
+        assert_eq!(c.name(), "webclip");
+    }
+
+    #[tokio::test]
+    async fn poll_returns_empty_outcome() {
+        // `poll` is never called in production (poll=false) but must be inert.
+        let c = WebClipConnector::new().unwrap();
+        let cx = PollContext::new(
+            Arc::new(cairn_connectors_core::CredentialHandle::empty()),
+            None,
+            0,
+            tokio_util::sync::CancellationToken::new(),
+        );
+        let out = c.poll(&cx).await.expect("poll ok");
+        assert!(out.events.is_empty());
+    }
+}
+```
+
+> **Note for the implementer:** the `poll_returns_empty_outcome` test references `tokio_util::sync::CancellationToken`. `tokio-util` is **not** a dependency of this crate. Drop that one test (the inert `poll` is also exercised end-to-end by the registry never calling it), OR if you want to keep it, add `tokio-util = { workspace = true }` to `[dev-dependencies]`. **Recommended: delete the `poll_returns_empty_outcome` test** — the other three unit tests plus the inert manifest flag fully cover the webhook-only contract, and it avoids an extra dev-dep.
+
+- [ ] **Step 2: Wire the module + public export** — in `src/lib.rs`, add after `mod clip;`:
+
+```rust
+mod connector;
+
+pub use connector::WebClipConnector;
+```
+
+- [ ] **Step 3: Run the tests — verify they pass**
+
+Run: `cargo nextest run -p cairn-connectors-webclip --locked connector`
+Expected: PASS (3 tests; the `poll_returns_empty_outcome` test deleted per the note).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-connectors-webclip/src/connector.rs crates/cairn-connectors-webclip/src/lib.rs
+git commit -m "feat(connectors-webclip): WebClipConnector Connector impl (#131)"
+```
+
+---
+
+### Task 6: Test kit
+
+**Files:**
+- Create: `crates/cairn-connectors-webclip/src/testkit.rs`
+- Modify: `crates/cairn-connectors-webclip/src/lib.rs`
+
+- [ ] **Step 1: Write `src/testkit.rs`**
+
+```rust
+//! Test-only helpers for building signed web-clip webhook requests.
+//!
+//! Cfg-gated; not part of the production API surface. Integration tests in
+//! `tests/` use these to construct `WebhookRequest`s for direct
+//! `ingest_webhook` calls.
+
+use cairn_connectors_core::WebhookRequest;
+use cairn_connectors_core::webhook::hex_hmac_sha256;
+
+/// Build a signed `application/json` clip request from a raw JSON body.
+#[must_use]
+pub fn json_clip_request(secret: &[u8], json_body: &str) -> WebhookRequest {
+    let sig = format!("sha256={}", hex_hmac_sha256(secret, json_body.as_bytes()));
+    WebhookRequest {
+        connector: "webclip".into(),
+        body: json_body.as_bytes().to_vec(),
+        headers: vec![
+            ("Content-Type".into(), "application/json".into()),
+            ("X-Cairn-Signature-256".into(), sig),
+        ],
+    }
+}
+
+/// Build a signed text-mode clip request (`mime` = `text/markdown` or
+/// `text/plain`) with the `X-Cairn-Clip-*` metadata headers.
+#[must_use]
+pub fn text_clip_request(
+    secret: &[u8],
+    mime: &str,
+    url: &str,
+    captured_at: i64,
+    body: &str,
+) -> WebhookRequest {
+    let sig = format!("sha256={}", hex_hmac_sha256(secret, body.as_bytes()));
+    WebhookRequest {
+        connector: "webclip".into(),
+        body: body.as_bytes().to_vec(),
+        headers: vec![
+            ("Content-Type".into(), mime.to_owned()),
+            ("X-Cairn-Signature-256".into(), sig),
+            ("X-Cairn-Clip-Url".into(), url.to_owned()),
+            ("X-Cairn-Clip-Captured-At".into(), captured_at.to_string()),
+        ],
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module** — in `src/lib.rs`, add at the end:
+
+```rust
+/// Test-only helpers exposed for integration tests. Cfg-gated; not part of the
+/// production API.
+#[cfg(any(test, feature = "testkit"))]
+pub mod testkit;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cargo check -p cairn-connectors-webclip --all-targets --locked`
+Expected: clean build (no warnings).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cairn-connectors-webclip/src/testkit.rs crates/cairn-connectors-webclip/src/lib.rs
+git commit -m "feat(connectors-webclip): testkit signed-request builders (#131)"
+```
+
+---
+
+### Task 7: Direct `ingest_webhook` integration tests
+
+**Files:**
+- Create: `crates/cairn-connectors-webclip/tests/fixtures/clip_json.json`
+- Create: `crates/cairn-connectors-webclip/tests/fixtures/clip_markdown.md`
+- Create: `crates/cairn-connectors-webclip/tests/ingest_json_clip.rs`
+- Create: `crates/cairn-connectors-webclip/tests/ingest_markdown_clip.rs`
+- Create: `crates/cairn-connectors-webclip/tests/content_negotiation.rs`
+- Create: `crates/cairn-connectors-webclip/tests/idempotent_event_id.rs`
+- Create: `crates/cairn-connectors-webclip/tests/malformed_payload.rs`
+- Create: `crates/cairn-connectors-webclip/tests/tags_not_promoted_to_labels.rs`
+
+- [ ] **Step 1: Write the fixtures**
+
+`tests/fixtures/clip_json.json`:
+```json
+{
+  "url": "https://en.wikipedia.org/wiki/Cairn",
+  "title": "Cairn - Wikipedia",
+  "captured_at": 1748563200,
+  "markdown": "## Cairn\nA cairn is a human-made pile of stones.",
+  "note": "trail markers",
+  "tags": ["hiking", "reference"]
+}
+```
+
+`tests/fixtures/clip_markdown.md`:
+```markdown
+## Cairn
+
+A cairn is a human-made pile (or stack) of stones raised for a purpose.
+```
+
+- [ ] **Step 2: Write `tests/ingest_json_clip.rs`**
+
+```rust
+//! JSON clip → one per-domain-scoped ConnectorEvent.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{Connector, ConnectorPayload, CredentialHandle, WebhookContext};
+use cairn_connectors_webclip::{WebClipConnector, testkit};
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+#[tokio::test]
+async fn json_clip_produces_one_scoped_event() {
+    let connector = WebClipConnector::new().expect("construct");
+    let body = include_str!("fixtures/clip_json.json");
+    let req = testkit::json_clip_request(b"secret", body);
+
+    let events = connector.ingest_webhook(&req, &ctx()).await.expect("ingest");
+    assert_eq!(events.len(), 1);
+    let e = &events[0];
+    assert_eq!(e.connector, "webclip");
+    assert_eq!(e.source_ref.kind, "clip");
+    assert_eq!(e.scope.kind, "domain");
+    assert_eq!(e.scope.value, "en.wikipedia.org");
+    assert_eq!(e.occurred_at, 1_748_563_200);
+    assert!(e.labels.contains("source:web"));
+    assert!(e.labels.contains("kind:clip"));
+    assert!(matches!(e.payload, ConnectorPayload::Json { .. }));
+}
+```
+
+- [ ] **Step 3: Write `tests/ingest_markdown_clip.rs`**
+
+```rust
+//! text/markdown clip body + X-Cairn-Clip-* headers → Text-payload event.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{Connector, ConnectorPayload, CredentialHandle, WebhookContext};
+use cairn_connectors_webclip::{WebClipConnector, testkit};
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+#[tokio::test]
+async fn markdown_clip_produces_text_payload_event() {
+    let connector = WebClipConnector::new().expect("construct");
+    let body = include_str!("fixtures/clip_markdown.md");
+    let req = testkit::text_clip_request(
+        b"secret",
+        "text/markdown",
+        "https://example.com/post/42",
+        1_748_563_200,
+        body,
+    );
+
+    let events = connector.ingest_webhook(&req, &ctx()).await.expect("ingest");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].scope.value, "example.com");
+    assert!(matches!(events[0].payload, ConnectorPayload::Text { .. }));
+}
+```
+
+- [ ] **Step 4: Write `tests/content_negotiation.rs`**
+
+```rust
+//! Content-Type acceptance / rejection table.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{
+    Connector, ConnectorError, CredentialHandle, WebhookContext, WebhookRequest,
+};
+use cairn_connectors_webclip::WebClipConnector;
+use rstest::rstest;
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+fn raw_request(content_type: &str, body: &[u8]) -> WebhookRequest {
+    WebhookRequest {
+        connector: "webclip".into(),
+        body: body.to_vec(),
+        headers: vec![("Content-Type".into(), content_type.into())],
+    }
+}
+
+#[rstest]
+#[case("text/html")]
+#[case("application/xml")]
+#[case("image/png")]
+#[tokio::test]
+async fn rejects_unsupported_content_type(#[case] content_type: &str) {
+    let connector = WebClipConnector::new().unwrap();
+    // media_type() errors before the body is read, so any body is fine.
+    let req = raw_request(content_type, b"whatever");
+    let result = connector.ingest_webhook(&req, &ctx()).await;
+    assert!(
+        matches!(result, Err(ConnectorError::MalformedPayload(_))),
+        "expected MalformedPayload for {content_type}, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn accepts_json_with_charset_parameter() {
+    let connector = WebClipConnector::new().unwrap();
+    let body = br#"{"url":"https://e.com/a","captured_at":1,"selection":"x"}"#;
+    let req = WebhookRequest {
+        connector: "webclip".into(),
+        body: body.to_vec(),
+        headers: vec![("Content-Type".into(), "application/json; charset=utf-8".into())],
+    };
+    assert!(connector.ingest_webhook(&req, &ctx()).await.is_ok());
+}
+```
+
+- [ ] **Step 5: Write `tests/idempotent_event_id.rs`**
+
+```rust
+//! Re-delivery idempotency + content-sensitivity of the event id.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{Connector, CredentialHandle, WebhookContext};
+use cairn_connectors_webclip::{WebClipConnector, testkit};
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+#[tokio::test]
+async fn same_clip_twice_yields_same_event_id() {
+    let c = WebClipConnector::new().unwrap();
+    let body = include_str!("fixtures/clip_json.json");
+    let e1 = c.ingest_webhook(&testkit::json_clip_request(b"s", body), &ctx()).await.unwrap();
+    let e2 = c.ingest_webhook(&testkit::json_clip_request(b"s", body), &ctx()).await.unwrap();
+    assert_eq!(e1[0].event_id.as_str(), e2[0].event_id.as_str());
+}
+
+#[tokio::test]
+async fn same_url_same_second_different_body_differs() {
+    let c = WebClipConnector::new().unwrap();
+    let b1 = r#"{"url":"https://e.com/a","captured_at":100,"markdown":"one"}"#;
+    let b2 = r#"{"url":"https://e.com/a","captured_at":100,"markdown":"two"}"#;
+    let e1 = c.ingest_webhook(&testkit::json_clip_request(b"s", b1), &ctx()).await.unwrap();
+    let e2 = c.ingest_webhook(&testkit::json_clip_request(b"s", b2), &ctx()).await.unwrap();
+    assert_ne!(e1[0].event_id.as_str(), e2[0].event_id.as_str());
+}
+```
+
+- [ ] **Step 6: Write `tests/malformed_payload.rs`**
+
+```rust
+//! Adapter-side rejections all surface as ConnectorError::MalformedPayload.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{
+    Connector, ConnectorError, CredentialHandle, WebhookContext, WebhookRequest,
+};
+use cairn_connectors_webclip::WebClipConnector;
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+async fn assert_malformed(req: WebhookRequest) {
+    let connector = WebClipConnector::new().unwrap();
+    let result = connector.ingest_webhook(&req, &ctx()).await;
+    assert!(
+        matches!(result, Err(ConnectorError::MalformedPayload(_))),
+        "expected MalformedPayload, got {result:?}"
+    );
+}
+
+fn json_req(body: &[u8]) -> WebhookRequest {
+    WebhookRequest {
+        connector: "webclip".into(),
+        body: body.to_vec(),
+        headers: vec![("Content-Type".into(), "application/json".into())],
+    }
+}
+
+#[tokio::test]
+async fn json_missing_url_is_malformed() {
+    assert_malformed(json_req(br#"{"captured_at":1,"markdown":"x"}"#)).await;
+}
+
+#[tokio::test]
+async fn json_missing_captured_at_is_malformed() {
+    assert_malformed(json_req(br#"{"url":"https://e.com/a","markdown":"x"}"#)).await;
+}
+
+#[tokio::test]
+async fn json_no_body_field_is_malformed() {
+    assert_malformed(json_req(br#"{"url":"https://e.com/a","captured_at":1}"#)).await;
+}
+
+#[tokio::test]
+async fn hostless_url_is_malformed() {
+    assert_malformed(json_req(br#"{"url":"file:///x","captured_at":1,"markdown":"x"}"#)).await;
+}
+
+#[tokio::test]
+async fn missing_content_type_is_malformed() {
+    assert_malformed(WebhookRequest {
+        connector: "webclip".into(),
+        body: b"{}".to_vec(),
+        headers: vec![],
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn text_mode_missing_url_header_is_malformed() {
+    assert_malformed(WebhookRequest {
+        connector: "webclip".into(),
+        body: b"body".to_vec(),
+        headers: vec![
+            ("Content-Type".into(), "text/plain".into()),
+            ("X-Cairn-Clip-Captured-At".into(), "1".into()),
+        ],
+    })
+    .await;
+}
+```
+
+- [ ] **Step 7: Write `tests/tags_not_promoted_to_labels.rs`**
+
+```rust
+//! User tags stay inside the payload; emitted labels are fixed.
+
+use std::sync::Arc;
+
+use cairn_connectors_core::{Connector, ConnectorPayload, CredentialHandle, WebhookContext};
+use cairn_connectors_webclip::{WebClipConnector, testkit};
+
+fn ctx() -> WebhookContext {
+    WebhookContext::new(Arc::new(CredentialHandle::empty()), 1000)
+}
+
+#[tokio::test]
+async fn tags_stay_in_payload_not_labels() {
+    let c = WebClipConnector::new().unwrap();
+    let body = include_str!("fixtures/clip_json.json"); // contains "tags"
+    let events = c.ingest_webhook(&testkit::json_clip_request(b"s", body), &ctx()).await.unwrap();
+    let e = &events[0];
+
+    // Exactly the two manifest-declared labels — tags are NOT promoted.
+    assert_eq!(e.labels.len(), 2);
+    assert!(e.labels.contains("source:web") && e.labels.contains("kind:clip"));
+
+    // Tags survive inside the JSON payload as data.
+    match &e.payload {
+        ConnectorPayload::Json { body, .. } => {
+            assert!(body.get("tags").is_some(), "tags must be preserved in payload");
+        }
+        other => panic!("expected Json payload, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 8: Run all integration tests — verify they pass**
+
+Run: `cargo nextest run -p cairn-connectors-webclip --locked`
+Expected: PASS (all unit + integration tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/cairn-connectors-webclip/tests/
+git commit -m "test(connectors-webclip): ingest, content-neg, idempotency, malformed (#131)"
+```
+
+---
+
+### Task 8: Registry end-to-end + verification
+
+**Files:**
+- Create: `crates/cairn-connectors-webclip/tests/registry_end_to_end.rs`
+
+- [ ] **Step 1: Write `tests/registry_end_to_end.rs`**
+
+```rust
+//! End-to-end: signed clip → real ConnectorRegistry webhook router → PipelineEmit.
+//!
+//! Proves the adapter's event passes the substrate's full gate (HMAC verify →
+//! consent → label → scope → redaction → spool → emit) with the real per-domain
+//! scope, and that a registered-but-not-enabled connector has no route.
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use tower::ServiceExt as _;
+
+use cairn_connectors_core::fixture::AcceptAllConsent;
+use cairn_connectors_core::manifest::ConnectorManifest;
+use cairn_connectors_core::webhook::hex_hmac_sha256;
+use cairn_connectors_core::{
+    ConnectorError, ConnectorRegistry, CredentialStore, InMemoryCredentialStore, PipelineEmit,
+};
+use cairn_connectors_webclip::{MANIFEST_TOML, WebClipConnector};
+use cairn_core::contract::connector_consent::ConsentGrant;
+use cairn_core::domain::Identity;
+use cairn_core::domain::capture::CaptureEvent;
+
+const SECRET: &[u8] = b"clip-secret";
+
+#[derive(Default)]
+struct Capturer(Mutex<Vec<CaptureEvent>>);
+
+#[async_trait::async_trait]
+impl PipelineEmit for Capturer {
+    async fn emit(&self, ev: CaptureEvent) -> Result<(), ConnectorError> {
+        self.0.lock().expect("mutex unpoisoned").push(ev);
+        Ok(())
+    }
+}
+
+/// Build a grant whose manifest_hash matches the compiled-in connector.toml.
+fn webclip_grant() -> ConsentGrant {
+    let manifest_hash = ConnectorManifest::parse_toml(MANIFEST_TOML)
+        .expect("webclip manifest valid")
+        .hash();
+    ConsentGrant::new(
+        "webclip",
+        manifest_hash,
+        BTreeSet::from(["source:web".to_string(), "kind:clip".to_string()]),
+        vec!["domain:*".to_string()],
+        1_700_000_000,
+        Identity::parse("hmn:alice").expect("valid identity"),
+    )
+}
+
+#[tokio::test]
+async fn signed_clip_reaches_pipeline_emit() {
+    let capturer = Arc::new(Capturer::default());
+    let creds = Arc::new(InMemoryCredentialStore::default());
+    creds
+        .put("connector/webclip/webhook_secret", SECRET.to_vec())
+        .await
+        .expect("secret put succeeds");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut reg = ConnectorRegistry::builder()
+        .credentials(Arc::clone(&creds) as Arc<dyn CredentialStore>)
+        .consent(Arc::new(AcceptAllConsent::default()))
+        .emit(capturer.clone() as Arc<dyn PipelineEmit>)
+        .spool_root(tmp.path().to_path_buf())
+        .build();
+
+    reg.register(WebClipConnector::new().expect("construct"))
+        .expect("register succeeds");
+    reg.enable("webclip", webclip_grant())
+        .await
+        .expect("enable succeeds");
+
+    let router = reg.webhook_router();
+
+    let body = include_str!("fixtures/clip_json.json");
+    let sig = format!("sha256={}", hex_hmac_sha256(SECRET, body.as_bytes()));
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/webhooks/webclip")
+        .header("content-type", "application/json")
+        .header("X-Cairn-Signature-256", &sig)
+        .body(Body::from(body))
+        .expect("request builds");
+
+    let resp = router.oneshot(req).await.expect("router responds");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "valid clip → 204");
+
+    {
+        let events = capturer.0.lock().expect("mutex unpoisoned");
+        assert_eq!(events.len(), 1, "exactly one CaptureEvent emitted");
+        assert_eq!(
+            events[0].source_family,
+            cairn_core::domain::capture::SourceFamily::External,
+            "clip event must be source_family External",
+        );
+    }
+
+    reg.shutdown().await;
+}
+
+#[tokio::test]
+async fn not_enabled_connector_has_no_route() {
+    let mut reg = ConnectorRegistry::builder()
+        .credentials(Arc::new(InMemoryCredentialStore::default()))
+        .consent(Arc::new(AcceptAllConsent::default()))
+        .emit(Arc::new(Capturer::default()) as Arc<dyn PipelineEmit>)
+        .build();
+
+    // Register but do NOT enable.
+    reg.register(WebClipConnector::new().unwrap())
+        .expect("register succeeds");
+
+    let router = reg.webhook_router();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/webhooks/webclip")
+        .body(Body::from(b"{}".as_slice()))
+        .expect("request builds");
+
+    let resp = router.oneshot(req).await.expect("router responds");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "disabled connector must not have a webhook route (fail-closed)"
+    );
+
+    reg.shutdown().await;
+}
+```
+
+- [ ] **Step 2: Run the end-to-end tests — verify they pass**
+
+Run: `cargo nextest run -p cairn-connectors-webclip --locked registry_end_to_end`
+Expected: PASS (`signed_clip_reaches_pipeline_emit`, `not_enabled_connector_has_no_route`).
+
+> If `signed_clip_reaches_pipeline_emit` returns a non-204 status, print the response: a `400` means the manifest `allowed_mimes` or the grant `scope_patterns`/`allowed_labels` don't match what the adapter emits; a `401` means the secret key path is wrong (`connector/webclip/webhook_secret`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/cairn-connectors-webclip/tests/registry_end_to_end.rs
+git commit -m "test(connectors-webclip): registry router end-to-end emit (#131)"
+```
+
+- [ ] **Step 4: Run the full local verification suite (CLAUDE.md §8)**
+
+```bash
+cargo fmt --all --check
+cargo clippy -p cairn-connectors-webclip --all-targets --locked -- -D warnings
+cargo check -p cairn-connectors-webclip --all-targets --locked
+cargo nextest run -p cairn-connectors-webclip --locked --no-fail-fast
+cargo test --doc -p cairn-connectors-webclip --locked
+./scripts/check-core-boundary.sh
+cargo deny check
+cargo machete
+```
+Expected: all green. Fix any clippy pedantic findings inline (e.g. add `#[must_use]`, doc comments). `cargo machete` must report no unused deps — if it flags one, remove it from `Cargo.toml`.
+
+- [ ] **Step 5: Regenerate docs (workspace membership changed)**
+
+```bash
+cargo run -p cairn-cli --bin cairn-docgen --locked -- --write
+```
+If this produces changes under `docs/site/src/reference/generated/`, stage them. If there is no diff, skip.
+
+- [ ] **Step 6: Full-workspace regression check**
+
+```bash
+cargo nextest run --workspace --locked --no-fail-fast
+```
+Expected: no regressions in other crates.
+
+- [ ] **Step 7: Commit any docgen output**
+
+```bash
+git add docs/site/src/reference/generated/ 2>/dev/null || true
+git commit -m "docs: regenerate reference after adding cairn-connectors-webclip (#131)" || echo "no docgen diff"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §1 in-scope webhook-only adapter → Task 5. ✓
+- §2 invariants (fail-closed, forbid unsafe, no core dep) → `#![forbid(unsafe_code)]` (Task 1/3), capabilities + `not_enabled_connector_has_no_route` (Task 8), cairn-core dev-only (Task 1 Cargo.toml). ✓
+- §3 crate topology → Tasks 1–6 create exactly the listed files. ✓
+- §4 manifest → Task 1 `connector.toml` + parse test. ✓
+- §5 wire contract (endpoint, JSON/text negotiation, headers, captured_at) → Task 4 `clip.rs` + tests. ✓
+- §6 event construction (event_id, scope, labels, tags-not-labels, delivery) → Tasks 3, 4, 7. ✓
+- §7 Connector impl → Task 5. ✓
+- §8 error mapping → Task 2. ✓
+- §9 tests → Tasks 7, 8. ✓
+- §10 acceptance/deviation: idempotency (`idempotent_event_id.rs`), auth/malformed (`malformed_payload.rs`, e2e 401/404), searchable/scoped (`signed_clip_reaches_pipeline_emit`). ✓
+- §11 CI verification → Task 8 Steps 4–6. ✓
+- §3.3 workspace wiring + docgen → Task 1 Step 4, Task 8 Step 5. ✓
+
+**2. Placeholder scan:** No `TBD`/`TODO`/"handle errors appropriately". Every code step shows full code. The one conditional (the `poll_returns_empty_outcome` test needing `tokio-util`) is resolved explicitly with a recommended action (delete it). ✓
+
+**3. Type consistency:** `WebClipConnector::new() -> Result<Self, ConnectorError>` used identically in Tasks 5, 7, 8. `clip::parse_request(req, signature_id)` signature matches its definition and its caller in `connector.rs`. `event_id::from_parts(kind, url, components)` / `payload_hash(bytes)` match between Task 3 and Task 4. `testkit::json_clip_request` / `text_clip_request` signatures match between Task 6 and Tasks 7/8. Manifest name `"webclip"`, scope `domain:*`, labels `{source:web, kind:clip}`, secret key `connector/webclip/webhook_secret`, signature header `X-Cairn-Signature-256` are consistent across manifest, adapter, testkit, and the e2e grant. ✓
+
+---
+
+## Execution Handoff
+
+(Filled in by the brainstorming/writing-plans operator after saving.)

--- a/docs/superpowers/specs/2026-05-30-issue-131-webclip-connector-design.md
+++ b/docs/superpowers/specs/2026-05-30-issue-131-webclip-connector-design.md
@@ -1,0 +1,417 @@
+# Issue #131 — Generic web-clipper connector adapter (slice 2)
+
+- **Issue:** [#131 — P2 Implement GitHub, email, Drive/OneDrive, Notion, and web clipper adapters](https://github.com/windoliver/cairn/issues/131)
+- **Parent epic:** #29 Source connectors and aggregate memory extension
+- **Substrate dependency:** #130 connector framework (closed; landed as `cairn-connectors-core`)
+- **Sibling slice:** #131 slice 1 — GitHub adapter (`cairn-connectors-github`, PR #424, merged). This spec reuses that slice's structure mechanically.
+- **Design brief reference:** §19 v0.3 connector set ("a generic web-clipper extension"); §9.1 source sensors; §14 privacy/consent
+- **Phase:** v0.3 — Federation + evolution (P2)
+
+---
+
+## 1. Scope
+
+Issue #131 enumerates **five** connector adapters: GitHub, email, Drive/OneDrive, Notion, web clipper. Per CLAUDE.md §5 ("keep the diff scoped"), each is its own L2 crate under `crates/cairn-connectors-<vendor>/` and its own PR. Slice 1 (GitHub) is merged. **This spec covers only the generic web-clipper adapter.** The remaining three (email, Drive/OneDrive, Notion) are deferred to follow-up slices.
+
+The web clipper is the **push-only** member of the connector set: there is no upstream service to poll. A browser extension (or any HTTP client) HMAC-signs and `POST`s a captured clip to the connector's webhook endpoint. This makes it the simplest slice and a useful proof that the substrate supports a **second delivery topology** (webhook-only) distinct from GitHub's poll-shaped adapter.
+
+### 1.1 In scope (this PR)
+
+- New crate `cairn-connectors-webclip` implementing `cairn_connectors_core::Connector` + `ConnectorPlugin`.
+- **Webhook-only delivery.** `capabilities = { poll: false, webhook: true, backfill: false }`.
+- **Content-negotiated payloads** in `ingest_webhook`, branching on `Content-Type`:
+  - `application/json` → structured clip envelope → `ConnectorPayload::Json`.
+  - `text/markdown` | `text/plain` → raw clip body → `ConnectorPayload::Text`; clip metadata supplied via `X-Cairn-Clip-*` headers.
+- **Per-domain consent scoping**: `scope = domain:<host>`, host parsed from the clip URL; manifest declares `kind = "domain", pattern = "*"`.
+- **Deterministic event IDs** for idempotent re-delivery (`from_parts("clip", url, &[captured_at, payload_hash])`), mirroring GitHub's `event_id.rs`.
+- Bundled `connector.toml` manifest, validated at construction time.
+- Substrate-backed integration tests (real `ConnectorRegistry` + `RedactionPipeline`); no network mock needed (no upstream HTTP).
+
+### 1.2 Out of scope (this PR, tracked separately)
+
+- Email, Drive/OneDrive, Notion adapter crates — follow-up slices against #131.
+- `cairn admin connector_enable` / `connector_disable` / `connector_backfill` CLI verbs and wiring the connector into the `cairn-cli` binary — those belong to the #29 epic / #161, not the per-adapter slice (GitHub slice 1 did not wire them either).
+- **Binary payloads** (image/PDF clips). The substrate rejects `ConnectorPayload::Binary` in P0 (see `cairn-connectors-core::event` — "P0 substrate rejects Binary payloads"); the spool-verified binary path is itself part of #131's broader work but **not** this slice. Clips are text/markdown/JSON only.
+- The browser-extension client itself. This PR defines and tests the **wire contract** (endpoint, headers, envelope); shipping an extension is separate.
+- Full-page HTML capture / readability extraction. The extension is expected to send already-extracted markdown or a structured selection; raw `text/html` is **not** in `allowed_mimes` for this slice.
+
+---
+
+## 2. Load-bearing invariants this PR touches
+
+From CLAUDE.md §4:
+
+| Invariant | How this PR honors it |
+|---|---|
+| 1. Harness-agnostic | No code path references any harness. |
+| 3. CLI is ground truth | Adapter exposes no verbs; substrate owns the webhook route. |
+| 4. Seven contracts | Implements `Connector` only; no new contract added. |
+| 5. WAL + two-phase apply | Emits `ConnectorEvent`s; substrate's `process_event` spools + emits via existing pipeline. Adapter never writes the DB. |
+| 6. Fail closed on capability | Manifest `capabilities` is authoritative: `poll = false` → no poll task spawned; route only mounted when enabled + `webhook = true`. |
+| 7. `#![forbid(unsafe_code)]` | Applied at crate root. |
+| 8. No `unwrap()`/`expect()` in core | Adapter is **not** core; `expect("invariant: …")` tolerated in bins/tests only. |
+| 9. Privacy by construction | Manifest label allow-list gates every emit; redaction runs in substrate before persist; raw clip bodies never logged above `trace`; per-domain consent scope. |
+| 10. Sources immutable | Adapter only ingests; never writes back to any source. |
+
+---
+
+## 3. Crate topology
+
+```
+crates/cairn-connectors-webclip/
+├── Cargo.toml
+├── connector.toml                 # bundled at compile time via include_str!
+├── src/
+│   ├── lib.rs                     # pub use WebClipConnector; #![forbid(unsafe_code)]
+│   ├── connector.rs               # Connector + ConnectorPlugin impls; inert poll(); ingest_webhook()
+│   ├── clip.rs                    # ClipEnvelope + Content-Type negotiation; parse request -> ConnectorEvent
+│   ├── event_id.rs                # deterministic ULID minting (from_parts + payload_hash)
+│   ├── error.rs                   # WebClipError -> ConnectorError mapping
+│   └── testkit.rs                 # cfg/feature-gated helpers: build signed WebhookRequest, sample clips
+└── tests/
+    ├── fixtures/
+    │   ├── clip_json.json          # structured envelope
+    │   └── clip_markdown.md        # raw markdown body
+    ├── ingest_json_clip.rs         # JSON clip -> one ConnectorEvent (scope/labels/source_ref)
+    ├── ingest_markdown_clip.rs     # markdown body + X-Cairn-Clip-* headers -> one event
+    ├── content_negotiation.rs      # rstest table over Content-Type values incl. params + unknown
+    ├── idempotent_event_id.rs      # same clip twice -> identical event_id
+    ├── malformed_payload.rs        # bad URL / missing captured_at / unsupported Content-Type -> MalformedPayload
+    ├── tags_not_promoted_to_labels.rs  # user tags stay in payload; labels stay {source:web, kind:clip}
+    ├── registry_end_to_end.rs      # register -> enable (grant domain:*) -> ingest_webhook -> emit
+    └── disabled_no_emit.rs         # ingest before enable / after disable -> rejected, no emit
+```
+
+### 3.1 Dependency rules
+
+- New crate depends on `cairn-connectors-core` only — **never** on `cairn-core` directly in non-dev code. Enforced by `scripts/check-core-boundary.sh`.
+- No cross-adapter imports (must not depend on `cairn-connectors-github` or any future sibling).
+
+### 3.2 Cargo.toml deps
+
+The web clipper is **stateless and network-free** — no HTTP client, no OAuth, no auth cache, no interior mutability. Its dependency set is therefore a strict subset of GitHub's.
+
+| Dep | Use | Notes |
+|---|---|---|
+| `cairn-connectors-core` | substrate trait + re-exported core types | workspace dep |
+| `async-trait` | `#[async_trait]` on the `Connector` impl | workspace |
+| `serde` / `serde_json` | clip envelope + payload JSON | workspace |
+| `sha2` | payload hash for deterministic event_id | workspace |
+| `ulid` | ULID construction for event_id | workspace |
+| `hex` | hex-encode the short payload hash | workspace |
+| `url` | parse clip URL → host (scope) | workspace (already used by GitHub) |
+| `tracing` | logging (metadata only; never bodies) | workspace |
+| `thiserror` | `WebClipError` enum | workspace |
+| **dev** `cairn-connectors-core` `features=["fixture"]` | substrate test helpers | |
+| **dev** `cairn-core` | construct `ConsentGrant`, assert `CaptureEvent` | for registry end-to-end test |
+| **dev** `tokio` `features=["macros","rt-multi-thread"]` | `#[tokio::test]` | |
+| **dev** `rstest` | content-negotiation table tests | workspace |
+| **dev** `insta` | snapshot of parsed event | workspace |
+| **dev** `proptest` | event_id determinism / URL parsing round-trips | workspace |
+| **dev** `tempfile` | spool dir for registry end-to-end test | workspace |
+
+**No** `reqwest`, `wiremock`, `jsonwebtoken`, `arc-swap`, `chrono`, or `tokio-util` direct dep — none apply to a push-only, stateless adapter. (`captured_at` is carried as **Unix seconds**, avoiding a date-parsing crate; see §5.)
+
+### 3.3 Workspace wiring
+
+- `members = ["crates/*"]` in the root `Cargo.toml` auto-includes the new crate; no members edit needed.
+- Add `cairn-connectors-webclip = { path = "crates/cairn-connectors-webclip", version = "0.0.1" }` to `[workspace.dependencies]` for symmetry with `cairn-connectors-github` and so a later CLI-registration PR can reference it.
+- Adding a workspace package triggers the docgen gate (CLAUDE.md §8): re-run `cairn-docgen --write` and commit the generated reference Markdown.
+
+---
+
+## 4. Manifest (`connector.toml`)
+
+Every block in `ConnectorManifest` is **mandatory** (`cairn-connectors-core::manifest`, `#[serde(deny_unknown_fields)]`). A webhook-only connector therefore still ships inert `[oauth]` and `[poll]` blocks.
+
+```toml
+[connector]
+name              = "webclip"
+contract          = "Connector"
+contract_version  = "0.1.0"
+sensor_identity   = "snr:local:connector:webclip:v1"
+
+[capabilities]
+poll     = false
+webhook  = true
+backfill = false
+
+# Inert: the web clipper authenticates via the per-connector HMAC webhook
+# secret (CredentialStore key "connector/webclip/webhook_secret"), not OAuth.
+# The block is required by the manifest schema; values are unused.
+[oauth]
+required_scopes = []
+token_lifetime  = "0s"
+refresh         = false
+
+[budget]
+max_items_per_hour = 600
+max_bytes_per_day  = "100MiB"
+
+[labels]
+allowed = ["source:web", "kind:clip"]
+
+[[scopes.declared]]
+kind    = "domain"
+pattern = "*"
+
+[webhook]
+"signature.algorithm" = "hmac-sha256"
+"signature.header"    = "X-Cairn-Signature-256"
+"signature.prefix"    = "sha256="
+allowed_mimes         = ["application/json", "text/markdown", "text/plain"]
+delivery_id_header    = "X-Cairn-Delivery"
+
+# Inert: poll = false means the registry never spawns a poll task. The block
+# is required by the manifest schema; values are placeholders.
+[poll]
+cursor_kind      = "opaque-string"
+min_interval     = "60s"
+default_interval = "5m"
+
+[payload]
+max_bytes = "1MiB"
+max_depth = 16
+```
+
+Bundled via `include_str!("../connector.toml")` and parsed by `ConnectorManifest::parse_toml` inside `WebClipConnector::new`. The substrate's `register()` checks that the runtime `sensor_identity()` equals the manifest declaration and that the wire form is `snr:local:connector:webclip:v…`.
+
+`delivery_id_header` is adapter-facing metadata only — the substrate keys its replay guard on the HMAC of the body, never on this header (see `manifest::WebhookBlock` docs). Identical-body dedup beyond that is handled by our deterministic `event_id`.
+
+---
+
+## 5. Wire contract
+
+### 5.1 Endpoint
+
+`POST /webhooks/webclip` — mounted by `ConnectorRegistry::webhook_router()` once the connector is registered **and** enabled. Before calling `ingest_webhook`, the substrate:
+
+1. Bounds the body by `payload.max_bytes` (`1MiB`) → `413` if exceeded.
+2. Looks up the secret at `CredentialStore::get("connector/webclip/webhook_secret")` → `401` if absent.
+3. Verifies HMAC-SHA256 over the raw body using header `X-Cairn-Signature-256` with prefix `sha256=` → `401` on mismatch.
+
+The adapter therefore **never** verifies the signature itself.
+
+### 5.2 JSON mode (`Content-Type: application/json`)
+
+Body is a structured envelope:
+
+```jsonc
+{
+  "url": "https://en.wikipedia.org/wiki/Cairn",   // required
+  "title": "Cairn - Wikipedia",                    // optional
+  "captured_at": 1748563200,                       // required, Unix seconds (i64)
+  "selection": "A cairn is a human-made pile…",    // clip body; one of selection|markdown required
+  "markdown": "## Cairn\nA cairn is…",             // clip body (markdown form)
+  "note": "for the trail-marker article",          // optional user note
+  "tags": ["hiking", "reference"]                   // optional; NOT promoted to labels (see §6)
+}
+```
+
+Parsed into a `ClipEnvelope` (`#[serde(deny_unknown_fields)]`). At least one of `selection` / `markdown` must be present. The resulting `ConnectorPayload::Json { mime: "application/json", body }` carries the re-serialized, validated envelope so downstream extract/classify sees full structure.
+
+### 5.3 Text mode (`Content-Type: text/markdown` or `text/plain`)
+
+Body is the raw clip text (opaque to the adapter). Metadata rides in headers:
+
+| Header | Required | Meaning |
+|---|---|---|
+| `X-Cairn-Clip-Url` | yes | source URL (→ scope + `source_ref`) |
+| `X-Cairn-Clip-Captured-At` | yes | Unix seconds (decimal string) |
+| `X-Cairn-Clip-Title` | no | clip title |
+
+Produces `ConnectorPayload::Text { mime: <content-type>, body: <raw text> }`. `note`/`tags` are JSON-mode only (text mode has no structured envelope).
+
+### 5.4 Content-Type matching
+
+`Content-Type` is read case-insensitively; parameters are stripped (`application/json; charset=utf-8` → `application/json`) and the result trimmed before matching. Any value not in `{application/json, text/markdown, text/plain}` → `WebClipError::UnsupportedContentType` → `ConnectorError::MalformedPayload`.
+
+`captured_at` is **required** in both modes. Carrying it explicitly (rather than stamping a server clock) keeps the adapter free of wall-clock reads, makes `occurred_at` and `event_id` deterministic, and makes every test reproducible. Missing/unparseable → `MalformedPayload`.
+
+---
+
+## 6. Event construction
+
+For each accepted request, `ingest_webhook` returns exactly **one** `ConnectorEvent`:
+
+| Field | Value |
+|---|---|
+| `event_id` | `event_id::from_parts("clip", &url, &[&captured_at.to_string(), &payload_hash])` — deterministic ULID. |
+| `connector` | `"webclip"`. |
+| `source_ref` | `{ kind: "clip", system_id: <url>, sub_id: None }`. |
+| `occurred_at` | `captured_at` (Unix seconds, `i64`). |
+| `labels` | fixed `{ "source:web", "kind:clip" }` (BTreeSet) — both declared in the manifest. |
+| `scope` | `ConnectorScope::new("domain", <host>)` where `<host>` = `Url::parse(url).host_str()`. Missing host → `MalformedPayload`. |
+| `payload` | `Json` (JSON mode) or `Text` (text mode) per §5. |
+| `delivery` | `DeliveryMode::Webhook { signature_id }` using the `X-Cairn-Signature-256` header value as the surrogate id (same pattern as GitHub). |
+
+`payload_hash` = `hex(sha256(<wire bytes>))[..16 hex chars]` — over the raw body bytes (text) or the canonical re-serialized JSON (json). This guarantees two distinct clips of the same URL at the same second still get distinct event IDs, while identical re-deliveries collapse to one.
+
+**Tags do not become labels.** Promoting user-supplied `tags` to `ConnectorEvent::labels` would trip the substrate's undeclared-label gate (`process_event` rejects any label outside the manifest allow-list and the grant). Tags are preserved inside the JSON payload as data, surfaced downstream by extract/classify — not as taxonomy labels.
+
+The substrate's `process_event` then runs: ULID path-safety check → name integrity → enabled check → manifest-hash/consent → grant + manifest label checks → grant scope-pattern + manifest scope match → MIME/size validation → budget reserve → **redaction** → spool (two-phase) → `build_capture_event` → re-check enabled → emit. The adapter contributes none of these; it only produces a well-formed event.
+
+---
+
+## 7. `Connector` implementation sketch
+
+```rust
+// connector.rs
+pub struct WebClipConnector {
+    manifest: ConnectorManifest,
+    sensor: Identity,
+}
+
+impl WebClipConnector {
+    pub fn new() -> Result<Self, ConnectorError> {
+        let manifest = ConnectorManifest::parse_toml(MANIFEST_TOML)?;
+        let sensor = Identity::parse("snr:local:connector:webclip:v1")?;
+        Ok(Self { manifest, sensor })
+    }
+}
+
+#[async_trait]
+impl Connector for WebClipConnector {
+    fn name(&self) -> &str { self.manifest.name() }
+    fn manifest(&self) -> &ConnectorManifest { &self.manifest }
+    fn capabilities(&self) -> &ConnectorCapabilities {
+        static C: ConnectorCapabilities =
+            ConnectorCapabilities { poll: false, webhook: true, backfill: false };
+        &C
+    }
+    fn sensor_identity(&self) -> &Identity { &self.sensor }
+    fn supported_contract_versions(&self) -> VersionRange {
+        <Self as ConnectorPlugin>::SUPPORTED_VERSIONS
+    }
+
+    // poll = false in the manifest, so the registry never calls this. The trait
+    // still requires a body; return an empty outcome.
+    async fn poll(&self, _cx: &PollContext) -> Result<PollOutcome, ConnectorError> {
+        Ok(PollOutcome::default())
+    }
+
+    async fn ingest_webhook(
+        &self,
+        req: &WebhookRequest,
+        _cx: &WebhookContext,
+    ) -> Result<Vec<ConnectorEvent>, ConnectorError> {
+        let signature_id = req.header("X-Cairn-Signature-256").unwrap_or("unverified").to_owned();
+        Ok(vec![clip::parse_request(req, &signature_id)?])
+    }
+}
+
+impl ConnectorPlugin for WebClipConnector {
+    const NAME: &'static str = "webclip";
+    const SUPPORTED_VERSIONS: VersionRange =
+        VersionRange::new(CONTRACT_VERSION, ContractVersion::new(0, 2, 0));
+}
+```
+
+`clip::parse_request` owns all the fallible parsing (Content-Type negotiation, URL/host, `captured_at`, envelope validation) and returns a `WebClipError` that converts (`#[from]`) into `ConnectorError::MalformedPayload`.
+
+---
+
+## 8. Error handling
+
+`WebClipError` (thiserror) → `ConnectorError`:
+
+| `WebClipError` | Cause | Maps to |
+|---|---|---|
+| `MissingContentType` | no `Content-Type` header | `MalformedPayload` |
+| `UnsupportedContentType(String)` | type not in allow-list | `MalformedPayload` |
+| `MissingField(&'static str)` | required url / captured_at / clip body absent | `MalformedPayload` |
+| `BadUrl(String)` | URL unparseable or has no host | `MalformedPayload` |
+| `BadCapturedAt(String)` | non-integer Unix seconds | `MalformedPayload` |
+| `Json(serde_json::Error)` | envelope parse failed (`#[from]`) | `MalformedPayload` |
+
+All adapter-side failures are `MalformedPayload`, which the webhook handler maps to a `4xx`. Signature (`401`), consent (`ConsentRevoked`), budget (`BudgetExceeded`), rate-limit, and spool errors are the substrate's responsibility. No `unwrap`/`expect` outside tests; no `panic!`.
+
+---
+
+## 9. Test strategy
+
+### 9.1 Integration tests (`tests/`) — real substrate, no network mock
+
+| Test file | What it proves |
+|---|---|
+| `ingest_json_clip.rs` | JSON envelope → one event: `scope = domain:en.wikipedia.org`, labels `{source:web,kind:clip}`, `source_ref.kind = "clip"`, `payload = Json`. |
+| `ingest_markdown_clip.rs` | `text/markdown` body + `X-Cairn-Clip-*` headers → one event with `payload = Text`. |
+| `content_negotiation.rs` | `rstest` table: `application/json`, `text/markdown`, `text/plain`, json-with-charset-param all accepted; `text/html` and `application/xml` rejected. |
+| `idempotent_event_id.rs` | Same clip parsed twice → identical `event_id`; same URL + same second but different body → different `event_id`. |
+| `malformed_payload.rs` | Missing URL, missing `captured_at`, hostless URL (`file:///x`), missing Content-Type, unsupported type → `ConnectorError::MalformedPayload`. |
+| `tags_not_promoted_to_labels.rs` | Envelope with `tags` → emitted labels are exactly `{source:web,kind:clip}`; tags present in payload JSON. |
+| `registry_end_to_end.rs` | `register` → `enable` with a `ConsentGrant` whose `scope_patterns = ["domain:*"]` and `allowed_labels = {source:web,kind:clip}` (and matching `manifest_hash`) → drive `ingest_webhook` via the connector → assert the spooled `CaptureEvent` emitted. Mirrors GitHub's `registry_end_to_end.rs`. |
+| `disabled_no_emit.rs` | `process_event` before enable / after disable rejects with no emit (substrate gate; asserts capability fail-closed). |
+
+Tests construct signed `WebhookRequest`s with `cairn_connectors_core::webhook::hex_hmac_sha256` (+ `sha256=` prefix) via a `testkit` helper. The registry end-to-end test uses a `tempfile::tempdir()` spool root and an in-memory consent journal / emit recorder from `cairn-connectors-core`'s fixture feature.
+
+### 9.2 Unit tests (inline `#[cfg(test)] mod tests`)
+
+- `clip.rs` — Content-Type normalization (param stripping, case); URL→host extraction; `captured_at` parsing; envelope `deny_unknown_fields`; "at least one of selection/markdown" rule.
+- `event_id.rs` — determinism (same inputs → same ULID), output is a valid ULID accepted by `ConnectorEventId::parse`, content-change → different id; `proptest` over arbitrary url/captured_at/body.
+- `error.rs` — `WebClipError` → `ConnectorError::MalformedPayload` mapping.
+- `connector.rs` — `new()` constructs; `name()=="webclip"`; capabilities `{false,true,false}`; sensor identity string; `poll()` returns empty.
+
+### 9.3 No mocking the substrate
+
+Per CLAUDE.md §6.4: integration tests use the **real** `ConnectorRegistry`, **real** consent gate, **real** `RedactionPipeline`. There is no upstream network to mock for a push-only connector.
+
+---
+
+## 10. Acceptance-criteria mapping (and the push-only deviation)
+
+Issue #131 acceptance criteria were written for the connector set as a whole and assume a **poll-shaped** source. The web clipper has no upstream to poll, so the cursor/backfill criteria are reinterpreted, not dropped:
+
+| Criterion | Web-clipper treatment |
+|---|---|
+| "Each connector can backfill and incrementally sync fixture data." | **Reinterpreted.** A push-only source has no cursor/backfill. The clipper's equivalent of incremental sync is **idempotent webhook ingestion**: deterministic `event_id` (§6) + the substrate's body-HMAC replay guard ensure re-delivered clips collapse to one record. `capabilities.poll = false`, `backfill = false` are declared honestly. Covered by `idempotent_event_id.rs`. |
+| "Rate limits and auth failures are reported without data corruption." | Per-scope item budget + daily byte budget are enforced by the substrate from the manifest (`max_items_per_hour`, `max_bytes_per_day`); over-budget events return `BudgetExceeded` with no partial spool (substrate two-phase write). "Auth failure" = missing/invalid webhook secret → `401` before `ingest_webhook`. Adapter-side malformed input → `MalformedPayload` (`4xx`), nothing persisted. Covered by `malformed_payload.rs` + substrate budget tests. |
+| "Imported records remain searchable, scoped, and forgettable." | Events flow through the unchanged substrate pipeline → existing `cairn-core` search/forget paths. Scope = `domain:<host>` makes per-site `forget` and scoped search work. Covered by `registry_end_to_end.rs` asserting a scoped `CaptureEvent`. |
+
+This deviation is intentional and documented so review does not read `poll = false` as a missing requirement. **Verification checklist** items map: "adapter fixture tests" → §9.1 ingest tests; "cursor/backfill tests" → N/A for push-only, replaced by `idempotent_event_id.rs` (documented above); "rate-limit/auth failure tests" → `malformed_payload.rs` + substrate budget/secret gates.
+
+---
+
+## 11. CI verification (run before opening the PR)
+
+Per CLAUDE.md §8:
+
+```bash
+cargo fmt --all --check
+cargo clippy -p cairn-connectors-webclip --all-targets --locked -- -D warnings
+cargo check -p cairn-connectors-webclip --all-targets --locked
+cargo nextest run -p cairn-connectors-webclip --locked --no-fail-fast
+cargo test --doc -p cairn-connectors-webclip --locked
+./scripts/check-core-boundary.sh
+cargo deny check
+cargo audit --deny warnings
+cargo machete
+# workspace package membership changed → regenerate docs:
+cargo run -p cairn-cli --bin cairn-docgen --locked -- --write   # commit generated Markdown
+```
+
+Then a full-workspace `cargo nextest run --workspace --locked --no-fail-fast` to confirm nothing else regressed.
+
+---
+
+## 12. Risks and open items
+
+| Risk | Mitigation |
+|---|---|
+| Acceptance criteria assume polling | §10 documents the push-only reinterpretation explicitly; reviewers sign off on it rather than discovering it. |
+| Single connector instance per process | Substrate registry keys by `name()`; manifest fixes name to `"webclip"`. One clipper per process is sufficient (one local endpoint). Matches GitHub slice's documented limitation. |
+| `text/html` / binary clips wanted later | Out of scope here (§1.2); `allowed_mimes` and the absence of `Binary` make the boundary explicit. Adding HTML is a one-line manifest change + a parse branch in a follow-up. |
+| Client must send `captured_at` | Documented in the wire contract (§5); the extension is ours to define. Avoids a server clock and keeps tests deterministic. |
+| Webhook secret provisioning | Out of scope for the slice (operator provisions `connector/webclip/webhook_secret` via the same path GitHub uses); the registry returns `401` until provisioned — fail-closed. |
+
+---
+
+## 13. Follow-ups (not in this PR)
+
+1. Email adapter (`cairn-connectors-email`) — IMAP poll + inbound webhook.
+2. Drive / OneDrive adapter (`cairn-connectors-drive`) — OAuth + change-feed cursors; needs the spool-verified Binary path.
+3. Notion adapter (`cairn-connectors-notion`) — Notion API poll + webhook.
+4. Wire `webclip` (and siblings) into `cairn-cli` connector registration + `cairn admin connector_*` verbs (#29 / #161).
+5. Ship the browser extension that produces the wire contract defined in §5.
+
+Each follow-up gets its own spec under `docs/superpowers/specs/` and reuses this slice's structure.


### PR DESCRIPTION
## Summary

Implements the **generic web-clipper connector** — slice 2 of #131 (slice 1 = GitHub adapter, #424). A new leaf crate `cairn-connectors-webclip` on top of the merged connector framework (#130).

- **Webhook-only, stateless** adapter (`poll=false, webhook=true, backfill=false`). A browser extension HMAC-signs and POSTs a clip to `POST /webhooks/webclip`; the substrate verifies the signature, then the adapter parses the request into exactly one `ConnectorEvent`. No HTTP client, OAuth, or state.
- **Content-negotiated payloads**: `application/json` envelope, or `text/markdown` | `text/plain` body with `X-Cairn-Clip-*` metadata headers.
- **Per-domain consent scope** (`domain:<host>`) for site-level grant/forget; fixed labels `{source:web, kind:clip}`. User `tags` stay in the payload and are **not** promoted to labels (guards the undeclared-label gate).
- **Deterministic `event_id`** (ULID from url+captured_at+payload hash) → idempotent re-delivery, the push-only stand-in for "incremental sync".
- All redaction/consent/budget/spool/emit is handled by the substrate's `process_event`; the adapter only produces a well-formed event.

Design + plan: `docs/superpowers/specs/2026-05-30-issue-131-webclip-connector-design.md`, `docs/superpowers/plans/2026-05-30-issue-131-webclip-connector.md`.

## Acceptance criteria (#131)

- **Sync fixture data** — reinterpreted for a push-only source as idempotent webhook ingestion (`tests/idempotent_event_id.rs`); `poll=false`/`backfill=false` declared honestly (documented deviation, spec §10).
- **Rate-limit/auth failures without corruption** — adapter-side malformed input → `MalformedPayload`/400 (`tests/malformed_payload.rs`); missing secret → 401, over-budget → `BudgetExceeded`, two-phase spool — all substrate-enforced.
- **Searchable/scoped/forgettable** — `tests/registry_end_to_end.rs` drives a signed clip through the **real** registry router and asserts a scoped `CaptureEvent` reaches `PipelineEmit`.

## Reviewer notes

- **Binary payloads out of scope** (P0 substrate rejects them); clips are JSON/markdown/plain text only.
- `axum`/`tower` added as **dev-deps** (not in the original spec table) to drive the real webhook router in the end-to-end test.
- `default = ["testkit"]` mirrors the GitHub sibling crate's pattern (testkit helpers ship by default).
- `tracing` intentionally omitted — the adapter logs nothing (would be an unused dep).

## Test Plan

- [x] `cargo nextest run -p cairn-connectors-webclip` — 35 tests pass (unit + ingest + content-neg + idempotency + malformed + tags + registry e2e)
- [x] `cargo clippy -p cairn-connectors-webclip --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `./scripts/check-core-boundary.sh` — OK (no direct cairn-core dep in non-dev)
- [x] `cargo nextest run --workspace` — 5967 pass, no regressions
- [x] `cargo deny check`, `cargo machete` — clean for this crate
- [x] `cairn-docgen --check` — in sync (package registered)