### PR TITLE
feat(mcp): wire ingest/capture_trace/forget through a mutating-verb host

### DIFF
--- a/crates/cairn-cli/src/mcp.rs
+++ b/crates/cairn-cli/src/mcp.rs
@@ -22,6 +22,69 @@ use cairn_workflows::{
     SqliteJobStore, SystemClock, default_golden_checks,
 };
 
+/// [`cairn_mcp::MutatingVerbHost`] implementation backed by the CLI's
+/// signed verb runtime.
+///
+/// Routes the MCP `ingest`, `capture_trace`, and `forget` tools through the
+/// exact functions the CLI verbs dispatch to — identity provisioning,
+/// server challenge, signed-intent verification, and WAL admission included
+/// (brief §5.6; CLAUDE.md §4 invariants 3 and 5). Each call opens its own
+/// verb context against the vault, mirroring a short-lived CLI invocation;
+/// `SQLite` WAL mode lets those connections co-exist with the long-lived
+/// MCP store connection.
+///
+/// Only the arg shapes the wire accepts are honored: `ingest` is body-only
+/// (file/folder/url/jsonl/recording resolvers are CLI-side and reject with
+/// `MalformedCapture`), and `forget` flush-plan modes fail closed.
+pub struct CliMutationHost {
+    vault_root: std::path::PathBuf,
+    config: CairnConfig,
+}
+
+impl CliMutationHost {
+    /// Create a host bound to a resolved vault root and loaded config.
+    #[must_use]
+    pub fn new(vault_root: std::path::PathBuf, config: CairnConfig) -> Self {
+        Self { vault_root, config }
+    }
+}
+
+#[async_trait::async_trait]
+impl cairn_mcp::MutatingVerbHost for CliMutationHost {
+    async fn ingest(
+        &self,
+        args: cairn_core::generated::verbs::ingest::IngestArgs,
+    ) -> cairn_core::generated::envelope::Response {
+        crate::verbs::ingest::ingest_body_response(
+            args,
+            self.vault_root.clone(),
+            self.config.clone(),
+        )
+        .await
+        .response
+    }
+
+    async fn capture_trace(
+        &self,
+        args: cairn_core::generated::verbs::capture_trace::CaptureTraceArgs,
+    ) -> cairn_core::generated::envelope::Response {
+        crate::verbs::capture_trace::capture_trace_response(
+            args,
+            self.vault_root.clone(),
+            self.config.clone(),
+        )
+        .await
+    }
+
+    async fn forget(
+        &self,
+        args: cairn_core::generated::verbs::forget::ForgetArgs,
+    ) -> cairn_core::generated::envelope::Response {
+        crate::verbs::forget::forget_response(args, self.vault_root.clone(), self.config.clone())
+            .await
+    }
+}
+
 /// Outcome of resolving the `[mcp.stdio]` block into runtime components.
 pub struct ResolvedMcpScope {
     /// The scope resolver derived from the configured principal.
@@ -377,7 +440,14 @@ pub fn run(
                     expiration: config.expiration.enabled,
                     evaluation: config.evaluation.enabled,
                 };
-                let serve_result = cairn_mcp::serve_stdio_with_store_workflows_ready(
+                // Mutating verbs (`ingest`, `capture_trace`, `forget`)
+                // dispatch through the CLI's signed verb runtime via
+                // `CliMutationHost` — same domain logic as the CLI verbs,
+                // WAL admission included (brief §5.6).
+                let mutation_host: Arc<dyn cairn_mcp::MutatingVerbHost> = Arc::new(
+                    CliMutationHost::new(vault_root.to_path_buf(), config.clone()),
+                );
+                let serve_result = cairn_mcp::serve_stdio_with_store_workflows_ready_and_mutation_host(
                     store,
                     sqlite_store,
                     resolver,
@@ -385,6 +455,7 @@ pub fn run(
                     principal,
                     Some(vault_root.to_path_buf()),
                     readiness,
+                    Some(mutation_host),
                 )
                 .await;
 

--- a/crates/cairn-cli/src/verbs/capture_trace.rs
+++ b/crates/cairn-cli/src/verbs/capture_trace.rs
@@ -1821,6 +1821,48 @@ pub fn run(sub: &ArgMatches, vault_root: PathBuf, config: CairnConfig) -> ExitCo
     response_exit_code(&resp)
 }
 
+/// Run `capture_trace` from already-parsed generated args.
+///
+/// Single dispatch path behind both `cairn capture_trace` and the MCP
+/// `capture_trace` tool (via [`crate::mcp::CliMutationHost`]) — one verb
+/// implementation, two surfaces (CLAUDE.md §4 invariant 3). The arg→input
+/// mapping mirrors the CLI matcher in [`run`], including the `@path` prefix
+/// normalization the IDL documents for `blocks`.
+pub(crate) async fn capture_trace_response(
+    args: cairn_core::generated::verbs::capture_trace::CaptureTraceArgs,
+    vault_root: PathBuf,
+    config: CairnConfig,
+) -> Response {
+    let from = args.from.map(|p| normalize_cli_path(Path::new(&p)));
+    let blocks = args.blocks.map(|p| normalize_cli_path(Path::new(&p)));
+    let input = match (from, blocks, args.session_id) {
+        (Some(from), None, None) => CaptureTraceInput::Jsonl(from),
+        (None, Some(path), Some(session_id)) => CaptureTraceInput::Blocks { path, session_id },
+        (Some(_), None, Some(_)) => {
+            return invalid_args_response(
+                ResponseVerb::CaptureTrace,
+                "session_id",
+                "session-scoped trace import is not yet supported for JSONL capture_trace",
+            );
+        }
+        (None, Some(_), None) => {
+            return invalid_args_response(
+                ResponseVerb::CaptureTrace,
+                "session_id",
+                "required when using --blocks",
+            );
+        }
+        _ => {
+            return invalid_args_response(
+                ResponseVerb::CaptureTrace,
+                "from|blocks",
+                "exactly one input mode is required",
+            );
+        }
+    };
+    run_async(input, vault_root, config).await
+}
+
 async fn run_async(input: CaptureTraceInput, vault_root: PathBuf, config: CairnConfig) -> Response {
     let ctx =
         match super::signed::open_context(ResponseVerb::CaptureTrace, &vault_root, config).await {

--- a/crates/cairn-cli/src/verbs/forget.rs
+++ b/crates/cairn-cli/src/verbs/forget.rs
@@ -867,7 +867,6 @@ impl ForgetOutcomeExt for cairn_store_sqlite::record_wal::forget::ForgetOutcome 
 
 #[allow(clippy::too_many_lines)]
 fn run_session(session_id: &str, vault_root: &Path, _config: &CairnConfig, json: bool) -> ExitCode {
-    let operation_id = new_operation_id();
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -892,53 +891,7 @@ fn run_session(session_id: &str, vault_root: &Path, _config: &CairnConfig, json:
         }
     };
 
-    let db_path = vault_root.join(".cairn/cairn.db");
-    let result = rt.block_on(async {
-        let store = cairn_store_sqlite::open(&db_path)
-            .await
-            .map_err(|e| ForgetSessionError::Other(anyhow::anyhow!("open store: {e}")))?;
-        let backup_targets = session_target_ids_for_forget(&store, session_id).await?;
-        super::admin_snapshot::validate_registered_backups_for_targets(vault_root, &backup_targets)
-            .map_err(|e| {
-                ForgetSessionError::Other(anyhow::anyhow!(
-                    "backup.replay_tombstones preflight: {e}"
-                ))
-            })?;
-        let projection_paths = session_projection_paths_for_forget(&store, session_id).await?;
-        remove_session_projection_files(vault_root, &projection_paths)
-            .map_err(ForgetSessionError::Other)?;
-        store
-            .forget_session(session_id)
-            .await
-            .and_then(|outcome| {
-                super::admin_snapshot::rewrite_registered_backups(
-                    vault_root,
-                    &backup_targets,
-                    outcome.operation_id.as_str(),
-                )
-                .map_err(|e| cairn_store_sqlite::StoreError::Invariant {
-                    what: format!("backup.replay_tombstones: {e}"),
-                })?;
-                Ok(SessionForgetReceipt {
-                    deleted_count: outcome.deleted_count,
-                    projection_paths: outcome.projection_paths,
-                    tombstones: outcome
-                        .tombstones
-                        .into_iter()
-                        .map(|id| Ulid(id.as_str().to_owned()))
-                        .collect(),
-                })
-            })
-            .map_err(|e| match e {
-                cairn_store_sqlite::StoreError::NotFound { id } => ForgetSessionError::NotFound(id),
-                cairn_store_sqlite::StoreError::Invariant { what }
-                    if what.contains("spans multiple scope partitions") =>
-                {
-                    ForgetSessionError::AmbiguousSession(session_id.to_owned())
-                }
-                other => ForgetSessionError::Other(anyhow::anyhow!("{other}")),
-            })
-    });
+    let result = rt.block_on(run_session_receipt(session_id, vault_root));
 
     match result {
         Ok(receipt) => {
@@ -954,70 +907,192 @@ fn run_session(session_id: &str, vault_root: &Path, _config: &CairnConfig, json:
                 }
                 return ExitCode::FAILURE;
             }
-            let resp = Response {
-                contract: "cairn.mcp.v1".to_owned(),
-                data: Some(ResponseData::Forget(ForgetData {
-                    deleted_count: receipt.deleted_count,
-                    plan_ref: None,
-                    tombstones: Some(receipt.tombstones),
-                })),
-                error: None,
-                operation_id,
-                policy_trace: Vec::<ResponsePolicyTrace>::new(),
-                status: ResponseStatus::Committed,
-                target: None,
-                verb: ResponseVerb::Forget,
-            };
+            let deleted_count = receipt.deleted_count;
+            let resp = session_committed_response(receipt, new_operation_id());
             if json {
                 emit_json(&resp);
             } else {
-                println!(
-                    "cairn forget: deleted {} record versions",
-                    receipt.deleted_count
-                );
+                println!("cairn forget: deleted {deleted_count} record versions");
             }
             ExitCode::SUCCESS
         }
-        Err(ForgetSessionError::NotFound(target)) => {
-            let resp = not_found_response(
-                ResponseVerb::Forget,
-                &target,
-                &format!("target `{target}` was not found"),
-            );
+        Err(err) => {
+            let (resp, code, human_code, message) = session_error_response(err);
             if json {
                 emit_json(&resp);
             } else {
-                human_error(
-                    "forget",
-                    "NotFound",
-                    &format!("target `{target}` was not found"),
-                    &resp.operation_id,
-                );
+                human_error("forget", human_code, &message, &resp.operation_id);
             }
-            ExitCode::FAILURE
+            code
         }
-        Err(ForgetSessionError::AmbiguousSession(session_id)) => {
+    }
+}
+
+/// The store-level session forget flow shared by the CLI (`run_session`)
+/// and the MCP surface (`run_session_response`): backup preflight,
+/// projection cleanup, `forget_session`, and backup rewrite.
+async fn run_session_receipt(
+    session_id: &str,
+    vault_root: &Path,
+) -> Result<SessionForgetReceipt, ForgetSessionError> {
+    let db_path = vault_root.join(".cairn/cairn.db");
+    let store = cairn_store_sqlite::open(&db_path)
+        .await
+        .map_err(|e| ForgetSessionError::Other(anyhow::anyhow!("open store: {e}")))?;
+    let backup_targets = session_target_ids_for_forget(&store, session_id).await?;
+    super::admin_snapshot::validate_registered_backups_for_targets(vault_root, &backup_targets)
+        .map_err(|e| {
+            ForgetSessionError::Other(anyhow::anyhow!("backup.replay_tombstones preflight: {e}"))
+        })?;
+    let projection_paths = session_projection_paths_for_forget(&store, session_id).await?;
+    remove_session_projection_files(vault_root, &projection_paths)
+        .map_err(ForgetSessionError::Other)?;
+    store
+        .forget_session(session_id)
+        .await
+        .and_then(|outcome| {
+            super::admin_snapshot::rewrite_registered_backups(
+                vault_root,
+                &backup_targets,
+                outcome.operation_id.as_str(),
+            )
+            .map_err(|e| cairn_store_sqlite::StoreError::Invariant {
+                what: format!("backup.replay_tombstones: {e}"),
+            })?;
+            Ok(SessionForgetReceipt {
+                deleted_count: outcome.deleted_count,
+                projection_paths: outcome.projection_paths,
+                tombstones: outcome
+                    .tombstones
+                    .into_iter()
+                    .map(|id| Ulid(id.as_str().to_owned()))
+                    .collect(),
+            })
+        })
+        .map_err(|e| match e {
+            cairn_store_sqlite::StoreError::NotFound { id } => ForgetSessionError::NotFound(id),
+            cairn_store_sqlite::StoreError::Invariant { what }
+                if what.contains("spans multiple scope partitions") =>
+            {
+                ForgetSessionError::AmbiguousSession(session_id.to_owned())
+            }
+            other => ForgetSessionError::Other(anyhow::anyhow!("{other}")),
+        })
+}
+
+fn session_committed_response(receipt: SessionForgetReceipt, operation_id: Ulid) -> Response {
+    Response {
+        contract: "cairn.mcp.v1".to_owned(),
+        data: Some(ResponseData::Forget(ForgetData {
+            deleted_count: receipt.deleted_count,
+            plan_ref: None,
+            tombstones: Some(receipt.tombstones),
+        })),
+        error: None,
+        operation_id,
+        policy_trace: Vec::<ResponsePolicyTrace>::new(),
+        status: ResponseStatus::Committed,
+        target: None,
+        verb: ResponseVerb::Forget,
+    }
+}
+
+/// Map a session-forget error to its response envelope, CLI exit code,
+/// human error label, and human message — shared between the CLI printer
+/// and the MCP surface (which uses only the envelope).
+fn session_error_response(err: ForgetSessionError) -> (Response, ExitCode, &'static str, String) {
+    match err {
+        ForgetSessionError::NotFound(target) => {
+            let message = format!("target `{target}` was not found");
+            let resp = not_found_response(ResponseVerb::Forget, &target, &message);
+            (resp, ExitCode::FAILURE, "NotFound", message)
+        }
+        ForgetSessionError::AmbiguousSession(session_id) => {
             let message = format!(
                 "session `{session_id}` spans multiple scope partitions; specify a narrower forget target"
             );
             let resp = invalid_args_response(ResponseVerb::Forget, "session_id", &message);
-            if json {
-                emit_json(&resp);
-            } else {
-                human_error("forget", "InvalidArgs", &message, &resp.operation_id);
-            }
-            ExitCode::from(64)
+            (resp, ExitCode::from(64), "InvalidArgs", message)
         }
-        Err(err) => {
-            let resp =
-                super::envelope::internal_error_response(ResponseVerb::Forget, &err.to_string());
-            if json {
-                emit_json(&resp);
-            } else {
-                human_error("forget", "Internal", &err.to_string(), &resp.operation_id);
-            }
-            ExitCode::FAILURE
+        err @ ForgetSessionError::Other(_) => {
+            let message = err.to_string();
+            let resp = super::envelope::internal_error_response(ResponseVerb::Forget, &message);
+            (resp, ExitCode::FAILURE, "Internal", message)
         }
+    }
+}
+
+/// Session-mode forget returning the response envelope (MCP surface).
+async fn run_session_response(session_id: &str, vault_root: &Path) -> Response {
+    match run_session_receipt(session_id, vault_root).await {
+        Ok(receipt) => {
+            if let Err(e) = remove_session_projection_files(vault_root, &receipt.projection_paths) {
+                return super::envelope::internal_error_response(
+                    ResponseVerb::Forget,
+                    &format!("projection cleanup failed after committed session forget: {e}"),
+                );
+            }
+            session_committed_response(receipt, new_operation_id())
+        }
+        Err(err) => session_error_response(err).0,
+    }
+}
+
+/// Run `forget` from already-parsed generated args.
+///
+/// Single dispatch path behind both `cairn forget` and the MCP `forget`
+/// tool (via [`crate::mcp::CliMutationHost`]) — one verb implementation,
+/// two surfaces (CLAUDE.md §4 invariant 3).
+///
+/// Mode mapping mirrors the CLI dispatcher in [`run`]:
+/// - `record` → the signed WAL tombstone path ([`run_record`]).
+/// - `session` → the store-level session forget ([`run_session_response`]).
+/// - `scope` → `CapabilityUnavailable`
+///   ([`cairn_core::status::wiring::FORGET_SCOPE_WIRED`] is `false`).
+/// - `dry_run` / `human_review` flush-plan modes are CLI-only placeholder
+///   planners (`ingest_plan_stub` writes vault-local plan files); they fail
+///   closed here rather than pretending a plan was produced.
+pub(crate) async fn forget_response(
+    args: cairn_core::generated::verbs::forget::ForgetArgs,
+    vault_root: PathBuf,
+    config: CairnConfig,
+) -> Response {
+    use cairn_core::generated::verbs::forget::ForgetArgs as Args;
+
+    let flush_plan_requested = match &args {
+        Args::Record {
+            dry_run,
+            human_review,
+            ..
+        }
+        | Args::Session {
+            dry_run,
+            human_review,
+            ..
+        }
+        | Args::Scope {
+            dry_run,
+            human_review,
+            ..
+        } => dry_run.unwrap_or(false) || human_review.unwrap_or(false),
+        _ => false,
+    };
+    if flush_plan_requested {
+        return invalid_args_response(
+            ResponseVerb::Forget,
+            "dry_run|human_review",
+            "flush-plan forget modes are not yet supported over MCP",
+        );
+    }
+
+    match args {
+        Args::Record { record_id, .. } => run_record(record_id.0, vault_root, config).await,
+        Args::Session { session_id, .. } => run_session_response(&session_id, &vault_root).await,
+        Args::Scope { .. } => {
+            capability_unavailable_response(ResponseVerb::Forget, "cairn.mcp.v1.forget.scope")
+        }
+        // Fail closed on future IDL modes this build does not know.
+        _ => invalid_args_response(ResponseVerb::Forget, "mode", "unknown forget mode"),
     }
 }
 

--- a/crates/cairn-cli/src/verbs/ingest.rs
+++ b/crates/cairn-cli/src/verbs/ingest.rs
@@ -639,10 +639,6 @@ fn emit_internal(json: bool, message: &str, policy_trace: Vec<ResponsePolicyTrac
     ExitCode::FAILURE
 }
 
-#[allow(
-    clippy::too_many_lines,
-    reason = "signed ingest CLI flow is guard, prepare, authorize, persist, and emit in source order"
-)]
 async fn run_async(
     sub: &ArgMatches,
     vault_root: PathBuf,
@@ -651,23 +647,62 @@ async fn run_async(
     body: String,
 ) -> ExitCode {
     let args = ingest_args_from_matches(sub, body);
+    let session_requested = args.session_id.is_some();
+    let out = ingest_body_response(args, vault_root, config).await;
+    if json {
+        emit_json(&out.response);
+    } else if session_requested {
+        human_error(
+            "ingest",
+            "InvalidArgs",
+            "`--session` ingest is not supported until signed intents carry a session scope dimension",
+            &out.response.operation_id,
+        );
+    }
+    out.exit
+}
+
+/// Outcome of the signed body-ingest path: the generated response envelope
+/// plus the historical per-branch CLI exit code (64 invalid args, 65 filter
+/// rejection, 78 context/abort, 1 store failure).
+pub(crate) struct IngestVerbOutcome {
+    /// Generated response envelope (shared with the MCP surface).
+    pub(crate) response: Response,
+    /// CLI exit code preserving the pre-refactor per-branch mapping.
+    pub(crate) exit: ExitCode,
+}
+
+/// Run the signed body-ingest path and return the response envelope.
+///
+/// This is the single body-ingest implementation behind both `cairn ingest
+/// --body` and the MCP `ingest` tool (via
+/// [`crate::mcp::CliMutationHost`]) — one verb path, two surfaces
+/// (CLAUDE.md §4 invariant 3). Only `args.body` ingest is supported here;
+/// file/folder/url/jsonl/recording sources are CLI-side resolvers.
+#[allow(
+    clippy::too_many_lines,
+    reason = "signed ingest flow is guard, prepare, authorize, persist, and emit in source order"
+)]
+pub(crate) async fn ingest_body_response(
+    args: IngestArgs,
+    vault_root: PathBuf,
+    config: cairn_core::config::CairnConfig,
+) -> IngestVerbOutcome {
     if args.session_id.is_some() {
         let reason = "`--session` ingest is not supported until signed intents carry a session scope dimension";
         let resp = super::envelope::invalid_args_response(ResponseVerb::Ingest, "session", reason);
-        if json {
-            emit_json(&resp);
-        } else {
-            human_error("ingest", "InvalidArgs", reason, &resp.operation_id);
-        }
-        return ExitCode::from(64);
+        return IngestVerbOutcome {
+            response: resp,
+            exit: ExitCode::from(64),
+        };
     }
     let ctx = match super::signed::open_context(ResponseVerb::Ingest, &vault_root, config).await {
         Ok(ctx) => ctx,
         Err(resp) => {
-            if json {
-                emit_json(&resp);
-            }
-            return ExitCode::from(78);
+            return IngestVerbOutcome {
+                response: resp,
+                exit: ExitCode::from(78),
+            };
         }
     };
     let issuer_wire =
@@ -675,11 +710,10 @@ async fn run_async(
     let prepared = match cairn_core::verbs::ingest::prepare_ingest_body(&args, &issuer_wire) {
         Ok(p) => p,
         Err(e) => {
-            let resp = super::signed::rejected_from_domain(ResponseVerb::Ingest, e);
-            if json {
-                emit_json(&resp);
-            }
-            return ExitCode::from(64);
+            return IngestVerbOutcome {
+                response: super::signed::rejected_from_domain(ResponseVerb::Ingest, e),
+                exit: ExitCode::from(64),
+            };
         }
     };
     match prepared {
@@ -691,10 +725,10 @@ async fn run_async(
                 },
             );
             resp.policy_trace = policy_trace;
-            if json {
-                emit_json(&resp);
+            IngestVerbOutcome {
+                response: resp,
+                exit: ExitCode::from(65),
             }
-            ExitCode::from(65)
         }
         cairn_core::verbs::ingest::PreparedIngest::Proceed {
             record,
@@ -705,18 +739,18 @@ async fn run_async(
             let issuer = match Identity::parse(issuer_wire) {
                 Ok(issuer) => issuer,
                 Err(e) => {
-                    let resp = super::signed::rejected_from_domain(ResponseVerb::Ingest, e);
-                    if json {
-                        emit_json(&resp);
-                    }
-                    return ExitCode::from(64);
+                    return IngestVerbOutcome {
+                        response: super::signed::rejected_from_domain(ResponseVerb::Ingest, e),
+                        exit: ExitCode::from(64),
+                    };
                 }
             };
             if let Err(resp) = ensure_ingest_issuer(&ctx, &issuer).await {
-                if json {
-                    emit_json(&resp);
-                }
-                return response_exit_code(&resp);
+                let exit = response_exit_code(&resp);
+                return IngestVerbOutcome {
+                    response: resp,
+                    exit,
+                };
             }
             bind_record_scope_to_ingest_context(&mut record, &ctx);
             let record_id = cairn_core::generated::common::Ulid(record.id.as_str().to_owned());
@@ -728,11 +762,10 @@ async fn run_async(
             let payload = match canonical_bytes_signed_payload(&record) {
                 Ok(payload) => payload,
                 Err(e) => {
-                    let resp = super::signed::rejected_from_domain(ResponseVerb::Ingest, e);
-                    if json {
-                        emit_json(&resp);
-                    }
-                    return ExitCode::from(64);
+                    return IngestVerbOutcome {
+                        response: super::signed::rejected_from_domain(ResponseVerb::Ingest, e),
+                        exit: ExitCode::from(64),
+                    };
                 }
             };
             let admission =
@@ -741,10 +774,11 @@ async fn run_async(
                 {
                     Ok(admission) => admission,
                     Err(resp) => {
-                        if json {
-                            emit_json(&resp);
-                        }
-                        return response_exit_code(&resp);
+                        let exit = response_exit_code(&resp);
+                        return IngestVerbOutcome {
+                            response: resp,
+                            exit,
+                        };
                     }
                 };
             let result = ctx
@@ -773,25 +807,23 @@ async fn run_async(
                         jsonl_summary: None,
                         recording_summary: None,
                     };
-                    let resp = super::signed::committed(
+                    IngestVerbOutcome {
+                        response: super::signed::committed(
+                            ResponseVerb::Ingest,
+                            op,
+                            ResponseData::Ingest(data),
+                            policy_trace,
+                        ),
+                        exit: ExitCode::SUCCESS,
+                    }
+                }
+                Err(e) => IngestVerbOutcome {
+                    response: super::signed::aborted(
                         ResponseVerb::Ingest,
-                        op,
-                        ResponseData::Ingest(data),
-                        policy_trace,
-                    );
-                    if json {
-                        emit_json(&resp);
-                    }
-                    ExitCode::SUCCESS
-                }
-                Err(e) => {
-                    let resp =
-                        super::signed::aborted(ResponseVerb::Ingest, format!("store upsert: {e}"));
-                    if json {
-                        emit_json(&resp);
-                    }
-                    ExitCode::FAILURE
-                }
+                        format!("store upsert: {e}"),
+                    ),
+                    exit: ExitCode::FAILURE,
+                },
             }
         }
     }

--- a/crates/cairn-cli/tests/mcp_handshake_e2e.rs
+++ b/crates/cairn-cli/tests/mcp_handshake_e2e.rs
@@ -142,6 +142,11 @@ fn cairn_mcp_subprocess_advertises_generated_tool_descriptions_byte_for_byte() {
     run_mcp_subprocess("e2e-cli-descriptions", run_tool_description_protocol);
 }
 
+#[test]
+fn cairn_mcp_subprocess_ingest_search_forget_round_trip() {
+    run_mcp_subprocess("e2e-cli-mutations", run_mutation_round_trip_protocol);
+}
+
 fn run_mcp_subprocess(tenant: &str, protocol: fn(&mut Child) -> Result<(), String>) {
     let vault = synth_vault(tenant);
     let child = Command::new(cli_bin())
@@ -149,6 +154,14 @@ fn run_mcp_subprocess(tenant: &str, protocol: fn(&mut Child) -> Result<(), Strin
         .arg(vault.path())
         .arg("mcp")
         .env_remove("CAIRN_VAULT")
+        // Offline file keystore: the signed-ingest path (round-trip test)
+        // provisions an identity on first ingest. The default OS keychain
+        // serializes through a system daemon, which under full-workspace
+        // `nextest` parallelism stalls the subprocess past FRAME_DEADLINE.
+        // The file keystore is deterministic, offline, and matches CI's
+        // ubuntu config (`CAIRN_KEYSTORE: file`). Harmless for the
+        // read-only protocols.
+        .env("CAIRN_KEYSTORE", "file")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -399,6 +412,109 @@ fn run_assemble_hot_protocol(child: &mut Child) -> Result<(), String> {
         .is_some_and(Value::is_array)
     {
         return Err(format!("assemble_hot must emit segments; got {envelope}"));
+    }
+
+    client.close_stdin();
+    Ok(())
+}
+
+/// Committed-envelope helper for the mutation round-trip: assert the call
+/// is a non-error result whose text content parses as a committed cairn
+/// envelope for `verb`, and return the parsed envelope JSON.
+fn committed_envelope(call_resp: &Value, label: &str, verb: &str) -> Result<Value, String> {
+    let is_error = call_resp
+        .pointer("/result/isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if is_error {
+        return Err(format!("{label} should commit; got {call_resp}"));
+    }
+    let text = first_text_content(call_resp)
+        .ok_or_else(|| format!("{label} response missing text content: {call_resp}"))?;
+    let envelope: Value = serde_json::from_str(text)
+        .map_err(|e| format!("{label} text must parse as JSON: {e}; text={text}"))?;
+    if envelope["contract"] != "cairn.mcp.v1"
+        || envelope["verb"] != verb
+        || envelope["status"] != "committed"
+    {
+        return Err(format!(
+            "{label} must return a committed cairn envelope; got {envelope}"
+        ));
+    }
+    Ok(envelope)
+}
+
+/// Full mutating round-trip over the real `cairn mcp` subprocess —
+/// the exact flow the desk-daemon `CairnMemoryAdapter` drives:
+/// `ingest` commits a record, `search` finds it, `forget` tombstones it,
+/// and a second `search` comes back empty.
+fn run_mutation_round_trip_protocol(child: &mut Child) -> Result<(), String> {
+    let mut client = ProtocolClient::new(child)?;
+    client.initialize("cli-e2e-mutations")?;
+
+    // ── ingest ───────────────────────────────────────────────────────────
+    client.send(
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ingest","arguments":{"kind":"reference","body":"Acme renewal terms land in Q3.","frontmatter":{"source":"e2e"}}}}"#,
+    )?;
+    let ingest_env = committed_envelope(&client.recv("ingest")?, "ingest", "ingest")?;
+    let record_id = ingest_env
+        .pointer("/data/record_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("ingest envelope missing data.record_id: {ingest_env}"))?
+        .to_owned();
+    if record_id.len() != 26 {
+        return Err(format!("ingest record_id must be a ULID; got {record_id}"));
+    }
+
+    // ── search round-trip ────────────────────────────────────────────────
+    client.send(
+        r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search","arguments":{"query":"acme","mode":"keyword","limit":10}}}"#,
+    )?;
+    let search_env = committed_envelope(&client.recv("search")?, "search", "search")?;
+    let hit_ids: Vec<&str> = search_env
+        .pointer("/data/hits")
+        .and_then(Value::as_array)
+        .map(|hits| {
+            hits.iter()
+                .filter_map(|h| h.get("record_id").and_then(Value::as_str))
+                .collect()
+        })
+        .unwrap_or_default();
+    if !hit_ids.contains(&record_id.as_str()) {
+        return Err(format!(
+            "keyword search must find the ingested record {record_id}; got hits {hit_ids:?} in {search_env}"
+        ));
+    }
+
+    // ── forget ───────────────────────────────────────────────────────────
+    let forget_call = format!(
+        r#"{{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{{"name":"forget","arguments":{{"mode":"record","record_id":"{record_id}"}}}}}}"#
+    );
+    client.send(&forget_call)?;
+    let forget_env = committed_envelope(&client.recv("forget")?, "forget", "forget")?;
+    if forget_env
+        .pointer("/data/deleted_count")
+        .and_then(Value::as_u64)
+        .is_none_or(|n| n < 1)
+    {
+        return Err(format!(
+            "forget must report at least one deleted version; got {forget_env}"
+        ));
+    }
+
+    // ── search again: record is gone ─────────────────────────────────────
+    client.send(
+        r#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"search","arguments":{"query":"acme","mode":"keyword","limit":10}}}"#,
+    )?;
+    let search_env = committed_envelope(&client.recv("search-after-forget")?, "search", "search")?;
+    let hits_after = search_env
+        .pointer("/data/hits")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    if hits_after != 0 {
+        return Err(format!(
+            "search after forget must return no hits; got {search_env}"
+        ));
     }
 
     client.close_stdin();

--- a/crates/cairn-cli/tests/mcp_mutation_host.rs
+++ b/crates/cairn-cli/tests/mcp_mutation_host.rs
@@ -1,0 +1,430 @@
+//! Integration tests for [`cairn_cli::mcp::CliMutationHost`] — the
+//! `MutatingVerbHost` implementation that routes MCP `ingest`,
+//! `capture_trace`, and `forget` calls through the same signed verb runtime
+//! the CLI verbs use (brief §5.6 WAL; CLAUDE.md §4 invariant 3).
+//!
+//! These tests exercise the host against a real bootstrapped vault: the
+//! signed write path (identity provisioning, server challenge, WAL
+//! admission, store tx) runs end-to-end, exactly as it does for
+//! `cairn ingest --body` / `cairn forget --record` / `cairn capture_trace
+//! --from`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, missing_docs)]
+
+use std::io::Write as _;
+use std::path::Path;
+
+use cairn_cli::mcp::CliMutationHost;
+use cairn_core::config::CairnConfig;
+use cairn_core::domain::{
+    ActorChainEntry, CaptureEvent, CaptureEventId, CaptureMode, CapturePayload, CaptureRefs,
+    ChainRole, Identity, PayloadHash, Rfc3339Timestamp, SourceFamily,
+};
+use cairn_core::generated::common::Ulid;
+use cairn_core::generated::envelope::{Response, ResponseData, ResponseStatus, ResponseVerb};
+use cairn_core::generated::verbs::capture_trace::CaptureTraceArgs;
+use cairn_core::generated::verbs::forget::ForgetArgs;
+use cairn_core::generated::verbs::ingest::IngestArgs;
+use cairn_mcp::MutatingVerbHost as _;
+
+fn bootstrap_vault(vault: &Path) {
+    cairn_cli::vault::bootstrap(&cairn_cli::vault::BootstrapOpts {
+        vault_path: vault.to_path_buf(),
+        force: false,
+    })
+    .expect("bootstrap vault");
+}
+
+/// Record consent + flip `sensors.hooks.enabled` in the vault config —
+/// the same opt-in a real operator performs before `capture_trace` will
+/// accept hook events (sensor gate, brief §14).
+fn enable_hook_sensor(vault: &Path) {
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_cairn"))
+        .args([
+            "sensor",
+            "enable",
+            "hook",
+            "--reason",
+            "mcp_mutation_host_test",
+            "--vault",
+        ])
+        .arg(vault)
+        .arg("--json")
+        .output()
+        .expect("spawn cairn sensor enable hook");
+    assert!(
+        out.status.success(),
+        "sensor enable hook failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Load the vault's on-disk config the way `cairn mcp` does at boot.
+fn vault_config(vault: &Path) -> CairnConfig {
+    cairn_cli::config::load(vault, &cairn_cli::config::CliOverrides::default())
+        .expect("load vault config")
+}
+
+fn host_for(vault: &Path) -> CliMutationHost {
+    CliMutationHost::new(vault.to_path_buf(), CairnConfig::default())
+}
+
+fn body_ingest_args(body: &str, kind: &str) -> IngestArgs {
+    IngestArgs {
+        batch_size: None,
+        body: Some(body.to_owned()),
+        dry_run: None,
+        exclude: None,
+        file: None,
+        folder: None,
+        frontmatter: Some(serde_json::json!({"source": "test-suite"})),
+        harness: None,
+        human_review: None,
+        include: None,
+        jsonl: None,
+        kind: kind.to_owned(),
+        limit: None,
+        mode: None,
+        no_cache: None,
+        no_diff: None,
+        recording: None,
+        recursive: None,
+        session_id: None,
+        session_id_from: None,
+        tags: None,
+        url: None,
+    }
+}
+
+fn error_code(resp: &Response) -> Option<&str> {
+    resp.error
+        .as_ref()
+        .and_then(|e| e.get("code"))
+        .and_then(serde_json::Value::as_str)
+}
+
+fn active_record_count(vault: &Path) -> i64 {
+    let conn = rusqlite::Connection::open(vault.join(".cairn/cairn.db")).expect("open cairn db");
+    conn.query_row(
+        "SELECT COUNT(*) FROM records WHERE active = 1 AND tombstoned = 0",
+        [],
+        |row| row.get(0),
+    )
+    .expect("count active records")
+}
+
+#[tokio::test]
+async fn host_ingest_commits_record_through_signed_store() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let host = host_for(vault.path());
+
+    let resp = host
+        .ingest(body_ingest_args(
+            "Acme renewal terms land in Q3.",
+            "reference",
+        ))
+        .await;
+
+    assert!(
+        matches!(resp.status, ResponseStatus::Committed),
+        "ingest should commit; got {resp:?}"
+    );
+    assert!(matches!(resp.verb, ResponseVerb::Ingest));
+    assert!(resp.error.is_none());
+    let Some(ResponseData::Ingest(data)) = &resp.data else {
+        panic!("committed ingest envelope must carry IngestData: {resp:?}");
+    };
+    assert_eq!(data.record_id.0.len(), 26, "record_id must be a ULID");
+    assert!(
+        !resp.policy_trace.is_empty(),
+        "ingest must surface the filter policy trace"
+    );
+    assert_eq!(active_record_count(vault.path()), 1);
+}
+
+#[tokio::test]
+async fn host_ingest_rejects_unknown_kind() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let host = host_for(vault.path());
+
+    let resp = host.ingest(body_ingest_args("some body", "email")).await;
+
+    assert!(
+        matches!(resp.status, ResponseStatus::Rejected),
+        "unknown taxonomy kind must reject; got {resp:?}"
+    );
+    assert_eq!(active_record_count(vault.path()), 0);
+}
+
+#[tokio::test]
+async fn host_ingest_rejects_session_scoped_body() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let host = host_for(vault.path());
+
+    let mut args = body_ingest_args("session body", "reference");
+    args.session_id = Some("01ARZ3NDEKTSV4RRFFQ69G5FAV".to_owned());
+    let resp = host.ingest(args).await;
+
+    assert!(
+        matches!(resp.status, ResponseStatus::Rejected),
+        "session-scoped ingest is unsupported until intents carry a session dimension; got {resp:?}"
+    );
+    assert_eq!(error_code(&resp), Some("InvalidArgs"));
+}
+
+#[tokio::test]
+async fn host_forget_record_round_trip() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let host = host_for(vault.path());
+
+    let ingest_resp = host
+        .ingest(body_ingest_args("Temporary note to forget.", "reference"))
+        .await;
+    let Some(ResponseData::Ingest(data)) = &ingest_resp.data else {
+        panic!("seed ingest must commit: {ingest_resp:?}");
+    };
+    let record_id = data.record_id.0.clone();
+
+    let resp = host
+        .forget(ForgetArgs::Record {
+            dry_run: None,
+            human_review: None,
+            no_diff: None,
+            record_id: Ulid(record_id),
+        })
+        .await;
+
+    assert!(
+        matches!(resp.status, ResponseStatus::Committed),
+        "forget --record should commit; got {resp:?}"
+    );
+    assert!(matches!(resp.verb, ResponseVerb::Forget));
+    let Some(ResponseData::Forget(data)) = &resp.data else {
+        panic!("committed forget envelope must carry ForgetData: {resp:?}");
+    };
+    assert!(data.deleted_count >= 1);
+    assert_eq!(active_record_count(vault.path()), 0);
+}
+
+#[tokio::test]
+async fn host_forget_scope_is_capability_unavailable() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let host = host_for(vault.path());
+
+    let resp = host
+        .forget(ForgetArgs::Scope {
+            dry_run: None,
+            human_review: None,
+            no_diff: None,
+            scope: cairn_core::generated::common::ScopeFilter {
+                agent: None,
+                entity: None,
+                kind: None,
+                record_ids: None,
+                session_id: None,
+                tags: None,
+                tenant: Some("acme".to_owned()),
+                tier: None,
+                user: None,
+                workspace: None,
+            },
+        })
+        .await;
+
+    assert!(
+        matches!(resp.status, ResponseStatus::Rejected),
+        "scope forget is unwired (FORGET_SCOPE_WIRED=false) and must fail closed; got {resp:?}"
+    );
+    assert_eq!(error_code(&resp), Some("CapabilityUnavailable"));
+}
+
+#[tokio::test]
+async fn host_forget_flush_plan_modes_fail_closed() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let host = host_for(vault.path());
+
+    let resp = host
+        .forget(ForgetArgs::Record {
+            dry_run: Some(true),
+            human_review: None,
+            no_diff: None,
+            record_id: Ulid("01HQZX9F5N0000000000000000".to_owned()),
+        })
+        .await;
+
+    assert!(
+        matches!(resp.status, ResponseStatus::Rejected),
+        "flush-plan forget modes are CLI-only placeholders and must fail closed over MCP; got {resp:?}"
+    );
+}
+
+// ── capture_trace fixture (mirrors capture_trace_verb.rs) ───────────────────
+
+fn sha256_hex(text: &str) -> String {
+    use sha2::{Digest as _, Sha256};
+    let mut h = Sha256::new();
+    h.update(text.as_bytes());
+    format!("{:x}", h.finalize())
+}
+
+fn write_source(vault: &Path, filename: &str, content: &str) -> String {
+    let dir = vault.join("sources").join("hook");
+    std::fs::create_dir_all(&dir).expect("create sources/hook");
+    std::fs::write(dir.join(filename), content).expect("write source file");
+    format!("sources/hook/{filename}")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn make_hook_event(
+    event_id: &str,
+    hook_name: &str,
+    session_id: &str,
+    turn_id: &str,
+    timestamp: &str,
+    tool_id: Option<String>,
+    payload_ref: &str,
+    payload_hash_hex: &str,
+) -> CaptureEvent {
+    let sensor =
+        Identity::parse("snr:local:hook:cc-session:v1").expect("invariant: valid sensor id");
+    CaptureEvent {
+        event_id: CaptureEventId::parse(event_id).expect("invariant: valid ULID"),
+        sensor_id: sensor.clone(),
+        capture_mode: CaptureMode::Auto,
+        actor_chain: vec![ActorChainEntry {
+            role: ChainRole::Author,
+            identity: sensor,
+            at: Rfc3339Timestamp::parse(timestamp).expect("invariant: valid RFC-3339"),
+        }],
+        refs: Some(CaptureRefs {
+            session_id: Some(session_id.to_owned()),
+            turn_id: Some(turn_id.to_owned()),
+            tool_id,
+        }),
+        payload_hash: PayloadHash::parse(format!("sha256:{payload_hash_hex}"))
+            .expect("invariant: valid sha256"),
+        payload_ref: payload_ref.to_owned(),
+        captured_at: Rfc3339Timestamp::parse(timestamp).expect("invariant: valid RFC-3339"),
+        payload: CapturePayload::Hook {
+            hook_name: hook_name.to_owned(),
+            tool_name: None,
+        },
+        source_family: SourceFamily::Hook,
+    }
+}
+
+fn write_single_turn_fixture(vault: &Path, jsonl_path: &Path) {
+    let session = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    let tool = "toolu_test_01";
+    let user_body = "Hello, please run ls";
+    let pre_body = r#"{"tool":"bash","input":{"command":"ls"}}"#;
+    let post_body = r#"{"tool":"bash","output":"file.txt"}"#;
+    let stop_body = "session ended";
+
+    let cases = [
+        (
+            "01ARZ3NDEKTSV4RRFFQ69G5FAA",
+            "UserPromptSubmit",
+            None,
+            user_body,
+            "2026-05-02T00:00:01Z",
+        ),
+        (
+            "01ARZ3NDEKTSV4RRFFQ69G5FAB",
+            "PreToolUse",
+            Some(tool.to_owned()),
+            pre_body,
+            "2026-05-02T00:00:02Z",
+        ),
+        (
+            "01ARZ3NDEKTSV4RRFFQ69G5FAC",
+            "PostToolUse",
+            Some(tool.to_owned()),
+            post_body,
+            "2026-05-02T00:00:03Z",
+        ),
+        (
+            "01ARZ3NDEKTSV4RRFFQ69G5FAD",
+            "Stop",
+            None,
+            stop_body,
+            "2026-05-02T00:00:04Z",
+        ),
+    ];
+
+    let mut f = std::fs::File::create(jsonl_path).expect("create JSONL file");
+    for (id, hook_name, tool_id, body, ts) in cases {
+        let payload_ref = write_source(vault, &format!("{id}.txt"), body);
+        let event = make_hook_event(
+            id,
+            hook_name,
+            session,
+            "turn-1",
+            ts,
+            tool_id,
+            &payload_ref,
+            &sha256_hex(body),
+        );
+        let line = serde_json::to_string(&event).expect("serialize event");
+        writeln!(f, "{line}").expect("write JSONL line");
+    }
+}
+
+#[tokio::test]
+async fn host_capture_trace_jsonl_commits() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    // Hook events pass the sensor gate only after operator opt-in; the
+    // host must read the post-opt-in config, as `cairn mcp` does at boot.
+    enable_hook_sensor(vault.path());
+    let jsonl_path = vault.path().join("trace.jsonl");
+    write_single_turn_fixture(vault.path(), &jsonl_path);
+    let host = CliMutationHost::new(vault.path().to_path_buf(), vault_config(vault.path()));
+
+    let resp = host
+        .capture_trace(CaptureTraceArgs {
+            blocks: None,
+            from: Some(jsonl_path.to_string_lossy().into_owned()),
+            session_id: None,
+        })
+        .await;
+
+    assert!(
+        matches!(resp.status, ResponseStatus::Committed),
+        "capture_trace --from should commit; got {resp:?}"
+    );
+    assert!(matches!(resp.verb, ResponseVerb::CaptureTrace));
+    let Some(ResponseData::CaptureTrace(data)) = &resp.data else {
+        panic!("committed capture_trace envelope must carry CaptureTraceData: {resp:?}");
+    };
+    assert!(data.failed_turns.is_empty(), "no failed turns expected");
+    assert_eq!(data.trace_id.0.len(), 26, "trace_id must be a ULID");
+}
+
+#[tokio::test]
+async fn host_capture_trace_blocks_without_session_rejects() {
+    let vault = tempfile::tempdir().expect("temp vault");
+    bootstrap_vault(vault.path());
+    let host = host_for(vault.path());
+
+    let resp = host
+        .capture_trace(CaptureTraceArgs {
+            blocks: Some("/tmp/blocks.json".to_owned()),
+            from: None,
+            session_id: None,
+        })
+        .await;
+
+    assert!(
+        matches!(resp.status, ResponseStatus::Rejected),
+        "blocks without a session id must reject (mirrors CLI); got {resp:?}"
+    );
+    assert_eq!(error_code(&resp), Some("InvalidArgs"));
+}

--- a/crates/cairn-mcp/src/handler.rs
+++ b/crates/cairn-mcp/src/handler.rs
@@ -155,7 +155,9 @@ pub struct FederationState {
 ///
 /// Implements [`rmcp::ServerHandler`]. When constructed with
 /// [`CairnMcpHandler::with_store`] the `search` tool dispatches through
-/// [`cairn_core::verbs::search::run`]; all other tools fall back to
+/// [`cairn_core::verbs::search::run`]; the mutating verbs (`ingest`,
+/// `capture_trace`, `forget`) dispatch through a host injected via
+/// [`CairnMcpHandler::with_mutation_host`]; remaining tools fall back to
 /// [`dispatch_stub`] until their real dispatch lands in a follow-up PR.
 // One bool per workflow's runtime-ready advertisement gate; collapsing
 // into a single struct doesn't add clarity here.
@@ -195,6 +197,11 @@ pub struct CairnMcpHandler {
     /// AND `federation` is `Some`. Controls federation capability
     /// advertisement.
     federation_runtime_ready: bool,
+    /// Host-injected dispatch for the mutating verbs (`ingest`,
+    /// `capture_trace`, `forget`). When `Some`, those tools route through
+    /// the host's signed write path (the same domain logic the CLI verbs
+    /// use); when `None`, they keep the fail-closed typed aborted stub.
+    mutation_host: Option<Arc<dyn crate::mutation_host::MutatingVerbHost>>,
 }
 
 impl Default for CairnMcpHandler {
@@ -236,6 +243,7 @@ impl CairnMcpHandler {
             evaluation_runtime_ready: false,
             federation: None,
             federation_runtime_ready: false,
+            mutation_host: None,
         }
     }
 
@@ -260,6 +268,7 @@ impl CairnMcpHandler {
             evaluation_runtime_ready: false,
             federation: None,
             federation_runtime_ready: false,
+            mutation_host: None,
         }
     }
 
@@ -288,6 +297,7 @@ impl CairnMcpHandler {
             evaluation_runtime_ready: false,
             federation: None,
             federation_runtime_ready: false,
+            mutation_host: None,
         }
     }
 
@@ -318,6 +328,7 @@ impl CairnMcpHandler {
             evaluation_runtime_ready: false,
             federation: None,
             federation_runtime_ready: false,
+            mutation_host: None,
         }
     }
 
@@ -348,6 +359,7 @@ impl CairnMcpHandler {
             evaluation_runtime_ready: false,
             federation: None,
             federation_runtime_ready: false,
+            mutation_host: None,
         }
     }
 
@@ -415,6 +427,21 @@ impl CairnMcpHandler {
     #[must_use]
     pub fn with_federation_runtime_ready(mut self, ready: bool) -> Self {
         self.federation_runtime_ready = ready;
+        self
+    }
+
+    /// Wire a [`crate::mutation_host::MutatingVerbHost`] into this handler.
+    ///
+    /// When set, the `ingest`, `capture_trace`, and `forget` tools dispatch
+    /// through the host's signed write path after the generated arg parsers
+    /// validate the payload. When absent, those tools keep the fail-closed
+    /// typed aborted stub ([`dispatch_stub`]).
+    #[must_use]
+    pub fn with_mutation_host(
+        mut self,
+        host: Arc<dyn crate::mutation_host::MutatingVerbHost>,
+    ) -> Self {
+        self.mutation_host = Some(host);
         self
     }
 
@@ -607,17 +634,22 @@ impl CairnMcpHandler {
 
         // Post-filter capabilities whose shared core wiring flags are true
         // for another surface but not yet honored by this MCP transport.
-        // MCP non-search verbs still fall through `dispatch_stub`; do not
-        // advertise them until MCP dispatch can honor them end-to-end.
+        // Retrieve verbs still fall through `dispatch_stub`; `forget` is
+        // honored only when a `MutatingVerbHost` is wired (the host routes
+        // it through the same signed write path the CLI uses). Do not
+        // advertise what this transport cannot honor end-to-end (brief §15).
+        let forget_honored = self.mutation_host.is_some();
         let mut capabilities = cairn_core::status::advertise(&gates);
         capabilities.retain(|c| {
-            !matches!(
+            !(matches!(
                 c,
-                cairn_core::generated::common::Capabilities::CairnMcpV1ForgetRecord
-                    | cairn_core::generated::common::Capabilities::CairnMcpV1RetrieveSession
+                cairn_core::generated::common::Capabilities::CairnMcpV1RetrieveSession
                     | cairn_core::generated::common::Capabilities::CairnMcpV1RetrieveTurn
                     | cairn_core::generated::common::Capabilities::CairnMcpV1RetrieveToolCall
-            )
+            ) || (matches!(
+                c,
+                cairn_core::generated::common::Capabilities::CairnMcpV1ForgetRecord
+            ) && !forget_honored))
         });
 
         // Post-filter replay capabilities to keep status advertisement and
@@ -847,8 +879,11 @@ impl ServerHandler for CairnMcpHandler {
     /// [`crate::graph_tools::dispatch`]. Validates that the requested verb
     /// exists in [`TOOLS`] for non-graph tools. When the verb is `"search"`
     /// and a store is wired, dispatches through
-    /// [`cairn_core::verbs::search::run`]. All other verbs (or `"search"` with
-    /// no store wired) fall back to [`dispatch_stub`].
+    /// [`cairn_core::verbs::search::run`]. The mutating verbs (`ingest`,
+    /// `capture_trace`, `forget`) dispatch through the wired
+    /// [`crate::mutation_host::MutatingVerbHost`] after generated arg
+    /// validation. All other verbs (or wired verbs whose runtime dependency
+    /// is absent) fall back to [`dispatch_stub`].
     #[allow(
         clippy::too_many_lines,
         reason = "central MCP dispatch table keeps tool routing auditable"
@@ -869,7 +904,12 @@ impl ServerHandler for CairnMcpHandler {
         async move {
             let verb_name = name.to_string();
             let started = Instant::now();
-            let call = async {
+            // Boxed: the dispatch future embeds every verb's arg/response
+            // state and trips `clippy::large_futures` at each `serve()`
+            // call site once it crosses the size threshold. Boxing keeps
+            // the outer `call_tool` future small regardless of how many
+            // verbs gain real dispatch paths.
+            let call = Box::pin(async {
                 // Prelude tool routing (`handshake`) — accept the call iff
                 // (a) the tool name is in PRELUDE_TOOLS, AND
                 // (b) a sqlite store is wired, AND
@@ -987,6 +1027,35 @@ impl ServerHandler for CairnMcpHandler {
                     }
                 };
 
+                // Mutating verbs route through the host-injected signed
+                // write path (issue: wire ingest/capture_trace/forget over
+                // MCP). The host runs the same domain logic the CLI verbs
+                // use — WAL admission included (brief §5.6) — so no write
+                // logic lives in this adapter. Arg validation already
+                // happened above; without a wired host these verbs fall
+                // through to the fail-closed stub below.
+                if matches!(name.as_ref(), "ingest" | "capture_trace" | "forget")
+                    && let Some(host) = self.mutation_host.as_ref()
+                {
+                    let response = match typed_args {
+                        cairn_core::generated::envelope::RequestArgs::Ingest(args) => {
+                            host.ingest(args).await
+                        }
+                        cairn_core::generated::envelope::RequestArgs::CaptureTrace(args) => {
+                            host.capture_trace(args).await
+                        }
+                        cairn_core::generated::envelope::RequestArgs::Forget(args) => {
+                            host.forget(args).await
+                        }
+                        _ => crate::verb_envelope::invalid_args_response(
+                            crate::verb_envelope::response_verb(request_verb),
+                            "args",
+                            "argument payload does not match verb",
+                        ),
+                    };
+                    return Ok(crate::verb_envelope::call_result_from_response(&response));
+                }
+
                 if name.as_ref() == "search"
                     && let Some(store) = store
                 {
@@ -1035,7 +1104,7 @@ impl ServerHandler for CairnMcpHandler {
                 }
 
                 Ok(dispatch_stub(&name))
-            };
+            });
             let result = if metric_config.observability.enabled
                 && metric_config.observability.local_traces
             {

--- a/crates/cairn-mcp/src/lib.rs
+++ b/crates/cairn-mcp/src/lib.rs
@@ -18,12 +18,14 @@ pub mod federation_tools;
 pub mod generated;
 pub mod graph_tools;
 pub mod handler;
+pub mod mutation_host;
 pub mod prelude_tools;
 pub mod relay;
 pub mod verb_envelope;
 
 pub use error::TransportError;
 pub use handler::{CairnMcpHandler, FederationState};
+pub use mutation_host::MutatingVerbHost;
 
 use std::{path::PathBuf, sync::Arc};
 
@@ -205,12 +207,24 @@ pub async fn serve_stdio_with_store_consolidation_ready(
         vault_root,
         tokio::io::stdin(),
         tokio::io::stdout(),
-        WorkflowReadiness {
-            consolidation: true,
-            ..WorkflowReadiness::default()
+        ServeOptions {
+            readiness: WorkflowReadiness {
+                consolidation: true,
+                ..WorkflowReadiness::default()
+            },
+            mutation_host: None,
         },
     ))
     .await
+}
+
+/// Handler wiring carried by [`serve_stdio_with_store_io_inner`] beyond the
+/// store/scope/config baseline: workflow-readiness advertisement flags and
+/// the optional mutating-verb host.
+#[derive(Default)]
+struct ServeOptions {
+    readiness: WorkflowReadiness,
+    mutation_host: Option<Arc<dyn MutatingVerbHost>>,
 }
 
 /// Per-workflow runtime-readiness flags. Passed by `cairn mcp serve`
@@ -248,6 +262,40 @@ pub async fn serve_stdio_with_store_workflows_ready(
     vault_root: Option<PathBuf>,
     readiness: WorkflowReadiness,
 ) -> Result<(), TransportError> {
+    serve_stdio_with_store_workflows_ready_and_mutation_host(
+        store,
+        sqlite_store,
+        scope,
+        config,
+        principal,
+        vault_root,
+        readiness,
+        None,
+    )
+    .await
+}
+
+/// Run the MCP stdio server with workflow-readiness flags and an optional
+/// [`MutatingVerbHost`] that dispatches `ingest`, `capture_trace`, and
+/// `forget` through the embedder's signed write path. Pass `None` to keep
+/// the mutating verbs on the fail-closed stub.
+///
+/// # Errors
+/// Same as [`serve_stdio_with_store`].
+#[allow(
+    clippy::too_many_arguments,
+    reason = "entry point mirrors serve_stdio_with_store_workflows_ready plus the host gate"
+)]
+pub async fn serve_stdio_with_store_workflows_ready_and_mutation_host(
+    store: Arc<dyn cairn_core::contract::memory_store::MemoryStore>,
+    sqlite_store: Arc<cairn_store_sqlite::SqliteMemoryStore>,
+    scope: Arc<dyn cairn_core::mcp_auth::McpSessionScope>,
+    config: cairn_core::config::CairnConfig,
+    principal: cairn_core::domain::ScopeTuple,
+    vault_root: Option<PathBuf>,
+    readiness: WorkflowReadiness,
+    mutation_host: Option<Arc<dyn MutatingVerbHost>>,
+) -> Result<(), TransportError> {
     Box::pin(serve_stdio_with_store_io_inner(
         store,
         sqlite_store,
@@ -257,7 +305,10 @@ pub async fn serve_stdio_with_store_workflows_ready(
         vault_root,
         tokio::io::stdin(),
         tokio::io::stdout(),
-        readiness,
+        ServeOptions {
+            readiness,
+            mutation_host,
+        },
     ))
     .await
 }
@@ -292,7 +343,7 @@ where
         None,
         input,
         output,
-        WorkflowReadiness::default(),
+        ServeOptions::default(),
     ))
     .await
 }
@@ -330,7 +381,7 @@ where
         Some(vault_root),
         input,
         output,
-        WorkflowReadiness::default(),
+        ServeOptions::default(),
     ))
     .await
 }
@@ -349,7 +400,7 @@ async fn serve_stdio_with_store_io_inner<I, O>(
     vault_root: Option<PathBuf>,
     input: I,
     output: O,
-    readiness: WorkflowReadiness,
+    options: ServeOptions,
 ) -> Result<(), TransportError>
 where
     I: AsyncRead + Unpin + Send + 'static,
@@ -360,7 +411,8 @@ where
     let (framer_reader, relay_writer) = tokio::io::duplex(64 * 1024);
     let mut relay_task = tokio::spawn(async move { relay::run_relay(input, relay_writer).await });
 
-    let handler = if let Some(vault_root) = vault_root {
+    let readiness = options.readiness;
+    let mut handler = if let Some(vault_root) = vault_root {
         CairnMcpHandler::with_store_scope_sqlite_and_vault(
             store,
             sqlite_store,
@@ -377,6 +429,9 @@ where
     .with_dream_runtime_ready(readiness.dream)
     .with_expiration_runtime_ready(readiness.expiration)
     .with_evaluation_runtime_ready(readiness.evaluation);
+    if let Some(host) = options.mutation_host {
+        handler = handler.with_mutation_host(host);
+    }
 
     // rmcp's `IntoTransport` is implemented for `(R, W)` tuples where R:
     // `AsyncRead + Unpin + Send + 'static` and W: `AsyncWrite + Unpin + Send +

--- a/crates/cairn-mcp/src/mutation_host.rs
+++ b/crates/cairn-mcp/src/mutation_host.rs
@@ -1,0 +1,47 @@
+//! Host-injected dispatch for the mutating core verbs (`ingest`,
+//! `capture_trace`, `forget`).
+//!
+//! The MCP adapter must not grow a parallel implementation of the signed
+//! write path (CLAUDE.md §4 invariant 3; brief §5.6 WAL + two-phase apply).
+//! The full path — identity registry, keystore, server challenge, signed
+//! intent verification, WAL admission — lives in the embedding process
+//! (`cairn mcp` in `cairn-cli`), which already drives it for the CLI verbs.
+//! Instead of duplicating that flow here, the embedder injects a
+//! [`MutatingVerbHost`] via
+//! [`CairnMcpHandler::with_mutation_host`](crate::CairnMcpHandler::with_mutation_host)
+//! and the handler routes the three mutating tools through it after the
+//! generated arg parsers have validated the payload.
+//!
+//! Without a wired host the handler keeps the pre-existing fail-closed
+//! behaviour: a typed aborted stub envelope, no memory operation performed.
+
+use cairn_core::generated::envelope::Response;
+use cairn_core::generated::verbs::capture_trace::CaptureTraceArgs;
+use cairn_core::generated::verbs::forget::ForgetArgs;
+use cairn_core::generated::verbs::ingest::IngestArgs;
+
+/// Dispatch already-validated mutating verb args through the host's signed
+/// write path and return the generated response envelope.
+///
+/// Contract for implementors:
+///
+/// - The returned [`Response`] must carry the matching `verb`
+///   (`Ingest` / `CaptureTrace` / `Forget`) and one of the three terminal
+///   statuses (`Committed`, `Rejected`, `Aborted`) — the handler serializes
+///   it verbatim into the MCP `CallToolResult` text content.
+/// - Every mutation must go through the WAL state machine (brief §5.6);
+///   implementors route to the same domain logic the CLI verbs use, never a
+///   parallel write path.
+/// - `async_trait` is used (not RPITIT) because the handler stores the host
+///   as a trait object.
+#[async_trait::async_trait]
+pub trait MutatingVerbHost: Send + Sync {
+    /// Run the `ingest` verb (brief §8) against the host's vault.
+    async fn ingest(&self, args: IngestArgs) -> Response;
+
+    /// Run the `capture_trace` verb (brief §8) against the host's vault.
+    async fn capture_trace(&self, args: CaptureTraceArgs) -> Response;
+
+    /// Run the `forget` verb (brief §8) against the host's vault.
+    async fn forget(&self, args: ForgetArgs) -> Response;
+}

--- a/crates/cairn-mcp/tests/mutation_host_tool.rs
+++ b/crates/cairn-mcp/tests/mutation_host_tool.rs
@@ -1,0 +1,301 @@
+//! MCP wire tests for mutating-verb dispatch through a wired
+//! [`cairn_mcp::MutatingVerbHost`].
+//!
+//! The MCP adapter must not grow a parallel implementation of the signed
+//! write path (CLAUDE.md §4 invariant 3) — instead the embedding process
+//! (`cairn mcp` in `cairn-cli`) injects a host that routes `ingest`,
+//! `capture_trace`, and `forget` through the same domain logic the CLI
+//! verbs use. These tests pin the routing contract with a fake host:
+//!
+//! - wired host + valid args → the host is called and its `Response`
+//!   envelope is returned verbatim;
+//! - wired host + malformed args → the generated arg parser rejects
+//!   before the host is consulted (fail-closed, no partial writes);
+//! - no host → the pre-existing typed aborted stub envelope.
+#![allow(missing_docs)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::sync::{Arc, Mutex};
+
+use cairn_core::generated::common::Ulid;
+use cairn_core::generated::envelope::{
+    Response, ResponseData, ResponsePolicyTrace, ResponseStatus, ResponseVerb,
+};
+use cairn_core::generated::verbs::capture_trace::{CaptureTraceArgs, CaptureTraceData};
+use cairn_core::generated::verbs::forget::{ForgetArgs, ForgetData};
+use cairn_core::generated::verbs::ingest::{IngestArgs, IngestData};
+use cairn_mcp::{CairnMcpHandler, MutatingVerbHost};
+use rmcp::ServiceExt as _;
+use tokio::io::BufReader;
+
+use common::{do_initialize, recv_frame, send_frame};
+
+const RECORD_ULID: &str = "01HQZX9F5N0000000000000000";
+const TRACE_ULID: &str = "01HQZX9F5N0000000000000001";
+
+fn committed(verb: ResponseVerb, data: ResponseData) -> Response {
+    Response {
+        contract: "cairn.mcp.v1".to_owned(),
+        data: Some(data),
+        error: None,
+        operation_id: Ulid("01HQZX9F5N0000000000000002".to_owned()),
+        policy_trace: Vec::<ResponsePolicyTrace>::new(),
+        status: ResponseStatus::Committed,
+        target: None,
+        verb,
+    }
+}
+
+/// Fake host that records every call and answers canned committed envelopes.
+#[derive(Default)]
+struct RecordingHost {
+    calls: Mutex<Vec<String>>,
+}
+
+#[async_trait::async_trait]
+impl MutatingVerbHost for RecordingHost {
+    async fn ingest(&self, args: IngestArgs) -> Response {
+        self.calls
+            .lock()
+            .expect("calls lock")
+            .push(format!("ingest:{}", args.body.as_deref().unwrap_or("")));
+        committed(
+            ResponseVerb::Ingest,
+            ResponseData::Ingest(IngestData {
+                cache_hits: None,
+                cache_misses: None,
+                cache_writes: None,
+                files_processed: None,
+                jsonl_summary: None,
+                plan_ref: None,
+                record_id: Ulid(RECORD_ULID.to_owned()),
+                recording_summary: None,
+                session_id: "default".to_owned(),
+            }),
+        )
+    }
+
+    async fn capture_trace(&self, args: CaptureTraceArgs) -> Response {
+        self.calls.lock().expect("calls lock").push(format!(
+            "capture_trace:{}",
+            args.from.as_deref().unwrap_or("")
+        ));
+        committed(
+            ResponseVerb::CaptureTrace,
+            ResponseData::CaptureTrace(CaptureTraceData {
+                failed_turns: Vec::new(),
+                trace_id: Ulid(TRACE_ULID.to_owned()),
+            }),
+        )
+    }
+
+    async fn forget(&self, args: ForgetArgs) -> Response {
+        let label = match &args {
+            ForgetArgs::Record { record_id, .. } => format!("forget:record:{}", record_id.0),
+            ForgetArgs::Session { session_id, .. } => format!("forget:session:{session_id}"),
+            ForgetArgs::Scope { .. } => "forget:scope".to_owned(),
+            _ => "forget:unknown".to_owned(),
+        };
+        self.calls.lock().expect("calls lock").push(label);
+        committed(
+            ResponseVerb::Forget,
+            ResponseData::Forget(ForgetData {
+                deleted_count: 1,
+                plan_ref: None,
+                tombstones: Some(vec![Ulid(RECORD_ULID.to_owned())]),
+            }),
+        )
+    }
+}
+
+struct Wire {
+    writer: tokio::io::WriteHalf<tokio::io::DuplexStream>,
+    reader: BufReader<tokio::io::ReadHalf<tokio::io::DuplexStream>>,
+}
+
+/// Serve `handler` over an in-process duplex pipe and complete the MCP
+/// initialize handshake.
+async fn start(handler: CairnMcpHandler) -> Wire {
+    let (server_half, client_half) = tokio::io::duplex(65_536);
+    let _server_task = tokio::spawn(async move {
+        handler
+            .serve(server_half)
+            .await
+            .expect("server init")
+            .waiting()
+            .await
+            .ok();
+    });
+    let (client_read, client_write) = tokio::io::split(client_half);
+    let mut wire = Wire {
+        writer: client_write,
+        reader: BufReader::new(client_read),
+    };
+    do_initialize(&mut wire.writer, &mut wire.reader).await;
+    wire
+}
+
+async fn call_tool(wire: &mut Wire, id: u32, name: &str, arguments: &str) -> serde_json::Value {
+    let frame = format!(
+        r#"{{"jsonrpc":"2.0","id":{id},"method":"tools/call","params":{{"name":"{name}","arguments":{arguments}}}}}"#
+    );
+    send_frame(&mut wire.writer, &frame).await;
+    recv_frame(&mut wire.reader).await
+}
+
+fn envelope_from(call_resp: &serde_json::Value) -> Response {
+    let text = call_resp
+        .pointer("/result/content/0/text")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("expected text content; got: {call_resp}"));
+    serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("text must be valid Response JSON: {e}; text={text}"))
+}
+
+fn is_error(call_resp: &serde_json::Value) -> bool {
+    call_resp
+        .pointer("/result/isError")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn host_handler(host: Arc<RecordingHost>) -> CairnMcpHandler {
+    CairnMcpHandler::new().with_mutation_host(host)
+}
+
+#[tokio::test]
+async fn ingest_routes_through_wired_host() {
+    let host = Arc::new(RecordingHost::default());
+    let mut wire = start(host_handler(host.clone())).await;
+
+    let resp = call_tool(
+        &mut wire,
+        2,
+        "ingest",
+        r#"{"kind":"reference","body":"acme renewal terms"}"#,
+    )
+    .await;
+
+    assert!(!is_error(&resp), "wired ingest must not error: {resp}");
+    let envelope = envelope_from(&resp);
+    assert!(matches!(envelope.status, ResponseStatus::Committed));
+    assert!(matches!(envelope.verb, ResponseVerb::Ingest));
+    let Some(ResponseData::Ingest(data)) = envelope.data else {
+        panic!("committed ingest envelope must carry IngestData");
+    };
+    assert_eq!(data.record_id.0, RECORD_ULID);
+    assert_eq!(
+        host.calls.lock().expect("calls lock").as_slice(),
+        ["ingest:acme renewal terms"]
+    );
+}
+
+#[tokio::test]
+async fn capture_trace_routes_through_wired_host() {
+    let host = Arc::new(RecordingHost::default());
+    let mut wire = start(host_handler(host.clone())).await;
+
+    let resp = call_tool(
+        &mut wire,
+        2,
+        "capture_trace",
+        r#"{"from":"/tmp/trace.jsonl"}"#,
+    )
+    .await;
+
+    assert!(
+        !is_error(&resp),
+        "wired capture_trace must not error: {resp}"
+    );
+    let envelope = envelope_from(&resp);
+    assert!(matches!(envelope.status, ResponseStatus::Committed));
+    assert!(matches!(envelope.verb, ResponseVerb::CaptureTrace));
+    let Some(ResponseData::CaptureTrace(data)) = envelope.data else {
+        panic!("committed capture_trace envelope must carry CaptureTraceData");
+    };
+    assert_eq!(data.trace_id.0, TRACE_ULID);
+    assert_eq!(
+        host.calls.lock().expect("calls lock").as_slice(),
+        ["capture_trace:/tmp/trace.jsonl"]
+    );
+}
+
+#[tokio::test]
+async fn forget_record_routes_through_wired_host() {
+    let host = Arc::new(RecordingHost::default());
+    let mut wire = start(host_handler(host.clone())).await;
+
+    let resp = call_tool(
+        &mut wire,
+        2,
+        "forget",
+        &format!(r#"{{"mode":"record","record_id":"{RECORD_ULID}"}}"#),
+    )
+    .await;
+
+    assert!(!is_error(&resp), "wired forget must not error: {resp}");
+    let envelope = envelope_from(&resp);
+    assert!(matches!(envelope.status, ResponseStatus::Committed));
+    assert!(matches!(envelope.verb, ResponseVerb::Forget));
+    let Some(ResponseData::Forget(data)) = envelope.data else {
+        panic!("committed forget envelope must carry ForgetData");
+    };
+    assert_eq!(data.deleted_count, 1);
+    assert_eq!(
+        host.calls.lock().expect("calls lock").as_slice(),
+        [format!("forget:record:{RECORD_ULID}")]
+    );
+}
+
+/// Malformed args must be rejected by the generated parser BEFORE the host
+/// runs — a host call on unvalidated args could mutate the vault.
+#[tokio::test]
+async fn malformed_args_reject_before_host_is_called() {
+    let host = Arc::new(RecordingHost::default());
+    let mut wire = start(host_handler(host.clone())).await;
+
+    // `kind` is required by the generated IngestArgs parser.
+    let resp = call_tool(&mut wire, 2, "ingest", r#"{"body":"no kind"}"#).await;
+
+    assert!(is_error(&resp), "malformed ingest args must error: {resp}");
+    let envelope = envelope_from(&resp);
+    assert!(matches!(envelope.status, ResponseStatus::Rejected));
+    assert!(matches!(envelope.verb, ResponseVerb::Ingest));
+    assert!(
+        host.calls.lock().expect("calls lock").is_empty(),
+        "host must not be consulted for unparseable args"
+    );
+}
+
+/// Without a wired host the pre-existing typed aborted stub is preserved —
+/// the adapter fails closed rather than guessing at a write path.
+#[tokio::test]
+async fn ingest_without_host_returns_typed_aborted_stub() {
+    let mut wire = start(CairnMcpHandler::new()).await;
+
+    let resp = call_tool(
+        &mut wire,
+        2,
+        "ingest",
+        r#"{"kind":"reference","body":"acme"}"#,
+    )
+    .await;
+
+    assert!(is_error(&resp), "stubbed ingest must error: {resp}");
+    let envelope = envelope_from(&resp);
+    assert!(matches!(envelope.status, ResponseStatus::Aborted));
+    assert!(matches!(envelope.verb, ResponseVerb::Ingest));
+    let message = envelope
+        .error
+        .as_ref()
+        .and_then(|e| e.get("message"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        message.contains("not yet implemented"),
+        "stub message must say not implemented; got: {message}"
+    );
+}


### PR DESCRIPTION
## Summary

The MCP adapter stubbed every mutating verb — `ingest`, `capture_trace`, and `forget` fell through `dispatch_stub` returning *"not yet implemented in MCP adapter"*. This wires them through a host injected by the embedder, so the write path stays in the CLI signed verb runtime. No parallel write logic lives in `cairn-mcp` (CLAUDE.md §4 invariant 3 — CLI is ground truth; brief §5.6 WAL + two-phase apply).

This unblocks the desk-daemon `CairnMemoryAdapter` (in `~/private/cos`), whose gated round-trip activates once upstream wires `ingest`.

### `cairn-mcp` (protocol-only)
- New `MutatingVerbHost` trait + `CairnMcpHandler::with_mutation_host`. `call_tool` routes the three verbs through the host **after** the generated arg parser validates and **before** `dispatch_stub` — malformed args reject before the host runs (fail-closed, no partial writes).
- `forget.record` capability advertised **only** when a host is wired (brief §15 fail-closed).
- New `serve_stdio_with_store_workflows_ready_and_mutation_host` entry; boxed the dispatch future to keep `clippy::large_futures` quiet at every `serve()` site.

### `cairn-cli`
- Extracted `ingest_body_response` / `capture_trace_response` / `forget_response` (each returns `Response`; CLI handlers now call these), and `CliMutationHost` implementing the trait over them. Wired into the `cairn mcp` single-tenant serve.
- `ingest` is body-only over MCP; `forget --scope` (FORGET_SCOPE_WIRED=false) and flush-plan modes fail closed.

## Invariants touched
- §4.3 CLI is ground truth — MCP reuses the CLI verb functions, no parallel write path.
- §4.5 WAL + two-phase apply — host calls `open_context` → signed admission → `prepare_wal_with_replay` / `commit_prepared_wal`, unchanged.
- §4.6 fail closed on capability — `forget.record` advertised only with a wired host; malformed args reject pre-host.

## Verification
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, codegen `--check`, docgen `--check`, doctests, `check-core-boundary.sh` — all green.
- Targeted tests green: `mutation_host_tool.rs` (5/5 wire routing), `mcp_mutation_host.rs` (8/8 real signed write path), `mcp_handshake_e2e.rs` ingest→search→forget round-trip. RED confirmed by disabling the routing line.
- Full `nextest run --workspace`: the only two failures were the round-trip (load-induced 90s `FRAME_DEADLINE` timeout on the macOS keychain — **fixed**, see below) and `nexus_sidecar_binary` (pre-existing health-endpoint flake under contention; passes in isolation, untouched by this diff).

### Round-trip e2e fix
The subprocess e2e now spawns with `CAIRN_KEYSTORE=file` (offline, deterministic, matches CI ubuntu). The default macOS keychain serializes through a system daemon that stalls the signed-ingest path past the 90s frame deadline under 16-way `nextest` parallelism. Reran at **11s under full parallel load** vs the 99.8s timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
